### PR TITLE
Replace lingering `mealGraph`s in test case

### DIFF
--- a/src/backend/graph.test.js
+++ b/src/backend/graph.test.js
@@ -297,7 +297,7 @@ describe("graph", () => {
 
       it("gets all nodes", () => {
         const expected = [heroNode(), bananasNode(), crabNode(), mealNode()];
-        const actual = mealGraph().getAllNodes();
+        const actual = advancedMealGraph().getAllNodes();
         expectSameSorted(expected, actual);
       });
 
@@ -309,8 +309,10 @@ describe("graph", () => {
           bananasIngredientEdge(),
           crabIngredientEdge(),
           eatEdge(),
+          crabLoopEdge(),
+          duplicateCookEdge(),
         ];
-        const actual = mealGraph().getAllEdges();
+        const actual = advancedMealGraph().getAllEdges();
         expectSameSorted(expected, actual);
       });
 


### PR DESCRIPTION
Summary:
In merging #54, there was a semantic merge conflict that was not also a
textual merge conflict; this created a failure that only appeared once
that commit was merged.

We propose that to fix this in the future, we only merge commits that
are directly ahead of master.

Test Plan:
This fixes `yarn flow` and `yarn test`.

wchargin-branch: fix-merge-conflict