### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,7 @@
 ## SourceCred
 
-The open-source community provides an enormous amount of value to the world. SourceCred aims to support that community by creating a sustainable model for funding open-source projects, and rewarding the contributors to those projects. We'll do that by enabling every open-source project to create its own digital token, called cred, which represents respect or "street cred" in the community. People will earn cred in a project by contributing to it.
+The open-source community provides an enormous amount of value to the world. However, open-source contributors go largely unrewarded and unrecognized. SourceCred aims to help that situation, by building tools that enable quantitatively measuring the value that open-source contributors provide to individual projects, and to the community as a whole.
 
-For a high-level overview of how SourceCred works, check out [overview.md](overview.md).
+SourceCred will create a "Cred Graph", which is a graph that shows how the contributions that compose open-source projects are related to and derive value from each other. From this, we'll be able to assign "cred" to users based on how valuable their contributions are. Cred will be assigned based on a mixture of objective data (e.g. references between GitHub pull requests) and subjective feedback (e.g. projects' own judgments on how important different contributions were).
 
-For an in-depth discussion of SourceCred's design, check out [design.md](design.md) (under construction).
-
-We aim to have design discussions on GitHub, so that people who contribute to the design will receive cred in SourceCred. For coordination and casual conversation, please join [our slack](https://join.slack.com/t/sourcecred/shared_invite/enQtMzA4NzI5ODIwODMyLWFiNDlhNWNiODc4MTk4MjNmZTAzMDNjNDAwYzEyZTBiNjAxZTFhMjU1MDg2YzNlN2FlNzgwYmU0NGM1NGEzM2M).
+If you'd like to contribute, please join [our slack](https://join.slack.com/t/sourcecred/shared_invite/enQtMzA4NzI5ODIwODMyLWFiNDlhNWNiODc4MTk4MjNmZTAzMDNjNDAwYzEyZTBiNjAxZTFhMjU1MDg2YzNlN2FlNzgwYmU0NGM1NGEzM2M).


### PR DESCRIPTION
This reflects our current vision that SourceCred is aimed at valuing open-source contributions via a credit graph, not on directly creating cryptotokens