### PR TITLE
Allow adding explicitly typed nodes/edges

### DIFF
--- a/src/backend/graph.js
+++ b/src/backend/graph.js
@@ -17,13 +17,13 @@ export type Edge<T> = {|
 |};
 
 export type GraphJSON = {|
-  +nodes: AddressMapJSON<Node<mixed>>,
-  +edges: AddressMapJSON<Edge<mixed>>,
+  +nodes: AddressMapJSON<Node<any>>,
+  +edges: AddressMapJSON<Edge<any>>,
 |};
 
 export class Graph {
-  _nodes: AddressMap<Node<mixed>>;
-  _edges: AddressMap<Edge<mixed>>;
+  _nodes: AddressMap<Node<any>>;
+  _edges: AddressMap<Edge<any>>;
 
   // The keyset of each of the following fields should equal the keyset
   // of `_nodes`. If `e` is an edge from `u` to `v`, then `e.address`
@@ -66,7 +66,7 @@ export class Graph {
     return result;
   }
 
-  addNode(node: Node<mixed>) {
+  addNode(node: Node<any>) {
     if (node == null) {
       throw new Error(`node is ${String(node)}`);
     }
@@ -81,7 +81,7 @@ export class Graph {
     return this;
   }
 
-  addEdge(edge: Edge<mixed>) {
+  addEdge(edge: Edge<any>) {
     if (edge == null) {
       throw new Error(`edge is ${String(edge)}`);
     }

--- a/src/backend/graph.test.js
+++ b/src/backend/graph.test.js
@@ -2,6 +2,7 @@
 
 import type {Address, Addressable} from "./address";
 import {sortedByAddress} from "./address";
+import type {Node, Edge} from "./graph";
 import {Graph} from "./graph";
 import * as demoData from "./graphDemoData";
 
@@ -531,6 +532,46 @@ describe("graph", () => {
       it("should no-op on a deserialization--serialization roundtrip", () => {
         const json = () => demoData.advancedMealGraph().toJSON();
         expect(Graph.fromJSON(json()).toJSON()).toEqual(json());
+      });
+    });
+
+    describe("type-checking", () => {
+      it("allows adding explicitly typed nodes", () => {
+        expect(() => {
+          const stringNode: Node<string> = {
+            address: demoData.makeAddress("hello"),
+            payload: "hello",
+          };
+          const numberNode: Node<number> = {
+            address: demoData.makeAddress("hello"),
+            payload: 17,
+          };
+          new Graph().addNode(stringNode).addNode(numberNode);
+        });
+      });
+
+      it("allows adding explicitly typed edges", () => {
+        expect(() => {
+          const src = {address: demoData.makeAddress("src"), payload: {}};
+          const dst = {address: demoData.makeAddress("dst"), payload: {}};
+          const stringEdge: Edge<string> = {
+            address: demoData.makeAddress("hello"),
+            src: src.address,
+            dst: dst.address,
+            payload: "hello",
+          };
+          const numberEdge: Edge<number> = {
+            address: demoData.makeAddress("hello"),
+            src: src.address,
+            dst: dst.address,
+            payload: 18,
+          };
+          new Graph()
+            .addNode(src)
+            .addNode(dst)
+            .addEdge(stringEdge)
+            .addEdge(numberEdge);
+        });
       });
     });
   });


### PR DESCRIPTION
Summary:
Flow doesn’t allow us to specify variance annotations in generic
function parameters, and doesn’t allow coercing `Node<T>` to
`Node<mixed>`. This forces us to put `any`s in our code, which…works.

Paired with @wchargin

Test Plan:
New unit tests trivially pass dynamically, and now pass statically
(failing before the changes to `graph.js`).