### PR TITLE
Make node and edge types exact

### DIFF
--- a/src/backend/graph.js
+++ b/src/backend/graph.js
@@ -6,17 +6,17 @@ export type Address = {
   id: string,
 };
 
-export type Node<T> = {
+export type Node<T> = {|
   address: Address,
   payload: T,
-};
+|};
 
-export type Edge<T> = {
+export type Edge<T> = {|
   address: Address,
   src: Address,
   dst: Address,
   payload: T,
-};
+|};
 
 export class Graph {
   _nodes: {[nodeAddress: string]: Node<mixed>};


### PR DESCRIPTION
Summary:
We’ve realized that `u: Edge<T>` implies `u: Node<T>`. That certainly
wasn’t what we were expecting! We might want something like that
eventually, to capture the fact that valuations are themselves valuable,
but for now the type system should encode the assumptions that we’re
actually making. See also #50.

Paired with @dandelionmane.

wchargin-branch: exact-types