### PR TITLE
 Move node/edge types to addresses

### DIFF
--- a/src/core/__snapshots__/address.test.js.snap
+++ b/src/core/__snapshots__/address.test.js.snap
@@ -2,11 +2,11 @@
 
 exports[`address AddressMap stringifies to JSON 1`] = `
 Object {
-  "{\\"repositoryName\\":\\"sourcecred/suburbia\\",\\"pluginName\\":\\"houseville\\",\\"id\\":\\"mansion\\"}": Object {
+  "{\\"repositoryName\\":\\"sourcecred/suburbia\\",\\"pluginName\\":\\"houseville\\",\\"id\\":\\"mansion\\",\\"type\\":\\"HOME\\"}": Object {
     "baths": 5,
     "beds": 10,
   },
-  "{\\"repositoryName\\":\\"sourcecred/suburbia\\",\\"pluginName\\":\\"houseville\\",\\"id\\":\\"mattressStore\\"}": Object {
+  "{\\"repositoryName\\":\\"sourcecred/suburbia\\",\\"pluginName\\":\\"houseville\\",\\"id\\":\\"mattressStore\\",\\"type\\":\\"BUSINESS\\"}": Object {
     "baths": 1,
     "beds": 99,
   },

--- a/src/core/__snapshots__/graph.test.js.snap
+++ b/src/core/__snapshots__/graph.test.js.snap
@@ -3,11 +3,12 @@
 exports[`graph #Graph JSON functions should serialize a simple graph 1`] = `
 Object {
   "edges": Object {
-    "{\\"repositoryName\\":\\"sourcecred/eventide\\",\\"pluginName\\":\\"hill_cooking_pot\\",\\"id\\":\\"crab-self-assessment\\"}": Object {
+    "{\\"repositoryName\\":\\"sourcecred/eventide\\",\\"pluginName\\":\\"hill_cooking_pot\\",\\"type\\":\\"demoType\\",\\"id\\":\\"crab-self-assessment\\"}": Object {
       "dst": Object {
         "id": "razorclaw_crab#2",
         "pluginName": "hill_cooking_pot",
         "repositoryName": "sourcecred/eventide",
+        "type": "demoType",
       },
       "payload": Object {
         "evaluation": "not effective at avoiding hero",
@@ -16,13 +17,15 @@ Object {
         "id": "razorclaw_crab#2",
         "pluginName": "hill_cooking_pot",
         "repositoryName": "sourcecred/eventide",
+        "type": "demoType",
       },
     },
-    "{\\"repositoryName\\":\\"sourcecred/eventide\\",\\"pluginName\\":\\"hill_cooking_pot\\",\\"id\\":\\"hero_of_time#0@again_cooks@seafood_fruit_mix#3\\"}": Object {
+    "{\\"repositoryName\\":\\"sourcecred/eventide\\",\\"pluginName\\":\\"hill_cooking_pot\\",\\"type\\":\\"demoType\\",\\"id\\":\\"hero_of_time#0@again_cooks@seafood_fruit_mix#3\\"}": Object {
       "dst": Object {
         "id": "hero_of_time#0",
         "pluginName": "hill_cooking_pot",
         "repositoryName": "sourcecred/eventide",
+        "type": "demoType",
       },
       "payload": Object {
         "crit": true,
@@ -32,13 +35,15 @@ Object {
         "id": "seafood_fruit_mix#3",
         "pluginName": "hill_cooking_pot",
         "repositoryName": "sourcecred/eventide",
+        "type": "demoType",
       },
     },
-    "{\\"repositoryName\\":\\"sourcecred/eventide\\",\\"pluginName\\":\\"hill_cooking_pot\\",\\"id\\":\\"hero_of_time#0@cooks@seafood_fruit_mix#3\\"}": Object {
+    "{\\"repositoryName\\":\\"sourcecred/eventide\\",\\"pluginName\\":\\"hill_cooking_pot\\",\\"type\\":\\"demoType\\",\\"id\\":\\"hero_of_time#0@cooks@seafood_fruit_mix#3\\"}": Object {
       "dst": Object {
         "id": "hero_of_time#0",
         "pluginName": "hill_cooking_pot",
         "repositoryName": "sourcecred/eventide",
+        "type": "demoType",
       },
       "payload": Object {
         "crit": false,
@@ -47,85 +52,96 @@ Object {
         "id": "seafood_fruit_mix#3",
         "pluginName": "hill_cooking_pot",
         "repositoryName": "sourcecred/eventide",
+        "type": "demoType",
       },
     },
-    "{\\"repositoryName\\":\\"sourcecred/eventide\\",\\"pluginName\\":\\"hill_cooking_pot\\",\\"id\\":\\"hero_of_time#0@eats@seafood_fruit_mix#3\\"}": Object {
+    "{\\"repositoryName\\":\\"sourcecred/eventide\\",\\"pluginName\\":\\"hill_cooking_pot\\",\\"type\\":\\"demoType\\",\\"id\\":\\"hero_of_time#0@eats@seafood_fruit_mix#3\\"}": Object {
       "dst": Object {
         "id": "seafood_fruit_mix#3",
         "pluginName": "hill_cooking_pot",
         "repositoryName": "sourcecred/eventide",
+        "type": "demoType",
       },
       "payload": Object {},
       "src": Object {
         "id": "hero_of_time#0",
         "pluginName": "hill_cooking_pot",
         "repositoryName": "sourcecred/eventide",
+        "type": "demoType",
       },
     },
-    "{\\"repositoryName\\":\\"sourcecred/eventide\\",\\"pluginName\\":\\"hill_cooking_pot\\",\\"id\\":\\"hero_of_time#0@grabs@razorclaw_crab#2\\"}": Object {
+    "{\\"repositoryName\\":\\"sourcecred/eventide\\",\\"pluginName\\":\\"hill_cooking_pot\\",\\"type\\":\\"demoType\\",\\"id\\":\\"hero_of_time#0@grabs@razorclaw_crab#2\\"}": Object {
       "dst": Object {
         "id": "hero_of_time#0",
         "pluginName": "hill_cooking_pot",
         "repositoryName": "sourcecred/eventide",
+        "type": "demoType",
       },
       "payload": Object {},
       "src": Object {
         "id": "razorclaw_crab#2",
         "pluginName": "hill_cooking_pot",
         "repositoryName": "sourcecred/eventide",
+        "type": "demoType",
       },
     },
-    "{\\"repositoryName\\":\\"sourcecred/eventide\\",\\"pluginName\\":\\"hill_cooking_pot\\",\\"id\\":\\"hero_of_time#0@picks@mighty_bananas#1\\"}": Object {
+    "{\\"repositoryName\\":\\"sourcecred/eventide\\",\\"pluginName\\":\\"hill_cooking_pot\\",\\"type\\":\\"demoType\\",\\"id\\":\\"hero_of_time#0@picks@mighty_bananas#1\\"}": Object {
       "dst": Object {
         "id": "hero_of_time#0",
         "pluginName": "hill_cooking_pot",
         "repositoryName": "sourcecred/eventide",
+        "type": "demoType",
       },
       "payload": Object {},
       "src": Object {
         "id": "mighty_bananas#1",
         "pluginName": "hill_cooking_pot",
         "repositoryName": "sourcecred/eventide",
+        "type": "demoType",
       },
     },
-    "{\\"repositoryName\\":\\"sourcecred/eventide\\",\\"pluginName\\":\\"hill_cooking_pot\\",\\"id\\":\\"mighty_bananas#1@included_in@seafood_fruit_mix#3\\"}": Object {
+    "{\\"repositoryName\\":\\"sourcecred/eventide\\",\\"pluginName\\":\\"hill_cooking_pot\\",\\"type\\":\\"demoType\\",\\"id\\":\\"mighty_bananas#1@included_in@seafood_fruit_mix#3\\"}": Object {
       "dst": Object {
         "id": "mighty_bananas#1",
         "pluginName": "hill_cooking_pot",
         "repositoryName": "sourcecred/eventide",
+        "type": "demoType",
       },
       "payload": Object {},
       "src": Object {
         "id": "seafood_fruit_mix#3",
         "pluginName": "hill_cooking_pot",
         "repositoryName": "sourcecred/eventide",
+        "type": "demoType",
       },
     },
-    "{\\"repositoryName\\":\\"sourcecred/eventide\\",\\"pluginName\\":\\"hill_cooking_pot\\",\\"id\\":\\"razorclaw_crab#2@included_in@seafood_fruit_mix#3\\"}": Object {
+    "{\\"repositoryName\\":\\"sourcecred/eventide\\",\\"pluginName\\":\\"hill_cooking_pot\\",\\"type\\":\\"demoType\\",\\"id\\":\\"razorclaw_crab#2@included_in@seafood_fruit_mix#3\\"}": Object {
       "dst": Object {
         "id": "razorclaw_crab#2",
         "pluginName": "hill_cooking_pot",
         "repositoryName": "sourcecred/eventide",
+        "type": "demoType",
       },
       "payload": Object {},
       "src": Object {
         "id": "seafood_fruit_mix#3",
         "pluginName": "hill_cooking_pot",
         "repositoryName": "sourcecred/eventide",
+        "type": "demoType",
       },
     },
   },
   "nodes": Object {
-    "{\\"repositoryName\\":\\"sourcecred/eventide\\",\\"pluginName\\":\\"hill_cooking_pot\\",\\"id\\":\\"hero_of_time#0\\"}": Object {
+    "{\\"repositoryName\\":\\"sourcecred/eventide\\",\\"pluginName\\":\\"hill_cooking_pot\\",\\"type\\":\\"demoType\\",\\"id\\":\\"hero_of_time#0\\"}": Object {
       "payload": Object {},
     },
-    "{\\"repositoryName\\":\\"sourcecred/eventide\\",\\"pluginName\\":\\"hill_cooking_pot\\",\\"id\\":\\"mighty_bananas#1\\"}": Object {
+    "{\\"repositoryName\\":\\"sourcecred/eventide\\",\\"pluginName\\":\\"hill_cooking_pot\\",\\"type\\":\\"demoType\\",\\"id\\":\\"mighty_bananas#1\\"}": Object {
       "payload": Object {},
     },
-    "{\\"repositoryName\\":\\"sourcecred/eventide\\",\\"pluginName\\":\\"hill_cooking_pot\\",\\"id\\":\\"razorclaw_crab#2\\"}": Object {
+    "{\\"repositoryName\\":\\"sourcecred/eventide\\",\\"pluginName\\":\\"hill_cooking_pot\\",\\"type\\":\\"demoType\\",\\"id\\":\\"razorclaw_crab#2\\"}": Object {
       "payload": Object {},
     },
