### PR TITLE
Allow removing nodes and edges from the graph

### DIFF
--- a/src/core/address.js
+++ b/src/core/address.js
@@ -96,6 +96,19 @@ export class AddressMap<T: Addressable> {
   getAll(): T[] {
     return Object.keys(this._data).map((k) => this._data[k]);
   }
+
+  /**
+   * Remove any object with the given address. If none exists, this
+   * method does nothing.
+   */
+  remove(address: Address): this {
+    if (address == null) {
+      throw new Error(`address is ${String(address)}`);
+    }
+    const key = toString(address);
+    delete this._data[key];
+    return this;
+  }
 }
 
 /**

--- a/src/core/address.test.js
+++ b/src/core/address.test.js
@@ -54,6 +54,14 @@ describe("address", () => {
       expect(sortedByAddress(actual)).toEqual(sortedByAddress(expected));
     });
 
+    it("removes objects by key", () => {
+      expect(
+        makeMap()
+          .remove(mansion().address)
+          .get(mansion().address)
+      ).toBeUndefined();
+    });
+
     it("stringifies to JSON", () => {
       expect(makeMap().toJSON()).toMatchSnapshot();
     });
@@ -111,6 +119,10 @@ describe("address", () => {
         it(`when getting ${String(bad)} elements`, () => {
           const message = `address is ${String(bad)}`;
           expect(() => makeMap().get((bad: any))).toThrow(message);
+        });
+        it(`when removing ${String(bad)} elements`, () => {
+          const message = `address is ${String(bad)}`;
+          expect(() => makeMap().remove((bad: any))).toThrow(message);
         });
         it(`when adding elements with ${String(bad)} address`, () => {
           const message = `address is ${String(bad)}`;


### PR DESCRIPTION
Summary:
Wherein we change the semantics to allow\* dangling edges. This is
necessary for plugins that want to update nodes, such as changing a
description or other noncritical field.

\* (It was technically possible before by abusing `merge`, but now you
can just do it.)

Paired with @dandelionmane.

Test Plan:
Extensive tests added. Run `yarn flow` and `yarn test`.

wchargin-branch: allow-removing-from-graph