### PR TITLE
 Add PropTypes to existing React components

### DIFF
--- a/explorer/src/App.test.js
+++ b/explorer/src/App.test.js
@@ -1,0 +1,10 @@
+import React from 'react';
+import ReactDOM from 'react-dom';
+import App from './App';
+
+// Check that PropTypes check out.
+it('renders without crashing', () => {
+  const div = document.createElement('div');
+  ReactDOM.render(<App />, div);
+  ReactDOM.unmountComponentAtNode(div);
+});

--- a/explorer/src/FileExplorer.js
+++ b/explorer/src/FileExplorer.js
@@ -1,7 +1,15 @@
 import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 import {buildTree} from './commitUtils';
+import {propTypes as commitUtilsPropTypes} from './commitUtils';
 
 export class FileExplorer extends Component {
+  static propTypes = {
+    selectedPath: PropTypes.string,
+    onSelectPath: PropTypes.func.isRequired,
+    data: commitUtilsPropTypes.commitData.isRequired,
+  }
+
   render() {
     // within the FileExplorer, paths start with "./", outside they don't
     // which is hacky and should be cleaned up
@@ -31,6 +39,18 @@ export class FileExplorer extends Component {
 }
 
 class FileEntry extends Component {
+  static propTypes = {
+    name: PropTypes.string.isRequired,
+    path: PropTypes.string.isRequired,
+    alwaysExpand: PropTypes.bool.isRequired,
+
+    // The type for the tree is recursive, and is annoying to specify as
+    // a proptype. The Flow type definition is in commitUtils.js.
+    tree: PropTypes.object.isRequired,
+
+    selectedPath: PropTypes.string.isRequired,
+    onSelectPath: PropTypes.func.isRequired,
+  }
 
   constructor() {
     super();

--- a/explorer/src/UserExplorer.js
+++ b/explorer/src/UserExplorer.js
@@ -1,7 +1,19 @@
 import React, { Component } from 'react';
-import {userWeightForPath, commitWeight} from './commitUtils';
+import PropTypes from 'prop-types';
+import {
+  commitWeight,
+  propTypes as commitUtilsPropTypes,
+  userWeightForPath,
+} from './commitUtils';
 
 export class UserExplorer extends Component {
+  static propTypes = {
+    selectedPath: PropTypes.string.isRequired,
+    selectedUser: PropTypes.string,
+    onSelectUser: PropTypes.func.isRequired,
+    data: commitUtilsPropTypes.commitData.isRequired,
+  }
+
   render() {
     const weights = userWeightForPath(this.props.selectedPath, this.props.data, commitWeight);
     const sortedUserWeightTuples = Object.entries(weights).sort((a,b) => b[1] - a[1]);
@@ -16,11 +28,15 @@ export class UserExplorer extends Component {
   }
 }
 
+/**
+ * Record the cred earned by the user in a given scope.
+ */
 class UserEntry extends Component {
-  // Record the cred earned by the user in a given scope
-  // Props: 
-  //  userId, string
-  //  weight, number
+  static propTypes = {
+    userId: PropTypes.string.isRequired,
+    weight: PropTypes.number.isRequired,
+  }
+
   render() {
     return <div className="user-entry">
       <span> {this.props.userId} </span>

--- a/explorer/src/UserExplorer.js
+++ b/explorer/src/UserExplorer.js
@@ -16,7 +16,10 @@ export class UserExplorer extends Component {
 
   render() {
     const weights = userWeightForPath(this.props.selectedPath, this.props.data, commitWeight);
-    const sortedUserWeightTuples = Object.entries(weights).sort((a,b) => b[1] - a[1]);
+    const sortedUserWeightTuples =
+        Object.keys(weights)
+        .map(k => [k, weights[k]])
+        .sort((a,b) => b[1] - a[1]);
     const entries = sortedUserWeightTuples.map(authorWeight => { 
       const [author, weight] = authorWeight;
       return <UserEntry userId={author} weight={weight} key={author}/>

--- a/explorer/src/commitUtils.js
+++ b/explorer/src/commitUtils.js
@@ -1,11 +1,30 @@
 // @flow
 
+import PropTypes from 'prop-types';
+
 type CommitData = {
   // TODO improve variable names
   fileToCommits: {[filename: string]: string[]};
   commits: {[commithash: string]: Commit};
   authors: string[];
 }
+
+export const propTypes = {
+  commitData: PropTypes.shape({
+    fileToCommits: PropTypes.objectOf(
+      PropTypes.arrayOf(PropTypes.string.isRequired).isRequired,
+    ).isRequired,
+    commits: PropTypes.objectOf(PropTypes.shape({
+      author: PropTypes.string.isRequired,
+      stats: PropTypes.objectOf(PropTypes.shape({
+        lines: PropTypes.number.isRequired,
+        insertions: PropTypes.number.isRequired,
+        deletions: PropTypes.number.isRequired,
+      }).isRequired).isRequired,
+    }).isRequired).isRequired,
+  }),
+};
+
 
 type Commit = {
   author: string;


### PR DESCRIPTION
Summary:
This should ensure that there aren’t any runtime PropTypes errors.

The change to reimplement `Object.entries` is due to the fact that my
local Node environment (v6.11.1) does not yet support that ESnext
function.

Test Plan:
Run `yarn start` and note that the app runs without any console
warnings, but that changing some of the PropTypes to introduce an error
actually does cause a warning.

Apply the following diff (`git apply`):
```diff
diff --git a/explorer/src/UserExplorer.js b/explorer/src/UserExplorer.js
index 8da252d..cdc1370 100644
--- a/explorer/src/UserExplorer.js
+++ b/explorer/src/UserExplorer.js
@@ -10,7 +10,7 @@ export class UserExplorer extends Component {
   static propTypes = {
     selectedPath: PropTypes.string.isRequired,
     selectedUser: PropTypes.string,
-    onSelectUser: PropTypes.func.isRequired,
+    onSelectUser: PropTypes.number.isRequired,
     data: commitUtilsPropTypes.commitData.isRequired,
   }
```
Then, `yarn test` should fail. Revert the diff, and `yarn test` should
pass.

wchargin-branch: react-proptypes-test