### PR TITLE
Frontend visual cleanup

### DIFF
--- a/explorer/public/index.html
+++ b/explorer/public/index.html
@@ -10,6 +10,7 @@
     -->
     <link rel="manifest" href="%PUBLIC_URL%/manifest.json">
     <link rel="shortcut icon" href="%PUBLIC_URL%/favicon.ico">
+    <link href="https://fonts.googleapis.com/css?family=Roboto" rel="stylesheet">
     <!--
       Notice the use of %PUBLIC_URL% in the tags above.
       It will be replaced with the URL of the `public` folder during the build.

--- a/explorer/public/index.html
+++ b/explorer/public/index.html
@@ -20,7 +20,7 @@
       work correctly both with client-side routing and a non-root public URL.
       Learn how to configure a non-root public URL by running `npm run build`.
     -->
-    <title>React App</title>
+    <title>SourceCred Explorer</title>
   </head>
   <body>
     <noscript>

--- a/explorer/src/App.css
+++ b/explorer/src/App.css
@@ -6,7 +6,7 @@
 
   grid-template-rows: 50px 1fr;
   grid-template-columns: 1fr 1fr;
-  grid-gap: 10px;
+  grid-gap: 4px;
   width: 100%;
 }
 
@@ -35,11 +35,15 @@ html, body, #root, .App {
   font-size: large;
 }
 
+.plugin-pane {
+  overflow: scroll;
+  background-color: white;
+  border-radius: 5px;
+  margin: 8px;
+}
 
 .file-explorer {
   grid-area: fileexplorer;
-  background-color: #aea;
-  overflow: scroll;
 }
 
 .user-explorer {

--- a/explorer/src/App.css
+++ b/explorer/src/App.css
@@ -23,11 +23,8 @@ html, body, #root, .App {
   background-color: #ddd;
 }
 
-.App-header {
-  background-color: #222;
-  padding: 5px;
-  color: white;
-  grid-area: header;
+.App-intro {
+  font-size: large;
 }
 
 .App-title {

--- a/explorer/src/App.css
+++ b/explorer/src/App.css
@@ -12,10 +12,7 @@
 
 html, body, #root, .App {
   height: 100%;
-}
-
-.App-header {
-  text-align: center;
+  font-family: Roboto, sans-serif;
 }
 
 .anchor-button:visited {

--- a/explorer/src/App.css
+++ b/explorer/src/App.css
@@ -6,7 +6,7 @@
 
   grid-template-rows: 50px 1fr;
   grid-template-columns: 1fr 1fr;
-
+  grid-gap: 10px;
   width: 100%;
 }
 

--- a/explorer/src/App.js
+++ b/explorer/src/App.js
@@ -16,9 +16,21 @@ class App extends Component<{}, AppState> {
   }
   render() {
     return (
-      <div className="App">
-        <header className="App-header">
-          <h1 className="App-title">SourceCred Explorer</h1>
+      <div className="App" style={{backgroundColor: "#eeeeee"}}>
+        <header
+
+          style={{
+            backgroundColor: "#01579B",
+            color: "white",
+            gridArea: "header",
+            textAlign: "center",
+            boxShadow: "0px 2px 2px #aeaeae",
+          }}
+          >
+          <h1
+            style={{fontSize: "1.5em"}}
+          >SourceCred Explorer
+          </h1>
         </header>
         <FileExplorer
           className="file-explorer"

--- a/explorer/src/FileExplorer.js
+++ b/explorer/src/FileExplorer.js
@@ -19,19 +19,18 @@ export class FileExplorer extends Component<{
       }
       this.props.onSelectPath(path);
     }
-    return <div className="file-explorer" style={{
-      fontFamily: "monospace",
-      textAlign: "left",
-    }}>
-      <h3>File Explorer</h3>
-      <FileEntry
-        alwaysExpand={true}
-        name=""
-        path="."
-        tree={tree}
-        onSelectPath={selectPath}
-        selectedPath={`./${this.props.selectedPath}`}
-      />
+    return <div className="file-explorer plugin-pane">
+      <h3 style={{textAlign: "center"}}>File Explorer</h3>
+      <div style={{fontFamily: "monospace"}}>
+        <FileEntry
+          alwaysExpand={true}
+          name=""
+          path="."
+          tree={tree}
+          onSelectPath={selectPath}
+          selectedPath={`./${this.props.selectedPath}`}
+        />
+      </div>
     </div>
   }
 }

--- a/explorer/src/UserExplorer.js
+++ b/explorer/src/UserExplorer.js
@@ -20,9 +20,13 @@ export class UserExplorer extends Component<{
       const [author, weight] = authorWeight;
       return <UserEntry userId={author} weight={weight} key={author}/>
     });
-    return <div className="user-explorer"> 
-      <h3> User Explorer </h3> 
-      {entries}
+    return <div
+      className="user-explorer plugin-pane"
+    >
+      <h3 style={{textAlign: "center"}}> User Explorer </h3>
+      <div style={{marginLeft: 8, marginRight: 8}}>
+        {entries}
+      </div>
     </div>
   }
 


### PR DESCRIPTION
Make a number of cleanups to the UI, such as:
- Using font roboto
- Changing the title to "SourceCred Explorer"
- Adding a grid gap
- Applying consistent styling to the two plugin panels
- Making a blue header, grey background, and white plugin panes.

Before:
![image](https://user-images.githubusercontent.com/1400023/36349157-44d4bf58-1435-11e8-8139-b588d2fb0bf5.png)

After:
![image](https://user-images.githubusercontent.com/1400023/36349152-295faa9e-1435-11e8-9c6c-d61f7061d857.png)

I tried to move styling away from the CSS files and into inline styles, but we don't yet have a style reuse abstraction, so the reusable styles I put in CSS.