### PR TITLE
Remove weights from the weighted graph

### DIFF
--- a/src/backend/graph.js
+++ b/src/backend/graph.js
@@ -17,7 +17,6 @@ export type Edge<T> = {
   address: Address,
   src: Address,
   dst: Address,
-  weight: number,
   payload: T,
 };
 


### PR DESCRIPTION
Summary:
This is an experiment. There are a couple diffferent meanings of
“weight” in play: most prominently, weights assigned by plugins versus
those suitable for comparison among other arbitrary weights. We’re not
sure what the right thing is to put in the actual graph object, so we’re
going to think about this a bit more before adding the field back in.

wchargin-branch: remove-weights