### PR TITLE
Extract Aphrodite-management test code to testUtil

### DIFF
--- a/src/plugins/artifact/editor/App.test.js
+++ b/src/plugins/artifact/editor/App.test.js
@@ -2,15 +2,7 @@ import React from "react";
 import ReactDOM from "react-dom";
 import App from "./App";
 
-import {StyleSheetTestUtils} from "aphrodite/no-important";
-
-beforeEach(() => {
-  StyleSheetTestUtils.suppressStyleInjection();
-});
-
-afterEach(() => {
-  StyleSheetTestUtils.clearBufferAndResumeStyleInjection();
-});
+require("./testUtil").configureAphrodite();
 
 // Check that PropTypes check out.
 it("renders without crashing", () => {

--- a/src/plugins/artifact/editor/testUtil.js
+++ b/src/plugins/artifact/editor/testUtil.js
@@ -1,0 +1,11 @@
+import {StyleSheetTestUtils} from "aphrodite/no-important";
+
+export function configureAphrodite() {
+  beforeEach(() => {
+    StyleSheetTestUtils.suppressStyleInjection();
+  });
+
+  afterEach(() => {
+    StyleSheetTestUtils.clearBufferAndResumeStyleInjection();
+  });
+}


### PR DESCRIPTION
Summary:
Any tests that render Aphrodite-styled React elements will need to do
this, so it’s nice to have the code in one place.

wchargin-branch: aphrodite-testutils