### PR TITLE
Updated npm by running `npm i npm`.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,6 @@
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+
+# redundant with yarn.lock
+package-lock.json

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "lint-staged": "^6.1.1",
     "lodash.isequal": "^4.5.0",
     "node-fetch": "^2.1.1",
+    "npm": "^5.7.1",
     "object-assign": "4.1.1",
     "postcss-flexbugs-fixes": "3.2.0",
     "postcss-loader": "2.0.8",


### PR DESCRIPTION
Running said command generated a package-lock.json file, and instructed
us to commit it. However, I believe this is redundant with yarn.lock, so
following
https://stackoverflow.com/questions/44552348/should-i-commit-yarn-lock-and-package-lock-json-files
I decided to gitignore it instead.