### PR TITLE
Make GitHub capitalization consistent within code

### DIFF
--- a/config/paths.js
+++ b/config/paths.js
@@ -59,8 +59,8 @@ module.exports = {
   // source file, and the key will be the filename of the bundled entry
   // point within the build directory.
   backendEntryPoints: {
-    fetchAndPrintGitHubRepo: resolveApp(
-      "src/plugins/github/bin/fetchAndPrintGitHubRepo.js"
+    fetchAndPrintGithubRepo: resolveApp(
+      "src/plugins/github/bin/fetchAndPrintGithubRepo.js"
     ),
   },
 };

--- a/src/plugins/artifact/editor/App.js
+++ b/src/plugins/artifact/editor/App.js
@@ -8,18 +8,18 @@ import "./pluginAdapter";
 import type {Graph, Node} from "../../../core/graph";
 import type {ArtifactNodePayload} from "../artifactPlugin";
 import type {
-  NodePayload as GitHubNodePayload,
-  EdgePayload as GitHubEdgePayload,
+  NodePayload as GithubNodePayload,
+  EdgePayload as GithubEdgePayload,
 } from "../../github/githubPlugin";
 import {ArtifactList} from "./ArtifactList";
 import {ContributionList} from "./ContributionList";
-import {GitHubGraphFetcher} from "./GitHubGraphFetcher";
+import {GithubGraphFetcher} from "./GithubGraphFetcher";
 import standardAdapterSet from "./standardAdapterSet";
 
 type Props = {};
 type State = {
   artifacts: Node<ArtifactNodePayload>[],
-  githubGraph: ?Graph<GitHubNodePayload, GitHubEdgePayload>,
+  githubGraph: ?Graph<GithubNodePayload, GithubEdgePayload>,
 };
 
 function createSampleArtifact(name) {
@@ -49,7 +49,7 @@ export default class App extends React.Component<Props, State> {
         <header className={css(styles.header)}>
           <h1>Artifact editor</h1>
         </header>
-        <GitHubGraphFetcher
+        <GithubGraphFetcher
           onCreateGraph={(githubGraph) => {
             this.setState({githubGraph});
           }}

--- a/src/plugins/artifact/editor/GithubGraphFetcher.js
+++ b/src/plugins/artifact/editor/GithubGraphFetcher.js
@@ -4,15 +4,15 @@ import React from "react";
 
 import type {Graph} from "../../../core/graph";
 import LocalStore from "./LocalStore";
-import fetchGitHubRepo from "../../github/fetchGitHubRepo";
+import fetchGithubRepo from "../../github/fetchGithubRepo";
 import type {
-  NodePayload as GitHubNodePayload,
-  EdgePayload as GitHubEdgePayload,
+  NodePayload as GithubNodePayload,
+  EdgePayload as GithubEdgePayload,
 } from "../../github/githubPlugin";
 import {GithubParser} from "../../github/githubPlugin";
 
 type Props = {
-  onCreateGraph: (graph: Graph<GitHubNodePayload, GitHubEdgePayload>) => void,
+  onCreateGraph: (graph: Graph<GithubNodePayload, GithubEdgePayload>) => void,
 };
 type State = {
   apiToken: string,
@@ -20,9 +20,9 @@ type State = {
   repoName: string,
 };
 
-const SETTINGS_KEY = "GitHubGraphFetcher.settings";
+const SETTINGS_KEY = "GithubGraphFetcher.settings";
 
-export class GitHubGraphFetcher extends React.Component<Props, State> {
+export class GithubGraphFetcher extends React.Component<Props, State> {
   constructor() {
     super();
     const defaultState = {
@@ -83,7 +83,7 @@ export class GitHubGraphFetcher extends React.Component<Props, State> {
   fetchGraph() {
     const {repoOwner, repoName, apiToken} = this.state;
     LocalStore.set(SETTINGS_KEY, {apiToken, repoOwner, repoName});
-    fetchGitHubRepo(repoOwner, repoName, apiToken)
+    fetchGithubRepo(repoOwner, repoName, apiToken)
       .then((json) => {
         const parser = new GithubParser(`${repoOwner}/${repoName}`);
         parser.addData(json.data);

--- a/src/plugins/artifact/editor/adapters/githubPluginAdapter.js
+++ b/src/plugins/artifact/editor/adapters/githubPluginAdapter.js
@@ -22,7 +22,7 @@ import {GITHUB_PLUGIN_NAME, getNodeType} from "../../../github/githubPlugin";
 const adapter: PluginAdapter<NodePayload> = {
   pluginName: GITHUB_PLUGIN_NAME,
 
-  renderer: class GitHubNodeRenderer extends React.Component<{
+  renderer: class GithubNodeRenderer extends React.Component<{
     graph: Graph<any, any>,
     node: Node<NodePayload>,
   }> {

--- a/src/plugins/github/bin/fetchAndPrintGithubRepo.js
+++ b/src/plugins/github/bin/fetchAndPrintGithubRepo.js
@@ -7,7 +7,7 @@
  *
  *   node bin/fetchAndPrintGithubRepo.js REPO_OWNER REPO_NAME [TOKEN]
  *
- * where TOKEN is an optional Github authentication token, as generated
+ * where TOKEN is an optional GitHub authentication token, as generated
  * from https://github.com/settings/tokens/new.
  */
 

--- a/src/plugins/github/bin/fetchAndPrintGithubRepo.js
+++ b/src/plugins/github/bin/fetchAndPrintGithubRepo.js
@@ -1,17 +1,17 @@
 /*
  * Command-line utility to fetch GitHub data using the API in
- * ../fetchGitHubRepo, and print it to stdout. Useful for testing or
+ * ../fetchGithubRepo, and print it to stdout. Useful for testing or
  * saving some data to disk.
  *
  * Usage:
  *
- *   node bin/fetchAndPrintGitHubRepo.js REPO_OWNER REPO_NAME [TOKEN]
+ *   node bin/fetchAndPrintGithubRepo.js REPO_OWNER REPO_NAME [TOKEN]
  *
- * where TOKEN is an optional GitHub authentication token, as generated
+ * where TOKEN is an optional Github authentication token, as generated
  * from https://github.com/settings/tokens/new.
  */
 
-import fetchGitHubRepo from "../fetchGitHubRepo";
+import fetchGithubRepo from "../fetchGithubRepo";
 import stringify from "json-stable-stringify";
 
 function parseArgs() {
@@ -35,7 +35,7 @@ function parseArgs() {
 
 function main() {
   const args = parseArgs();
-  fetchGitHubRepo(args.repoOwner, args.repoName, args.token)
+  fetchGithubRepo(args.repoOwner, args.repoName, args.token)
     .then((data) => {
       console.log(stringify(data, {space: 4}));
     })

--- a/src/plugins/github/fetchGithubRepo.js
+++ b/src/plugins/github/fetchGithubRepo.js
@@ -24,7 +24,7 @@ import * as GraphQLQueries from "../../graphql/queries";
  *    scraped from the repository, with data format to be specified
  *    later
  */
-export default function fetchGitHubRepo(
+export default function fetchGithubRepo(
   repoOwner: string,
   repoName: string,
   token: string

--- a/src/plugins/github/fetchGithubRepoTest.sh
+++ b/src/plugins/github/fetchGithubRepoTest.sh
@@ -14,7 +14,7 @@ main() {
     return 1
   fi
   output="$(mktemp)"
-  node bin/fetchAndPrintGitHubRepo.js \
+  node bin/fetchAndPrintGithubRepo.js \
     sourcecred example-repo "${GITHUB_TOKEN}" \
     >"${output}" \
     ;


### PR DESCRIPTION
We now never capitalize the H in GitHub within variable or function
names. We still capitalize it in comments or user facing strings.

Test plan:
Unit tests, the fetchGithubRepoTest.sh, and
`git grep itHub` only shows comment lines and print statements.