### PR TITLE
Upgrade: babel-plugin-flow-react-proptypes@^18.0.0

### DIFF
--- a/explorer/package.json
+++ b/explorer/package.json
@@ -105,6 +105,6 @@
     "extends": "react-app"
   },
   "devDependencies": {
-    "babel-plugin-flow-react-proptypes": "^17.1.2"
+    "babel-plugin-flow-react-proptypes": "^18.0.0"
   }
 }

--- a/explorer/yarn.lock
+++ b/explorer/yarn.lock
@@ -522,9 +522,9 @@ babel-plugin-dynamic-import-node@1.1.0:
     babel-template "^6.26.0"
     babel-types "^6.26.0"
 
-babel-plugin-flow-react-proptypes@^17.1.2:
-  version "17.1.2"
-  resolved "https://registry.yarnpkg.com/babel-plugin-flow-react-proptypes/-/babel-plugin-flow-react-proptypes-17.1.2.tgz#89f75928a47ea869dab312605f42542dd7b6755c"
+babel-plugin-flow-react-proptypes@^18.0.0:
+  version "18.0.0"
+  resolved "https://registry.yarnpkg.com/babel-plugin-flow-react-proptypes/-/babel-plugin-flow-react-proptypes-18.0.0.tgz#2faca86de2f5353ed775538ac808a6fc05164ada"
   dependencies:
     babel-core "^6.25.0"
     babel-template "^6.25.0"


### PR DESCRIPTION
Summary:
Generated: `yarn add --dev babel-plugin-flow-react-proptypes@^18.0.0`.

This pulls in brigand/babel-plugin-flow-react-proptypes#182 and
brigand/babel-plugin-flow-react-proptypes#184, both of which affect this
project.

wchargin-branch: upgrade-flow-proptypes-18.0.0