### PR TITLE
Allow filtering by type in the contribution list

### DIFF
--- a/src/plugins/artifact/editor/ContributionList.js
+++ b/src/plugins/artifact/editor/ContributionList.js
@@ -3,6 +3,7 @@
 import React from "react";
 
 import type {Address} from "../../../core/address";
+import type {Node} from "../../../core/graph";
 import {AdapterSet} from "./adapterSet";
 import {Graph} from "../../../core/graph";
 
@@ -10,15 +11,77 @@ type Props = {
   graph: ?Graph<any, any>,
   adapters: AdapterSet,
 };
-type State = {};
+type State = {
+  typeFilter: ?{|
+    +pluginName: string,
+    +type: string,
+  |},
+};
 
 export class ContributionList extends React.Component<Props, State> {
+  constructor() {
+    super();
+    this.state = {
+      typeFilter: null,
+    };
+  }
+
   render() {
     return (
       <div>
         <h2>Contributions</h2>
+        {this.renderFilterSelect()}
         {this.renderTable()}
       </div>
+    );
+  }
+
+  renderFilterSelect() {
+    if (this.props.graph == null) {
+      return null;
+    }
+    const graph: Graph<any, any> = this.props.graph;
+    const typesByPlugin: {[pluginName: string]: Set<string>} = {};
+    graph.getAllNodes().forEach((node) => {
+      const adapter = this.props.adapters.getAdapter(node);
+      if (adapter == null) {
+        return;
+      }
+      if (!typesByPlugin[adapter.pluginName]) {
+        typesByPlugin[adapter.pluginName] = new Set();
+      }
+      typesByPlugin[adapter.pluginName].add(adapter.extractType(graph, node));
+    });
+    function optionGroup(pluginName: string) {
+      const header = (
+        <option key={pluginName} disabled style={{fontWeight: "bold"}}>
+          {pluginName}
+        </option>
+      );
+      const entries = Array.from(typesByPlugin[pluginName])
+        .sort()
+        .map((type) => (
+          <option key={type} value={JSON.stringify({pluginName, type})}>
+            {"\u2003" + type}
+          </option>
+        ));
+      return [header, ...entries];
+    }
+    return (
+      <label>
+        Filter by contribution type:{" "}
+        <select
+          value={JSON.stringify(this.state.typeFilter)}
+          onChange={(e) => {
+            this.setState({typeFilter: JSON.parse(e.target.value)});
+          }}
+        >
+          <option value={JSON.stringify(null)}>Show all</option>
+          {Object.keys(typesByPlugin)
+            .sort()
+            .map(optionGroup)}
+        </select>
+      </label>
     );
   }
 
@@ -27,6 +90,17 @@ export class ContributionList extends React.Component<Props, State> {
       return <div>(no graph)</div>;
     } else {
       const graph: Graph<any, any> = this.props.graph;
+      const {typeFilter} = this.state;
+      const shouldDisplay: (node: Node<any>) => boolean = typeFilter
+        ? (node) => {
+            const adapter = this.props.adapters.getAdapter(node);
+            return (
+              !!adapter &&
+              adapter.pluginName === typeFilter.pluginName &&
+              adapter.extractType(graph, node) === typeFilter.type
+            );
+          }
+        : (node) => true;
       return (
         <table>
           <thead>
@@ -38,10 +112,13 @@ export class ContributionList extends React.Component<Props, State> {
           </thead>
           <tbody>
             {this.props.graph.getAllNodes().map((node) => {
+              if (!shouldDisplay(node)) {
+                return null;
+              }
               const adapter = this.props.adapters.getAdapter(node);
               if (adapter == null) {
                 return (
-                  <tr>
+                  <tr key={JSON.stringify(node.address)}>
                     <td colspan={3}>
                       <i>unknown</i> (plugin: {node.address.pluginName})
                     </td>
@@ -49,7 +126,7 @@ export class ContributionList extends React.Component<Props, State> {
                 );
               } else {
                 return (
-                  <tr>
+                  <tr key={JSON.stringify(node.address)}>
                     <td>{adapter.extractTitle(graph, node)}</td>
                     <td>[TODO]</td>
                     <td>[TODO]</td>

--- a/src/plugins/artifact/editor/__snapshots__/ContributionList.test.js.snap
+++ b/src/plugins/artifact/editor/__snapshots__/ContributionList.test.js.snap
@@ -1,0 +1,131 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`ContributionList renders some test data in the default state 1`] = `
+<div>
+  <h2>
+    Contributions
+  </h2>
+  <label>
+    Filter by contribution type:
+     
+    <select
+      onChange={[Function]}
+      value="null"
+    >
+      <option
+        value="null"
+      >
+        Show all
+      </option>
+      <option
+        disabled={true}
+        style={
+          Object {
+            "fontWeight": "bold",
+          }
+        }
+      >
+        sourcecred/example-plugin-a
+      </option>
+      <option
+        value="{\\"pluginName\\":\\"sourcecred/example-plugin-a\\",\\"type\\":\\"big\\"}"
+      >
+         big
+      </option>
+      <option
+        value="{\\"pluginName\\":\\"sourcecred/example-plugin-a\\",\\"type\\":\\"small\\"}"
+      >
+         small
+      </option>
+      <option
+        disabled={true}
+        style={
+          Object {
+            "fontWeight": "bold",
+          }
+        }
+      >
+        sourcecred/example-plugin-b
+      </option>
+      <option
+        value="{\\"pluginName\\":\\"sourcecred/example-plugin-b\\",\\"type\\":\\"very true\\"}"
+      >
+         very true
+      </option>
+    </select>
+  </label>
+  <table>
+    <thead>
+      <tr>
+        <th>
+          Title
+        </th>
+        <th>
+          Artifact
+        </th>
+        <th>
+          Weight
+        </th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td>
+          the number 111
+        </td>
+        <td>
+          [TODO]
+        </td>
+        <td>
+          [TODO]
+        </td>
+      </tr>
+      <tr>
+        <td>
+          the number 234
+        </td>
+        <td>
+          [TODO]
+        </td>
+        <td>
+          [TODO]
+        </td>
+      </tr>
+      <tr>
+        <td>
+          the number 616
+        </td>
+        <td>
+          [TODO]
+        </td>
+        <td>
+          [TODO]
+        </td>
+      </tr>
+      <tr>
+        <td>
+          TRUE!
+        </td>
+        <td>
+          [TODO]
+        </td>
+        <td>
+          [TODO]
+        </td>
+      </tr>
+      <tr>
+        <td
+          colspan={3}
+        >
+          <i>
+            unknown
+          </i>
+           (plugin: 
+          sourcecred/example-plugin-c
+          )
+        </td>
+      </tr>
+    </tbody>
+  </table>
+</div>
+`;


### PR DESCRIPTION
Summary:
Filter options are “all contributions” or a specific plugin/type
combination. This includes a snapshot test for the static state. I’ll
add an interaction test in a subsequent commit.

Test Plan:
`yarn start`, fetch graph, play with the filtering options.

wchargin-branch: filter-contributions