### PR TITLE
Rename `sourceId`/`destId` to `src`/`dst`

### DIFF
--- a/src/backend/graph.js
+++ b/src/backend/graph.js
@@ -15,8 +15,8 @@ export type Node<T> = {
 
 export type Edge<T> = {
   address: Address,
-  sourceId: Address,
-  destId: Address,
+  src: Address,
+  dst: Address,
   weight: number,
   payload: T,
 };


### PR DESCRIPTION
Summary:
The “ID” parts were left-over from the Great Address Migration, and we
think that abbreviations are fine here, anyway.

Test Plan:
`yarn flow && yarn test`

wchargin-branch: src-dst-rename