### PR TITLE
s/Cred/Ͼred/

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 ## SourceCred
 
-SourceCred is a system for creating digital tokens, called 'Cred' (¤), for open-source projects. Cred represents credit for doing the work of developing and maintaining the project. For example, people who contribute to SourceCred's development will receive SourceCred¤.
+SourceCred is a system for creating digital tokens, called 'Ͼred', for open-source projects. Ͼred represents credit for doing the work of developing and maintaining the project. For example, people who contribute to SourceCred's development will receive SourceCredϾ.
 
-The world benefits tremendously from open-source software, but most open-source developers don't get any recognition or reward. We want to build tools for fairly distributing Cred to those contributors, and incentives that act as rewards for having Cred. We hope these tools will reward open-source developers, and result in the creation of more open software.
+The world benefits tremendously from open-source software, but most open-source developers don't get any recognition or reward. We want to build tools for fairly distributing Ͼred to those contributors, and incentives that act as rewards for having Ͼred. We hope these tools will reward open-source developers, and result in the creation of more open software.
 
 SourceCred is in very early stages: as of 2/3/2018, we have just started work. Dandelion is currently working on an initial documentation push:
 
@@ -18,4 +18,4 @@ SourceCred is in very early stages: as of 2/3/2018, we have just started work. D
 
    implementation strategy and roadmap
 
-We aim to have design discussions on GitHub, so that people who contribute to the design will receive Cred. For coordination and casual conversation, please join [our slack](https://join.slack.com/t/sourcecred/shared_invite/enQtMzA4NzI5ODIwODMyLWFiNDlhNWNiODc4MTk4MjNmZTAzMDNjNDAwYzEyZTBiNjAxZTFhMjU1MDg2YzNlN2FlNzgwYmU0NGM1NGEzM2M).
+We aim to have design discussions on GitHub, so that people who contribute to the design will receive Ͼred. For coordination and casual conversation, please join [our slack](https://join.slack.com/t/sourcecred/shared_invite/enQtMzA4NzI5ODIwODMyLWFiNDlhNWNiODc4MTk4MjNmZTAzMDNjNDAwYzEyZTBiNjAxZTFhMjU1MDg2YzNlN2FlNzgwYmU0NGM1NGEzM2M).


### PR DESCRIPTION
@000drax suggested in #2 using Ͼ as our unicode symbol.
This PR is an experiment in spelling Cred as Ͼred, so that it's really clear from context what Ͼ means.

But maybe it is too clever / kinda ugly / a pain in the ass to follow as possible since keyboards don't ship with Ͼ keys. Also, depending on the font my brain wants to read it as "Gred" :( 

Also, it's bikeshedding. Don't take this too seriously, but tell me what you think :) 
