### PR TITLE
Avoid forward references in `commitUtils` types

### DIFF
--- a/explorer/src/commitUtils.js
+++ b/explorer/src/commitUtils.js
@@ -2,21 +2,19 @@
 
 import PropTypes from "prop-types";
 
-export type CommitData = {
-  // TODO improve variable names
-  fileToCommits: {[filename: string]: string[]},
-  commits: {[commithash: string]: Commit},
+type FileStats = {
+  lines: number,
+  insertions: number,
+  deletions: number,
 };
-
 type Commit = {
   author: string,
   stats: {[filename: string]: FileStats},
 };
-
-type FileStats = {
-  lines: number,
-  added: number,
-  deleted: number,
+export type CommitData = {
+  // TODO improve variable names
+  fileToCommits: {[filename: string]: string[]},
+  commits: {[commithash: string]: Commit},
 };
 
 export function commitWeight(commit: Commit, filepath: string): number {


### PR DESCRIPTION
Summary:
The resulting types less logically structured (as discussed), but while
Flow considers them equivalent, the linter does not—and, more
importantly, the runtime `PropTypes` are not generated correctly when
forward-uses are in play, due to the following issue:

https://github.com/brigand/babel-plugin-flow-react-proptypes/issues/185

I _think_ this is the lesser of two evils—but am happy to be convinced
otherwise.

Test Plan:
Note that `yarn flow` and `yarn test` are both fine, and `yarn start`
has no lint errors or runtime errors. Note further that when reverting
`insertions → added` and `deletions → deleted`, there are prop-type
errors in both `yarn test` and `yarn start`. (Without the permutation of
the types, this does not occur.)

wchargin-branch: avoid-forward-references