### PR TITLE
Add overview of cred to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,21 +1,13 @@
 ## SourceCred
 
-SourceCred is a system for creating digital tokens, called 'Cred' (¤), for open-source projects. Cred represents credit for doing the work of developing and maintaining the project. For example, people who contribute to SourceCred's development will receive SourceCred¤.
+SourceCred is a cryptoeconomic mechanism for valuing and incentivizing open-source development. The goal of SourceCred is to create a funding model for open-source projects that rewards contributors and maintainers.
 
-The world benefits tremendously from open-source software, but most open-source developers don't get any recognition or reward. We want to build tools for fairly distributing Cred to those contributors, and incentives that act as rewards for having Cred. We hope these tools will reward open-source developers, and result in the creation of more open software.
+SourceCred allows any project to create *cred* (Ͼ), which is a cryptographic token representing work done in that project. Every project has its own, particular cred - for example, PythonϾ and EthereumϾ would be two totally separate creds. Each project creates cred via Cred Allocations, which are periodic events when cred is given to people that contributed to the project. That cred is allocated based on community feedback, where users with more cred have more weight, a la [PageRank](https://en.wikipedia.org/wiki/PageRank). The exact mechanics are up to each project, although SourceCred will suggest good norms and useful tools. One such norm is that every project should give 20% of its cred to the other projects that it depends on, so as to support and reward shared infrastructure.
 
-SourceCred is in very early stages: as of 2/3/2018, we have just started work. Dandelion is currently working on an initial documentation push:
+When an existing project starts using SourceCred, they will have an Initial Cred Allocation (ICA), which determines how to retroactively give cred to the people that developed that project. This is just a special case of the standard cred allocation process. SourceCred will provide tools that scan the history of the project, and suggest a starting point for the allocation, but ultimately the allocation is decided by the community.
 
-* **overview.md**
+Each project's cred will be a implemented as an [ERC20 token](https://theethereum.wiki/w/index.php/ERC20_Token_Standard) on Ethereum. That means that contributors can use the Ethereum infrastructure to buy and sell cred. One reason that others would want to buy cred is to have influence over the project. For example, consider a business that depends on an open-source project, and needs it to add some new features and fix bugs. If that business buys cred in the project, they can influence the Cred Allocations - e.g. to ensure that people that work on their priorities get a lot of cred. That would be more efficient than having their engineers try to fix the project directly.
 
-   high level overview for a general audience
-
-* **cryptoeconomics.md**
-
-   details on SourceCred's economic design, and precise token mechanics
-
-* **implementation.md**
-
-   implementation strategy and roadmap
+SourceCred is in very early stages: as of 2/3/2018, we have just started work. Dandelion is currently working on an initial documentation push.
 
 We aim to have design discussions on GitHub, so that people who contribute to the design will receive Cred. For coordination and casual conversation, please join [our slack](https://join.slack.com/t/sourcecred/shared_invite/enQtMzA4NzI5ODIwODMyLWFiNDlhNWNiODc4MTk4MjNmZTAzMDNjNDAwYzEyZTBiNjAxZTFhMjU1MDg2YzNlN2FlNzgwYmU0NGM1NGEzM2M).


### PR DESCRIPTION
Originally, I planned to keep the README very succinct, and put an overview of SourceCred into a separate overview document.

This PR contains a first draft of the overview, but it seemed short enough to include in the README directly. I welcome feedback on whether this is a good fit for the README, or if keeping a separate overview is a good idea.