### PR TITLE
Remove console.log that alerts us of hacks

### DIFF
--- a/explorer/src/commitUtils.js
+++ b/explorer/src/commitUtils.js
@@ -38,7 +38,6 @@ function *userWeights(files: string[], data: CommitData, weightFn: WeightFn): It
       let w;
       if (commit.stats[file] == null) {
         // hack - likely due to the GitPython file rename issue
-        console.log(`commit ${commitHash} missing file ${file}`);
         w = 0;
       } else {
         w = weightFn(commit, file);


### PR DESCRIPTION
Summary:
It produces a lot of noise, and we know about it.

wchargin-branch: remove-spurious-log