### PR TITLE
Make `Address`, `Node`, `Edge` read-only and exact

### DIFF
--- a/src/backend/graph.js
+++ b/src/backend/graph.js
@@ -1,21 +1,21 @@
 // @flow
 
-export type Address = {
-  repositoryName: string,
-  pluginName: string,
-  id: string,
-};
+export type Address = {|
+  +repositoryName: string,
+  +pluginName: string,
+  +id: string,
+|};
 
 export type Node<T> = {|
-  address: Address,
-  payload: T,
+  +address: Address,
+  +payload: T,
 |};
 
 export type Edge<T> = {|
-  address: Address,
-  src: Address,
-  dst: Address,
-  payload: T,
+  +address: Address,
+  +src: Address,
+  +dst: Address,
+  +payload: T,
 |};
 
 export class Graph {

--- a/src/backend/graph.test.js
+++ b/src/backend/graph.test.js
@@ -9,7 +9,7 @@ describe("graph", () => {
     // array with undefined order. We use these functions to
     // canonicalize the ordering so that we can then test equality with
     // `expect(...).toEqual(...)`.
-    function sortedByAddress<T: {address: Address}>(xs: T[]) {
+    function sortedByAddress<T: {+address: Address}>(xs: T[]) {
       function cmp(x1: T, x2: T) {
         const a1 = addressToString(x1.address);
         const a2 = addressToString(x2.address);
@@ -17,7 +17,7 @@ describe("graph", () => {
       }
       return [...xs].sort(cmp);
     }
-    function expectSameSorted<T: {address: Address}>(xs: T[], ys: T[]) {
+    function expectSameSorted<T: {+address: Address}>(xs: T[], ys: T[]) {
       expect(sortedByAddress(xs)).toEqual(sortedByAddress(ys));
     }
 


### PR DESCRIPTION
Summary:
Again: we assume these invariants, so we may as well encode them.
We should just keep in mind that non-Flow users may wantonly violate
these, so we should still code defensively.

wchargin-branch: readonly-exact