### PR TITLE
Promote `Graph` to a class with useful methods

### DIFF
--- a/src/backend/graph.js
+++ b/src/backend/graph.js
@@ -18,12 +18,88 @@ export type Edge<T> = {
   payload: T,
 };
 
-export type Graph = {
-  nodes: {[stringAddress: string]: Node<mixed>},
-  edges: {[stringAddress: string]: Edge<mixed>},
-  outEdges: {[nodeAddress: string]: Address[]},
-  inEdges: {[nodeAddress: string]: Address[]},
-};
+export class Graph {
+  _nodes: {[nodeAddress: string]: Node<mixed>};
+  _edges: {[edgeAddress: string]: Edge<mixed>};
+
+  // The keyset of each of the following fields should equal the keyset
+  // of `_nodes`. If `e` is an edge from `u` to `v`, then `e.address`
+  // should appear exactly once in `_outEdges[u.address]` and exactly
+  // once in `_inEdges[v.address]` (and every entry in `_inEdges` and
+  // `_outEdges` should be of this form).
+  _outEdges: {[nodeAddress: string]: Address[]};
+  _inEdges: {[nodeAddress: string]: Address[]};
+
+  constructor() {
+    this._nodes = {};
+    this._edges = {};
+    this._outEdges = {};
+    this._inEdges = {};
+  }
+
+  addNode(node: Node<mixed>) {
+    if (this.getNode(node.address) !== undefined) {
+      throw new Error(
+        `node at address ${JSON.stringify(node.address)} already exists`
+      );
+    }
+    const addressString = addressToString(node.address);
+    this._nodes[addressString] = node;
+    this._outEdges[addressString] = [];
+    this._inEdges[addressString] = [];
+    return this;
+  }
+
+  addEdge(edge: Edge<mixed>) {
+    if (this.getEdge(edge.address) !== undefined) {
+      throw new Error(
+        `edge at address ${JSON.stringify(edge.address)} already exists`
+      );
+    }
+    if (this.getNode(edge.src) === undefined) {
+      throw new Error(`source ${JSON.stringify(edge.src)} does not exist`);
+    }
+    if (this.getNode(edge.dst) === undefined) {
+      throw new Error(`source ${JSON.stringify(edge.dst)} does not exist`);
+    }
+    this._edges[addressToString(edge.address)] = edge;
+    this._outEdges[addressToString(edge.src)].push(edge.address);
+    this._inEdges[addressToString(edge.dst)].push(edge.address);
+    return this;
+  }
+
+  getNode(address: Address): Node<mixed> {
+    return this._nodes[addressToString(address)];
+  }
+
+  getEdge(address: Address): Edge<mixed> {
+    return this._edges[addressToString(address)];
+  }
+
+  /**
+   * Gets the array of all out-edges from the node at the given address.
+   * The order of the resulting array is unspecified.
+   */
+  getOutEdges(nodeAddress: Address): Edge<mixed>[] {
+    const addresses = this._outEdges[addressToString(nodeAddress)];
+    if (addresses === undefined) {
+      throw new Error(`no node for address ${JSON.stringify(nodeAddress)}`);
+    }
+    return addresses.map((e) => this.getEdge(e));
+  }
+
+  /**
+   * Gets the array of all in-edges to the node at the given address.
+   * The order of the resulting array is unspecified.
+   */
+  getInEdges(nodeAddress: Address): Edge<mixed>[] {
+    const addresses = this._inEdges[addressToString(nodeAddress)];
+    if (addresses === undefined) {
+      throw new Error(`no node for address ${JSON.stringify(nodeAddress)}`);
+    }
+    return addresses.map((e) => this.getEdge(e));
+  }
+}
 
 export function addressToString(address: Address) {
   if (address.repositoryName.includes("$")) {

--- a/src/backend/graph.test.js
+++ b/src/backend/graph.test.js
@@ -1,74 +1,357 @@
-import {addressToString, stringToAddress} from "./graph";
+// @flow
+
+import type {Address} from "./graph";
+import {Graph, addressToString, stringToAddress} from "./graph";
 
 describe("graph", () => {
-  describe("addressToString", () => {
-    const makeSimpleAddress = () => ({
-      repositoryName: "megacorp/megawidget",
-      pluginName: "widgets",
-      id: "issue#123",
-    });
-    it("stringifies a simple Address", () => {
-      const input = makeSimpleAddress();
-      const expected = "megacorp/megawidget$widgets$issue#123";
-      expect(addressToString(input)).toEqual(expected);
-    });
-    function expectRejection(attribute, value) {
-      const input = {...makeSimpleAddress(), [attribute]: value};
-      expect(() => addressToString(input)).toThrow(RegExp(attribute));
-      // (escaping regexp in JavaScript is a nightmare; ignore it)
-    }
-    it("rejects an Address with $-signs in plugin name", () => {
-      expectRejection("pluginName", "widg$ets");
-    });
-    it("rejects an Address with $-signs in repository name", () => {
-      expectRejection("repositoryName", "megacorp$megawidget");
-    });
-    it("rejects an Address with $-signs in id", () => {
-      expectRejection("id", "issue$123");
-    });
-  });
-
-  describe("stringToAddress", () => {
-    it("parses a simple Address-string", () => {
-      const input = "megacorp/megawidget$widgets$issue#123";
-      const expected = {
-        repositoryName: "megacorp/megawidget",
-        pluginName: "widgets",
-        id: "issue#123",
+  describe("#Graph", () => {
+    // A Seafood Fruit Mix is made by cooking Mighty Bananas (picked
+    // from a tree) and a Razorclaw Crab (grabbed from the beach). In
+    // this graph, an edge from `u` to `v` means that `u` thanks `v` for
+    // a particular contribution. For example, the meal thanks the hero
+    // for cooking it, as well as thanking the bananas and the crab for
+    // composing it.
+    function makeAddress(id: string): Address {
+      return {
+        repositoryName: "sourcecred/eventide",
+        pluginName: "hill_cooking_pot",
+        id,
       };
-      expect(stringToAddress(input)).toEqual(expected);
+    }
+    const heroNode = () => ({
+      address: makeAddress("hero_of_time#0"),
+      payload: {},
     });
-    [0, 1, 3, 4].forEach((n) => {
-      it(`rejects an Address-string with ${n} occurrences of "\$"`, () => {
-        const dollars = Array(n + 1).join("$");
-        const input = `mega${dollars}corp`;
-        expect(() => stringToAddress(input)).toThrow(/exactly two \$s/);
+    const bananasNode = () => ({
+      address: makeAddress("mighty_bananas#1"),
+      payload: {},
+    });
+    const crabNode = () => ({
+      address: makeAddress("razorclaw_crab#2"),
+      payload: {},
+    });
+    const mealNode = () => ({
+      address: makeAddress("seafood_fruit_mix#3"),
+      payload: {
+        effect: ["attack_power", 1],
+      },
+    });
+    const pickEdge = () => ({
+      address: makeAddress("hero_of_time#0@picks@mighty_bananas#1"),
+      src: bananasNode().address,
+      dst: heroNode().address,
+      payload: {},
+    });
+    const grabEdge = () => ({
+      address: makeAddress("hero_of_time#0@grabs@razorclaw_crab#2"),
+      src: crabNode().address,
+      dst: heroNode().address,
+      payload: {},
+    });
+    const cookEdge = () => ({
+      address: makeAddress("hero_of_time#0@cooks@seafood_fruit_mix#3"),
+      src: mealNode().address,
+      dst: heroNode().address,
+      payload: {
+        crit: false,
+      },
+    });
+    const bananasIngredientEdge = () => ({
+      address: makeAddress("mighty_bananas#1@included_in@seafood_fruit_mix#3"),
+      src: mealNode().address,
+      dst: bananasNode().address,
+      payload: {},
+    });
+    const crabIngredientEdge = () => ({
+      address: makeAddress("razorclaw_crab#2@included_in@seafood_fruit_mix#3"),
+      src: mealNode().address,
+      dst: crabNode().address,
+      payload: {},
+    });
+    const eatEdge = () => ({
+      address: makeAddress("hero_of_time#0@eats@seafood_fruit_mix#3"),
+      src: heroNode().address,
+      dst: mealNode().address,
+      payload: {},
+    });
+    const mealGraph = () =>
+      new Graph()
+        .addNode(heroNode())
+        .addNode(bananasNode())
+        .addNode(crabNode())
+        .addNode(mealNode())
+        .addEdge(pickEdge())
+        .addEdge(grabEdge())
+        .addEdge(cookEdge())
+        .addEdge(bananasIngredientEdge())
+        .addEdge(crabIngredientEdge())
+        .addEdge(eatEdge());
+
+    describe("construction", () => {
+      it("works for a simple graph", () => {
+        mealGraph();
+      });
+
+      it("forbids adding an edge with dangling `dst`", () => {
+        expect(() => {
+          mealGraph().addEdge({
+            address: makeAddress(
+              "treasure_octorok#5@helps_cook@seafood_fruit_mix#3"
+            ),
+            src: mealNode().address,
+            dst: makeAddress("treasure_octorok#5"),
+            payload: {},
+          });
+        }).toThrow(/does not exist/);
+      });
+
+      it("forbids adding an edge with dangling `src`", () => {
+        expect(() => {
+          mealGraph().addEdge({
+            address: makeAddress("health_bar#6@healed_by@seafood_fruit_mix#3"),
+            src: makeAddress("health_bar#6"),
+            dst: mealNode().address,
+            payload: {},
+          });
+        }).toThrow(/does not exist/);
+      });
+    });
+
+    describe("getting nodes and edges", () => {
+      it("correctly gets nodes that exist", () => {
+        const g = mealGraph();
+        [heroNode(), bananasNode(), crabNode(), mealNode()].forEach((x) => {
+          expect(g.getNode(x.address)).toEqual(x);
+        });
+      });
+
+      it("correctly gets edges that exist", () => {
+        const g = mealGraph();
+        [
+          pickEdge(),
+          grabEdge(),
+          cookEdge(),
+          bananasIngredientEdge(),
+          crabIngredientEdge(),
+          eatEdge(),
+        ].forEach((x) => {
+          expect(g.getEdge(x.address)).toEqual(x);
+        });
+      });
+
+      it("returns `undefined` for nodes that do not exist", () => {
+        expect(
+          mealGraph().getNode(makeAddress("treasure_octorok#5"))
+        ).toBeUndefined();
+      });
+
+      it("returns `undefined` for edges that do not exist", () => {
+        expect(
+          mealGraph().getNode(
+            makeAddress("treasure_octorok#5@helps_cook@seafood_fruit_mix#3")
+          )
+        ).toBeUndefined();
+      });
+
+      it("forbids adding a node with existing address", () => {
+        expect(() =>
+          mealGraph().addNode({
+            address: crabNode().address,
+            payload: {anotherCrab: true},
+          })
+        ).toThrow(/already exists/);
+      });
+
+      it("forbids adding an edge with existing address", () => {
+        expect(() =>
+          mealGraph().addEdge({
+            address: cookEdge().address,
+            src: crabNode().address,
+            dst: crabNode().address,
+            payload: {},
+          })
+        ).toThrow(/already exists/);
+      });
+
+      it("allows creating self-loops", () => {
+        const g = mealGraph();
+        const crabLoop = {
+          address: makeAddress("crab-self-assessment"),
+          src: crabNode().address,
+          dst: crabNode().address,
+          payload: {evaluation: "not effective at avoiding hero"},
+        };
+        g.addEdge(crabLoop);
+        expect(g.getOutEdges(crabNode().address)).toContainEqual(crabLoop);
+        expect(g.getInEdges(crabNode().address)).toContainEqual(crabLoop);
+      });
+
+      it("allows creating multiple edges between the same nodes", () => {
+        const g = mealGraph();
+        const critCookEdge = () => ({
+          address: makeAddress(
+            "hero_of_time#0@again_cooks@seafood_fruit_mix#3"
+          ),
+          src: mealNode().address,
+          dst: heroNode().address,
+          payload: {
+            crit: true,
+            saveScummed: true,
+          },
+        });
+        g.addEdge(critCookEdge());
+        [cookEdge(), critCookEdge()].forEach((e) => {
+          expect(g.getOutEdges(mealNode().address)).toContainEqual(e);
+          expect(g.getEdge(e.address)).toEqual(e);
+        });
+      });
+
+      // For the next two test cases: we're documenting this behavior,
+      // though we're not sure if it's the right behavior. Perhaps we want
+      // the namespaces to be forced to be disjoint. In that case, we can
+      // certainly change these tests.
+      it("allows adding an edge with an existing node's address", () => {
+        mealGraph().addEdge({
+          address: crabNode().address,
+          src: crabNode().address,
+          dst: crabNode().address,
+          payload: {message: "thanks for being you"},
+        });
+      });
+      it("allows adding a node with an existing edge's address", () => {
+        mealGraph().addNode({
+          address: cookEdge().address,
+          payload: {},
+        });
+      });
+    });
+
+    describe("in- and out-edges", () => {
+      function sortedByAddress<T: {address: Address}>(xs: T[]) {
+        function cmp(x1: T, x2: T) {
+          const a1 = addressToString(x1.address);
+          const a2 = addressToString(x2.address);
+          return a1 > a2 ? 1 : a1 < a2 ? -1 : 0;
+        }
+        return [...xs].sort(cmp);
+      }
+      function expectSameSorted<T: {address: Address}>(xs: T[], ys: T[]) {
+        expect(sortedByAddress(xs)).toEqual(sortedByAddress(ys));
+      }
+
+      it("gets out-edges", () => {
+        const nodeAndExpectedEdgePairs = [
+          [heroNode(), [eatEdge()]],
+          [bananasNode(), [pickEdge()]],
+          [crabNode(), [grabEdge()]],
+          [
+            mealNode(),
+            [bananasIngredientEdge(), crabIngredientEdge(), cookEdge()],
+          ],
+        ];
+        nodeAndExpectedEdgePairs.forEach(([node, expectedEdges]) => {
+          const actual = mealGraph().getOutEdges(node.address);
+          expectSameSorted(actual, expectedEdges);
+        });
+      });
+
+      it("gets in-edges", () => {
+        const nodeAndExpectedEdgePairs = [
+          [heroNode(), [pickEdge(), grabEdge(), cookEdge()]],
+          [bananasNode(), [bananasIngredientEdge()]],
+          [crabNode(), [crabIngredientEdge()]],
+          [mealNode(), [eatEdge()]],
+        ];
+        nodeAndExpectedEdgePairs.forEach(([node, expectedEdges]) => {
+          const actual = mealGraph().getInEdges(node.address);
+          expectSameSorted(actual, expectedEdges);
+        });
+      });
+
+      it("fails to get out-edges for a nonexistent node", () => {
+        expect(() => {
+          mealGraph().getOutEdges(makeAddress("hinox"));
+        }).toThrow(/no node for address/);
+      });
+
+      it("fails to get in-edges for a nonexistent node", () => {
+        expect(() => {
+          mealGraph().getInEdges(makeAddress("hinox"));
+        }).toThrow(/no node for address/);
       });
     });
   });
 
-  describe("stringToAddress and addressToString interop", () => {
-    const examples = () => [
-      {
-        object: {
+  describe("string functions", () => {
+    describe("addressToString", () => {
+      const makeSimpleAddress = () => ({
+        repositoryName: "megacorp/megawidget",
+        pluginName: "widgets",
+        id: "issue#123",
+      });
+      it("stringifies a simple Address", () => {
+        const input = makeSimpleAddress();
+        const expected = "megacorp/megawidget$widgets$issue#123";
+        expect(addressToString(input)).toEqual(expected);
+      });
+      function expectRejection(attribute, value) {
+        const input = {...makeSimpleAddress(), [attribute]: value};
+        expect(() => addressToString(input)).toThrow(RegExp(attribute));
+        // (escaping regexp in JavaScript is a nightmare; ignore it)
+      }
+      it("rejects an Address with $-signs in plugin name", () => {
+        expectRejection("pluginName", "widg$ets");
+      });
+      it("rejects an Address with $-signs in repository name", () => {
+        expectRejection("repositoryName", "megacorp$megawidget");
+      });
+      it("rejects an Address with $-signs in id", () => {
+        expectRejection("id", "issue$123");
+      });
+    });
+
+    describe("stringToAddress", () => {
+      it("parses a simple Address-string", () => {
+        const input = "megacorp/megawidget$widgets$issue#123";
+        const expected = {
           repositoryName: "megacorp/megawidget",
           pluginName: "widgets",
           id: "issue#123",
-        },
-        string: "megacorp/megawidget$widgets$issue#123",
-      },
-    ];
-    examples().forEach((example, index) => {
-      describe(`for example at 0-index ${index}`, () => {
-        it("has stringToAddress a left identity for addressToString", () => {
-          expect(stringToAddress(addressToString(example.object))).toEqual(
-            example.object
-          );
+        };
+        expect(stringToAddress(input)).toEqual(expected);
+      });
+      [0, 1, 3, 4].forEach((n) => {
+        it(`rejects an Address-string with ${n} occurrences of "\$"`, () => {
+          const dollars = Array(n + 1).join("$");
+          const input = `mega${dollars}corp`;
+          expect(() => stringToAddress(input)).toThrow(/exactly two \$s/);
         });
-        it("has stringToAddress a right identity for addressToString", () => {
-          expect(addressToString(stringToAddress(example.string))).toEqual(
-            example.string
-          );
+      });
+    });
+
+    describe("stringToAddress and addressToString interop", () => {
+      const examples = () => [
+        {
+          object: {
+            repositoryName: "megacorp/megawidget",
+            pluginName: "widgets",
+            id: "issue#123",
+          },
+          string: "megacorp/megawidget$widgets$issue#123",
+        },
+      ];
+      examples().forEach((example, index) => {
+        describe(`for example at 0-index ${index}`, () => {
+          it("has stringToAddress a left identity for addressToString", () => {
+            expect(stringToAddress(addressToString(example.object))).toEqual(
+              example.object
+            );
+          });
+          it("has stringToAddress a right identity for addressToString", () => {
+            expect(addressToString(stringToAddress(example.string))).toEqual(
+              example.string
+            );
+          });
         });
       });
     });


### PR DESCRIPTION
Summary:
We had planned to expose our core types as simple Plain Old JavaScript
Objects, with accompanying standalone functions to act directly on these
data structures. We chose this instead of creating `class`es for the
types because it simplifies serialization interop: it obviates the need
for serialization and deserialization functions, because the code is
separated from the data entirely. Reconsidering, we now think that the
convenience benefits of using classes probably outweigh these
serialization cons. Furthermore, this design enables us to separate
ancillary data structures and caches from the raw data, presenting a
cleaner API for consumers of the data.

This commit introduces a `Graph` class and some related logic. With lots
of tests! And 100% code coverage! :-)

Paired with @dandelionmane.

Test Plan:
Run `yarn flow && yarn test` to see the new tests.

wchargin-branch: graph-class