-    "{\\"repositoryName\\":\\"sourcecred/eventide\\",\\"pluginName\\":\\"hill_cooking_pot\\",\\"id\\":\\"seafood_fruit_mix#3\\"}": Object {
+    "{\\"repositoryName\\":\\"sourcecred/eventide\\",\\"pluginName\\":\\"hill_cooking_pot\\",\\"type\\":\\"demoType\\",\\"id\\":\\"seafood_fruit_mix#3\\"}": Object {
       "payload": Object {
         "effect": Array [
           "attack_power",

--- a/src/core/address.js
+++ b/src/core/address.js
@@ -6,6 +6,7 @@ export type Address = {|
   +repositoryName: string,
   +pluginName: string,
   +id: string,
+  +type: string,
 |};
 
 export interface Addressable {

--- a/src/core/address.test.js
+++ b/src/core/address.test.js
@@ -10,26 +10,27 @@ describe("address", () => {
     +beds: number,
     +baths: number,
   |};
-  function makeAddress(id: string): Address {
+  function makeAddress(type: "HOME" | "BUSINESS", id: string): Address {
     return {
       repositoryName: "sourcecred/suburbia",
       pluginName: "houseville",
       id,
+      type,
     };
   }
   const mansion = (): House => ({
-    address: makeAddress("mansion"),
+    address: makeAddress("HOME", "mansion"),
     beds: 10,
     baths: 5,
   });
   const fakeMansion = (): House => ({
     // Same address, different content.
-    address: makeAddress("mansion"),
+    address: makeAddress("HOME", "mansion"),
     beds: 33,
     baths: 88,
   });
   const mattressStore = (): House => ({
-    address: makeAddress("mattressStore"),
+    address: makeAddress("BUSINESS", "mattressStore"),
     beds: 99,
     baths: 1,
   });

--- a/src/core/graphDemoData.js
+++ b/src/core/graphDemoData.js
@@ -11,6 +11,7 @@ export function makeAddress(id: string): Address {
   return {
     repositoryName: "sourcecred/eventide",
     pluginName: "hill_cooking_pot",
+    type: "demoType",
     id,
   };
 }

--- a/src/plugins/artifact/editor/App.js
+++ b/src/plugins/artifact/editor/App.js
@@ -29,6 +29,7 @@ function createSampleArtifact(name) {
       repositoryName: "sourcecred/devnull",
       pluginName: "sourcecred/artifact-beta",
       id,
+      type: "artifact",
     },
     payload: {name},
   };

--- a/src/plugins/artifact/editor/ContributionList.js
+++ b/src/plugins/artifact/editor/ContributionList.js
@@ -50,7 +50,7 @@ export class ContributionList extends React.Component<Props, State> {
       if (!typesByPlugin[adapter.pluginName]) {
         typesByPlugin[adapter.pluginName] = new Set();
       }
-      typesByPlugin[adapter.pluginName].add(adapter.extractType(graph, node));
+      typesByPlugin[adapter.pluginName].add(node.address.type);
     });
     function optionGroup(pluginName: string) {
       const header = (
@@ -97,7 +97,7 @@ export class ContributionList extends React.Component<Props, State> {
             return (
               !!adapter &&
               adapter.pluginName === typeFilter.pluginName &&
-              adapter.extractType(graph, node) === typeFilter.type
+              node.address.type === typeFilter.type
             );
           }
         : (node) => true;

--- a/src/plugins/artifact/editor/ContributionList.test.js
+++ b/src/plugins/artifact/editor/ContributionList.test.js
@@ -28,43 +28,45 @@ function createTestData(): * {
 
   function makeAddress(
     pluginName: typeof PLUGIN_A | typeof PLUGIN_B | typeof PLUGIN_C,
+    type: string,
     id: string
   ): Address {
     return {
       repositoryName: "sourcecred/tests",
       pluginName,
       id,
+      type,
     };
   }
 
   const nodeA1 = () => ({
-    address: makeAddress(PLUGIN_A, "one"),
+    address: makeAddress(PLUGIN_A, "small", "one"),
     payload: (111: PayloadA),
   });
   const nodeA2 = () => ({
-    address: makeAddress(PLUGIN_A, "two"),
+    address: makeAddress(PLUGIN_A, "small", "two"),
     payload: (234: PayloadA),
   });
   const nodeA3 = () => ({
-    address: makeAddress(PLUGIN_A, "three"),
+    address: makeAddress(PLUGIN_A, "big", "three"),
     payload: (616: PayloadA),
   });
   const nodeB4 = () => ({
-    address: makeAddress(PLUGIN_B, "four"),
+    address: makeAddress(PLUGIN_B, "very true", "four"),
     payload: (true: PayloadB),
   });
   const nodeC5 = () => ({
-    address: makeAddress(PLUGIN_C, "five"),
+    address: makeAddress(PLUGIN_C, "ctype", "five"),
     payload: ("I have no adapter :-(": PayloadC),
   });
   const edgeA1A2 = () => ({
-    address: makeAddress(PLUGIN_A, "one-to-two"),
+    address: makeAddress(PLUGIN_A, "atype", "one-to-two"),
     payload: null,
     src: nodeA1().address,
     dst: nodeA2().address,
   });
   const edgeB4A3 = () => ({
-    address: makeAddress(PLUGIN_C, "four-to-three"),
+    address: makeAddress(PLUGIN_C, "ctype", "four-to-three"),
     payload: null,
     src: nodeB4().address,
     dst: nodeA3().address,
@@ -97,9 +99,6 @@ function createTestData(): * {
         );
       }
     },
-    extractType(graph: Graph<NodePayload, EdgePayload>, node: Node<PayloadA>) {
-      return node.payload < 500 ? "small" : "big";
-    },
     extractTitle(graph: Graph<NodePayload, EdgePayload>, node: Node<PayloadA>) {
       return `the number ${String(node.payload)}`;
     },
@@ -119,9 +118,6 @@ function createTestData(): * {
           </span>
         );
       }
-    },
-    extractType(graph: Graph<NodePayload, EdgePayload>, node: Node<PayloadB>) {
-      return node.payload ? "very true" : "not so";
     },
     extractTitle(graph: Graph<NodePayload, EdgePayload>, node: Node<PayloadB>) {
       return String(node.payload).toUpperCase() + "!";

--- a/src/plugins/artifact/editor/__snapshots__/ContributionList.test.js.snap
+++ b/src/plugins/artifact/editor/__snapshots__/ContributionList.test.js.snap
@@ -75,7 +75,7 @@ exports[`ContributionList renders some test data in the default state 1`] = `
     </thead>
     <tbody>
       <tr
-        key="{\\"repositoryName\\":\\"sourcecred/tests\\",\\"pluginName\\":\\"sourcecred/example-plugin-a\\",\\"id\\":\\"one\\"}"
+        key="{\\"repositoryName\\":\\"sourcecred/tests\\",\\"pluginName\\":\\"sourcecred/example-plugin-a\\",\\"id\\":\\"one\\",\\"type\\":\\"small\\"}"
       >
         <td>
           the number 111
@@ -88,7 +88,7 @@ exports[`ContributionList renders some test data in the default state 1`] = `
         </td>
       </tr>
       <tr
-        key="{\\"repositoryName\\":\\"sourcecred/tests\\",\\"pluginName\\":\\"sourcecred/example-plugin-a\\",\\"id\\":\\"two\\"}"
+        key="{\\"repositoryName\\":\\"sourcecred/tests\\",\\"pluginName\\":\\"sourcecred/example-plugin-a\\",\\"id\\":\\"two\\",\\"type\\":\\"small\\"}"
       >
         <td>
           the number 234
@@ -101,7 +101,7 @@ exports[`ContributionList renders some test data in the default state 1`] = `
         </td>
       </tr>
       <tr
-        key="{\\"repositoryName\\":\\"sourcecred/tests\\",\\"pluginName\\":\\"sourcecred/example-plugin-a\\",\\"id\\":\\"three\\"}"
+        key="{\\"repositoryName\\":\\"sourcecred/tests\\",\\"pluginName\\":\\"sourcecred/example-plugin-a\\",\\"id\\":\\"three\\",\\"type\\":\\"big\\"}"
       >
         <td>
           the number 616
@@ -114,7 +114,7 @@ exports[`ContributionList renders some test data in the default state 1`] = `
         </td>
       </tr>
       <tr
-        key="{\\"repositoryName\\":\\"sourcecred/tests\\",\\"pluginName\\":\\"sourcecred/example-plugin-b\\",\\"id\\":\\"four\\"}"
+        key="{\\"repositoryName\\":\\"sourcecred/tests\\",\\"pluginName\\":\\"sourcecred/example-plugin-b\\",\\"id\\":\\"four\\",\\"type\\":\\"very true\\"}"
       >
         <td>
           TRUE!
@@ -127,7 +127,7 @@ exports[`ContributionList renders some test data in the default state 1`] = `
         </td>
       </tr>
       <tr
-        key="{\\"repositoryName\\":\\"sourcecred/tests\\",\\"pluginName\\":\\"sourcecred/example-plugin-c\\",\\"id\\":\\"five\\"}"
+        key="{\\"repositoryName\\":\\"sourcecred/tests\\",\\"pluginName\\":\\"sourcecred/example-plugin-c\\",\\"id\\":\\"five\\",\\"type\\":\\"ctype\\"}"
       >
         <td
           colSpan={3}
@@ -220,7 +220,7 @@ exports[`ContributionList updates the node table when a filter is selected 1`] =
     </thead>
     <tbody>
       <tr
-        key="{\\"repositoryName\\":\\"sourcecred/tests\\",\\"pluginName\\":\\"sourcecred/example-plugin-a\\",\\"id\\":\\"one\\"}"
+        key="{\\"repositoryName\\":\\"sourcecred/tests\\",\\"pluginName\\":\\"sourcecred/example-plugin-a\\",\\"id\\":\\"one\\",\\"type\\":\\"small\\"}"
       >
         <td>
           the number 111
@@ -233,7 +233,7 @@ exports[`ContributionList updates the node table when a filter is selected 1`] =
         </td>
       </tr>
       <tr
-        key="{\\"repositoryName\\":\\"sourcecred/tests\\",\\"pluginName\\":\\"sourcecred/example-plugin-a\\",\\"id\\":\\"two\\"}"
+        key="{\\"repositoryName\\":\\"sourcecred/tests\\",\\"pluginName\\":\\"sourcecred/example-plugin-a\\",\\"id\\":\\"two\\",\\"type\\":\\"small\\"}"
       >
         <td>
           the number 234

--- a/src/plugins/artifact/editor/adapters/__snapshots__/githubPluginAdapter.test.js.snap
+++ b/src/plugins/artifact/editor/adapters/__snapshots__/githubPluginAdapter.test.js.snap
@@ -3,10 +3,7 @@
 exports[`githubPluginAdapter operates on the example repo 1`] = `
 Array [
   Object {
-    "id": Object {
-      "id": "MDE3OlB1bGxSZXF1ZXN0UmV2aWV3MTAwMzE0MDM4",
-      "type": "PULL_REQUEST_REVIEW",
-    },
+    "id": "MDE3OlB1bGxSZXF1ZXN0UmV2aWV3MTAwMzE0MDM4",
     "payload": Object {
       "body": "I'm sold",
       "state": "APPROVED",
@@ -20,10 +17,7 @@ Array [
     "type": "PULL_REQUEST_REVIEW",
   },
   Object {
-    "id": Object {
-      "id": "MDE3OlB1bGxSZXF1ZXN0UmV2aWV3MTAwMzEzODk5",
-      "type": "PULL_REQUEST_REVIEW",
-    },
+    "id": "MDE3OlB1bGxSZXF1ZXN0UmV2aWV3MTAwMzEzODk5",
     "payload": Object {
       "body": "hmmm.jpg",
       "state": "CHANGES_REQUESTED",
@@ -37,10 +31,7 @@ Array [
     "type": "PULL_REQUEST_REVIEW",
   },
   Object {
-    "id": Object {
-      "id": "MDExOlB1bGxSZXF1ZXN0MTcxODg3NzQx",
-      "type": "PULL_REQUEST",
-    },
+    "id": "MDExOlB1bGxSZXF1ZXN0MTcxODg3NzQx",
     "payload": Object {
       "body": "Oh look, it's a pull request.",
       "number": 3,
@@ -55,10 +46,7 @@ Array [
     "type": "PULL_REQUEST",
   },
   Object {
-    "id": Object {
-      "id": "MDExOlB1bGxSZXF1ZXN0MTcxODg4NTIy",
-      "type": "PULL_REQUEST",
-    },
+    "id": "MDExOlB1bGxSZXF1ZXN0MTcxODg4NTIy",
     "payload": Object {
       "body": "@wchargin could you please do the following:
 - add a commit comment
@@ -77,10 +65,7 @@ Array [
     "type": "PULL_REQUEST",
   },
   Object {
-    "id": Object {
-      "id": "MDEyOklzc3VlQ29tbWVudDM2OTE2MjIyMg==",
-      "type": "COMMENT",
-    },
+    "id": "MDEyOklzc3VlQ29tbWVudDM2OTE2MjIyMg==",
     "payload": Object {
       "body": "It seems apropos to reference something from a pull request comment... eg: #2 ",
       "url": "https://github.com/sourcecred/example-repo/pull/3#issuecomment-369162222",
@@ -94,10 +79,7 @@ Array [
     "type": "COMMENT",
   },
   Object {
-    "id": Object {
-      "id": "MDEyOklzc3VlQ29tbWVudDM3Mzc2ODQ0Mg==",
-      "type": "COMMENT",
-    },
+    "id": "MDEyOklzc3VlQ29tbWVudDM3Mzc2ODQ0Mg==",
     "payload": Object {
       "body": "A wild COMMENT appeared!",
       "url": "https://github.com/sourcecred/example-repo/issues/6#issuecomment-373768442",
@@ -111,10 +93,7 @@ Array [
     "type": "COMMENT",
   },
   Object {
-    "id": Object {
-      "id": "MDEyOklzc3VlQ29tbWVudDM3Mzc2ODUzOA==",
-      "type": "COMMENT",
-    },
+    "id": "MDEyOklzc3VlQ29tbWVudDM3Mzc2ODUzOA==",
     "payload": Object {
       "body": "And the maintainer said, \\"Let there be comments!\\"",
       "url": "https://github.com/sourcecred/example-repo/issues/6#issuecomment-373768538",
@@ -128,10 +107,7 @@ Array [
     "type": "COMMENT",
   },
   Object {
-    "id": Object {
-      "id": "MDEyOklzc3VlQ29tbWVudDM3Mzc2ODcwMw==",
-      "type": "COMMENT",
-    },
+    "id": "MDEyOklzc3VlQ29tbWVudDM3Mzc2ODcwMw==",
     "payload": Object {
       "body": "It should also be possible to reference by exact url: https://github.com/sourcecred/example-repo/issues/6",
       "url": "https://github.com/sourcecred/example-repo/issues/2#issuecomment-373768703",
@@ -145,10 +121,7 @@ Array [
     "type": "COMMENT",
   },
   Object {
-    "id": Object {
-      "id": "MDEyOklzc3VlQ29tbWVudDM3Mzc2ODg1MA==",
-      "type": "COMMENT",
-    },
+    "id": "MDEyOklzc3VlQ29tbWVudDM3Mzc2ODg1MA==",
     "payload": Object {
       "body": "We might also reference individual comments directly.
 https://github.com/sourcecred/example-repo/issues/6#issuecomment-373768538",
@@ -163,10 +136,7 @@ https://github.com/sourcecred/example-repo/issues/6#issuecomment-373768538",
     "type": "COMMENT",
   },
   Object {
-    "id": Object {
-      "id": "MDI0OlB1bGxSZXF1ZXN0UmV2aWV3Q29tbWVudDE3MTQ2MDE5OA==",
-      "type": "PULL_REQUEST_REVIEW_COMMENT",
-    },
+    "id": "MDI0OlB1bGxSZXF1ZXN0UmV2aWV3Q29tbWVudDE3MTQ2MDE5OA==",
     "payload": Object {
       "body": "seems a bit capricious",
       "url": "https://github.com/sourcecred/example-repo/pull/5#discussion_r171460198",
@@ -180,10 +150,7 @@ https://github.com/sourcecred/example-repo/issues/6#issuecomment-373768538",
     "type": "PULL_REQUEST_REVIEW_COMMENT",
   },
   Object {
-    "id": Object {
-      "id": "MDQ6VXNlcjE0MDAwMjM=",
-      "type": "USER",
-    },
+    "id": "MDQ6VXNlcjE0MDAwMjM=",
     "payload": Object {
       "login": "dandelionmane",
     },
@@ -196,10 +163,7 @@ https://github.com/sourcecred/example-repo/issues/6#issuecomment-373768538",
     "type": "USER",
   },
   Object {
-    "id": Object {
-      "id": "MDQ6VXNlcjQzMTc4MDY=",
-      "type": "USER",
-    },
+    "id": "MDQ6VXNlcjQzMTc4MDY=",
     "payload": Object {
       "login": "wchargin",
     },
@@ -212,10 +176,7 @@ https://github.com/sourcecred/example-repo/issues/6#issuecomment-373768538",
     "type": "USER",
   },
   Object {
-    "id": Object {
-      "id": "MDU6SXNzdWUzMDA5MzQ4MTg=",
-      "type": "ISSUE",
-    },
+    "id": "MDU6SXNzdWUzMDA5MzQ4MTg=",
     "payload": Object {
       "body": "This is just an example issue.",
       "number": 1,
@@ -230,10 +191,7 @@ https://github.com/sourcecred/example-repo/issues/6#issuecomment-373768538",
     "type": "ISSUE",
   },
   Object {
-    "id": Object {
-      "id": "MDU6SXNzdWUzMDA5MzQ5ODA=",
-      "type": "ISSUE",
-    },
+    "id": "MDU6SXNzdWUzMDA5MzQ5ODA=",
     "payload": Object {
       "body": "This issue references another issue, namely #1",
       "number": 2,
@@ -248,10 +206,7 @@ https://github.com/sourcecred/example-repo/issues/6#issuecomment-373768538",
     "type": "ISSUE",
   },
   Object {
-    "id": Object {
-      "id": "MDU6SXNzdWUzMDA5MzYzNzQ=",
-      "type": "ISSUE",
-    },
+    "id": "MDU6SXNzdWUzMDA5MzYzNzQ=",
     "payload": Object {
       "body": "Alas, its life as an open issue had only just begun.",
       "number": 4,
@@ -266,10 +221,7 @@ https://github.com/sourcecred/example-repo/issues/6#issuecomment-373768538",
     "type": "ISSUE",
   },
   Object {
-    "id": Object {
-      "id": "MDU6SXNzdWUzMDU5OTM3NzM=",
-      "type": "ISSUE",
-    },
+    "id": "MDU6SXNzdWUzMDU5OTM3NzM=",
     "payload": Object {
       "body": "This issue shall shortly have a few comments.",
       "number": 6,
@@ -284,10 +236,7 @@ https://github.com/sourcecred/example-repo/issues/6#issuecomment-373768538",
     "type": "ISSUE",
   },
   Object {
-    "id": Object {
-      "id": "MDU6SXNzdWUzMDY5ODM1NTI=",
-      "type": "ISSUE",
-    },
+    "id": "MDU6SXNzdWUzMDY5ODM1NTI=",
     "payload": Object {
       "body": "Deal with this, naive string display algorithms!!!!!",
       "number": 7,
@@ -302,10 +251,7 @@ https://github.com/sourcecred/example-repo/issues/6#issuecomment-373768538",
     "type": "ISSUE",
   },
   Object {
-    "id": Object {
-      "id": "MDU6SXNzdWUzMDY5ODUzNjc=",
-      "type": "ISSUE",
-    },
+    "id": "MDU6SXNzdWUzMDY5ODUzNjc=",
     "payload": Object {
       "body": "Issue with Unicode: ȴሲ𣐳楢👍 :heart: 𐤔𐤁𐤀𐤑𐤍𐤉𐤔𐤌𐤄𐤍𐤍 ❤️
 Issue with Unicode: ȴሲ𣐳楢👍 :heart: 𐤔𐤁𐤀𐤑𐤍𐤉𐤔𐤌𐤄𐤍𐤍 ❤️",

--- a/src/plugins/artifact/editor/adapters/githubPluginAdapter.js
+++ b/src/plugins/artifact/editor/adapters/githubPluginAdapter.js
@@ -17,7 +17,7 @@ import type {
   AuthorNodePayload,
 } from "../../../github/githubPlugin";
 import type {PluginAdapter} from "../pluginAdapter";
-import {GITHUB_PLUGIN_NAME, getNodeType} from "../../../github/githubPlugin";
+import {GITHUB_PLUGIN_NAME} from "../../../github/githubPlugin";
 
 const adapter: PluginAdapter<NodePayload> = {
   pluginName: GITHUB_PLUGIN_NAME,
@@ -27,13 +27,9 @@ const adapter: PluginAdapter<NodePayload> = {
     node: Node<NodePayload>,
   }> {
     render() {
-      const type = adapter.extractType(this.props.graph, this.props.node);
+      const type = this.props.node.address.type;
       return <div>type: {type} (details to be implemented)</div>;
     }
-  },
-
-  extractType(graph: *, node: Node<NodePayload>): NodeType {
-    return getNodeType(node);
   },
 
   extractTitle(graph: *, node: Node<NodePayload>): string {
@@ -44,10 +40,7 @@ const adapter: PluginAdapter<NodePayload> = {
     function extractParentTitles(node: Node<NodePayload>): string[] {
       return graph
         .getInEdges(node.address)
-        .filter((e) => {
-          const edgeID: EdgeID = JSON.parse(e.address.id);
-          return edgeID.type === "CONTAINMENT";
-        })
+        .filter((e) => e.address.type === "CONTAINMENT")
         .map((e) => graph.getNode(e.src))
         .map((container) => {
           return adapter.extractTitle(graph, container);
@@ -99,9 +92,9 @@ const adapter: PluginAdapter<NodePayload> = {
       BOT: extractAuthorTitle,
     };
     function fallbackAccessor(node: Node<NodePayload>) {
-      throw new Error(`unknown node type: ${getNodeType(node)}`);
+      throw new Error(`unknown node type: ${node.address.type}`);
     }
-    return (extractors[getNodeType(node)] || fallbackAccessor)(
+    return (extractors[node.address.type] || fallbackAccessor)(
       (node: Node<any>)
     );
   },

--- a/src/plugins/artifact/editor/adapters/githubPluginAdapter.test.js
+++ b/src/plugins/artifact/editor/adapters/githubPluginAdapter.test.js
@@ -5,7 +5,6 @@ import {shallow} from "enzyme";
 import enzymeToJSON from "enzyme-to-json";
 import stringify from "json-stable-stringify";
 
-import type {NodeID} from "../../../github/githubPlugin";
 import {GithubParser} from "../../../github/githubPlugin";
 import exampleRepoData from "../../../github/demoData/example-repo.json";
 import adapter from "./githubPluginAdapter";
@@ -21,9 +20,9 @@ describe("githubPluginAdapter", () => {
     const result = graph
       .getAllNodes()
       .map((node) => ({
-        id: (JSON.parse(node.address.id): NodeID),
+        id: node.address.id,
         payload: node.payload,
-        type: adapter.extractType(graph, node),
+        type: node.address.type,
         title: adapter.extractTitle(graph, node),
         rendered: enzymeToJSON(
           shallow(<adapter.renderer graph={graph} node={node} />)

--- a/src/plugins/artifact/editor/pluginAdapter.js
+++ b/src/plugins/artifact/editor/pluginAdapter.js
@@ -8,6 +8,5 @@ export interface PluginAdapter<-NodePayload> {
   renderer: $Subtype<
     ComponentType<{graph: Graph<any, any>, node: Node<NodePayload>}>
   >;
-  extractType(graph: Graph<any, any>, node: Node<NodePayload>): string;
   extractTitle(graph: Graph<any, any>, node: Node<NodePayload>): string;
 }

--- a/src/plugins/github/__snapshots__/githubPlugin.test.js.snap
+++ b/src/plugins/github/__snapshots__/githubPlugin.test.js.snap
@@ -3,31 +3,33 @@
 exports[`GithubParser issue parsing parses a simple issue (https://github.com/sourcecred/example-repo/issues/1) 1`] = `
 Object {
   "edges": Object {
-    "{\\"pluginName\\":\\"sourcecred/github-beta\\",\\"repositoryName\\":\\"sourcecred/example-repo\\",\\"id\\":\\"{\\\\\\"authorID\\\\\\":{\\\\\\"id\\\\\\":\\\\\\"MDQ6VXNlcjE0MDAwMjM=\\\\\\",\\\\\\"type\\\\\\":\\\\\\"USER\\\\\\"},\\\\\\"contributionID\\\\\\":{\\\\\\"id\\\\\\":\\\\\\"MDU6SXNzdWUzMDA5MzQ4MTg=\\\\\\",\\\\\\"type\\\\\\":\\\\\\"ISSUE\\\\\\"},\\\\\\"type\\\\\\":\\\\\\"AUTHORSHIP\\\\\\"}\\"}": Object {
+    "{\\"pluginName\\":\\"sourcecred/github-beta\\",\\"repositoryName\\":\\"sourcecred/example-repo\\",\\"type\\":\\"AUTHORSHIP\\",\\"id\\":\\"{\\\\\\"author\\\\\\":{\\\\\\"id\\\\\\":\\\\\\"MDQ6VXNlcjE0MDAwMjM=\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"repositoryName\\\\\\":\\\\\\"sourcecred/example-repo\\\\\\",\\\\\\"type\\\\\\":\\\\\\"USER\\\\\\"},\\\\\\"contribution\\\\\\":{\\\\\\"id\\\\\\":\\\\\\"MDU6SXNzdWUzMDA5MzQ4MTg=\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"repositoryName\\\\\\":\\\\\\"sourcecred/example-repo\\\\\\",\\\\\\"type\\\\\\":\\\\\\"ISSUE\\\\\\"}}\\"}": Object {
       "dst": Object {
-        "id": "{\\"id\\":\\"MDQ6VXNlcjE0MDAwMjM=\\",\\"type\\":\\"USER\\"}",
+        "id": "MDQ6VXNlcjE0MDAwMjM=",
         "pluginName": "sourcecred/github-beta",
         "repositoryName": "sourcecred/example-repo",
+        "type": "USER",
       },
       "payload": Object {},
       "src": Object {
-        "id": "{\\"id\\":\\"MDU6SXNzdWUzMDA5MzQ4MTg=\\",\\"type\\":\\"ISSUE\\"}",
+        "id": "MDU6SXNzdWUzMDA5MzQ4MTg=",
         "pluginName": "sourcecred/github-beta",
         "repositoryName": "sourcecred/example-repo",
+        "type": "ISSUE",
       },
     },
   },
   "nodes": Object {
-    "{\\"pluginName\\":\\"sourcecred/github-beta\\",\\"repositoryName\\":\\"sourcecred/example-repo\\",\\"id\\":\\"{\\\\\\"id\\\\\\":\\\\\\"MDQ6VXNlcjE0MDAwMjM=\\\\\\",\\\\\\"type\\\\\\":\\\\\\"USER\\\\\\"}\\"}": Object {
-      "payload": Object {
-        "login": "dandelionmane",
-      },
-    },
-    "{\\"pluginName\\":\\"sourcecred/github-beta\\",\\"repositoryName\\":\\"sourcecred/example-repo\\",\\"id\\":\\"{\\\\\\"id\\\\\\":\\\\\\"MDU6SXNzdWUzMDA5MzQ4MTg=\\\\\\",\\\\\\"type\\\\\\":\\\\\\"ISSUE\\\\\\"}\\"}": Object {
+    "{\\"pluginName\\":\\"sourcecred/github-beta\\",\\"repositoryName\\":\\"sourcecred/example-repo\\",\\"type\\":\\"ISSUE\\",\\"id\\":\\"MDU6SXNzdWUzMDA5MzQ4MTg=\\"}": Object {
       "payload": Object {
         "body": "This is just an example issue.",
         "number": 1,
         "title": "An example issue.",
+      },
+    },
+    "{\\"pluginName\\":\\"sourcecred/github-beta\\",\\"repositoryName\\":\\"sourcecred/example-repo\\",\\"type\\":\\"USER\\",\\"id\\":\\"MDQ6VXNlcjE0MDAwMjM=\\"}": Object {
+      "payload": Object {
+        "login": "dandelionmane",
       },
     },
   },
@@ -37,95 +39,105 @@ Object {
 exports[`GithubParser issue parsing parses an issue with comments (https://github.com/sourcecred/example-repo/issues/6) 1`] = `
 Object {
   "edges": Object {
-    "{\\"pluginName\\":\\"sourcecred/github-beta\\",\\"repositoryName\\":\\"sourcecred/example-repo\\",\\"id\\":\\"{\\\\\\"authorID\\\\\\":{\\\\\\"id\\\\\\":\\\\\\"MDQ6VXNlcjE0MDAwMjM=\\\\\\",\\\\\\"type\\\\\\":\\\\\\"USER\\\\\\"},\\\\\\"contributionID\\\\\\":{\\\\\\"id\\\\\\":\\\\\\"MDEyOklzc3VlQ29tbWVudDM3Mzc2ODQ0Mg==\\\\\\",\\\\\\"type\\\\\\":\\\\\\"COMMENT\\\\\\"},\\\\\\"type\\\\\\":\\\\\\"AUTHORSHIP\\\\\\"}\\"}": Object {
+    "{\\"pluginName\\":\\"sourcecred/github-beta\\",\\"repositoryName\\":\\"sourcecred/example-repo\\",\\"type\\":\\"AUTHORSHIP\\",\\"id\\":\\"{\\\\\\"author\\\\\\":{\\\\\\"id\\\\\\":\\\\\\"MDQ6VXNlcjE0MDAwMjM=\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"repositoryName\\\\\\":\\\\\\"sourcecred/example-repo\\\\\\",\\\\\\"type\\\\\\":\\\\\\"USER\\\\\\"},\\\\\\"contribution\\\\\\":{\\\\\\"id\\\\\\":\\\\\\"MDEyOklzc3VlQ29tbWVudDM3Mzc2ODQ0Mg==\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"repositoryName\\\\\\":\\\\\\"sourcecred/example-repo\\\\\\",\\\\\\"type\\\\\\":\\\\\\"COMMENT\\\\\\"}}\\"}": Object {
       "dst": Object {
-        "id": "{\\"id\\":\\"MDQ6VXNlcjE0MDAwMjM=\\",\\"type\\":\\"USER\\"}",
+        "id": "MDQ6VXNlcjE0MDAwMjM=",
         "pluginName": "sourcecred/github-beta",
         "repositoryName": "sourcecred/example-repo",
+        "type": "USER",
       },
       "payload": Object {},
       "src": Object {
-        "id": "{\\"id\\":\\"MDEyOklzc3VlQ29tbWVudDM3Mzc2ODQ0Mg==\\",\\"type\\":\\"COMMENT\\"}",
+        "id": "MDEyOklzc3VlQ29tbWVudDM3Mzc2ODQ0Mg==",
         "pluginName": "sourcecred/github-beta",
         "repositoryName": "sourcecred/example-repo",
+        "type": "COMMENT",
       },
     },
-    "{\\"pluginName\\":\\"sourcecred/github-beta\\",\\"repositoryName\\":\\"sourcecred/example-repo\\",\\"id\\":\\"{\\\\\\"authorID\\\\\\":{\\\\\\"id\\\\\\":\\\\\\"MDQ6VXNlcjE0MDAwMjM=\\\\\\",\\\\\\"type\\\\\\":\\\\\\"USER\\\\\\"},\\\\\\"contributionID\\\\\\":{\\\\\\"id\\\\\\":\\\\\\"MDEyOklzc3VlQ29tbWVudDM3Mzc2ODUzOA==\\\\\\",\\\\\\"type\\\\\\":\\\\\\"COMMENT\\\\\\"},\\\\\\"type\\\\\\":\\\\\\"AUTHORSHIP\\\\\\"}\\"}": Object {
+    "{\\"pluginName\\":\\"sourcecred/github-beta\\",\\"repositoryName\\":\\"sourcecred/example-repo\\",\\"type\\":\\"AUTHORSHIP\\",\\"id\\":\\"{\\\\\\"author\\\\\\":{\\\\\\"id\\\\\\":\\\\\\"MDQ6VXNlcjE0MDAwMjM=\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"repositoryName\\\\\\":\\\\\\"sourcecred/example-repo\\\\\\",\\\\\\"type\\\\\\":\\\\\\"USER\\\\\\"},\\\\\\"contribution\\\\\\":{\\\\\\"id\\\\\\":\\\\\\"MDEyOklzc3VlQ29tbWVudDM3Mzc2ODUzOA==\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"repositoryName\\\\\\":\\\\\\"sourcecred/example-repo\\\\\\",\\\\\\"type\\\\\\":\\\\\\"COMMENT\\\\\\"}}\\"}": Object {
       "dst": Object {
-        "id": "{\\"id\\":\\"MDQ6VXNlcjE0MDAwMjM=\\",\\"type\\":\\"USER\\"}",
+        "id": "MDQ6VXNlcjE0MDAwMjM=",
         "pluginName": "sourcecred/github-beta",
         "repositoryName": "sourcecred/example-repo",
+        "type": "USER",
       },
       "payload": Object {},
       "src": Object {
-        "id": "{\\"id\\":\\"MDEyOklzc3VlQ29tbWVudDM3Mzc2ODUzOA==\\",\\"type\\":\\"COMMENT\\"}",
+        "id": "MDEyOklzc3VlQ29tbWVudDM3Mzc2ODUzOA==",
         "pluginName": "sourcecred/github-beta",
         "repositoryName": "sourcecred/example-repo",
+        "type": "COMMENT",
       },
     },
-    "{\\"pluginName\\":\\"sourcecred/github-beta\\",\\"repositoryName\\":\\"sourcecred/example-repo\\",\\"id\\":\\"{\\\\\\"authorID\\\\\\":{\\\\\\"id\\\\\\":\\\\\\"MDQ6VXNlcjE0MDAwMjM=\\\\\\",\\\\\\"type\\\\\\":\\\\\\"USER\\\\\\"},\\\\\\"contributionID\\\\\\":{\\\\\\"id\\\\\\":\\\\\\"MDU6SXNzdWUzMDU5OTM3NzM=\\\\\\",\\\\\\"type\\\\\\":\\\\\\"ISSUE\\\\\\"},\\\\\\"type\\\\\\":\\\\\\"AUTHORSHIP\\\\\\"}\\"}": Object {
+    "{\\"pluginName\\":\\"sourcecred/github-beta\\",\\"repositoryName\\":\\"sourcecred/example-repo\\",\\"type\\":\\"AUTHORSHIP\\",\\"id\\":\\"{\\\\\\"author\\\\\\":{\\\\\\"id\\\\\\":\\\\\\"MDQ6VXNlcjE0MDAwMjM=\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"repositoryName\\\\\\":\\\\\\"sourcecred/example-repo\\\\\\",\\\\\\"type\\\\\\":\\\\\\"USER\\\\\\"},\\\\\\"contribution\\\\\\":{\\\\\\"id\\\\\\":\\\\\\"MDU6SXNzdWUzMDU5OTM3NzM=\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"repositoryName\\\\\\":\\\\\\"sourcecred/example-repo\\\\\\",\\\\\\"type\\\\\\":\\\\\\"ISSUE\\\\\\"}}\\"}": Object {
       "dst": Object {
-        "id": "{\\"id\\":\\"MDQ6VXNlcjE0MDAwMjM=\\",\\"type\\":\\"USER\\"}",
+        "id": "MDQ6VXNlcjE0MDAwMjM=",
         "pluginName": "sourcecred/github-beta",
         "repositoryName": "sourcecred/example-repo",
+        "type": "USER",
       },
       "payload": Object {},
       "src": Object {
-        "id": "{\\"id\\":\\"MDU6SXNzdWUzMDU5OTM3NzM=\\",\\"type\\":\\"ISSUE\\"}",
+        "id": "MDU6SXNzdWUzMDU5OTM3NzM=",
         "pluginName": "sourcecred/github-beta",
         "repositoryName": "sourcecred/example-repo",
+        "type": "ISSUE",
       },
     },
-    "{\\"pluginName\\":\\"sourcecred/github-beta\\",\\"repositoryName\\":\\"sourcecred/example-repo\\",\\"id\\":\\"{\\\\\\"childID\\\\\\":{\\\\\\"id\\\\\\":\\\\\\"MDEyOklzc3VlQ29tbWVudDM3Mzc2ODQ0Mg==\\\\\\",\\\\\\"type\\\\\\":\\\\\\"COMMENT\\\\\\"},\\\\\\"parentID\\\\\\":{\\\\\\"id\\\\\\":\\\\\\"MDU6SXNzdWUzMDU5OTM3NzM=\\\\\\",\\\\\\"type\\\\\\":\\\\\\"ISSUE\\\\\\"},\\\\\\"type\\\\\\":\\\\\\"CONTAINMENT\\\\\\"}\\"}": Object {
+    "{\\"pluginName\\":\\"sourcecred/github-beta\\",\\"repositoryName\\":\\"sourcecred/example-repo\\",\\"type\\":\\"CONTAINMENT\\",\\"id\\":\\"{\\\\\\"child\\\\\\":{\\\\\\"id\\\\\\":\\\\\\"MDEyOklzc3VlQ29tbWVudDM3Mzc2ODQ0Mg==\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"repositoryName\\\\\\":\\\\\\"sourcecred/example-repo\\\\\\",\\\\\\"type\\\\\\":\\\\\\"COMMENT\\\\\\"},\\\\\\"parent\\\\\\":{\\\\\\"id\\\\\\":\\\\\\"MDU6SXNzdWUzMDU5OTM3NzM=\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"repositoryName\\\\\\":\\\\\\"sourcecred/example-repo\\\\\\",\\\\\\"type\\\\\\":\\\\\\"ISSUE\\\\\\"}}\\"}": Object {
       "dst": Object {
-        "id": "{\\"id\\":\\"MDEyOklzc3VlQ29tbWVudDM3Mzc2ODQ0Mg==\\",\\"type\\":\\"COMMENT\\"}",
+        "id": "MDEyOklzc3VlQ29tbWVudDM3Mzc2ODQ0Mg==",
         "pluginName": "sourcecred/github-beta",
         "repositoryName": "sourcecred/example-repo",
+        "type": "COMMENT",
       },
       "payload": Object {},
       "src": Object {
-        "id": "{\\"id\\":\\"MDU6SXNzdWUzMDU5OTM3NzM=\\",\\"type\\":\\"ISSUE\\"}",
+        "id": "MDU6SXNzdWUzMDU5OTM3NzM=",
         "pluginName": "sourcecred/github-beta",
         "repositoryName": "sourcecred/example-repo",
+        "type": "ISSUE",
       },
     },
-    "{\\"pluginName\\":\\"sourcecred/github-beta\\",\\"repositoryName\\":\\"sourcecred/example-repo\\",\\"id\\":\\"{\\\\\\"childID\\\\\\":{\\\\\\"id\\\\\\":\\\\\\"MDEyOklzc3VlQ29tbWVudDM3Mzc2ODUzOA==\\\\\\",\\\\\\"type\\\\\\":\\\\\\"COMMENT\\\\\\"},\\\\\\"parentID\\\\\\":{\\\\\\"id\\\\\\":\\\\\\"MDU6SXNzdWUzMDU5OTM3NzM=\\\\\\",\\\\\\"type\\\\\\":\\\\\\"ISSUE\\\\\\"},\\\\\\"type\\\\\\":\\\\\\"CONTAINMENT\\\\\\"}\\"}": Object {
+    "{\\"pluginName\\":\\"sourcecred/github-beta\\",\\"repositoryName\\":\\"sourcecred/example-repo\\",\\"type\\":\\"CONTAINMENT\\",\\"id\\":\\"{\\\\\\"child\\\\\\":{\\\\\\"id\\\\\\":\\\\\\"MDEyOklzc3VlQ29tbWVudDM3Mzc2ODUzOA==\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"repositoryName\\\\\\":\\\\\\"sourcecred/example-repo\\\\\\",\\\\\\"type\\\\\\":\\\\\\"COMMENT\\\\\\"},\\\\\\"parent\\\\\\":{\\\\\\"id\\\\\\":\\\\\\"MDU6SXNzdWUzMDU5OTM3NzM=\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"repositoryName\\\\\\":\\\\\\"sourcecred/example-repo\\\\\\",\\\\\\"type\\\\\\":\\\\\\"ISSUE\\\\\\"}}\\"}": Object {
       "dst": Object {
-        "id": "{\\"id\\":\\"MDEyOklzc3VlQ29tbWVudDM3Mzc2ODUzOA==\\",\\"type\\":\\"COMMENT\\"}",
+        "id": "MDEyOklzc3VlQ29tbWVudDM3Mzc2ODUzOA==",
         "pluginName": "sourcecred/github-beta",
         "repositoryName": "sourcecred/example-repo",
+        "type": "COMMENT",
       },
       "payload": Object {},
       "src": Object {
-        "id": "{\\"id\\":\\"MDU6SXNzdWUzMDU5OTM3NzM=\\",\\"type\\":\\"ISSUE\\"}",
+        "id": "MDU6SXNzdWUzMDU5OTM3NzM=",
         "pluginName": "sourcecred/github-beta",
         "repositoryName": "sourcecred/example-repo",
+        "type": "ISSUE",
       },
     },
   },
   "nodes": Object {
-    "{\\"pluginName\\":\\"sourcecred/github-beta\\",\\"repositoryName\\":\\"sourcecred/example-repo\\",\\"id\\":\\"{\\\\\\"id\\\\\\":\\\\\\"MDEyOklzc3VlQ29tbWVudDM3Mzc2ODQ0Mg==\\\\\\",\\\\\\"type\\\\\\":\\\\\\"COMMENT\\\\\\"}\\"}": Object {
+    "{\\"pluginName\\":\\"sourcecred/github-beta\\",\\"repositoryName\\":\\"sourcecred/example-repo\\",\\"type\\":\\"COMMENT\\",\\"id\\":\\"MDEyOklzc3VlQ29tbWVudDM3Mzc2ODQ0Mg==\\"}": Object {
       "payload": Object {
         "body": "A wild COMMENT appeared!",
         "url": "https://github.com/sourcecred/example-repo/issues/6#issuecomment-373768442",
       },
     },
-    "{\\"pluginName\\":\\"sourcecred/github-beta\\",\\"repositoryName\\":\\"sourcecred/example-repo\\",\\"id\\":\\"{\\\\\\"id\\\\\\":\\\\\\"MDEyOklzc3VlQ29tbWVudDM3Mzc2ODUzOA==\\\\\\",\\\\\\"type\\\\\\":\\\\\\"COMMENT\\\\\\"}\\"}": Object {
+    "{\\"pluginName\\":\\"sourcecred/github-beta\\",\\"repositoryName\\":\\"sourcecred/example-repo\\",\\"type\\":\\"COMMENT\\",\\"id\\":\\"MDEyOklzc3VlQ29tbWVudDM3Mzc2ODUzOA==\\"}": Object {
       "payload": Object {
         "body": "And the maintainer said, \\"Let there be comments!\\"",
         "url": "https://github.com/sourcecred/example-repo/issues/6#issuecomment-373768538",
       },
     },
-    "{\\"pluginName\\":\\"sourcecred/github-beta\\",\\"repositoryName\\":\\"sourcecred/example-repo\\",\\"id\\":\\"{\\\\\\"id\\\\\\":\\\\\\"MDQ6VXNlcjE0MDAwMjM=\\\\\\",\\\\\\"type\\\\\\":\\\\\\"USER\\\\\\"}\\"}": Object {
-      "payload": Object {
-        "login": "dandelionmane",
-      },
-    },
-    "{\\"pluginName\\":\\"sourcecred/github-beta\\",\\"repositoryName\\":\\"sourcecred/example-repo\\",\\"id\\":\\"{\\\\\\"id\\\\\\":\\\\\\"MDU6SXNzdWUzMDU5OTM3NzM=\\\\\\",\\\\\\"type\\\\\\":\\\\\\"ISSUE\\\\\\"}\\"}": Object {
+    "{\\"pluginName\\":\\"sourcecred/github-beta\\",\\"repositoryName\\":\\"sourcecred/example-repo\\",\\"type\\":\\"ISSUE\\",\\"id\\":\\"MDU6SXNzdWUzMDU5OTM3NzM=\\"}": Object {
       "payload": Object {
         "body": "This issue shall shortly have a few comments.",
         "number": 6,
         "title": "An issue with comments",
+      },
+    },
+    "{\\"pluginName\\":\\"sourcecred/github-beta\\",\\"repositoryName\\":\\"sourcecred/example-repo\\",\\"type\\":\\"USER\\",\\"id\\":\\"MDQ6VXNlcjE0MDAwMjM=\\"}": Object {
+      "payload": Object {
+        "login": "dandelionmane",
       },
     },
   },
@@ -135,112 +147,114 @@ Object {
 exports[`GithubParser pull request parsing parses a pr with review comments (https://github.com/sourcecred/example-repo/pull/3) 1`] = `
 Object {
   "edges": Object {
-    "{\\"pluginName\\":\\"sourcecred/github-beta\\",\\"repositoryName\\":\\"sourcecred/example-repo\\",\\"id\\":\\"{\\\\\\"authorID\\\\\\":{\\\\\\"id\\\\\\":\\\\\\"MDQ6VXNlcjE0MDAwMjM=\\\\\\",\\\\\\"type\\\\\\":\\\\\\"USER\\\\\\"},\\\\\\"contributionID\\\\\\":{\\\\\\"id\\\\\\":\\\\\\"MDExOlB1bGxSZXF1ZXN0MTcxODg4NTIy\\\\\\",\\\\\\"type\\\\\\":\\\\\\"PULL_REQUEST\\\\\\"},\\\\\\"type\\\\\\":\\\\\\"AUTHORSHIP\\\\\\"}\\"}": Object {
+    "{\\"pluginName\\":\\"sourcecred/github-beta\\",\\"repositoryName\\":\\"sourcecred/example-repo\\",\\"type\\":\\"AUTHORSHIP\\",\\"id\\":\\"{\\\\\\"author\\\\\\":{\\\\\\"id\\\\\\":\\\\\\"MDQ6VXNlcjE0MDAwMjM=\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"repositoryName\\\\\\":\\\\\\"sourcecred/example-repo\\\\\\",\\\\\\"type\\\\\\":\\\\\\"USER\\\\\\"},\\\\\\"contribution\\\\\\":{\\\\\\"id\\\\\\":\\\\\\"MDExOlB1bGxSZXF1ZXN0MTcxODg4NTIy\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"repositoryName\\\\\\":\\\\\\"sourcecred/example-repo\\\\\\",\\\\\\"type\\\\\\":\\\\\\"PULL_REQUEST\\\\\\"}}\\"}": Object {
       "dst": Object {
-        "id": "{\\"id\\":\\"MDQ6VXNlcjE0MDAwMjM=\\",\\"type\\":\\"USER\\"}",
+        "id": "MDQ6VXNlcjE0MDAwMjM=",
         "pluginName": "sourcecred/github-beta",
         "repositoryName": "sourcecred/example-repo",
+        "type": "USER",
       },
       "payload": Object {},
       "src": Object {
-        "id": "{\\"id\\":\\"MDExOlB1bGxSZXF1ZXN0MTcxODg4NTIy\\",\\"type\\":\\"PULL_REQUEST\\"}",
+        "id": "MDExOlB1bGxSZXF1ZXN0MTcxODg4NTIy",
         "pluginName": "sourcecred/github-beta",
         "repositoryName": "sourcecred/example-repo",
+        "type": "PULL_REQUEST",
       },
     },
-    "{\\"pluginName\\":\\"sourcecred/github-beta\\",\\"repositoryName\\":\\"sourcecred/example-repo\\",\\"id\\":\\"{\\\\\\"authorID\\\\\\":{\\\\\\"id\\\\\\":\\\\\\"MDQ6VXNlcjQzMTc4MDY=\\\\\\",\\\\\\"type\\\\\\":\\\\\\"USER\\\\\\"},\\\\\\"contributionID\\\\\\":{\\\\\\"id\\\\\\":\\\\\\"MDE3OlB1bGxSZXF1ZXN0UmV2aWV3MTAwMzE0MDM4\\\\\\",\\\\\\"type\\\\\\":\\\\\\"PULL_REQUEST_REVIEW\\\\\\"},\\\\\\"type\\\\\\":\\\\\\"AUTHORSHIP\\\\\\"}\\"}": Object {
+    "{\\"pluginName\\":\\"sourcecred/github-beta\\",\\"repositoryName\\":\\"sourcecred/example-repo\\",\\"type\\":\\"AUTHORSHIP\\",\\"id\\":\\"{\\\\\\"author\\\\\\":{\\\\\\"id\\\\\\":\\\\\\"MDQ6VXNlcjQzMTc4MDY=\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"repositoryName\\\\\\":\\\\\\"sourcecred/example-repo\\\\\\",\\\\\\"type\\\\\\":\\\\\\"USER\\\\\\"},\\\\\\"contribution\\\\\\":{\\\\\\"id\\\\\\":\\\\\\"MDE3OlB1bGxSZXF1ZXN0UmV2aWV3MTAwMzE0MDM4\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"repositoryName\\\\\\":\\\\\\"sourcecred/example-repo\\\\\\",\\\\\\"type\\\\\\":\\\\\\"PULL_REQUEST_REVIEW\\\\\\"}}\\"}": Object {
       "dst": Object {
-        "id": "{\\"id\\":\\"MDQ6VXNlcjQzMTc4MDY=\\",\\"type\\":\\"USER\\"}",
+        "id": "MDQ6VXNlcjQzMTc4MDY=",
         "pluginName": "sourcecred/github-beta",
         "repositoryName": "sourcecred/example-repo",
+        "type": "USER",
       },
       "payload": Object {},
       "src": Object {
-        "id": "{\\"id\\":\\"MDE3OlB1bGxSZXF1ZXN0UmV2aWV3MTAwMzE0MDM4\\",\\"type\\":\\"PULL_REQUEST_REVIEW\\"}",
+        "id": "MDE3OlB1bGxSZXF1ZXN0UmV2aWV3MTAwMzE0MDM4",
         "pluginName": "sourcecred/github-beta",
         "repositoryName": "sourcecred/example-repo",
+        "type": "PULL_REQUEST_REVIEW",
       },
     },
-    "{\\"pluginName\\":\\"sourcecred/github-beta\\",\\"repositoryName\\":\\"sourcecred/example-repo\\",\\"id\\":\\"{\\\\\\"authorID\\\\\\":{\\\\\\"id\\\\\\":\\\\\\"MDQ6VXNlcjQzMTc4MDY=\\\\\\",\\\\\\"type\\\\\\":\\\\\\"USER\\\\\\"},\\\\\\"contributionID\\\\\\":{\\\\\\"id\\\\\\":\\\\\\"MDE3OlB1bGxSZXF1ZXN0UmV2aWV3MTAwMzEzODk5\\\\\\",\\\\\\"type\\\\\\":\\\\\\"PULL_REQUEST_REVIEW\\\\\\"},\\\\\\"type\\\\\\":\\\\\\"AUTHORSHIP\\\\\\"}\\"}": Object {
+    "{\\"pluginName\\":\\"sourcecred/github-beta\\",\\"repositoryName\\":\\"sourcecred/example-repo\\",\\"type\\":\\"AUTHORSHIP\\",\\"id\\":\\"{\\\\\\"author\\\\\\":{\\\\\\"id\\\\\\":\\\\\\"MDQ6VXNlcjQzMTc4MDY=\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"repositoryName\\\\\\":\\\\\\"sourcecred/example-repo\\\\\\",\\\\\\"type\\\\\\":\\\\\\"USER\\\\\\"},\\\\\\"contribution\\\\\\":{\\\\\\"id\\\\\\":\\\\\\"MDE3OlB1bGxSZXF1ZXN0UmV2aWV3MTAwMzEzODk5\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"repositoryName\\\\\\":\\\\\\"sourcecred/example-repo\\\\\\",\\\\\\"type\\\\\\":\\\\\\"PULL_REQUEST_REVIEW\\\\\\"}}\\"}": Object {
       "dst": Object {
-        "id": "{\\"id\\":\\"MDQ6VXNlcjQzMTc4MDY=\\",\\"type\\":\\"USER\\"}",
+        "id": "MDQ6VXNlcjQzMTc4MDY=",
         "pluginName": "sourcecred/github-beta",
         "repositoryName": "sourcecred/example-repo",
+        "type": "USER",
       },
       "payload": Object {},
       "src": Object {
-        "id": "{\\"id\\":\\"MDE3OlB1bGxSZXF1ZXN0UmV2aWV3MTAwMzEzODk5\\",\\"type\\":\\"PULL_REQUEST_REVIEW\\"}",
+        "id": "MDE3OlB1bGxSZXF1ZXN0UmV2aWV3MTAwMzEzODk5",
         "pluginName": "sourcecred/github-beta",
         "repositoryName": "sourcecred/example-repo",
+        "type": "PULL_REQUEST_REVIEW",
       },
     },
-    "{\\"pluginName\\":\\"sourcecred/github-beta\\",\\"repositoryName\\":\\"sourcecred/example-repo\\",\\"id\\":\\"{\\\\\\"authorID\\\\\\":{\\\\\\"id\\\\\\":\\\\\\"MDQ6VXNlcjQzMTc4MDY=\\\\\\",\\\\\\"type\\\\\\":\\\\\\"USER\\\\\\"},\\\\\\"contributionID\\\\\\":{\\\\\\"id\\\\\\":\\\\\\"MDI0OlB1bGxSZXF1ZXN0UmV2aWV3Q29tbWVudDE3MTQ2MDE5OA==\\\\\\",\\\\\\"type\\\\\\":\\\\\\"PULL_REQUEST_REVIEW_COMMENT\\\\\\"},\\\\\\"type\\\\\\":\\\\\\"AUTHORSHIP\\\\\\"}\\"}": Object {
+    "{\\"pluginName\\":\\"sourcecred/github-beta\\",\\"repositoryName\\":\\"sourcecred/example-repo\\",\\"type\\":\\"AUTHORSHIP\\",\\"id\\":\\"{\\\\\\"author\\\\\\":{\\\\\\"id\\\\\\":\\\\\\"MDQ6VXNlcjQzMTc4MDY=\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"repositoryName\\\\\\":\\\\\\"sourcecred/example-repo\\\\\\",\\\\\\"type\\\\\\":\\\\\\"USER\\\\\\"},\\\\\\"contribution\\\\\\":{\\\\\\"id\\\\\\":\\\\\\"MDI0OlB1bGxSZXF1ZXN0UmV2aWV3Q29tbWVudDE3MTQ2MDE5OA==\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"repositoryName\\\\\\":\\\\\\"sourcecred/example-repo\\\\\\",\\\\\\"type\\\\\\":\\\\\\"PULL_REQUEST_REVIEW_COMMENT\\\\\\"}}\\"}": Object {
       "dst": Object {
-        "id": "{\\"id\\":\\"MDQ6VXNlcjQzMTc4MDY=\\",\\"type\\":\\"USER\\"}",
+        "id": "MDQ6VXNlcjQzMTc4MDY=",
         "pluginName": "sourcecred/github-beta",
         "repositoryName": "sourcecred/example-repo",
+        "type": "USER",
       },
       "payload": Object {},
       "src": Object {
-        "id": "{\\"id\\":\\"MDI0OlB1bGxSZXF1ZXN0UmV2aWV3Q29tbWVudDE3MTQ2MDE5OA==\\",\\"type\\":\\"PULL_REQUEST_REVIEW_COMMENT\\"}",
+        "id": "MDI0OlB1bGxSZXF1ZXN0UmV2aWV3Q29tbWVudDE3MTQ2MDE5OA==",
         "pluginName": "sourcecred/github-beta",
         "repositoryName": "sourcecred/example-repo",
+        "type": "PULL_REQUEST_REVIEW_COMMENT",
       },
     },
-    "{\\"pluginName\\":\\"sourcecred/github-beta\\",\\"repositoryName\\":\\"sourcecred/example-repo\\",\\"id\\":\\"{\\\\\\"childID\\\\\\":{\\\\\\"id\\\\\\":\\\\\\"MDE3OlB1bGxSZXF1ZXN0UmV2aWV3MTAwMzE0MDM4\\\\\\",\\\\\\"type\\\\\\":\\\\\\"PULL_REQUEST_REVIEW\\\\\\"},\\\\\\"parentID\\\\\\":{\\\\\\"id\\\\\\":\\\\\\"MDExOlB1bGxSZXF1ZXN0MTcxODg4NTIy\\\\\\",\\\\\\"type\\\\\\":\\\\\\"PULL_REQUEST\\\\\\"},\\\\\\"type\\\\\\":\\\\\\"CONTAINMENT\\\\\\"}\\"}": Object {
+    "{\\"pluginName\\":\\"sourcecred/github-beta\\",\\"repositoryName\\":\\"sourcecred/example-repo\\",\\"type\\":\\"CONTAINMENT\\",\\"id\\":\\"{\\\\\\"child\\\\\\":{\\\\\\"id\\\\\\":\\\\\\"MDE3OlB1bGxSZXF1ZXN0UmV2aWV3MTAwMzE0MDM4\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"repositoryName\\\\\\":\\\\\\"sourcecred/example-repo\\\\\\",\\\\\\"type\\\\\\":\\\\\\"PULL_REQUEST_REVIEW\\\\\\"},\\\\\\"parent\\\\\\":{\\\\\\"id\\\\\\":\\\\\\"MDExOlB1bGxSZXF1ZXN0MTcxODg4NTIy\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"repositoryName\\\\\\":\\\\\\"sourcecred/example-repo\\\\\\",\\\\\\"type\\\\\\":\\\\\\"PULL_REQUEST\\\\\\"}}\\"}": Object {
       "dst": Object {
-        "id": "{\\"id\\":\\"MDE3OlB1bGxSZXF1ZXN0UmV2aWV3MTAwMzE0MDM4\\",\\"type\\":\\"PULL_REQUEST_REVIEW\\"}",
+        "id": "MDE3OlB1bGxSZXF1ZXN0UmV2aWV3MTAwMzE0MDM4",
         "pluginName": "sourcecred/github-beta",
         "repositoryName": "sourcecred/example-repo",
+        "type": "PULL_REQUEST_REVIEW",
       },
       "payload": Object {},
       "src": Object {
-        "id": "{\\"id\\":\\"MDExOlB1bGxSZXF1ZXN0MTcxODg4NTIy\\",\\"type\\":\\"PULL_REQUEST\\"}",
+        "id": "MDExOlB1bGxSZXF1ZXN0MTcxODg4NTIy",
         "pluginName": "sourcecred/github-beta",
         "repositoryName": "sourcecred/example-repo",
+        "type": "PULL_REQUEST",
       },
     },
-    "{\\"pluginName\\":\\"sourcecred/github-beta\\",\\"repositoryName\\":\\"sourcecred/example-repo\\",\\"id\\":\\"{\\\\\\"childID\\\\\\":{\\\\\\"id\\\\\\":\\\\\\"MDE3OlB1bGxSZXF1ZXN0UmV2aWV3MTAwMzEzODk5\\\\\\",\\\\\\"type\\\\\\":\\\\\\"PULL_REQUEST_REVIEW\\\\\\"},\\\\\\"parentID\\\\\\":{\\\\\\"id\\\\\\":\\\\\\"MDExOlB1bGxSZXF1ZXN0MTcxODg4NTIy\\\\\\",\\\\\\"type\\\\\\":\\\\\\"PULL_REQUEST\\\\\\"},\\\\\\"type\\\\\\":\\\\\\"CONTAINMENT\\\\\\"}\\"}": Object {
+    "{\\"pluginName\\":\\"sourcecred/github-beta\\",\\"repositoryName\\":\\"sourcecred/example-repo\\",\\"type\\":\\"CONTAINMENT\\",\\"id\\":\\"{\\\\\\"child\\\\\\":{\\\\\\"id\\\\\\":\\\\\\"MDE3OlB1bGxSZXF1ZXN0UmV2aWV3MTAwMzEzODk5\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"repositoryName\\\\\\":\\\\\\"sourcecred/example-repo\\\\\\",\\\\\\"type\\\\\\":\\\\\\"PULL_REQUEST_REVIEW\\\\\\"},\\\\\\"parent\\\\\\":{\\\\\\"id\\\\\\":\\\\\\"MDExOlB1bGxSZXF1ZXN0MTcxODg4NTIy\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"repositoryName\\\\\\":\\\\\\"sourcecred/example-repo\\\\\\",\\\\\\"type\\\\\\":\\\\\\"PULL_REQUEST\\\\\\"}}\\"}": Object {
       "dst": Object {
-        "id": "{\\"id\\":\\"MDE3OlB1bGxSZXF1ZXN0UmV2aWV3MTAwMzEzODk5\\",\\"type\\":\\"PULL_REQUEST_REVIEW\\"}",
+        "id": "MDE3OlB1bGxSZXF1ZXN0UmV2aWV3MTAwMzEzODk5",
         "pluginName": "sourcecred/github-beta",
         "repositoryName": "sourcecred/example-repo",
+        "type": "PULL_REQUEST_REVIEW",
       },
       "payload": Object {},
       "src": Object {
-        "id": "{\\"id\\":\\"MDExOlB1bGxSZXF1ZXN0MTcxODg4NTIy\\",\\"type\\":\\"PULL_REQUEST\\"}",
+        "id": "MDExOlB1bGxSZXF1ZXN0MTcxODg4NTIy",
         "pluginName": "sourcecred/github-beta",
         "repositoryName": "sourcecred/example-repo",
+        "type": "PULL_REQUEST",
       },
     },
-    "{\\"pluginName\\":\\"sourcecred/github-beta\\",\\"repositoryName\\":\\"sourcecred/example-repo\\",\\"id\\":\\"{\\\\\\"childID\\\\\\":{\\\\\\"id\\\\\\":\\\\\\"MDI0OlB1bGxSZXF1ZXN0UmV2aWV3Q29tbWVudDE3MTQ2MDE5OA==\\\\\\",\\\\\\"type\\\\\\":\\\\\\"PULL_REQUEST_REVIEW_COMMENT\\\\\\"},\\\\\\"parentID\\\\\\":{\\\\\\"id\\\\\\":\\\\\\"MDE3OlB1bGxSZXF1ZXN0UmV2aWV3MTAwMzEzODk5\\\\\\",\\\\\\"type\\\\\\":\\\\\\"PULL_REQUEST_REVIEW\\\\\\"},\\\\\\"type\\\\\\":\\\\\\"CONTAINMENT\\\\\\"}\\"}": Object {
+    "{\\"pluginName\\":\\"sourcecred/github-beta\\",\\"repositoryName\\":\\"sourcecred/example-repo\\",\\"type\\":\\"CONTAINMENT\\",\\"id\\":\\"{\\\\\\"child\\\\\\":{\\\\\\"id\\\\\\":\\\\\\"MDI0OlB1bGxSZXF1ZXN0UmV2aWV3Q29tbWVudDE3MTQ2MDE5OA==\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"repositoryName\\\\\\":\\\\\\"sourcecred/example-repo\\\\\\",\\\\\\"type\\\\\\":\\\\\\"PULL_REQUEST_REVIEW_COMMENT\\\\\\"},\\\\\\"parent\\\\\\":{\\\\\\"id\\\\\\":\\\\\\"MDE3OlB1bGxSZXF1ZXN0UmV2aWV3MTAwMzEzODk5\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"repositoryName\\\\\\":\\\\\\"sourcecred/example-repo\\\\\\",\\\\\\"type\\\\\\":\\\\\\"PULL_REQUEST_REVIEW\\\\\\"}}\\"}": Object {
       "dst": Object {
-        "id": "{\\"id\\":\\"MDI0OlB1bGxSZXF1ZXN0UmV2aWV3Q29tbWVudDE3MTQ2MDE5OA==\\",\\"type\\":\\"PULL_REQUEST_REVIEW_COMMENT\\"}",
+        "id": "MDI0OlB1bGxSZXF1ZXN0UmV2aWV3Q29tbWVudDE3MTQ2MDE5OA==",
         "pluginName": "sourcecred/github-beta",
         "repositoryName": "sourcecred/example-repo",
+        "type": "PULL_REQUEST_REVIEW_COMMENT",
       },
       "payload": Object {},
       "src": Object {
-        "id": "{\\"id\\":\\"MDE3OlB1bGxSZXF1ZXN0UmV2aWV3MTAwMzEzODk5\\",\\"type\\":\\"PULL_REQUEST_REVIEW\\"}",
+        "id": "MDE3OlB1bGxSZXF1ZXN0UmV2aWV3MTAwMzEzODk5",
         "pluginName": "sourcecred/github-beta",
         "repositoryName": "sourcecred/example-repo",
+        "type": "PULL_REQUEST_REVIEW",
       },
     },
   },
   "nodes": Object {
-    "{\\"pluginName\\":\\"sourcecred/github-beta\\",\\"repositoryName\\":\\"sourcecred/example-repo\\",\\"id\\":\\"{\\\\\\"id\\\\\\":\\\\\\"MDE3OlB1bGxSZXF1ZXN0UmV2aWV3MTAwMzE0MDM4\\\\\\",\\\\\\"type\\\\\\":\\\\\\"PULL_REQUEST_REVIEW\\\\\\"}\\"}": Object {
-      "payload": Object {
-        "body": "I'm sold",
-        "state": "APPROVED",
-      },
-    },
-    "{\\"pluginName\\":\\"sourcecred/github-beta\\",\\"repositoryName\\":\\"sourcecred/example-repo\\",\\"id\\":\\"{\\\\\\"id\\\\\\":\\\\\\"MDE3OlB1bGxSZXF1ZXN0UmV2aWV3MTAwMzEzODk5\\\\\\",\\\\\\"type\\\\\\":\\\\\\"PULL_REQUEST_REVIEW\\\\\\"}\\"}": Object {
-      "payload": Object {
-        "body": "hmmm.jpg",
-        "state": "CHANGES_REQUESTED",
-      },
-    },
-    "{\\"pluginName\\":\\"sourcecred/github-beta\\",\\"repositoryName\\":\\"sourcecred/example-repo\\",\\"id\\":\\"{\\\\\\"id\\\\\\":\\\\\\"MDExOlB1bGxSZXF1ZXN0MTcxODg4NTIy\\\\\\",\\\\\\"type\\\\\\":\\\\\\"PULL_REQUEST\\\\\\"}\\"}": Object {
+    "{\\"pluginName\\":\\"sourcecred/github-beta\\",\\"repositoryName\\":\\"sourcecred/example-repo\\",\\"type\\":\\"PULL_REQUEST\\",\\"id\\":\\"MDExOlB1bGxSZXF1ZXN0MTcxODg4NTIy\\"}": Object {
       "payload": Object {
         "body": "@wchargin could you please do the following:
 - add a commit comment
@@ -251,18 +265,30 @@ Object {
         "title": "This pull request will be more contentious. I can feel it...",
       },
     },
-    "{\\"pluginName\\":\\"sourcecred/github-beta\\",\\"repositoryName\\":\\"sourcecred/example-repo\\",\\"id\\":\\"{\\\\\\"id\\\\\\":\\\\\\"MDI0OlB1bGxSZXF1ZXN0UmV2aWV3Q29tbWVudDE3MTQ2MDE5OA==\\\\\\",\\\\\\"type\\\\\\":\\\\\\"PULL_REQUEST_REVIEW_COMMENT\\\\\\"}\\"}": Object {
+    "{\\"pluginName\\":\\"sourcecred/github-beta\\",\\"repositoryName\\":\\"sourcecred/example-repo\\",\\"type\\":\\"PULL_REQUEST_REVIEW\\",\\"id\\":\\"MDE3OlB1bGxSZXF1ZXN0UmV2aWV3MTAwMzE0MDM4\\"}": Object {
+      "payload": Object {
+        "body": "I'm sold",
+        "state": "APPROVED",
+      },
+    },
+    "{\\"pluginName\\":\\"sourcecred/github-beta\\",\\"repositoryName\\":\\"sourcecred/example-repo\\",\\"type\\":\\"PULL_REQUEST_REVIEW\\",\\"id\\":\\"MDE3OlB1bGxSZXF1ZXN0UmV2aWV3MTAwMzEzODk5\\"}": Object {
+      "payload": Object {
+        "body": "hmmm.jpg",
+        "state": "CHANGES_REQUESTED",
+      },
+    },
+    "{\\"pluginName\\":\\"sourcecred/github-beta\\",\\"repositoryName\\":\\"sourcecred/example-repo\\",\\"type\\":\\"PULL_REQUEST_REVIEW_COMMENT\\",\\"id\\":\\"MDI0OlB1bGxSZXF1ZXN0UmV2aWV3Q29tbWVudDE3MTQ2MDE5OA==\\"}": Object {
       "payload": Object {
         "body": "seems a bit capricious",
         "url": "https://github.com/sourcecred/example-repo/pull/5#discussion_r171460198",
       },
     },
-    "{\\"pluginName\\":\\"sourcecred/github-beta\\",\\"repositoryName\\":\\"sourcecred/example-repo\\",\\"id\\":\\"{\\\\\\"id\\\\\\":\\\\\\"MDQ6VXNlcjE0MDAwMjM=\\\\\\",\\\\\\"type\\\\\\":\\\\\\"USER\\\\\\"}\\"}": Object {
+    "{\\"pluginName\\":\\"sourcecred/github-beta\\",\\"repositoryName\\":\\"sourcecred/example-repo\\",\\"type\\":\\"USER\\",\\"id\\":\\"MDQ6VXNlcjE0MDAwMjM=\\"}": Object {
       "payload": Object {
         "login": "dandelionmane",
       },
     },
-    "{\\"pluginName\\":\\"sourcecred/github-beta\\",\\"repositoryName\\":\\"sourcecred/example-repo\\",\\"id\\":\\"{\\\\\\"id\\\\\\":\\\\\\"MDQ6VXNlcjQzMTc4MDY=\\\\\\",\\\\\\"type\\\\\\":\\\\\\"USER\\\\\\"}\\"}": Object {
+    "{\\"pluginName\\":\\"sourcecred/github-beta\\",\\"repositoryName\\":\\"sourcecred/example-repo\\",\\"type\\":\\"USER\\",\\"id\\":\\"MDQ6VXNlcjQzMTc4MDY=\\"}": Object {
       "payload": Object {
         "login": "wchargin",
       },
@@ -274,61 +300,67 @@ Object {
 exports[`GithubParser pull request parsing parses a simple pull request (https://github.com/sourcecred/example-repo/pull/3) 1`] = `
 Object {
   "edges": Object {
-    "{\\"pluginName\\":\\"sourcecred/github-beta\\",\\"repositoryName\\":\\"sourcecred/example-repo\\",\\"id\\":\\"{\\\\\\"authorID\\\\\\":{\\\\\\"id\\\\\\":\\\\\\"MDQ6VXNlcjE0MDAwMjM=\\\\\\",\\\\\\"type\\\\\\":\\\\\\"USER\\\\\\"},\\\\\\"contributionID\\\\\\":{\\\\\\"id\\\\\\":\\\\\\"MDExOlB1bGxSZXF1ZXN0MTcxODg3NzQx\\\\\\",\\\\\\"type\\\\\\":\\\\\\"PULL_REQUEST\\\\\\"},\\\\\\"type\\\\\\":\\\\\\"AUTHORSHIP\\\\\\"}\\"}": Object {
+    "{\\"pluginName\\":\\"sourcecred/github-beta\\",\\"repositoryName\\":\\"sourcecred/example-repo\\",\\"type\\":\\"AUTHORSHIP\\",\\"id\\":\\"{\\\\\\"author\\\\\\":{\\\\\\"id\\\\\\":\\\\\\"MDQ6VXNlcjE0MDAwMjM=\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"repositoryName\\\\\\":\\\\\\"sourcecred/example-repo\\\\\\",\\\\\\"type\\\\\\":\\\\\\"USER\\\\\\"},\\\\\\"contribution\\\\\\":{\\\\\\"id\\\\\\":\\\\\\"MDExOlB1bGxSZXF1ZXN0MTcxODg3NzQx\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"repositoryName\\\\\\":\\\\\\"sourcecred/example-repo\\\\\\",\\\\\\"type\\\\\\":\\\\\\"PULL_REQUEST\\\\\\"}}\\"}": Object {
       "dst": Object {
-        "id": "{\\"id\\":\\"MDQ6VXNlcjE0MDAwMjM=\\",\\"type\\":\\"USER\\"}",
+        "id": "MDQ6VXNlcjE0MDAwMjM=",
         "pluginName": "sourcecred/github-beta",
         "repositoryName": "sourcecred/example-repo",
+        "type": "USER",
       },
       "payload": Object {},
       "src": Object {
-        "id": "{\\"id\\":\\"MDExOlB1bGxSZXF1ZXN0MTcxODg3NzQx\\",\\"type\\":\\"PULL_REQUEST\\"}",
+        "id": "MDExOlB1bGxSZXF1ZXN0MTcxODg3NzQx",
         "pluginName": "sourcecred/github-beta",
         "repositoryName": "sourcecred/example-repo",
+        "type": "PULL_REQUEST",
       },
     },
-    "{\\"pluginName\\":\\"sourcecred/github-beta\\",\\"repositoryName\\":\\"sourcecred/example-repo\\",\\"id\\":\\"{\\\\\\"authorID\\\\\\":{\\\\\\"id\\\\\\":\\\\\\"MDQ6VXNlcjE0MDAwMjM=\\\\\\",\\\\\\"type\\\\\\":\\\\\\"USER\\\\\\"},\\\\\\"contributionID\\\\\\":{\\\\\\"id\\\\\\":\\\\\\"MDEyOklzc3VlQ29tbWVudDM2OTE2MjIyMg==\\\\\\",\\\\\\"type\\\\\\":\\\\\\"COMMENT\\\\\\"},\\\\\\"type\\\\\\":\\\\\\"AUTHORSHIP\\\\\\"}\\"}": Object {
+    "{\\"pluginName\\":\\"sourcecred/github-beta\\",\\"repositoryName\\":\\"sourcecred/example-repo\\",\\"type\\":\\"AUTHORSHIP\\",\\"id\\":\\"{\\\\\\"author\\\\\\":{\\\\\\"id\\\\\\":\\\\\\"MDQ6VXNlcjE0MDAwMjM=\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"repositoryName\\\\\\":\\\\\\"sourcecred/example-repo\\\\\\",\\\\\\"type\\\\\\":\\\\\\"USER\\\\\\"},\\\\\\"contribution\\\\\\":{\\\\\\"id\\\\\\":\\\\\\"MDEyOklzc3VlQ29tbWVudDM2OTE2MjIyMg==\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"repositoryName\\\\\\":\\\\\\"sourcecred/example-repo\\\\\\",\\\\\\"type\\\\\\":\\\\\\"COMMENT\\\\\\"}}\\"}": Object {
       "dst": Object {
-        "id": "{\\"id\\":\\"MDQ6VXNlcjE0MDAwMjM=\\",\\"type\\":\\"USER\\"}",
+        "id": "MDQ6VXNlcjE0MDAwMjM=",
         "pluginName": "sourcecred/github-beta",
         "repositoryName": "sourcecred/example-repo",
+        "type": "USER",
       },
       "payload": Object {},
       "src": Object {
-        "id": "{\\"id\\":\\"MDEyOklzc3VlQ29tbWVudDM2OTE2MjIyMg==\\",\\"type\\":\\"COMMENT\\"}",
+        "id": "MDEyOklzc3VlQ29tbWVudDM2OTE2MjIyMg==",
         "pluginName": "sourcecred/github-beta",
         "repositoryName": "sourcecred/example-repo",
+        "type": "COMMENT",
       },
     },
-    "{\\"pluginName\\":\\"sourcecred/github-beta\\",\\"repositoryName\\":\\"sourcecred/example-repo\\",\\"id\\":\\"{\\\\\\"childID\\\\\\":{\\\\\\"id\\\\\\":\\\\\\"MDEyOklzc3VlQ29tbWVudDM2OTE2MjIyMg==\\\\\\",\\\\\\"type\\\\\\":\\\\\\"COMMENT\\\\\\"},\\\\\\"parentID\\\\\\":{\\\\\\"id\\\\\\":\\\\\\"MDExOlB1bGxSZXF1ZXN0MTcxODg3NzQx\\\\\\",\\\\\\"type\\\\\\":\\\\\\"PULL_REQUEST\\\\\\"},\\\\\\"type\\\\\\":\\\\\\"CONTAINMENT\\\\\\"}\\"}": Object {
+    "{\\"pluginName\\":\\"sourcecred/github-beta\\",\\"repositoryName\\":\\"sourcecred/example-repo\\",\\"type\\":\\"CONTAINMENT\\",\\"id\\":\\"{\\\\\\"child\\\\\\":{\\\\\\"id\\\\\\":\\\\\\"MDEyOklzc3VlQ29tbWVudDM2OTE2MjIyMg==\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"repositoryName\\\\\\":\\\\\\"sourcecred/example-repo\\\\\\",\\\\\\"type\\\\\\":\\\\\\"COMMENT\\\\\\"},\\\\\\"parent\\\\\\":{\\\\\\"id\\\\\\":\\\\\\"MDExOlB1bGxSZXF1ZXN0MTcxODg3NzQx\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"repositoryName\\\\\\":\\\\\\"sourcecred/example-repo\\\\\\",\\\\\\"type\\\\\\":\\\\\\"PULL_REQUEST\\\\\\"}}\\"}": Object {
       "dst": Object {
-        "id": "{\\"id\\":\\"MDEyOklzc3VlQ29tbWVudDM2OTE2MjIyMg==\\",\\"type\\":\\"COMMENT\\"}",
+        "id": "MDEyOklzc3VlQ29tbWVudDM2OTE2MjIyMg==",
         "pluginName": "sourcecred/github-beta",
         "repositoryName": "sourcecred/example-repo",
+        "type": "COMMENT",
       },
       "payload": Object {},
       "src": Object {
-        "id": "{\\"id\\":\\"MDExOlB1bGxSZXF1ZXN0MTcxODg3NzQx\\",\\"type\\":\\"PULL_REQUEST\\"}",
+        "id": "MDExOlB1bGxSZXF1ZXN0MTcxODg3NzQx",
         "pluginName": "sourcecred/github-beta",
         "repositoryName": "sourcecred/example-repo",
+        "type": "PULL_REQUEST",
       },
     },
   },
   "nodes": Object {
-    "{\\"pluginName\\":\\"sourcecred/github-beta\\",\\"repositoryName\\":\\"sourcecred/example-repo\\",\\"id\\":\\"{\\\\\\"id\\\\\\":\\\\\\"MDExOlB1bGxSZXF1ZXN0MTcxODg3NzQx\\\\\\",\\\\\\"type\\\\\\":\\\\\\"PULL_REQUEST\\\\\\"}\\"}": Object {
+    "{\\"pluginName\\":\\"sourcecred/github-beta\\",\\"repositoryName\\":\\"sourcecred/example-repo\\",\\"type\\":\\"COMMENT\\",\\"id\\":\\"MDEyOklzc3VlQ29tbWVudDM2OTE2MjIyMg==\\"}": Object {
+      "payload": Object {
+        "body": "It seems apropos to reference something from a pull request comment... eg: #2 ",
+        "url": "https://github.com/sourcecred/example-repo/pull/3#issuecomment-369162222",
+      },
+    },
+    "{\\"pluginName\\":\\"sourcecred/github-beta\\",\\"repositoryName\\":\\"sourcecred/example-repo\\",\\"type\\":\\"PULL_REQUEST\\",\\"id\\":\\"MDExOlB1bGxSZXF1ZXN0MTcxODg3NzQx\\"}": Object {
       "payload": Object {
         "body": "Oh look, it's a pull request.",
         "number": 3,
         "title": "Add README, merge via PR.",
       },
     },
-    "{\\"pluginName\\":\\"sourcecred/github-beta\\",\\"repositoryName\\":\\"sourcecred/example-repo\\",\\"id\\":\\"{\\\\\\"id\\\\\\":\\\\\\"MDEyOklzc3VlQ29tbWVudDM2OTE2MjIyMg==\\\\\\",\\\\\\"type\\\\\\":\\\\\\"COMMENT\\\\\\"}\\"}": Object {
-      "payload": Object {
-        "body": "It seems apropos to reference something from a pull request comment... eg: #2 ",
-        "url": "https://github.com/sourcecred/example-repo/pull/3#issuecomment-369162222",
-      },
-    },
-    "{\\"pluginName\\":\\"sourcecred/github-beta\\",\\"repositoryName\\":\\"sourcecred/example-repo\\",\\"id\\":\\"{\\\\\\"id\\\\\\":\\\\\\"MDQ6VXNlcjE0MDAwMjM=\\\\\\",\\\\\\"type\\\\\\":\\\\\\"USER\\\\\\"}\\"}": Object {
+    "{\\"pluginName\\":\\"sourcecred/github-beta\\",\\"repositoryName\\":\\"sourcecred/example-repo\\",\\"type\\":\\"USER\\",\\"id\\":\\"MDQ6VXNlcjE0MDAwMjM=\\"}": Object {
       "payload": Object {
         "login": "dandelionmane",
       },
@@ -340,340 +372,450 @@ Object {
 exports[`GithubParser whole repo parsing parses the entire example-repo as expected 1`] = `
 Object {
   "edges": Object {
-    "{\\"pluginName\\":\\"sourcecred/github-beta\\",\\"repositoryName\\":\\"sourcecred/example-repo\\",\\"id\\":\\"{\\\\\\"authorID\\\\\\":{\\\\\\"id\\\\\\":\\\\\\"MDQ6VXNlcjE0MDAwMjM=\\\\\\",\\\\\\"type\\\\\\":\\\\\\"USER\\\\\\"},\\\\\\"contributionID\\\\\\":{\\\\\\"id\\\\\\":\\\\\\"MDExOlB1bGxSZXF1ZXN0MTcxODg3NzQx\\\\\\",\\\\\\"type\\\\\\":\\\\\\"PULL_REQUEST\\\\\\"},\\\\\\"type\\\\\\":\\\\\\"AUTHORSHIP\\\\\\"}\\"}": Object {
+    "{\\"pluginName\\":\\"sourcecred/github-beta\\",\\"repositoryName\\":\\"sourcecred/example-repo\\",\\"type\\":\\"AUTHORSHIP\\",\\"id\\":\\"{\\\\\\"author\\\\\\":{\\\\\\"id\\\\\\":\\\\\\"MDQ6VXNlcjE0MDAwMjM=\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"repositoryName\\\\\\":\\\\\\"sourcecred/example-repo\\\\\\",\\\\\\"type\\\\\\":\\\\\\"USER\\\\\\"},\\\\\\"contribution\\\\\\":{\\\\\\"id\\\\\\":\\\\\\"MDExOlB1bGxSZXF1ZXN0MTcxODg3NzQx\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"repositoryName\\\\\\":\\\\\\"sourcecred/example-repo\\\\\\",\\\\\\"type\\\\\\":\\\\\\"PULL_REQUEST\\\\\\"}}\\"}": Object {
       "dst": Object {
-        "id": "{\\"id\\":\\"MDQ6VXNlcjE0MDAwMjM=\\",\\"type\\":\\"USER\\"}",
+        "id": "MDQ6VXNlcjE0MDAwMjM=",
         "pluginName": "sourcecred/github-beta",
         "repositoryName": "sourcecred/example-repo",
+        "type": "USER",
       },
       "payload": Object {},
       "src": Object {
-        "id": "{\\"id\\":\\"MDExOlB1bGxSZXF1ZXN0MTcxODg3NzQx\\",\\"type\\":\\"PULL_REQUEST\\"}",
+        "id": "MDExOlB1bGxSZXF1ZXN0MTcxODg3NzQx",
         "pluginName": "sourcecred/github-beta",
         "repositoryName": "sourcecred/example-repo",
+        "type": "PULL_REQUEST",
       },
     },
-    "{\\"pluginName\\":\\"sourcecred/github-beta\\",\\"repositoryName\\":\\"sourcecred/example-repo\\",\\"id\\":\\"{\\\\\\"authorID\\\\\\":{\\\\\\"id\\\\\\":\\\\\\"MDQ6VXNlcjE0MDAwMjM=\\\\\\",\\\\\\"type\\\\\\":\\\\\\"USER\\\\\\"},\\\\\\"contributionID\\\\\\":{\\\\\\"id\\\\\\":\\\\\\"MDExOlB1bGxSZXF1ZXN0MTcxODg4NTIy\\\\\\",\\\\\\"type\\\\\\":\\\\\\"PULL_REQUEST\\\\\\"},\\\\\\"type\\\\\\":\\\\\\"AUTHORSHIP\\\\\\"}\\"}": Object {
+    "{\\"pluginName\\":\\"sourcecred/github-beta\\",\\"repositoryName\\":\\"sourcecred/example-repo\\",\\"type\\":\\"AUTHORSHIP\\",\\"id\\":\\"{\\\\\\"author\\\\\\":{\\\\\\"id\\\\\\":\\\\\\"MDQ6VXNlcjE0MDAwMjM=\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"repositoryName\\\\\\":\\\\\\"sourcecred/example-repo\\\\\\",\\\\\\"type\\\\\\":\\\\\\"USER\\\\\\"},\\\\\\"contribution\\\\\\":{\\\\\\"id\\\\\\":\\\\\\"MDExOlB1bGxSZXF1ZXN0MTcxODg4NTIy\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"repositoryName\\\\\\":\\\\\\"sourcecred/example-repo\\\\\\",\\\\\\"type\\\\\\":\\\\\\"PULL_REQUEST\\\\\\"}}\\"}": Object {
       "dst": Object {
-        "id": "{\\"id\\":\\"MDQ6VXNlcjE0MDAwMjM=\\",\\"type\\":\\"USER\\"}",
+        "id": "MDQ6VXNlcjE0MDAwMjM=",
         "pluginName": "sourcecred/github-beta",
         "repositoryName": "sourcecred/example-repo",
+        "type": "USER",
       },
       "payload": Object {},
       "src": Object {
-        "id": "{\\"id\\":\\"MDExOlB1bGxSZXF1ZXN0MTcxODg4NTIy\\",\\"type\\":\\"PULL_REQUEST\\"}",
+        "id": "MDExOlB1bGxSZXF1ZXN0MTcxODg4NTIy",
         "pluginName": "sourcecred/github-beta",
         "repositoryName": "sourcecred/example-repo",
+        "type": "PULL_REQUEST",
       },
     },
-    "{\\"pluginName\\":\\"sourcecred/github-beta\\",\\"repositoryName\\":\\"sourcecred/example-repo\\",\\"id\\":\\"{\\\\\\"authorID\\\\\\":{\\\\\\"id\\\\\\":\\\\\\"MDQ6VXNlcjE0MDAwMjM=\\\\\\",\\\\\\"type\\\\\\":\\\\\\"USER\\\\\\"},\\\\\\"contributionID\\\\\\":{\\\\\\"id\\\\\\":\\\\\\"MDEyOklzc3VlQ29tbWVudDM2OTE2MjIyMg==\\\\\\",\\\\\\"type\\\\\\":\\\\\\"COMMENT\\\\\\"},\\\\\\"type\\\\\\":\\\\\\"AUTHORSHIP\\\\\\"}\\"}": Object {
+    "{\\"pluginName\\":\\"sourcecred/github-beta\\",\\"repositoryName\\":\\"sourcecred/example-repo\\",\\"type\\":\\"AUTHORSHIP\\",\\"id\\":\\"{\\\\\\"author\\\\\\":{\\\\\\"id\\\\\\":\\\\\\"MDQ6VXNlcjE0MDAwMjM=\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"repositoryName\\\\\\":\\\\\\"sourcecred/example-repo\\\\\\",\\\\\\"type\\\\\\":\\\\\\"USER\\\\\\"},\\\\\\"contribution\\\\\\":{\\\\\\"id\\\\\\":\\\\\\"MDEyOklzc3VlQ29tbWVudDM2OTE2MjIyMg==\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"repositoryName\\\\\\":\\\\\\"sourcecred/example-repo\\\\\\",\\\\\\"type\\\\\\":\\\\\\"COMMENT\\\\\\"}}\\"}": Object {
       "dst": Object {
-        "id": "{\\"id\\":\\"MDQ6VXNlcjE0MDAwMjM=\\",\\"type\\":\\"USER\\"}",
+        "id": "MDQ6VXNlcjE0MDAwMjM=",
         "pluginName": "sourcecred/github-beta",
         "repositoryName": "sourcecred/example-repo",
+        "type": "USER",
       },
       "payload": Object {},
       "src": Object {
-        "id": "{\\"id\\":\\"MDEyOklzc3VlQ29tbWVudDM2OTE2MjIyMg==\\",\\"type\\":\\"COMMENT\\"}",
+        "id": "MDEyOklzc3VlQ29tbWVudDM2OTE2MjIyMg==",
         "pluginName": "sourcecred/github-beta",
         "repositoryName": "sourcecred/example-repo",
+        "type": "COMMENT",
       },
     },
-    "{\\"pluginName\\":\\"sourcecred/github-beta\\",\\"repositoryName\\":\\"sourcecred/example-repo\\",\\"id\\":\\"{\\\\\\"authorID\\\\\\":{\\\\\\"id\\\\\\":\\\\\\"MDQ6VXNlcjE0MDAwMjM=\\\\\\",\\\\\\"type\\\\\\":\\\\\\"USER\\\\\\"},\\\\\\"contributionID\\\\\\":{\\\\\\"id\\\\\\":\\\\\\"MDEyOklzc3VlQ29tbWVudDM3Mzc2ODQ0Mg==\\\\\\",\\\\\\"type\\\\\\":\\\\\\"COMMENT\\\\\\"},\\\\\\"type\\\\\\":\\\\\\"AUTHORSHIP\\\\\\"}\\"}": Object {
+    "{\\"pluginName\\":\\"sourcecred/github-beta\\",\\"repositoryName\\":\\"sourcecred/example-repo\\",\\"type\\":\\"AUTHORSHIP\\",\\"id\\":\\"{\\\\\\"author\\\\\\":{\\\\\\"id\\\\\\":\\\\\\"MDQ6VXNlcjE0MDAwMjM=\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"repositoryName\\\\\\":\\\\\\"sourcecred/example-repo\\\\\\",\\\\\\"type\\\\\\":\\\\\\"USER\\\\\\"},\\\\\\"contribution\\\\\\":{\\\\\\"id\\\\\\":\\\\\\"MDEyOklzc3VlQ29tbWVudDM3Mzc2ODQ0Mg==\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"repositoryName\\\\\\":\\\\\\"sourcecred/example-repo\\\\\\",\\\\\\"type\\\\\\":\\\\\\"COMMENT\\\\\\"}}\\"}": Object {
       "dst": Object {
-        "id": "{\\"id\\":\\"MDQ6VXNlcjE0MDAwMjM=\\",\\"type\\":\\"USER\\"}",
+        "id": "MDQ6VXNlcjE0MDAwMjM=",
         "pluginName": "sourcecred/github-beta",
         "repositoryName": "sourcecred/example-repo",
+        "type": "USER",
       },
       "payload": Object {},
       "src": Object {
-        "id": "{\\"id\\":\\"MDEyOklzc3VlQ29tbWVudDM3Mzc2ODQ0Mg==\\",\\"type\\":\\"COMMENT\\"}",
+        "id": "MDEyOklzc3VlQ29tbWVudDM3Mzc2ODQ0Mg==",
         "pluginName": "sourcecred/github-beta",
         "repositoryName": "sourcecred/example-repo",
+        "type": "COMMENT",
       },
     },
-    "{\\"pluginName\\":\\"sourcecred/github-beta\\",\\"repositoryName\\":\\"sourcecred/example-repo\\",\\"id\\":\\"{\\\\\\"authorID\\\\\\":{\\\\\\"id\\\\\\":\\\\\\"MDQ6VXNlcjE0MDAwMjM=\\\\\\",\\\\\\"type\\\\\\":\\\\\\"USER\\\\\\"},\\\\\\"contributionID\\\\\\":{\\\\\\"id\\\\\\":\\\\\\"MDEyOklzc3VlQ29tbWVudDM3Mzc2ODUzOA==\\\\\\",\\\\\\"type\\\\\\":\\\\\\"COMMENT\\\\\\"},\\\\\\"type\\\\\\":\\\\\\"AUTHORSHIP\\\\\\"}\\"}": Object {
+    "{\\"pluginName\\":\\"sourcecred/github-beta\\",\\"repositoryName\\":\\"sourcecred/example-repo\\",\\"type\\":\\"AUTHORSHIP\\",\\"id\\":\\"{\\\\\\"author\\\\\\":{\\\\\\"id\\\\\\":\\\\\\"MDQ6VXNlcjE0MDAwMjM=\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"repositoryName\\\\\\":\\\\\\"sourcecred/example-repo\\\\\\",\\\\\\"type\\\\\\":\\\\\\"USER\\\\\\"},\\\\\\"contribution\\\\\\":{\\\\\\"id\\\\\\":\\\\\\"MDEyOklzc3VlQ29tbWVudDM3Mzc2ODUzOA==\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"repositoryName\\\\\\":\\\\\\"sourcecred/example-repo\\\\\\",\\\\\\"type\\\\\\":\\\\\\"COMMENT\\\\\\"}}\\"}": Object {
       "dst": Object {
-        "id": "{\\"id\\":\\"MDQ6VXNlcjE0MDAwMjM=\\",\\"type\\":\\"USER\\"}",
+        "id": "MDQ6VXNlcjE0MDAwMjM=",
         "pluginName": "sourcecred/github-beta",
         "repositoryName": "sourcecred/example-repo",
+        "type": "USER",
       },
       "payload": Object {},
       "src": Object {
-        "id": "{\\"id\\":\\"MDEyOklzc3VlQ29tbWVudDM3Mzc2ODUzOA==\\",\\"type\\":\\"COMMENT\\"}",
+        "id": "MDEyOklzc3VlQ29tbWVudDM3Mzc2ODUzOA==",
         "pluginName": "sourcecred/github-beta",
         "repositoryName": "sourcecred/example-repo",
+        "type": "COMMENT",
       },
     },
-    "{\\"pluginName\\":\\"sourcecred/github-beta\\",\\"repositoryName\\":\\"sourcecred/example-repo\\",\\"id\\":\\"{\\\\\\"authorID\\\\\\":{\\\\\\"id\\\\\\":\\\\\\"MDQ6VXNlcjE0MDAwMjM=\\\\\\",\\\\\\"type\\\\\\":\\\\\\"USER\\\\\\"},\\\\\\"contributionID\\\\\\":{\\\\\\"id\\\\\\":\\\\\\"MDEyOklzc3VlQ29tbWVudDM3Mzc2ODcwMw==\\\\\\",\\\\\\"type\\\\\\":\\\\\\"COMMENT\\\\\\"},\\\\\\"type\\\\\\":\\\\\\"AUTHORSHIP\\\\\\"}\\"}": Object {
+    "{\\"pluginName\\":\\"sourcecred/github-beta\\",\\"repositoryName\\":\\"sourcecred/example-repo\\",\\"type\\":\\"AUTHORSHIP\\",\\"id\\":\\"{\\\\\\"author\\\\\\":{\\\\\\"id\\\\\\":\\\\\\"MDQ6VXNlcjE0MDAwMjM=\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"repositoryName\\\\\\":\\\\\\"sourcecred/example-repo\\\\\\",\\\\\\"type\\\\\\":\\\\\\"USER\\\\\\"},\\\\\\"contribution\\\\\\":{\\\\\\"id\\\\\\":\\\\\\"MDEyOklzc3VlQ29tbWVudDM3Mzc2ODcwMw==\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"repositoryName\\\\\\":\\\\\\"sourcecred/example-repo\\\\\\",\\\\\\"type\\\\\\":\\\\\\"COMMENT\\\\\\"}}\\"}": Object {
       "dst": Object {
-        "id": "{\\"id\\":\\"MDQ6VXNlcjE0MDAwMjM=\\",\\"type\\":\\"USER\\"}",
+        "id": "MDQ6VXNlcjE0MDAwMjM=",
         "pluginName": "sourcecred/github-beta",
         "repositoryName": "sourcecred/example-repo",
+        "type": "USER",
       },
       "payload": Object {},
       "src": Object {
-        "id": "{\\"id\\":\\"MDEyOklzc3VlQ29tbWVudDM3Mzc2ODcwMw==\\",\\"type\\":\\"COMMENT\\"}",
+        "id": "MDEyOklzc3VlQ29tbWVudDM3Mzc2ODcwMw==",
         "pluginName": "sourcecred/github-beta",
         "repositoryName": "sourcecred/example-repo",
+        "type": "COMMENT",
       },
     },
-    "{\\"pluginName\\":\\"sourcecred/github-beta\\",\\"repositoryName\\":\\"sourcecred/example-repo\\",\\"id\\":\\"{\\\\\\"authorID\\\\\\":{\\\\\\"id\\\\\\":\\\\\\"MDQ6VXNlcjE0MDAwMjM=\\\\\\",\\\\\\"type\\\\\\":\\\\\\"USER\\\\\\"},\\\\\\"contributionID\\\\\\":{\\\\\\"id\\\\\\":\\\\\\"MDEyOklzc3VlQ29tbWVudDM3Mzc2ODg1MA==\\\\\\",\\\\\\"type\\\\\\":\\\\\\"COMMENT\\\\\\"},\\\\\\"type\\\\\\":\\\\\\"AUTHORSHIP\\\\\\"}\\"}": Object {
+    "{\\"pluginName\\":\\"sourcecred/github-beta\\",\\"repositoryName\\":\\"sourcecred/example-repo\\",\\"type\\":\\"AUTHORSHIP\\",\\"id\\":\\"{\\\\\\"author\\\\\\":{\\\\\\"id\\\\\\":\\\\\\"MDQ6VXNlcjE0MDAwMjM=\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"repositoryName\\\\\\":\\\\\\"sourcecred/example-repo\\\\\\",\\\\\\"type\\\\\\":\\\\\\"USER\\\\\\"},\\\\\\"contribution\\\\\\":{\\\\\\"id\\\\\\":\\\\\\"MDEyOklzc3VlQ29tbWVudDM3Mzc2ODg1MA==\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"repositoryName\\\\\\":\\\\\\"sourcecred/example-repo\\\\\\",\\\\\\"type\\\\\\":\\\\\\"COMMENT\\\\\\"}}\\"}": Object {
       "dst": Object {
-        "id": "{\\"id\\":\\"MDQ6VXNlcjE0MDAwMjM=\\",\\"type\\":\\"USER\\"}",
+        "id": "MDQ6VXNlcjE0MDAwMjM=",
         "pluginName": "sourcecred/github-beta",
         "repositoryName": "sourcecred/example-repo",
+        "type": "USER",
       },
       "payload": Object {},
       "src": Object {
-        "id": "{\\"id\\":\\"MDEyOklzc3VlQ29tbWVudDM3Mzc2ODg1MA==\\",\\"type\\":\\"COMMENT\\"}",
+        "id": "MDEyOklzc3VlQ29tbWVudDM3Mzc2ODg1MA==",
         "pluginName": "sourcecred/github-beta",
         "repositoryName": "sourcecred/example-repo",
+        "type": "COMMENT",
       },
     },
-    "{\\"pluginName\\":\\"sourcecred/github-beta\\",\\"repositoryName\\":\\"sourcecred/example-repo\\",\\"id\\":\\"{\\\\\\"authorID\\\\\\":{\\\\\\"id\\\\\\":\\\\\\"MDQ6VXNlcjE0MDAwMjM=\\\\\\",\\\\\\"type\\\\\\":\\\\\\"USER\\\\\\"},\\\\\\"contributionID\\\\\\":{\\\\\\"id\\\\\\":\\\\\\"MDU6SXNzdWUzMDA5MzQ4MTg=\\\\\\",\\\\\\"type\\\\\\":\\\\\\"ISSUE\\\\\\"},\\\\\\"type\\\\\\":\\\\\\"AUTHORSHIP\\\\\\"}\\"}": Object {
+    "{\\"pluginName\\":\\"sourcecred/github-beta\\",\\"repositoryName\\":\\"sourcecred/example-repo\\",\\"type\\":\\"AUTHORSHIP\\",\\"id\\":\\"{\\\\\\"author\\\\\\":{\\\\\\"id\\\\\\":\\\\\\"MDQ6VXNlcjE0MDAwMjM=\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"repositoryName\\\\\\":\\\\\\"sourcecred/example-repo\\\\\\",\\\\\\"type\\\\\\":\\\\\\"USER\\\\\\"},\\\\\\"contribution\\\\\\":{\\\\\\"id\\\\\\":\\\\\\"MDU6SXNzdWUzMDA5MzQ4MTg=\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"repositoryName\\\\\\":\\\\\\"sourcecred/example-repo\\\\\\",\\\\\\"type\\\\\\":\\\\\\"ISSUE\\\\\\"}}\\"}": Object {
       "dst": Object {
-        "id": "{\\"id\\":\\"MDQ6VXNlcjE0MDAwMjM=\\",\\"type\\":\\"USER\\"}",
+        "id": "MDQ6VXNlcjE0MDAwMjM=",
         "pluginName": "sourcecred/github-beta",
         "repositoryName": "sourcecred/example-repo",
+        "type": "USER",
       },
       "payload": Object {},
       "src": Object {
-        "id": "{\\"id\\":\\"MDU6SXNzdWUzMDA5MzQ4MTg=\\",\\"type\\":\\"ISSUE\\"}",
+        "id": "MDU6SXNzdWUzMDA5MzQ4MTg=",
         "pluginName": "sourcecred/github-beta",
         "repositoryName": "sourcecred/example-repo",
+        "type": "ISSUE",
       },
     },
-    "{\\"pluginName\\":\\"sourcecred/github-beta\\",\\"repositoryName\\":\\"sourcecred/example-repo\\",\\"id\\":\\"{\\\\\\"authorID\\\\\\":{\\\\\\"id\\\\\\":\\\\\\"MDQ6VXNlcjE0MDAwMjM=\\\\\\",\\\\\\"type\\\\\\":\\\\\\"USER\\\\\\"},\\\\\\"contributionID\\\\\\":{\\\\\\"id\\\\\\":\\\\\\"MDU6SXNzdWUzMDA5MzQ5ODA=\\\\\\",\\\\\\"type\\\\\\":\\\\\\"ISSUE\\\\\\"},\\\\\\"type\\\\\\":\\\\\\"AUTHORSHIP\\\\\\"}\\"}": Object {
+    "{\\"pluginName\\":\\"sourcecred/github-beta\\",\\"repositoryName\\":\\"sourcecred/example-repo\\",\\"type\\":\\"AUTHORSHIP\\",\\"id\\":\\"{\\\\\\"author\\\\\\":{\\\\\\"id\\\\\\":\\\\\\"MDQ6VXNlcjE0MDAwMjM=\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"repositoryName\\\\\\":\\\\\\"sourcecred/example-repo\\\\\\",\\\\\\"type\\\\\\":\\\\\\"USER\\\\\\"},\\\\\\"contribution\\\\\\":{\\\\\\"id\\\\\\":\\\\\\"MDU6SXNzdWUzMDA5MzQ5ODA=\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"repositoryName\\\\\\":\\\\\\"sourcecred/example-repo\\\\\\",\\\\\\"type\\\\\\":\\\\\\"ISSUE\\\\\\"}}\\"}": Object {
       "dst": Object {
-        "id": "{\\"id\\":\\"MDQ6VXNlcjE0MDAwMjM=\\",\\"type\\":\\"USER\\"}",
+        "id": "MDQ6VXNlcjE0MDAwMjM=",
         "pluginName": "sourcecred/github-beta",
         "repositoryName": "sourcecred/example-repo",
+        "type": "USER",
       },
       "payload": Object {},
       "src": Object {
-        "id": "{\\"id\\":\\"MDU6SXNzdWUzMDA5MzQ5ODA=\\",\\"type\\":\\"ISSUE\\"}",
+        "id": "MDU6SXNzdWUzMDA5MzQ5ODA=",
         "pluginName": "sourcecred/github-beta",
         "repositoryName": "sourcecred/example-repo",
+        "type": "ISSUE",
       },
     },
-    "{\\"pluginName\\":\\"sourcecred/github-beta\\",\\"repositoryName\\":\\"sourcecred/example-repo\\",\\"id\\":\\"{\\\\\\"authorID\\\\\\":{\\\\\\"id\\\\\\":\\\\\\"MDQ6VXNlcjE0MDAwMjM=\\\\\\",\\\\\\"type\\\\\\":\\\\\\"USER\\\\\\"},\\\\\\"contributionID\\\\\\":{\\\\\\"id\\\\\\":\\\\\\"MDU6SXNzdWUzMDA5MzYzNzQ=\\\\\\",\\\\\\"type\\\\\\":\\\\\\"ISSUE\\\\\\"},\\\\\\"type\\\\\\":\\\\\\"AUTHORSHIP\\\\\\"}\\"}": Object {
+    "{\\"pluginName\\":\\"sourcecred/github-beta\\",\\"repositoryName\\":\\"sourcecred/example-repo\\",\\"type\\":\\"AUTHORSHIP\\",\\"id\\":\\"{\\\\\\"author\\\\\\":{\\\\\\"id\\\\\\":\\\\\\"MDQ6VXNlcjE0MDAwMjM=\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"repositoryName\\\\\\":\\\\\\"sourcecred/example-repo\\\\\\",\\\\\\"type\\\\\\":\\\\\\"USER\\\\\\"},\\\\\\"contribution\\\\\\":{\\\\\\"id\\\\\\":\\\\\\"MDU6SXNzdWUzMDA5MzYzNzQ=\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"repositoryName\\\\\\":\\\\\\"sourcecred/example-repo\\\\\\",\\\\\\"type\\\\\\":\\\\\\"ISSUE\\\\\\"}}\\"}": Object {
       "dst": Object {
-        "id": "{\\"id\\":\\"MDQ6VXNlcjE0MDAwMjM=\\",\\"type\\":\\"USER\\"}",
+        "id": "MDQ6VXNlcjE0MDAwMjM=",
         "pluginName": "sourcecred/github-beta",
         "repositoryName": "sourcecred/example-repo",
+        "type": "USER",
       },
       "payload": Object {},
       "src": Object {
-        "id": "{\\"id\\":\\"MDU6SXNzdWUzMDA5MzYzNzQ=\\",\\"type\\":\\"ISSUE\\"}",
+        "id": "MDU6SXNzdWUzMDA5MzYzNzQ=",
         "pluginName": "sourcecred/github-beta",
         "repositoryName": "sourcecred/example-repo",
+        "type": "ISSUE",
       },
     },
-    "{\\"pluginName\\":\\"sourcecred/github-beta\\",\\"repositoryName\\":\\"sourcecred/example-repo\\",\\"id\\":\\"{\\\\\\"authorID\\\\\\":{\\\\\\"id\\\\\\":\\\\\\"MDQ6VXNlcjE0MDAwMjM=\\\\\\",\\\\\\"type\\\\\\":\\\\\\"USER\\\\\\"},\\\\\\"contributionID\\\\\\":{\\\\\\"id\\\\\\":\\\\\\"MDU6SXNzdWUzMDU5OTM3NzM=\\\\\\",\\\\\\"type\\\\\\":\\\\\\"ISSUE\\\\\\"},\\\\\\"type\\\\\\":\\\\\\"AUTHORSHIP\\\\\\"}\\"}": Object {
+    "{\\"pluginName\\":\\"sourcecred/github-beta\\",\\"repositoryName\\":\\"sourcecred/example-repo\\",\\"type\\":\\"AUTHORSHIP\\",\\"id\\":\\"{\\\\\\"author\\\\\\":{\\\\\\"id\\\\\\":\\\\\\"MDQ6VXNlcjE0MDAwMjM=\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"repositoryName\\\\\\":\\\\\\"sourcecred/example-repo\\\\\\",\\\\\\"type\\\\\\":\\\\\\"USER\\\\\\"},\\\\\\"contribution\\\\\\":{\\\\\\"id\\\\\\":\\\\\\"MDU6SXNzdWUzMDU5OTM3NzM=\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"repositoryName\\\\\\":\\\\\\"sourcecred/example-repo\\\\\\",\\\\\\"type\\\\\\":\\\\\\"ISSUE\\\\\\"}}\\"}": Object {
       "dst": Object {
-        "id": "{\\"id\\":\\"MDQ6VXNlcjE0MDAwMjM=\\",\\"type\\":\\"USER\\"}",
+        "id": "MDQ6VXNlcjE0MDAwMjM=",
         "pluginName": "sourcecred/github-beta",
         "repositoryName": "sourcecred/example-repo",
+        "type": "USER",
       },
       "payload": Object {},
       "src": Object {
-        "id": "{\\"id\\":\\"MDU6SXNzdWUzMDU5OTM3NzM=\\",\\"type\\":\\"ISSUE\\"}",
+        "id": "MDU6SXNzdWUzMDU5OTM3NzM=",
         "pluginName": "sourcecred/github-beta",
         "repositoryName": "sourcecred/example-repo",
+        "type": "ISSUE",
       },
     },
-    "{\\"pluginName\\":\\"sourcecred/github-beta\\",\\"repositoryName\\":\\"sourcecred/example-repo\\",\\"id\\":\\"{\\\\\\"authorID\\\\\\":{\\\\\\"id\\\\\\":\\\\\\"MDQ6VXNlcjE0MDAwMjM=\\\\\\",\\\\\\"type\\\\\\":\\\\\\"USER\\\\\\"},\\\\\\"contributionID\\\\\\":{\\\\\\"id\\\\\\":\\\\\\"MDU6SXNzdWUzMDY5ODM1NTI=\\\\\\",\\\\\\"type\\\\\\":\\\\\\"ISSUE\\\\\\"},\\\\\\"type\\\\\\":\\\\\\"AUTHORSHIP\\\\\\"}\\"}": Object {
+    "{\\"pluginName\\":\\"sourcecred/github-beta\\",\\"repositoryName\\":\\"sourcecred/example-repo\\",\\"type\\":\\"AUTHORSHIP\\",\\"id\\":\\"{\\\\\\"author\\\\\\":{\\\\\\"id\\\\\\":\\\\\\"MDQ6VXNlcjE0MDAwMjM=\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"repositoryName\\\\\\":\\\\\\"sourcecred/example-repo\\\\\\",\\\\\\"type\\\\\\":\\\\\\"USER\\\\\\"},\\\\\\"contribution\\\\\\":{\\\\\\"id\\\\\\":\\\\\\"MDU6SXNzdWUzMDY5ODM1NTI=\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"repositoryName\\\\\\":\\\\\\"sourcecred/example-repo\\\\\\",\\\\\\"type\\\\\\":\\\\\\"ISSUE\\\\\\"}}\\"}": Object {
       "dst": Object {
-        "id": "{\\"id\\":\\"MDQ6VXNlcjE0MDAwMjM=\\",\\"type\\":\\"USER\\"}",
+        "id": "MDQ6VXNlcjE0MDAwMjM=",
         "pluginName": "sourcecred/github-beta",
         "repositoryName": "sourcecred/example-repo",
+        "type": "USER",
       },
       "payload": Object {},
       "src": Object {
-        "id": "{\\"id\\":\\"MDU6SXNzdWUzMDY5ODM1NTI=\\",\\"type\\":\\"ISSUE\\"}",
+        "id": "MDU6SXNzdWUzMDY5ODM1NTI=",
         "pluginName": "sourcecred/github-beta",
         "repositoryName": "sourcecred/example-repo",
+        "type": "ISSUE",
       },
     },
-    "{\\"pluginName\\":\\"sourcecred/github-beta\\",\\"repositoryName\\":\\"sourcecred/example-repo\\",\\"id\\":\\"{\\\\\\"authorID\\\\\\":{\\\\\\"id\\\\\\":\\\\\\"MDQ6VXNlcjE0MDAwMjM=\\\\\\",\\\\\\"type\\\\\\":\\\\\\"USER\\\\\\"},\\\\\\"contributionID\\\\\\":{\\\\\\"id\\\\\\":\\\\\\"MDU6SXNzdWUzMDY5ODUzNjc=\\\\\\",\\\\\\"type\\\\\\":\\\\\\"ISSUE\\\\\\"},\\\\\\"type\\\\\\":\\\\\\"AUTHORSHIP\\\\\\"}\\"}": Object {
+    "{\\"pluginName\\":\\"sourcecred/github-beta\\",\\"repositoryName\\":\\"sourcecred/example-repo\\",\\"type\\":\\"AUTHORSHIP\\",\\"id\\":\\"{\\\\\\"author\\\\\\":{\\\\\\"id\\\\\\":\\\\\\"MDQ6VXNlcjE0MDAwMjM=\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"repositoryName\\\\\\":\\\\\\"sourcecred/example-repo\\\\\\",\\\\\\"type\\\\\\":\\\\\\"USER\\\\\\"},\\\\\\"contribution\\\\\\":{\\\\\\"id\\\\\\":\\\\\\"MDU6SXNzdWUzMDY5ODUzNjc=\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"repositoryName\\\\\\":\\\\\\"sourcecred/example-repo\\\\\\",\\\\\\"type\\\\\\":\\\\\\"ISSUE\\\\\\"}}\\"}": Object {
       "dst": Object {
-        "id": "{\\"id\\":\\"MDQ6VXNlcjE0MDAwMjM=\\",\\"type\\":\\"USER\\"}",
+        "id": "MDQ6VXNlcjE0MDAwMjM=",
         "pluginName": "sourcecred/github-beta",
         "repositoryName": "sourcecred/example-repo",
+        "type": "USER",
       },
       "payload": Object {},
       "src": Object {
-        "id": "{\\"id\\":\\"MDU6SXNzdWUzMDY5ODUzNjc=\\",\\"type\\":\\"ISSUE\\"}",
+        "id": "MDU6SXNzdWUzMDY5ODUzNjc=",
         "pluginName": "sourcecred/github-beta",
         "repositoryName": "sourcecred/example-repo",
+        "type": "ISSUE",
       },
     },
-    "{\\"pluginName\\":\\"sourcecred/github-beta\\",\\"repositoryName\\":\\"sourcecred/example-repo\\",\\"id\\":\\"{\\\\\\"authorID\\\\\\":{\\\\\\"id\\\\\\":\\\\\\"MDQ6VXNlcjQzMTc4MDY=\\\\\\",\\\\\\"type\\\\\\":\\\\\\"USER\\\\\\"},\\\\\\"contributionID\\\\\\":{\\\\\\"id\\\\\\":\\\\\\"MDE3OlB1bGxSZXF1ZXN0UmV2aWV3MTAwMzE0MDM4\\\\\\",\\\\\\"type\\\\\\":\\\\\\"PULL_REQUEST_REVIEW\\\\\\"},\\\\\\"type\\\\\\":\\\\\\"AUTHORSHIP\\\\\\"}\\"}": Object {
+    "{\\"pluginName\\":\\"sourcecred/github-beta\\",\\"repositoryName\\":\\"sourcecred/example-repo\\",\\"type\\":\\"AUTHORSHIP\\",\\"id\\":\\"{\\\\\\"author\\\\\\":{\\\\\\"id\\\\\\":\\\\\\"MDQ6VXNlcjQzMTc4MDY=\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"repositoryName\\\\\\":\\\\\\"sourcecred/example-repo\\\\\\",\\\\\\"type\\\\\\":\\\\\\"USER\\\\\\"},\\\\\\"contribution\\\\\\":{\\\\\\"id\\\\\\":\\\\\\"MDE3OlB1bGxSZXF1ZXN0UmV2aWV3MTAwMzE0MDM4\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"repositoryName\\\\\\":\\\\\\"sourcecred/example-repo\\\\\\",\\\\\\"type\\\\\\":\\\\\\"PULL_REQUEST_REVIEW\\\\\\"}}\\"}": Object {
       "dst": Object {
-        "id": "{\\"id\\":\\"MDQ6VXNlcjQzMTc4MDY=\\",\\"type\\":\\"USER\\"}",
+        "id": "MDQ6VXNlcjQzMTc4MDY=",
         "pluginName": "sourcecred/github-beta",
         "repositoryName": "sourcecred/example-repo",
+        "type": "USER",
       },
       "payload": Object {},
       "src": Object {
-        "id": "{\\"id\\":\\"MDE3OlB1bGxSZXF1ZXN0UmV2aWV3MTAwMzE0MDM4\\",\\"type\\":\\"PULL_REQUEST_REVIEW\\"}",
+        "id": "MDE3OlB1bGxSZXF1ZXN0UmV2aWV3MTAwMzE0MDM4",
         "pluginName": "sourcecred/github-beta",
         "repositoryName": "sourcecred/example-repo",
+        "type": "PULL_REQUEST_REVIEW",
       },
     },
-    "{\\"pluginName\\":\\"sourcecred/github-beta\\",\\"repositoryName\\":\\"sourcecred/example-repo\\",\\"id\\":\\"{\\\\\\"authorID\\\\\\":{\\\\\\"id\\\\\\":\\\\\\"MDQ6VXNlcjQzMTc4MDY=\\\\\\",\\\\\\"type\\\\\\":\\\\\\"USER\\\\\\"},\\\\\\"contributionID\\\\\\":{\\\\\\"id\\\\\\":\\\\\\"MDE3OlB1bGxSZXF1ZXN0UmV2aWV3MTAwMzEzODk5\\\\\\",\\\\\\"type\\\\\\":\\\\\\"PULL_REQUEST_REVIEW\\\\\\"},\\\\\\"type\\\\\\":\\\\\\"AUTHORSHIP\\\\\\"}\\"}": Object {
+    "{\\"pluginName\\":\\"sourcecred/github-beta\\",\\"repositoryName\\":\\"sourcecred/example-repo\\",\\"type\\":\\"AUTHORSHIP\\",\\"id\\":\\"{\\\\\\"author\\\\\\":{\\\\\\"id\\\\\\":\\\\\\"MDQ6VXNlcjQzMTc4MDY=\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"repositoryName\\\\\\":\\\\\\"sourcecred/example-repo\\\\\\",\\\\\\"type\\\\\\":\\\\\\"USER\\\\\\"},\\\\\\"contribution\\\\\\":{\\\\\\"id\\\\\\":\\\\\\"MDE3OlB1bGxSZXF1ZXN0UmV2aWV3MTAwMzEzODk5\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"repositoryName\\\\\\":\\\\\\"sourcecred/example-repo\\\\\\",\\\\\\"type\\\\\\":\\\\\\"PULL_REQUEST_REVIEW\\\\\\"}}\\"}": Object {
       "dst": Object {
-        "id": "{\\"id\\":\\"MDQ6VXNlcjQzMTc4MDY=\\",\\"type\\":\\"USER\\"}",
+        "id": "MDQ6VXNlcjQzMTc4MDY=",
         "pluginName": "sourcecred/github-beta",
         "repositoryName": "sourcecred/example-repo",
+        "type": "USER",
       },
       "payload": Object {},
       "src": Object {
-        "id": "{\\"id\\":\\"MDE3OlB1bGxSZXF1ZXN0UmV2aWV3MTAwMzEzODk5\\",\\"type\\":\\"PULL_REQUEST_REVIEW\\"}",
+        "id": "MDE3OlB1bGxSZXF1ZXN0UmV2aWV3MTAwMzEzODk5",
         "pluginName": "sourcecred/github-beta",
         "repositoryName": "sourcecred/example-repo",
+        "type": "PULL_REQUEST_REVIEW",
       },
     },
-    "{\\"pluginName\\":\\"sourcecred/github-beta\\",\\"repositoryName\\":\\"sourcecred/example-repo\\",\\"id\\":\\"{\\\\\\"authorID\\\\\\":{\\\\\\"id\\\\\\":\\\\\\"MDQ6VXNlcjQzMTc4MDY=\\\\\\",\\\\\\"type\\\\\\":\\\\\\"USER\\\\\\"},\\\\\\"contributionID\\\\\\":{\\\\\\"id\\\\\\":\\\\\\"MDI0OlB1bGxSZXF1ZXN0UmV2aWV3Q29tbWVudDE3MTQ2MDE5OA==\\\\\\",\\\\\\"type\\\\\\":\\\\\\"PULL_REQUEST_REVIEW_COMMENT\\\\\\"},\\\\\\"type\\\\\\":\\\\\\"AUTHORSHIP\\\\\\"}\\"}": Object {
+    "{\\"pluginName\\":\\"sourcecred/github-beta\\",\\"repositoryName\\":\\"sourcecred/example-repo\\",\\"type\\":\\"AUTHORSHIP\\",\\"id\\":\\"{\\\\\\"author\\\\\\":{\\\\\\"id\\\\\\":\\\\\\"MDQ6VXNlcjQzMTc4MDY=\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"repositoryName\\\\\\":\\\\\\"sourcecred/example-repo\\\\\\",\\\\\\"type\\\\\\":\\\\\\"USER\\\\\\"},\\\\\\"contribution\\\\\\":{\\\\\\"id\\\\\\":\\\\\\"MDI0OlB1bGxSZXF1ZXN0UmV2aWV3Q29tbWVudDE3MTQ2MDE5OA==\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"repositoryName\\\\\\":\\\\\\"sourcecred/example-repo\\\\\\",\\\\\\"type\\\\\\":\\\\\\"PULL_REQUEST_REVIEW_COMMENT\\\\\\"}}\\"}": Object {
       "dst": Object {
-        "id": "{\\"id\\":\\"MDQ6VXNlcjQzMTc4MDY=\\",\\"type\\":\\"USER\\"}",
+        "id": "MDQ6VXNlcjQzMTc4MDY=",
         "pluginName": "sourcecred/github-beta",
         "repositoryName": "sourcecred/example-repo",
+        "type": "USER",
       },
       "payload": Object {},
       "src": Object {
-        "id": "{\\"id\\":\\"MDI0OlB1bGxSZXF1ZXN0UmV2aWV3Q29tbWVudDE3MTQ2MDE5OA==\\",\\"type\\":\\"PULL_REQUEST_REVIEW_COMMENT\\"}",
+        "id": "MDI0OlB1bGxSZXF1ZXN0UmV2aWV3Q29tbWVudDE3MTQ2MDE5OA==",
         "pluginName": "sourcecred/github-beta",
         "repositoryName": "sourcecred/example-repo",
+        "type": "PULL_REQUEST_REVIEW_COMMENT",
       },
     },
-    "{\\"pluginName\\":\\"sourcecred/github-beta\\",\\"repositoryName\\":\\"sourcecred/example-repo\\",\\"id\\":\\"{\\\\\\"childID\\\\\\":{\\\\\\"id\\\\\\":\\\\\\"MDE3OlB1bGxSZXF1ZXN0UmV2aWV3MTAwMzE0MDM4\\\\\\",\\\\\\"type\\\\\\":\\\\\\"PULL_REQUEST_REVIEW\\\\\\"},\\\\\\"parentID\\\\\\":{\\\\\\"id\\\\\\":\\\\\\"MDExOlB1bGxSZXF1ZXN0MTcxODg4NTIy\\\\\\",\\\\\\"type\\\\\\":\\\\\\"PULL_REQUEST\\\\\\"},\\\\\\"type\\\\\\":\\\\\\"CONTAINMENT\\\\\\"}\\"}": Object {
+    "{\\"pluginName\\":\\"sourcecred/github-beta\\",\\"repositoryName\\":\\"sourcecred/example-repo\\",\\"type\\":\\"CONTAINMENT\\",\\"id\\":\\"{\\\\\\"child\\\\\\":{\\\\\\"id\\\\\\":\\\\\\"MDE3OlB1bGxSZXF1ZXN0UmV2aWV3MTAwMzE0MDM4\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"repositoryName\\\\\\":\\\\\\"sourcecred/example-repo\\\\\\",\\\\\\"type\\\\\\":\\\\\\"PULL_REQUEST_REVIEW\\\\\\"},\\\\\\"parent\\\\\\":{\\\\\\"id\\\\\\":\\\\\\"MDExOlB1bGxSZXF1ZXN0MTcxODg4NTIy\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"repositoryName\\\\\\":\\\\\\"sourcecred/example-repo\\\\\\",\\\\\\"type\\\\\\":\\\\\\"PULL_REQUEST\\\\\\"}}\\"}": Object {
       "dst": Object {
-        "id": "{\\"id\\":\\"MDE3OlB1bGxSZXF1ZXN0UmV2aWV3MTAwMzE0MDM4\\",\\"type\\":\\"PULL_REQUEST_REVIEW\\"}",
+        "id": "MDE3OlB1bGxSZXF1ZXN0UmV2aWV3MTAwMzE0MDM4",
         "pluginName": "sourcecred/github-beta",
         "repositoryName": "sourcecred/example-repo",
+        "type": "PULL_REQUEST_REVIEW",
       },
       "payload": Object {},
       "src": Object {
-        "id": "{\\"id\\":\\"MDExOlB1bGxSZXF1ZXN0MTcxODg4NTIy\\",\\"type\\":\\"PULL_REQUEST\\"}",
+        "id": "MDExOlB1bGxSZXF1ZXN0MTcxODg4NTIy",
         "pluginName": "sourcecred/github-beta",
         "repositoryName": "sourcecred/example-repo",
+        "type": "PULL_REQUEST",
       },
     },
-    "{\\"pluginName\\":\\"sourcecred/github-beta\\",\\"repositoryName\\":\\"sourcecred/example-repo\\",\\"id\\":\\"{\\\\\\"childID\\\\\\":{\\\\\\"id\\\\\\":\\\\\\"MDE3OlB1bGxSZXF1ZXN0UmV2aWV3MTAwMzEzODk5\\\\\\",\\\\\\"type\\\\\\":\\\\\\"PULL_REQUEST_REVIEW\\\\\\"},\\\\\\"parentID\\\\\\":{\\\\\\"id\\\\\\":\\\\\\"MDExOlB1bGxSZXF1ZXN0MTcxODg4NTIy\\\\\\",\\\\\\"type\\\\\\":\\\\\\"PULL_REQUEST\\\\\\"},\\\\\\"type\\\\\\":\\\\\\"CONTAINMENT\\\\\\"}\\"}": Object {
+    "{\\"pluginName\\":\\"sourcecred/github-beta\\",\\"repositoryName\\":\\"sourcecred/example-repo\\",\\"type\\":\\"CONTAINMENT\\",\\"id\\":\\"{\\\\\\"child\\\\\\":{\\\\\\"id\\\\\\":\\\\\\"MDE3OlB1bGxSZXF1ZXN0UmV2aWV3MTAwMzEzODk5\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"repositoryName\\\\\\":\\\\\\"sourcecred/example-repo\\\\\\",\\\\\\"type\\\\\\":\\\\\\"PULL_REQUEST_REVIEW\\\\\\"},\\\\\\"parent\\\\\\":{\\\\\\"id\\\\\\":\\\\\\"MDExOlB1bGxSZXF1ZXN0MTcxODg4NTIy\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"repositoryName\\\\\\":\\\\\\"sourcecred/example-repo\\\\\\",\\\\\\"type\\\\\\":\\\\\\"PULL_REQUEST\\\\\\"}}\\"}": Object {
       "dst": Object {
-        "id": "{\\"id\\":\\"MDE3OlB1bGxSZXF1ZXN0UmV2aWV3MTAwMzEzODk5\\",\\"type\\":\\"PULL_REQUEST_REVIEW\\"}",
+        "id": "MDE3OlB1bGxSZXF1ZXN0UmV2aWV3MTAwMzEzODk5",
         "pluginName": "sourcecred/github-beta",
         "repositoryName": "sourcecred/example-repo",
+        "type": "PULL_REQUEST_REVIEW",
       },
       "payload": Object {},
       "src": Object {
-        "id": "{\\"id\\":\\"MDExOlB1bGxSZXF1ZXN0MTcxODg4NTIy\\",\\"type\\":\\"PULL_REQUEST\\"}",
+        "id": "MDExOlB1bGxSZXF1ZXN0MTcxODg4NTIy",
         "pluginName": "sourcecred/github-beta",
         "repositoryName": "sourcecred/example-repo",
+        "type": "PULL_REQUEST",
       },
     },
-    "{\\"pluginName\\":\\"sourcecred/github-beta\\",\\"repositoryName\\":\\"sourcecred/example-repo\\",\\"id\\":\\"{\\\\\\"childID\\\\\\":{\\\\\\"id\\\\\\":\\\\\\"MDEyOklzc3VlQ29tbWVudDM2OTE2MjIyMg==\\\\\\",\\\\\\"type\\\\\\":\\\\\\"COMMENT\\\\\\"},\\\\\\"parentID\\\\\\":{\\\\\\"id\\\\\\":\\\\\\"MDExOlB1bGxSZXF1ZXN0MTcxODg3NzQx\\\\\\",\\\\\\"type\\\\\\":\\\\\\"PULL_REQUEST\\\\\\"},\\\\\\"type\\\\\\":\\\\\\"CONTAINMENT\\\\\\"}\\"}": Object {
+    "{\\"pluginName\\":\\"sourcecred/github-beta\\",\\"repositoryName\\":\\"sourcecred/example-repo\\",\\"type\\":\\"CONTAINMENT\\",\\"id\\":\\"{\\\\\\"child\\\\\\":{\\\\\\"id\\\\\\":\\\\\\"MDEyOklzc3VlQ29tbWVudDM2OTE2MjIyMg==\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"repositoryName\\\\\\":\\\\\\"sourcecred/example-repo\\\\\\",\\\\\\"type\\\\\\":\\\\\\"COMMENT\\\\\\"},\\\\\\"parent\\\\\\":{\\\\\\"id\\\\\\":\\\\\\"MDExOlB1bGxSZXF1ZXN0MTcxODg3NzQx\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"repositoryName\\\\\\":\\\\\\"sourcecred/example-repo\\\\\\",\\\\\\"type\\\\\\":\\\\\\"PULL_REQUEST\\\\\\"}}\\"}": Object {
       "dst": Object {
-        "id": "{\\"id\\":\\"MDEyOklzc3VlQ29tbWVudDM2OTE2MjIyMg==\\",\\"type\\":\\"COMMENT\\"}",
+        "id": "MDEyOklzc3VlQ29tbWVudDM2OTE2MjIyMg==",
         "pluginName": "sourcecred/github-beta",
         "repositoryName": "sourcecred/example-repo",
+        "type": "COMMENT",
       },
       "payload": Object {},
       "src": Object {
-        "id": "{\\"id\\":\\"MDExOlB1bGxSZXF1ZXN0MTcxODg3NzQx\\",\\"type\\":\\"PULL_REQUEST\\"}",
+        "id": "MDExOlB1bGxSZXF1ZXN0MTcxODg3NzQx",
         "pluginName": "sourcecred/github-beta",
         "repositoryName": "sourcecred/example-repo",
+        "type": "PULL_REQUEST",
       },
     },
-    "{\\"pluginName\\":\\"sourcecred/github-beta\\",\\"repositoryName\\":\\"sourcecred/example-repo\\",\\"id\\":\\"{\\\\\\"childID\\\\\\":{\\\\\\"id\\\\\\":\\\\\\"MDEyOklzc3VlQ29tbWVudDM3Mzc2ODQ0Mg==\\\\\\",\\\\\\"type\\\\\\":\\\\\\"COMMENT\\\\\\"},\\\\\\"parentID\\\\\\":{\\\\\\"id\\\\\\":\\\\\\"MDU6SXNzdWUzMDU5OTM3NzM=\\\\\\",\\\\\\"type\\\\\\":\\\\\\"ISSUE\\\\\\"},\\\\\\"type\\\\\\":\\\\\\"CONTAINMENT\\\\\\"}\\"}": Object {
+    "{\\"pluginName\\":\\"sourcecred/github-beta\\",\\"repositoryName\\":\\"sourcecred/example-repo\\",\\"type\\":\\"CONTAINMENT\\",\\"id\\":\\"{\\\\\\"child\\\\\\":{\\\\\\"id\\\\\\":\\\\\\"MDEyOklzc3VlQ29tbWVudDM3Mzc2ODQ0Mg==\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"repositoryName\\\\\\":\\\\\\"sourcecred/example-repo\\\\\\",\\\\\\"type\\\\\\":\\\\\\"COMMENT\\\\\\"},\\\\\\"parent\\\\\\":{\\\\\\"id\\\\\\":\\\\\\"MDU6SXNzdWUzMDU5OTM3NzM=\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"repositoryName\\\\\\":\\\\\\"sourcecred/example-repo\\\\\\",\\\\\\"type\\\\\\":\\\\\\"ISSUE\\\\\\"}}\\"}": Object {
       "dst": Object {
-        "id": "{\\"id\\":\\"MDEyOklzc3VlQ29tbWVudDM3Mzc2ODQ0Mg==\\",\\"type\\":\\"COMMENT\\"}",
+        "id": "MDEyOklzc3VlQ29tbWVudDM3Mzc2ODQ0Mg==",
         "pluginName": "sourcecred/github-beta",
         "repositoryName": "sourcecred/example-repo",
+        "type": "COMMENT",
       },
       "payload": Object {},
       "src": Object {
-        "id": "{\\"id\\":\\"MDU6SXNzdWUzMDU5OTM3NzM=\\",\\"type\\":\\"ISSUE\\"}",
+        "id": "MDU6SXNzdWUzMDU5OTM3NzM=",
         "pluginName": "sourcecred/github-beta",
         "repositoryName": "sourcecred/example-repo",
+        "type": "ISSUE",
       },
     },
-    "{\\"pluginName\\":\\"sourcecred/github-beta\\",\\"repositoryName\\":\\"sourcecred/example-repo\\",\\"id\\":\\"{\\\\\\"childID\\\\\\":{\\\\\\"id\\\\\\":\\\\\\"MDEyOklzc3VlQ29tbWVudDM3Mzc2ODUzOA==\\\\\\",\\\\\\"type\\\\\\":\\\\\\"COMMENT\\\\\\"},\\\\\\"parentID\\\\\\":{\\\\\\"id\\\\\\":\\\\\\"MDU6SXNzdWUzMDU5OTM3NzM=\\\\\\",\\\\\\"type\\\\\\":\\\\\\"ISSUE\\\\\\"},\\\\\\"type\\\\\\":\\\\\\"CONTAINMENT\\\\\\"}\\"}": Object {
+    "{\\"pluginName\\":\\"sourcecred/github-beta\\",\\"repositoryName\\":\\"sourcecred/example-repo\\",\\"type\\":\\"CONTAINMENT\\",\\"id\\":\\"{\\\\\\"child\\\\\\":{\\\\\\"id\\\\\\":\\\\\\"MDEyOklzc3VlQ29tbWVudDM3Mzc2ODUzOA==\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"repositoryName\\\\\\":\\\\\\"sourcecred/example-repo\\\\\\",\\\\\\"type\\\\\\":\\\\\\"COMMENT\\\\\\"},\\\\\\"parent\\\\\\":{\\\\\\"id\\\\\\":\\\\\\"MDU6SXNzdWUzMDU5OTM3NzM=\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"repositoryName\\\\\\":\\\\\\"sourcecred/example-repo\\\\\\",\\\\\\"type\\\\\\":\\\\\\"ISSUE\\\\\\"}}\\"}": Object {
       "dst": Object {
-        "id": "{\\"id\\":\\"MDEyOklzc3VlQ29tbWVudDM3Mzc2ODUzOA==\\",\\"type\\":\\"COMMENT\\"}",
+        "id": "MDEyOklzc3VlQ29tbWVudDM3Mzc2ODUzOA==",
         "pluginName": "sourcecred/github-beta",
         "repositoryName": "sourcecred/example-repo",
+        "type": "COMMENT",
       },
       "payload": Object {},
       "src": Object {
-        "id": "{\\"id\\":\\"MDU6SXNzdWUzMDU5OTM3NzM=\\",\\"type\\":\\"ISSUE\\"}",
+        "id": "MDU6SXNzdWUzMDU5OTM3NzM=",
         "pluginName": "sourcecred/github-beta",
         "repositoryName": "sourcecred/example-repo",
+        "type": "ISSUE",
       },
     },
-    "{\\"pluginName\\":\\"sourcecred/github-beta\\",\\"repositoryName\\":\\"sourcecred/example-repo\\",\\"id\\":\\"{\\\\\\"childID\\\\\\":{\\\\\\"id\\\\\\":\\\\\\"MDEyOklzc3VlQ29tbWVudDM3Mzc2ODcwMw==\\\\\\",\\\\\\"type\\\\\\":\\\\\\"COMMENT\\\\\\"},\\\\\\"parentID\\\\\\":{\\\\\\"id\\\\\\":\\\\\\"MDU6SXNzdWUzMDA5MzQ5ODA=\\\\\\",\\\\\\"type\\\\\\":\\\\\\"ISSUE\\\\\\"},\\\\\\"type\\\\\\":\\\\\\"CONTAINMENT\\\\\\"}\\"}": Object {
+    "{\\"pluginName\\":\\"sourcecred/github-beta\\",\\"repositoryName\\":\\"sourcecred/example-repo\\",\\"type\\":\\"CONTAINMENT\\",\\"id\\":\\"{\\\\\\"child\\\\\\":{\\\\\\"id\\\\\\":\\\\\\"MDEyOklzc3VlQ29tbWVudDM3Mzc2ODcwMw==\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"repositoryName\\\\\\":\\\\\\"sourcecred/example-repo\\\\\\",\\\\\\"type\\\\\\":\\\\\\"COMMENT\\\\\\"},\\\\\\"parent\\\\\\":{\\\\\\"id\\\\\\":\\\\\\"MDU6SXNzdWUzMDA5MzQ5ODA=\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"repositoryName\\\\\\":\\\\\\"sourcecred/example-repo\\\\\\",\\\\\\"type\\\\\\":\\\\\\"ISSUE\\\\\\"}}\\"}": Object {
       "dst": Object {
-        "id": "{\\"id\\":\\"MDEyOklzc3VlQ29tbWVudDM3Mzc2ODcwMw==\\",\\"type\\":\\"COMMENT\\"}",
+        "id": "MDEyOklzc3VlQ29tbWVudDM3Mzc2ODcwMw==",
         "pluginName": "sourcecred/github-beta",
         "repositoryName": "sourcecred/example-repo",
+        "type": "COMMENT",
       },
       "payload": Object {},
       "src": Object {
-        "id": "{\\"id\\":\\"MDU6SXNzdWUzMDA5MzQ5ODA=\\",\\"type\\":\\"ISSUE\\"}",
+        "id": "MDU6SXNzdWUzMDA5MzQ5ODA=",
         "pluginName": "sourcecred/github-beta",
         "repositoryName": "sourcecred/example-repo",
+        "type": "ISSUE",
       },
     },
-    "{\\"pluginName\\":\\"sourcecred/github-beta\\",\\"repositoryName\\":\\"sourcecred/example-repo\\",\\"id\\":\\"{\\\\\\"childID\\\\\\":{\\\\\\"id\\\\\\":\\\\\\"MDEyOklzc3VlQ29tbWVudDM3Mzc2ODg1MA==\\\\\\",\\\\\\"type\\\\\\":\\\\\\"COMMENT\\\\\\"},\\\\\\"parentID\\\\\\":{\\\\\\"id\\\\\\":\\\\\\"MDU6SXNzdWUzMDA5MzQ5ODA=\\\\\\",\\\\\\"type\\\\\\":\\\\\\"ISSUE\\\\\\"},\\\\\\"type\\\\\\":\\\\\\"CONTAINMENT\\\\\\"}\\"}": Object {
+    "{\\"pluginName\\":\\"sourcecred/github-beta\\",\\"repositoryName\\":\\"sourcecred/example-repo\\",\\"type\\":\\"CONTAINMENT\\",\\"id\\":\\"{\\\\\\"child\\\\\\":{\\\\\\"id\\\\\\":\\\\\\"MDEyOklzc3VlQ29tbWVudDM3Mzc2ODg1MA==\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"repositoryName\\\\\\":\\\\\\"sourcecred/example-repo\\\\\\",\\\\\\"type\\\\\\":\\\\\\"COMMENT\\\\\\"},\\\\\\"parent\\\\\\":{\\\\\\"id\\\\\\":\\\\\\"MDU6SXNzdWUzMDA5MzQ5ODA=\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"repositoryName\\\\\\":\\\\\\"sourcecred/example-repo\\\\\\",\\\\\\"type\\\\\\":\\\\\\"ISSUE\\\\\\"}}\\"}": Object {
       "dst": Object {
-        "id": "{\\"id\\":\\"MDEyOklzc3VlQ29tbWVudDM3Mzc2ODg1MA==\\",\\"type\\":\\"COMMENT\\"}",
+        "id": "MDEyOklzc3VlQ29tbWVudDM3Mzc2ODg1MA==",
         "pluginName": "sourcecred/github-beta",
         "repositoryName": "sourcecred/example-repo",
+        "type": "COMMENT",
       },
       "payload": Object {},
       "src": Object {
-        "id": "{\\"id\\":\\"MDU6SXNzdWUzMDA5MzQ5ODA=\\",\\"type\\":\\"ISSUE\\"}",
+        "id": "MDU6SXNzdWUzMDA5MzQ5ODA=",
         "pluginName": "sourcecred/github-beta",
         "repositoryName": "sourcecred/example-repo",
+        "type": "ISSUE",
       },
     },
-    "{\\"pluginName\\":\\"sourcecred/github-beta\\",\\"repositoryName\\":\\"sourcecred/example-repo\\",\\"id\\":\\"{\\\\\\"childID\\\\\\":{\\\\\\"id\\\\\\":\\\\\\"MDI0OlB1bGxSZXF1ZXN0UmV2aWV3Q29tbWVudDE3MTQ2MDE5OA==\\\\\\",\\\\\\"type\\\\\\":\\\\\\"PULL_REQUEST_REVIEW_COMMENT\\\\\\"},\\\\\\"parentID\\\\\\":{\\\\\\"id\\\\\\":\\\\\\"MDE3OlB1bGxSZXF1ZXN0UmV2aWV3MTAwMzEzODk5\\\\\\",\\\\\\"type\\\\\\":\\\\\\"PULL_REQUEST_REVIEW\\\\\\"},\\\\\\"type\\\\\\":\\\\\\"CONTAINMENT\\\\\\"}\\"}": Object {
+    "{\\"pluginName\\":\\"sourcecred/github-beta\\",\\"repositoryName\\":\\"sourcecred/example-repo\\",\\"type\\":\\"CONTAINMENT\\",\\"id\\":\\"{\\\\\\"child\\\\\\":{\\\\\\"id\\\\\\":\\\\\\"MDI0OlB1bGxSZXF1ZXN0UmV2aWV3Q29tbWVudDE3MTQ2MDE5OA==\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"repositoryName\\\\\\":\\\\\\"sourcecred/example-repo\\\\\\",\\\\\\"type\\\\\\":\\\\\\"PULL_REQUEST_REVIEW_COMMENT\\\\\\"},\\\\\\"parent\\\\\\":{\\\\\\"id\\\\\\":\\\\\\"MDE3OlB1bGxSZXF1ZXN0UmV2aWV3MTAwMzEzODk5\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"repositoryName\\\\\\":\\\\\\"sourcecred/example-repo\\\\\\",\\\\\\"type\\\\\\":\\\\\\"PULL_REQUEST_REVIEW\\\\\\"}}\\"}": Object {
       "dst": Object {
-        "id": "{\\"id\\":\\"MDI0OlB1bGxSZXF1ZXN0UmV2aWV3Q29tbWVudDE3MTQ2MDE5OA==\\",\\"type\\":\\"PULL_REQUEST_REVIEW_COMMENT\\"}",
+        "id": "MDI0OlB1bGxSZXF1ZXN0UmV2aWV3Q29tbWVudDE3MTQ2MDE5OA==",
         "pluginName": "sourcecred/github-beta",
         "repositoryName": "sourcecred/example-repo",
+        "type": "PULL_REQUEST_REVIEW_COMMENT",
       },
       "payload": Object {},
       "src": Object {
-        "id": "{\\"id\\":\\"MDE3OlB1bGxSZXF1ZXN0UmV2aWV3MTAwMzEzODk5\\",\\"type\\":\\"PULL_REQUEST_REVIEW\\"}",
+        "id": "MDE3OlB1bGxSZXF1ZXN0UmV2aWV3MTAwMzEzODk5",
         "pluginName": "sourcecred/github-beta",
         "repositoryName": "sourcecred/example-repo",
+        "type": "PULL_REQUEST_REVIEW",
       },
     },
   },
   "nodes": Object {
-    "{\\"pluginName\\":\\"sourcecred/github-beta\\",\\"repositoryName\\":\\"sourcecred/example-repo\\",\\"id\\":\\"{\\\\\\"id\\\\\\":\\\\\\"MDE3OlB1bGxSZXF1ZXN0UmV2aWV3MTAwMzE0MDM4\\\\\\",\\\\\\"type\\\\\\":\\\\\\"PULL_REQUEST_REVIEW\\\\\\"}\\"}": Object {
+    "{\\"pluginName\\":\\"sourcecred/github-beta\\",\\"repositoryName\\":\\"sourcecred/example-repo\\",\\"type\\":\\"COMMENT\\",\\"id\\":\\"MDEyOklzc3VlQ29tbWVudDM2OTE2MjIyMg==\\"}": Object {
       "payload": Object {
-        "body": "I'm sold",
-        "state": "APPROVED",
+        "body": "It seems apropos to reference something from a pull request comment... eg: #2 ",
+        "url": "https://github.com/sourcecred/example-repo/pull/3#issuecomment-369162222",
       },
     },
-    "{\\"pluginName\\":\\"sourcecred/github-beta\\",\\"repositoryName\\":\\"sourcecred/example-repo\\",\\"id\\":\\"{\\\\\\"id\\\\\\":\\\\\\"MDE3OlB1bGxSZXF1ZXN0UmV2aWV3MTAwMzEzODk5\\\\\\",\\\\\\"type\\\\\\":\\\\\\"PULL_REQUEST_REVIEW\\\\\\"}\\"}": Object {
+    "{\\"pluginName\\":\\"sourcecred/github-beta\\",\\"repositoryName\\":\\"sourcecred/example-repo\\",\\"type\\":\\"COMMENT\\",\\"id\\":\\"MDEyOklzc3VlQ29tbWVudDM3Mzc2ODQ0Mg==\\"}": Object {
       "payload": Object {
-        "body": "hmmm.jpg",
-        "state": "CHANGES_REQUESTED",
+        "body": "A wild COMMENT appeared!",
+        "url": "https://github.com/sourcecred/example-repo/issues/6#issuecomment-373768442",
       },
     },
-    "{\\"pluginName\\":\\"sourcecred/github-beta\\",\\"repositoryName\\":\\"sourcecred/example-repo\\",\\"id\\":\\"{\\\\\\"id\\\\\\":\\\\\\"MDExOlB1bGxSZXF1ZXN0MTcxODg3NzQx\\\\\\",\\\\\\"type\\\\\\":\\\\\\"PULL_REQUEST\\\\\\"}\\"}": Object {
+    "{\\"pluginName\\":\\"sourcecred/github-beta\\",\\"repositoryName\\":\\"sourcecred/example-repo\\",\\"type\\":\\"COMMENT\\",\\"id\\":\\"MDEyOklzc3VlQ29tbWVudDM3Mzc2ODUzOA==\\"}": Object {
+      "payload": Object {
+        "body": "And the maintainer said, \\"Let there be comments!\\"",
+        "url": "https://github.com/sourcecred/example-repo/issues/6#issuecomment-373768538",
+      },
+    },
+    "{\\"pluginName\\":\\"sourcecred/github-beta\\",\\"repositoryName\\":\\"sourcecred/example-repo\\",\\"type\\":\\"COMMENT\\",\\"id\\":\\"MDEyOklzc3VlQ29tbWVudDM3Mzc2ODcwMw==\\"}": Object {
+      "payload": Object {
+        "body": "It should also be possible to reference by exact url: https://github.com/sourcecred/example-repo/issues/6",
+        "url": "https://github.com/sourcecred/example-repo/issues/2#issuecomment-373768703",
+      },
+    },
+    "{\\"pluginName\\":\\"sourcecred/github-beta\\",\\"repositoryName\\":\\"sourcecred/example-repo\\",\\"type\\":\\"COMMENT\\",\\"id\\":\\"MDEyOklzc3VlQ29tbWVudDM3Mzc2ODg1MA==\\"}": Object {
+      "payload": Object {
+        "body": "We might also reference individual comments directly.
+https://github.com/sourcecred/example-repo/issues/6#issuecomment-373768538",
+        "url": "https://github.com/sourcecred/example-repo/issues/2#issuecomment-373768850",
+      },
+    },
+    "{\\"pluginName\\":\\"sourcecred/github-beta\\",\\"repositoryName\\":\\"sourcecred/example-repo\\",\\"type\\":\\"ISSUE\\",\\"id\\":\\"MDU6SXNzdWUzMDA5MzQ4MTg=\\"}": Object {
+      "payload": Object {
+        "body": "This is just an example issue.",
+        "number": 1,
+        "title": "An example issue.",
+      },
+    },
+    "{\\"pluginName\\":\\"sourcecred/github-beta\\",\\"repositoryName\\":\\"sourcecred/example-repo\\",\\"type\\":\\"ISSUE\\",\\"id\\":\\"MDU6SXNzdWUzMDA5MzQ5ODA=\\"}": Object {
+      "payload": Object {
+        "body": "This issue references another issue, namely #1",
+        "number": 2,
+        "title": "A referencing issue.",
+      },
+    },
+    "{\\"pluginName\\":\\"sourcecred/github-beta\\",\\"repositoryName\\":\\"sourcecred/example-repo\\",\\"type\\":\\"ISSUE\\",\\"id\\":\\"MDU6SXNzdWUzMDA5MzYzNzQ=\\"}": Object {
+      "payload": Object {
+        "body": "Alas, its life as an open issue had only just begun.",
+        "number": 4,
+        "title": "A closed pull request",
+      },
+    },
+    "{\\"pluginName\\":\\"sourcecred/github-beta\\",\\"repositoryName\\":\\"sourcecred/example-repo\\",\\"type\\":\\"ISSUE\\",\\"id\\":\\"MDU6SXNzdWUzMDU5OTM3NzM=\\"}": Object {
+      "payload": Object {
+        "body": "This issue shall shortly have a few comments.",
+        "number": 6,
+        "title": "An issue with comments",
+      },
+    },
+    "{\\"pluginName\\":\\"sourcecred/github-beta\\",\\"repositoryName\\":\\"sourcecred/example-repo\\",\\"type\\":\\"ISSUE\\",\\"id\\":\\"MDU6SXNzdWUzMDY5ODM1NTI=\\"}": Object {
+      "payload": Object {
+        "body": "Deal with this, naive string display algorithms!!!!!",
+        "number": 7,
+        "title": "An issue with an extremely long title, which even has a VerySuperFragicalisticialiManyCharacterUberLongTriplePlusGood word in it, and should really be truncated intelligently or something",
+      },
+    },
+    "{\\"pluginName\\":\\"sourcecred/github-beta\\",\\"repositoryName\\":\\"sourcecred/example-repo\\",\\"type\\":\\"ISSUE\\",\\"id\\":\\"MDU6SXNzdWUzMDY5ODUzNjc=\\"}": Object {
+      "payload": Object {
+        "body": "Issue with Unicode: ȴሲ𣐳楢👍 :heart: 𐤔𐤁𐤀𐤑𐤍𐤉𐤔𐤌𐤄𐤍𐤍 ❤️
+Issue with Unicode: ȴሲ𣐳楢👍 :heart: 𐤔𐤁𐤀𐤑𐤍𐤉𐤔𐤌𐤄𐤍𐤍 ❤️",
+        "number": 8,
+        "title": "Issue with Unicode: ȴሲ𣐳楢👍 :heart: 𐤔𐤁𐤀𐤑𐤍𐤉𐤔𐤌𐤄𐤍𐤍 ❤️",
+      },
+    },
+    "{\\"pluginName\\":\\"sourcecred/github-beta\\",\\"repositoryName\\":\\"sourcecred/example-repo\\",\\"type\\":\\"PULL_REQUEST\\",\\"id\\":\\"MDExOlB1bGxSZXF1ZXN0MTcxODg3NzQx\\"}": Object {
       "payload": Object {
         "body": "Oh look, it's a pull request.",
         "number": 3,
         "title": "Add README, merge via PR.",
       },
     },
-    "{\\"pluginName\\":\\"sourcecred/github-beta\\",\\"repositoryName\\":\\"sourcecred/example-repo\\",\\"id\\":\\"{\\\\\\"id\\\\\\":\\\\\\"MDExOlB1bGxSZXF1ZXN0MTcxODg4NTIy\\\\\\",\\\\\\"type\\\\\\":\\\\\\"PULL_REQUEST\\\\\\"}\\"}": Object {
+    "{\\"pluginName\\":\\"sourcecred/github-beta\\",\\"repositoryName\\":\\"sourcecred/example-repo\\",\\"type\\":\\"PULL_REQUEST\\",\\"id\\":\\"MDExOlB1bGxSZXF1ZXN0MTcxODg4NTIy\\"}": Object {
       "payload": Object {
         "body": "@wchargin could you please do the following:
 - add a commit comment
@@ -684,94 +826,32 @@ Object {
         "title": "This pull request will be more contentious. I can feel it...",
       },
     },
-    "{\\"pluginName\\":\\"sourcecred/github-beta\\",\\"repositoryName\\":\\"sourcecred/example-repo\\",\\"id\\":\\"{\\\\\\"id\\\\\\":\\\\\\"MDEyOklzc3VlQ29tbWVudDM2OTE2MjIyMg==\\\\\\",\\\\\\"type\\\\\\":\\\\\\"COMMENT\\\\\\"}\\"}": Object {
+    "{\\"pluginName\\":\\"sourcecred/github-beta\\",\\"repositoryName\\":\\"sourcecred/example-repo\\",\\"type\\":\\"PULL_REQUEST_REVIEW\\",\\"id\\":\\"MDE3OlB1bGxSZXF1ZXN0UmV2aWV3MTAwMzE0MDM4\\"}": Object {
       "payload": Object {
-        "body": "It seems apropos to reference something from a pull request comment... eg: #2 ",
-        "url": "https://github.com/sourcecred/example-repo/pull/3#issuecomment-369162222",
+        "body": "I'm sold",
+        "state": "APPROVED",
       },
     },
-    "{\\"pluginName\\":\\"sourcecred/github-beta\\",\\"repositoryName\\":\\"sourcecred/example-repo\\",\\"id\\":\\"{\\\\\\"id\\\\\\":\\\\\\"MDEyOklzc3VlQ29tbWVudDM3Mzc2ODQ0Mg==\\\\\\",\\\\\\"type\\\\\\":\\\\\\"COMMENT\\\\\\"}\\"}": Object {
+    "{\\"pluginName\\":\\"sourcecred/github-beta\\",\\"repositoryName\\":\\"sourcecred/example-repo\\",\\"type\\":\\"PULL_REQUEST_REVIEW\\",\\"id\\":\\"MDE3OlB1bGxSZXF1ZXN0UmV2aWV3MTAwMzEzODk5\\"}": Object {
       "payload": Object {
-        "body": "A wild COMMENT appeared!",
-        "url": "https://github.com/sourcecred/example-repo/issues/6#issuecomment-373768442",
+        "body": "hmmm.jpg",
+        "state": "CHANGES_REQUESTED",
       },
     },
-    "{\\"pluginName\\":\\"sourcecred/github-beta\\",\\"repositoryName\\":\\"sourcecred/example-repo\\",\\"id\\":\\"{\\\\\\"id\\\\\\":\\\\\\"MDEyOklzc3VlQ29tbWVudDM3Mzc2ODUzOA==\\\\\\",\\\\\\"type\\\\\\":\\\\\\"COMMENT\\\\\\"}\\"}": Object {
-      "payload": Object {
-        "body": "And the maintainer said, \\"Let there be comments!\\"",
-        "url": "https://github.com/sourcecred/example-repo/issues/6#issuecomment-373768538",
-      },
-    },
-    "{\\"pluginName\\":\\"sourcecred/github-beta\\",\\"repositoryName\\":\\"sourcecred/example-repo\\",\\"id\\":\\"{\\\\\\"id\\\\\\":\\\\\\"MDEyOklzc3VlQ29tbWVudDM3Mzc2ODcwMw==\\\\\\",\\\\\\"type\\\\\\":\\\\\\"COMMENT\\\\\\"}\\"}": Object {
-      "payload": Object {
-        "body": "It should also be possible to reference by exact url: https://github.com/sourcecred/example-repo/issues/6",
-        "url": "https://github.com/sourcecred/example-repo/issues/2#issuecomment-373768703",
-      },
-    },
-    "{\\"pluginName\\":\\"sourcecred/github-beta\\",\\"repositoryName\\":\\"sourcecred/example-repo\\",\\"id\\":\\"{\\\\\\"id\\\\\\":\\\\\\"MDEyOklzc3VlQ29tbWVudDM3Mzc2ODg1MA==\\\\\\",\\\\\\"type\\\\\\":\\\\\\"COMMENT\\\\\\"}\\"}": Object {
-      "payload": Object {
-        "body": "We might also reference individual comments directly.
-https://github.com/sourcecred/example-repo/issues/6#issuecomment-373768538",
-        "url": "https://github.com/sourcecred/example-repo/issues/2#issuecomment-373768850",
-      },
-    },
-    "{\\"pluginName\\":\\"sourcecred/github-beta\\",\\"repositoryName\\":\\"sourcecred/example-repo\\",\\"id\\":\\"{\\\\\\"id\\\\\\":\\\\\\"MDI0OlB1bGxSZXF1ZXN0UmV2aWV3Q29tbWVudDE3MTQ2MDE5OA==\\\\\\",\\\\\\"type\\\\\\":\\\\\\"PULL_REQUEST_REVIEW_COMMENT\\\\\\"}\\"}": Object {
+    "{\\"pluginName\\":\\"sourcecred/github-beta\\",\\"repositoryName\\":\\"sourcecred/example-repo\\",\\"type\\":\\"PULL_REQUEST_REVIEW_COMMENT\\",\\"id\\":\\"MDI0OlB1bGxSZXF1ZXN0UmV2aWV3Q29tbWVudDE3MTQ2MDE5OA==\\"}": Object {
       "payload": Object {
         "body": "seems a bit capricious",
         "url": "https://github.com/sourcecred/example-repo/pull/5#discussion_r171460198",
       },
     },
-    "{\\"pluginName\\":\\"sourcecred/github-beta\\",\\"repositoryName\\":\\"sourcecred/example-repo\\",\\"id\\":\\"{\\\\\\"id\\\\\\":\\\\\\"MDQ6VXNlcjE0MDAwMjM=\\\\\\",\\\\\\"type\\\\\\":\\\\\\"USER\\\\\\"}\\"}": Object {
+    "{\\"pluginName\\":\\"sourcecred/github-beta\\",\\"repositoryName\\":\\"sourcecred/example-repo\\",\\"type\\":\\"USER\\",\\"id\\":\\"MDQ6VXNlcjE0MDAwMjM=\\"}": Object {
       "payload": Object {
         "login": "dandelionmane",
       },
     },
-    "{\\"pluginName\\":\\"sourcecred/github-beta\\",\\"repositoryName\\":\\"sourcecred/example-repo\\",\\"id\\":\\"{\\\\\\"id\\\\\\":\\\\\\"MDQ6VXNlcjQzMTc4MDY=\\\\\\",\\\\\\"type\\\\\\":\\\\\\"USER\\\\\\"}\\"}": Object {
+    "{\\"pluginName\\":\\"sourcecred/github-beta\\",\\"repositoryName\\":\\"sourcecred/example-repo\\",\\"type\\":\\"USER\\",\\"id\\":\\"MDQ6VXNlcjQzMTc4MDY=\\"}": Object {
       "payload": Object {
         "login": "wchargin",
-      },
-    },
-    "{\\"pluginName\\":\\"sourcecred/github-beta\\",\\"repositoryName\\":\\"sourcecred/example-repo\\",\\"id\\":\\"{\\\\\\"id\\\\\\":\\\\\\"MDU6SXNzdWUzMDA5MzQ4MTg=\\\\\\",\\\\\\"type\\\\\\":\\\\\\"ISSUE\\\\\\"}\\"}": Object {
-      "payload": Object {
-        "body": "This is just an example issue.",
-        "number": 1,
-        "title": "An example issue.",
-      },
-    },
-    "{\\"pluginName\\":\\"sourcecred/github-beta\\",\\"repositoryName\\":\\"sourcecred/example-repo\\",\\"id\\":\\"{\\\\\\"id\\\\\\":\\\\\\"MDU6SXNzdWUzMDA5MzQ5ODA=\\\\\\",\\\\\\"type\\\\\\":\\\\\\"ISSUE\\\\\\"}\\"}": Object {
-      "payload": Object {
-        "body": "This issue references another issue, namely #1",
-        "number": 2,
-        "title": "A referencing issue.",
-      },
-    },
-    "{\\"pluginName\\":\\"sourcecred/github-beta\\",\\"repositoryName\\":\\"sourcecred/example-repo\\",\\"id\\":\\"{\\\\\\"id\\\\\\":\\\\\\"MDU6SXNzdWUzMDA5MzYzNzQ=\\\\\\",\\\\\\"type\\\\\\":\\\\\\"ISSUE\\\\\\"}\\"}": Object {
-      "payload": Object {
-        "body": "Alas, its life as an open issue had only just begun.",
-        "number": 4,
-        "title": "A closed pull request",
-      },
-    },
-    "{\\"pluginName\\":\\"sourcecred/github-beta\\",\\"repositoryName\\":\\"sourcecred/example-repo\\",\\"id\\":\\"{\\\\\\"id\\\\\\":\\\\\\"MDU6SXNzdWUzMDU5OTM3NzM=\\\\\\",\\\\\\"type\\\\\\":\\\\\\"ISSUE\\\\\\"}\\"}": Object {
-      "payload": Object {
-        "body": "This issue shall shortly have a few comments.",
-        "number": 6,
-        "title": "An issue with comments",
-      },
-    },
-    "{\\"pluginName\\":\\"sourcecred/github-beta\\",\\"repositoryName\\":\\"sourcecred/example-repo\\",\\"id\\":\\"{\\\\\\"id\\\\\\":\\\\\\"MDU6SXNzdWUzMDY5ODM1NTI=\\\\\\",\\\\\\"type\\\\\\":\\\\\\"ISSUE\\\\\\"}\\"}": Object {
-      "payload": Object {
-        "body": "Deal with this, naive string display algorithms!!!!!",
-        "number": 7,
-        "title": "An issue with an extremely long title, which even has a VerySuperFragicalisticialiManyCharacterUberLongTriplePlusGood word in it, and should really be truncated intelligently or something",
-      },
-    },
-    "{\\"pluginName\\":\\"sourcecred/github-beta\\",\\"repositoryName\\":\\"sourcecred/example-repo\\",\\"id\\":\\"{\\\\\\"id\\\\\\":\\\\\\"MDU6SXNzdWUzMDY5ODUzNjc=\\\\\\",\\\\\\"type\\\\\\":\\\\\\"ISSUE\\\\\\"}\\"}": Object {
-      "payload": Object {
-        "body": "Issue with Unicode: ȴሲ𣐳楢👍 :heart: 𐤔𐤁𐤀𐤑𐤍𐤉𐤔𐤌𐤄𐤍𐤍 ❤️
-Issue with Unicode: ȴሲ𣐳楢👍 :heart: 𐤔𐤁𐤀𐤑𐤍𐤉𐤔𐤌𐤄𐤍𐤍 ❤️",
-        "number": 8,
-        "title": "Issue with Unicode: ȴሲ𣐳楢👍 :heart: 𐤔𐤁𐤀𐤑𐤍𐤉𐤔𐤌𐤄𐤍𐤍 ❤️",
       },
     },
   },

--- a/src/plugins/github/githubPlugin.js
+++ b/src/plugins/github/githubPlugin.js
@@ -7,24 +7,20 @@ const stringify = require("json-stable-stringify");
 
 export const GITHUB_PLUGIN_NAME = "sourcecred/github-beta";
 
+/** Node Types */
+// TODO consider moving types to github/types.js
+export type IssueNodeType = "ISSUE";
 export type IssueNodePayload = {|
   +title: string,
   +number: number,
   +body: string,
 |};
-export type IssueNodeID = {|
-  +type: "ISSUE",
-  +id: string,
-|};
 
+export type PullRequestNodeType = "PULL_REQUEST";
 export type PullRequestNodePayload = {|
   +title: string,
   +number: number,
   +body: string,
-|};
-export type PullRequestNodeID = {|
-  +type: "PULL_REQUEST",
-  +id: string,
 |};
 
 export type PullRequestReviewState =
@@ -33,65 +29,76 @@ export type PullRequestReviewState =
   | "COMMENTED"
   | "DISMISSED"
   | "PENDING";
+export type PullRequestReviewNodeType = "PULL_REQUEST_REVIEW";
 export type PullRequestReviewNodePayload = {|
   +body: string,
   +state: PullRequestReviewState,
 |};
-export type PullRequestReviewNodeID = {|
-  +type: "PULL_REQUEST_REVIEW",
-  +id: string,
-|};
 
+export type CommentNodeType = "COMMENT";
 export type CommentNodePayload = {|
   +url: string,
   +body: string,
-|};
-export type CommentNodeID = {|
-  +type: "COMMENT",
-  +id: string,
 |};
 
 // We have this as a separate type from regular comments because we may
 // be interested in diff hunks, which are only present on PR review
 // comments.
+export type PullRequestReviewCommentNodeType = "PULL_REQUEST_REVIEW_COMMENT";
 export type PullRequestReviewCommentNodePayload = {|
   +url: string,
   +body: string,
 |};
-export type PullRequestReviewCommentNodeID = {|
-  +type: "PULL_REQUEST_REVIEW_COMMENT",
-  +id: string,
-|};
 
+export type UserNodeType = "USER";
 export type UserNodePayload = {|
   +login: string,
 |};
-export type UserNodeID = {|
-  +type: "USER",
-  +id: string,
-|};
 
+export type BotNodeType = "BOT";
 export type BotNodePayload = {|
   +login: string,
 |};
-export type BotNodeID = {|
-  +type: "BOT",
-  +id: string,
-|};
 
+export type OrganizationNodeType = "ORGANIZATION";
 export type OrganizationNodePayload = {|
   +login: string,
 |};
-export type OrganizationNodeID = {|
-  +type: "ORGANIZATION",
-  +id: string,
-|};
 
+export type AuthorNodeType = UserNodeType | BotNodeType | OrganizationNodeType;
 export type AuthorNodePayload =
   | UserNodePayload
   | BotNodePayload
   | OrganizationNodePayload;
-export type AuthorNodeID = UserNodeID | BotNodeID | OrganizationNodeID;
+
+// A map from NodeType string to the corresponding type and payload.
+// Primarily useful for adding static assertions with $ObjMap, but also
+// useful at the value layer as $ElementType<NodeTypes, "ISSUE">, for
+// instance.
+export type NodeTypes = {|
+  ISSUE: {payload: IssueNodePayload, type: IssueNodeType},
+  PULL_REQUEST: {payload: PullRequestNodePayload, type: PullRequestNodeType},
+  COMMENT: {payload: CommentNodePayload, type: CommentNodeType},
+  PULL_REQUEST_REVIEW_COMMENT: {
+    payload: PullRequestReviewCommentNodePayload,
+    type: PullRequestReviewCommentNodeType,
+  },
+  PULL_REQUEST_REVIEW: {
+    payload: PullRequestReviewNodePayload,
+    type: PullRequestReviewNodeType,
+  },
+  USER: {payload: UserNodePayload, type: UserNodeType},
+  ORGANIZATION: {payload: OrganizationNodePayload, type: OrganizationNodeType},
+  BOT: {payload: BotNodePayload, type: BotNodeType},
+|};
+
+export type NodeType =
+  | IssueNodeType
+  | PullRequestNodeType
+  | CommentNodeType
+  | PullRequestReviewNodeType
+  | PullRequestReviewCommentNodeType
+  | AuthorNodeType;
 
 export type NodePayload =
   | IssueNodePayload
@@ -100,68 +107,55 @@ export type NodePayload =
   | PullRequestReviewCommentNodePayload
   | PullRequestReviewNodePayload
   | AuthorNodePayload;
-export type NodeID =
-  | IssueNodeID
-  | PullRequestNodeID
-  | PullRequestReviewCommentNodeID
-  | CommentNodeID
-  | PullRequestReviewNodeID
-  | AuthorNodeID;
-export type NodeType = $ElementType<NodeID, "type">;
 
-// A map from NodeType string to the corresponding ID and payload types.
-// Primarily useful for adding static assertions with $ObjMap, but also
-// useful at the value layer as $ElementType<NodeTypes, "ISSUE">, for
-// instance.
-export type NodeTypes = {|
-  ISSUE: {
-    id: IssueNodeID,
-    payload: IssueNodePayload,
-  },
-  PULL_REQUEST: {
-    id: PullRequestNodeID,
-    payload: PullRequestNodePayload,
-  },
-  COMMENT: {
-    id: CommentNodeID,
-    payload: CommentNodePayload,
-  },
-  PULL_REQUEST_REVIEW_COMMENT: {
-    id: PullRequestReviewCommentNodeID,
-    payload: PullRequestReviewCommentNodePayload,
-  },
-  PULL_REQUEST_REVIEW: {
-    id: PullRequestReviewNodeID,
-    payload: PullRequestReviewNodePayload,
-  },
-  USER: {
-    id: UserNodeID,
-    payload: UserNodePayload,
-  },
-  ORGANIZATION: {
-    id: OrganizationNodeID,
-    payload: OrganizationNodePayload,
-  },
-  BOT: {
-    id: BotNodeID,
-    payload: BotNodePayload,
-  },
-|};
+/** Edge Types */
+// TODO(dandelionmane): remove the ID types when we move
+// edge address generation to core Graph code
+export type AuthorshipEdgePayload = {};
+export type AuthorshipEdgeType = "AUTHORSHIP";
+export type AuthorshipEdgeID = {
+  +contribution: Address,
+  +author: Address,
+};
+export type ContainmentEdgePayload = {};
+export type ContainmentEdgeType = "CONTAINMENT";
+export type ContainmentEdgeID = {
+  +child: Address,
+  +parent: Address,
+};
+export type ReferenceEdgePayload = {};
+export type ReferenceEdgeType = "REFERENCE";
+export type ReferenceEdgeID = {
+  +referrer: Address,
+  +referent: Address,
+};
 
 export type EdgeTypes = {|
   AUTHORSHIP: {
-    id: AuthorshipEdgeID,
     payload: AuthorshipEdgePayload,
+    type: AuthorshipEdgeType,
+    ID: AuthorshipEdgeID,
   },
   CONTAINMENT: {
-    id: ContainmentEdgeID,
     payload: ContainmentEdgePayload,
+    type: ContainmentEdgeType,
+    ID: ContainmentEdgeID,
   },
   REFERENCE: {
-    id: ReferenceEdgeID,
     payload: ReferenceEdgePayload,
+    type: ReferenceEdgeType,
+    ID: ReferenceEdgeID,
   },
 |};
+export type EdgeID = AuthorshipEdgeID | ContainmentEdgeID | ReferenceEdgeID;
+export type EdgePayload =
+  | AuthorshipEdgePayload
+  | ContainmentEdgePayload
+  | ReferenceEdgePayload;
+export type EdgeType =
+  | AuthorshipEdgeType
+  | ContainmentEdgeType
+  | ReferenceEdgeType;
 
 (function staticAssertions() {
   // Check that node & edge payload types are exhaustive.
@@ -180,41 +174,6 @@ export type EdgeTypes = {|
   //   "type"
   // > => x;
 });
-
-export type AuthorshipEdgePayload = {};
-export type AuthorshipEdgeID = {
-  +type: "AUTHORSHIP",
-  +contributionID: NodeID,
-  +authorID: NodeID,
-};
-export type ContainmentEdgePayload = {};
-export type ContainmentEdgeID = {
-  +type: "CONTAINMENT",
-  +childID: NodeID,
-  +parentID: NodeID,
-};
-export type ReferenceEdgePayload = {};
-export type ReferenceEdgeID = {
-  +type: "REFERENCE",
-  +referrer: NodeID,
-  +referent: NodeID,
-};
-
-export type EdgePayload =
-  | AuthorshipEdgePayload
-  | ContainmentEdgePayload
-  | ReferenceEdgePayload;
-export type EdgeID = AuthorshipEdgeID | ContainmentEdgeID | ReferenceEdgeID;
-export type EdgeType = $ElementType<EdgeID, "type">;
-
-export function getNodeType(n: Node<NodePayload>): NodeType {
-  return JSON.parse(n.address.id).type;
-}
-
-export function getEdgeType(e: Edge<EdgePayload>): EdgeType {
-  return JSON.parse(e.address.id).type;
-}
-
 export class GithubParser {
   repositoryName: string;
   graph: Graph<NodePayload, EdgePayload>;
@@ -224,21 +183,25 @@ export class GithubParser {
     this.graph = new Graph();
   }
 
-  makeAddress(id: NodeID | EdgeID): Address {
+  makeNodeAddress(type: NodeType, id: string): Address {
     return {
       pluginName: GITHUB_PLUGIN_NAME,
       repositoryName: this.repositoryName,
+      type,
+      id,
+    };
+  }
+
+  makeEdgeAddress(type: EdgeType, id: EdgeID): Address {
+    return {
+      pluginName: GITHUB_PLUGIN_NAME,
+      repositoryName: this.repositoryName,
+      type,
       id: stringify(id),
     };
   }
 
   addAuthorship(
-    authoredNodeID:
-      | IssueNodeID
-      | PullRequestNodeID
-      | CommentNodeID
-      | PullRequestReviewCommentNodeID
-      | PullRequestReviewNodeID,
     authoredNode: Node<
       | IssueNodePayload
       | PullRequestNodePayload
@@ -249,16 +212,16 @@ export class GithubParser {
     authorJson: *
   ) {
     let authorPayload: AuthorNodePayload = {login: authorJson.login};
-    let authorID: AuthorNodeID;
+    let authorType: NodeType;
     switch (authorJson.__typename) {
       case "User":
-        authorID = {type: "USER", id: authorJson.id};
+        authorType = "USER";
         break;
       case "Bot":
-        authorID = {type: "BOT", id: authorJson.id};
+        authorType = "BOT";
         break;
       case "Organization":
-        authorID = {type: "ORGANIZATION", id: authorJson.id};
+        authorType = "ORGANIZATION";
         break;
       default:
         throw new Error(
@@ -269,18 +232,17 @@ export class GithubParser {
     }
 
     const authorNode: Node<AuthorNodePayload> = {
-      address: this.makeAddress(authorID),
+      address: this.makeNodeAddress(authorType, authorJson.id),
       payload: authorPayload,
     };
     this.graph.addNode(authorNode);
 
     const authorshipID = {
-      type: "AUTHORSHIP",
-      contributionID: authoredNodeID,
-      authorID,
+      contribution: authoredNode.address,
+      author: authorNode.address,
     };
     const authorshipEdge: Edge<AuthorshipEdgePayload> = {
-      address: this.makeAddress(authorshipID),
+      address: this.makeEdgeAddress("AUTHORSHIP", authorshipID),
       payload: {},
       src: authoredNode.address,
       dst: authorNode.address,
@@ -289,20 +251,26 @@ export class GithubParser {
   }
 
   addComment(
-    parentID: IssueNodeID | PullRequestNodeID | PullRequestReviewNodeID,
     parentNode: Node<
       IssueNodePayload | PullRequestNodePayload | PullRequestReviewNodePayload
     >,
     commentJson: *
   ) {
-    let commentID: CommentNodeID | PullRequestReviewCommentNodeID;
-    if (parentID.type === "PULL_REQUEST_REVIEW") {
-      commentID = {type: "PULL_REQUEST_REVIEW_COMMENT", id: commentJson.id};
-    } else if (parentID.type === "ISSUE" || parentID.type === "PULL_REQUEST") {
-      commentID = {type: "COMMENT", id: commentJson.id};
-    } else {
-      throw new Error(`Unexpected comment parent type ${parentID.type}`);
+    let commentType: NodeType;
+    switch (parentNode.address.type) {
+      case "PULL_REQUEST_REVIEW":
+        commentType = "PULL_REQUEST_REVIEW_COMMENT";
+        break;
+      case "PULL_REQUEST":
+      case "ISSUE":
+        commentType = "COMMENT";
+        break;
+      default:
+        throw new Error(
+          `Unexpected comment parent type ${parentNode.address.type}`
+        );
     }
+
     const commentNodePayload:
       | CommentNodePayload
       | PullRequestReviewCommentNodePayload = {
@@ -312,24 +280,19 @@ export class GithubParser {
     const commentNode: Node<
       CommentNodePayload | PullRequestReviewCommentNodePayload
     > = {
-      address: this.makeAddress(commentID),
+      address: this.makeNodeAddress(commentType, commentJson.id),
       payload: commentNodePayload,
     };
     this.graph.addNode(commentNode);
 
-    this.addAuthorship(commentID, commentNode, commentJson.author);
-    this.addContainment(parentID, parentNode, commentID, commentNode);
+    this.addAuthorship(commentNode, commentJson.author);
+    this.addContainment(parentNode, commentNode);
   }
 
   addContainment(
-    parentID: IssueNodeID | PullRequestNodeID | PullRequestReviewNodeID,
     parentNode: Node<
       IssueNodePayload | PullRequestNodePayload | PullRequestReviewNodePayload
     >,
-    childID:
-      | CommentNodeID
-      | PullRequestReviewCommentNodeID
-      | PullRequestReviewNodeID,
     childNode: Node<
       | CommentNodePayload
       | PullRequestReviewCommentNodePayload
@@ -337,12 +300,11 @@ export class GithubParser {
     >
   ) {
     const containmentID: ContainmentEdgeID = {
-      type: "CONTAINMENT",
-      childID,
-      parentID,
+      child: childNode.address,
+      parent: parentNode.address,
     };
     const containmentEdge = {
-      address: this.makeAddress(containmentID),
+      address: this.makeEdgeAddress("CONTAINMENT", containmentID),
       payload: {},
       src: parentNode.address,
       dst: childNode.address,
@@ -351,74 +313,58 @@ export class GithubParser {
   }
 
   addIssue(issueJson: *) {
-    const issueID: IssueNodeID = {type: "ISSUE", id: issueJson.id};
     const issuePayload: IssueNodePayload = {
       number: issueJson.number,
       title: issueJson.title,
       body: issueJson.body,
     };
     const issueNode: Node<IssueNodePayload> = {
-      address: this.makeAddress(issueID),
+      address: this.makeNodeAddress("ISSUE", issueJson.id),
       payload: issuePayload,
     };
     this.graph.addNode(issueNode);
 
-    this.addAuthorship(issueID, issueNode, issueJson.author);
+    this.addAuthorship(issueNode, issueJson.author);
 
-    issueJson.comments.nodes.forEach((c) =>
-      this.addComment(issueID, issueNode, c)
-    );
+    issueJson.comments.nodes.forEach((c) => this.addComment(issueNode, c));
   }
 
   addPullRequest(prJson: *) {
-    const pullRequestID: PullRequestNodeID = {
-      type: "PULL_REQUEST",
-      id: prJson.id,
-    };
     const pullRequestPayload: PullRequestNodePayload = {
       number: prJson.number,
       title: prJson.title,
       body: prJson.body,
     };
     const pullRequestNode: Node<PullRequestNodePayload> = {
-      address: this.makeAddress(pullRequestID),
+      address: this.makeNodeAddress("PULL_REQUEST", prJson.id),
       payload: pullRequestPayload,
     };
     this.graph.addNode(pullRequestNode);
 
-    this.addAuthorship(pullRequestID, pullRequestNode, prJson.author);
-    prJson.comments.nodes.forEach((c) =>
-      this.addComment(pullRequestID, pullRequestNode, c)
-    );
+    this.addAuthorship(pullRequestNode, prJson.author);
+    prJson.comments.nodes.forEach((c) => this.addComment(pullRequestNode, c));
 
     prJson.reviews.nodes.forEach((r) =>
-      this.addPullRequestReview(pullRequestID, pullRequestNode, r)
+      this.addPullRequestReview(pullRequestNode, r)
     );
   }
 
   addPullRequestReview(
-    pullRequestID: PullRequestNodeID,
     pullRequestNode: Node<PullRequestNodePayload>,
     reviewJson: *
   ) {
-    const reviewID: PullRequestReviewNodeID = {
-      type: "PULL_REQUEST_REVIEW",
-      id: reviewJson.id,
-    };
     const reviewPayload: PullRequestReviewNodePayload = {
       state: reviewJson.state,
       body: reviewJson.body,
     };
     const reviewNode: Node<PullRequestReviewNodePayload> = {
-      address: this.makeAddress(reviewID),
+      address: this.makeNodeAddress("PULL_REQUEST_REVIEW", reviewJson.id),
       payload: reviewPayload,
     };
     this.graph.addNode(reviewNode);
-    this.addContainment(pullRequestID, pullRequestNode, reviewID, reviewNode);
-    this.addAuthorship(reviewID, reviewNode, reviewJson.author);
-    reviewJson.comments.nodes.forEach((c) =>
-      this.addComment(reviewID, reviewNode, c)
-    );
+    this.addContainment(pullRequestNode, reviewNode);
+    this.addAuthorship(reviewNode, reviewJson.author);
+    reviewJson.comments.nodes.forEach((c) => this.addComment(reviewNode, c));
   }
 
   addData(dataJson: *) {

--- a/src/plugins/github/githubPlugin.test.js
+++ b/src/plugins/github/githubPlugin.test.js
@@ -1,6 +1,6 @@
 // @flow
 
-import {GithubParser, getNodeType, getEdgeType} from "./githubPlugin";
+import {GithubParser} from "./githubPlugin";
 import exampleRepoData from "./demoData/example-repo.json";
 
 describe("GithubParser", () => {
@@ -33,16 +33,16 @@ describe("GithubParser", () => {
     it("every comment has an author and container", () => {
       const comments = graph
         .getAllNodes()
-        .filter((n) => getNodeType(n) === "COMMENT");
+        .filter((n) => n.address.type === "COMMENT");
       expect(comments).not.toHaveLength(0);
       comments.forEach((c) => {
         const authorEdges = graph
           .getOutEdges(c.address)
-          .filter((e) => getEdgeType(e) === "AUTHORSHIP");
+          .filter((e) => e.address.type === "AUTHORSHIP");
         expect(authorEdges.length).toBe(1);
         const containerEdges = graph
           .getInEdges(c.address)
-          .filter((e) => getEdgeType(e) === "CONTAINMENT");
+          .filter((e) => e.address.type === "CONTAINMENT");
         expect(containerEdges.length).toBe(1);
       });
     });
@@ -51,13 +51,13 @@ describe("GithubParser", () => {
       const issuesAndPRs = graph
         .getAllNodes()
         .filter(
-          (n) => ["ISSUE", "PULL_REQUEST"].indexOf(getNodeType(n)) !== -1
+          (n) => ["ISSUE", "PULL_REQUEST"].indexOf(n.address.type) !== -1
         );
       expect(issuesAndPRs).not.toHaveLength(0);
       issuesAndPRs.forEach((x) => {
         const outEdges = graph.getOutEdges(x.address);
         const authorEdges = outEdges.filter(
-          (e) => getEdgeType(e) === "AUTHORSHIP"
+          (e) => e.address.type === "AUTHORSHIP"
         );
         expect(authorEdges.length).toBe(1);
       });


### PR DESCRIPTION
This pull request adds a string type as a field of the address, thus canonicalizing that all Nodes and Edges have a Type. This allows for simpler PluginAdapters, and simpler implementation of the GitHub plugin (as it no longer needs to invent its own mechanism for storing types).

I explored making the Address interface generic, with a Type parameter that is a subtype of string. Unfortunately, Flow type resolution seems to have an exponential performance degradation with many subtyped parameters, and adding the extra type parameters to Graph.merge resulted in my flow instance locking. Maybe we can explore adding the subtypes later.

In the GitHub plugin, we entirely do away with the NodeIDs, but we still have EdgeIDs. I plan to remove the need for EdgeIDs in a separate PR which will enforce uniqueness of (srcAddress, dstAddress, pluginName, type) tuples, so that explicitly generating IDs for edges will be unnecessary. In the mean time, I bifurcated the makeAddress function in the GitHub plugin to makeEdgeAddress and makeNodeAddress.

Test plan:
Flow and unit tests all pass. Inspect snapshots, and verify that all the changes are reasonable. Note that since we order by serialized address, adding the type field to address has changed the snapshot order in a few cases.

Close #103