### PR TITLE
Update example data for @decentralion name change

### DIFF
--- a/src/plugins/artifact/editor/adapters/__snapshots__/githubPluginAdapter.test.js.snap
+++ b/src/plugins/artifact/editor/adapters/__snapshots__/githubPluginAdapter.test.js.snap
@@ -152,14 +152,14 @@ https://github.com/sourcecred/example-repo/issues/6#issuecomment-373768538",
   Object {
     "id": "MDQ6VXNlcjE0MDAwMjM=",
     "payload": Object {
-      "login": "dandelionmane",
+      "login": "decentralion",
     },
     "rendered": <div>
       type: 
       USER
        (details to be implemented)
 </div>,
-    "title": "dandelionmane",
+    "title": "decentralion",
     "type": "USER",
   },
   Object {

--- a/src/plugins/github/__snapshots__/githubPlugin.test.js.snap
+++ b/src/plugins/github/__snapshots__/githubPlugin.test.js.snap
@@ -22,7 +22,7 @@ Object {
   "nodes": Object {
     "{\\"id\\":\\"MDQ6VXNlcjE0MDAwMjM=\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"repositoryName\\":\\"sourcecred/example-repo\\",\\"type\\":\\"USER\\"}": Object {
       "payload": Object {
-        "login": "dandelionmane",
+        "login": "decentralion",
       },
     },
     "{\\"id\\":\\"MDU6SXNzdWUzMDA5MzQ4MTg=\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"repositoryName\\":\\"sourcecred/example-repo\\",\\"type\\":\\"ISSUE\\"}": Object {
@@ -130,7 +130,7 @@ Object {
     },
     "{\\"id\\":\\"MDQ6VXNlcjE0MDAwMjM=\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"repositoryName\\":\\"sourcecred/example-repo\\",\\"type\\":\\"USER\\"}": Object {
       "payload": Object {
-        "login": "dandelionmane",
+        "login": "decentralion",
       },
     },
     "{\\"id\\":\\"MDU6SXNzdWUzMDU5OTM3NzM=\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"repositoryName\\":\\"sourcecred/example-repo\\",\\"type\\":\\"ISSUE\\"}": Object {
@@ -285,7 +285,7 @@ Object {
     },
     "{\\"id\\":\\"MDQ6VXNlcjE0MDAwMjM=\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"repositoryName\\":\\"sourcecred/example-repo\\",\\"type\\":\\"USER\\"}": Object {
       "payload": Object {
-        "login": "dandelionmane",
+        "login": "decentralion",
       },
     },
     "{\\"id\\":\\"MDQ6VXNlcjQzMTc4MDY=\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"repositoryName\\":\\"sourcecred/example-repo\\",\\"type\\":\\"USER\\"}": Object {
@@ -362,7 +362,7 @@ Object {
     },
     "{\\"id\\":\\"MDQ6VXNlcjE0MDAwMjM=\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"repositoryName\\":\\"sourcecred/example-repo\\",\\"type\\":\\"USER\\"}": Object {
       "payload": Object {
-        "login": "dandelionmane",
+        "login": "decentralion",
       },
     },
   },
@@ -803,7 +803,7 @@ https://github.com/sourcecred/example-repo/issues/6#issuecomment-373768538",
     },
     "{\\"id\\":\\"MDQ6VXNlcjE0MDAwMjM=\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"repositoryName\\":\\"sourcecred/example-repo\\",\\"type\\":\\"USER\\"}": Object {
       "payload": Object {
-        "login": "dandelionmane",
+        "login": "decentralion",
       },
     },
     "{\\"id\\":\\"MDQ6VXNlcjQzMTc4MDY=\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"repositoryName\\":\\"sourcecred/example-repo\\",\\"type\\":\\"USER\\"}": Object {

--- a/src/plugins/github/demoData/example-repo.json
+++ b/src/plugins/github/demoData/example-repo.json
@@ -7,7 +7,7 @@
                         "author": {
                             "__typename": "User",
                             "id": "MDQ6VXNlcjE0MDAwMjM=",
-                            "login": "dandelionmane"
+                            "login": "decentralion"
                         },
                         "body": "This is just an example issue.",
                         "comments": {
@@ -25,7 +25,7 @@
                         "author": {
                             "__typename": "User",
                             "id": "MDQ6VXNlcjE0MDAwMjM=",
-                            "login": "dandelionmane"
+                            "login": "decentralion"
                         },
                         "body": "This issue references another issue, namely #1",
                         "comments": {
@@ -34,7 +34,7 @@
                                     "author": {
                                         "__typename": "User",
                                         "id": "MDQ6VXNlcjE0MDAwMjM=",
-                                        "login": "dandelionmane"
+                                        "login": "decentralion"
                                     },
                                     "body": "It should also be possible to reference by exact url: https://github.com/sourcecred/example-repo/issues/6",
                                     "id": "MDEyOklzc3VlQ29tbWVudDM3Mzc2ODcwMw==",
@@ -44,7 +44,7 @@
                                     "author": {
                                         "__typename": "User",
                                         "id": "MDQ6VXNlcjE0MDAwMjM=",
-                                        "login": "dandelionmane"
+                                        "login": "decentralion"
                                     },
                                     "body": "We might also reference individual comments directly.\r\nhttps://github.com/sourcecred/example-repo/issues/6#issuecomment-373768538",
                                     "id": "MDEyOklzc3VlQ29tbWVudDM3Mzc2ODg1MA==",
@@ -63,7 +63,7 @@
                         "author": {
                             "__typename": "User",
                             "id": "MDQ6VXNlcjE0MDAwMjM=",
-                            "login": "dandelionmane"
+                            "login": "decentralion"
                         },
                         "body": "Alas, its life as an open issue had only just begun.",
                         "comments": {
@@ -81,7 +81,7 @@
                         "author": {
                             "__typename": "User",
                             "id": "MDQ6VXNlcjE0MDAwMjM=",
-                            "login": "dandelionmane"
+                            "login": "decentralion"
                         },
                         "body": "This issue shall shortly have a few comments.",
                         "comments": {
@@ -90,7 +90,7 @@
                                     "author": {
                                         "__typename": "User",
                                         "id": "MDQ6VXNlcjE0MDAwMjM=",
-                                        "login": "dandelionmane"
+                                        "login": "decentralion"
                                     },
                                     "body": "A wild COMMENT appeared!",
                                     "id": "MDEyOklzc3VlQ29tbWVudDM3Mzc2ODQ0Mg==",
@@ -100,7 +100,7 @@
                                     "author": {
                                         "__typename": "User",
                                         "id": "MDQ6VXNlcjE0MDAwMjM=",
-                                        "login": "dandelionmane"
+                                        "login": "decentralion"
                                     },
                                     "body": "And the maintainer said, \"Let there be comments!\"",
                                     "id": "MDEyOklzc3VlQ29tbWVudDM3Mzc2ODUzOA==",
@@ -119,7 +119,7 @@
                         "author": {
                             "__typename": "User",
                             "id": "MDQ6VXNlcjE0MDAwMjM=",
-                            "login": "dandelionmane"
+                            "login": "decentralion"
                         },
                         "body": "Deal with this, naive string display algorithms!!!!!",
                         "comments": {
@@ -137,7 +137,7 @@
                         "author": {
                             "__typename": "User",
                             "id": "MDQ6VXNlcjE0MDAwMjM=",
-                            "login": "dandelionmane"
+                            "login": "decentralion"
                         },
                         "body": "Issue with Unicode: ȴሲ𣐳楢👍 :heart: 𐤔𐤁𐤀𐤑𐤍𐤉𐤔𐤌𐤄𐤍𐤍 ❤️\r\nIssue with Unicode: ȴሲ𣐳楢👍 :heart: 𐤔𐤁𐤀𐤑𐤍𐤉𐤔𐤌𐤄𐤍𐤍 ❤️",
                         "comments": {
@@ -162,7 +162,7 @@
                         "author": {
                             "__typename": "User",
                             "id": "MDQ6VXNlcjE0MDAwMjM=",
-                            "login": "dandelionmane"
+                            "login": "decentralion"
                         },
                         "body": "Oh look, it's a pull request.",
                         "comments": {
@@ -171,7 +171,7 @@
                                     "author": {
                                         "__typename": "User",
                                         "id": "MDQ6VXNlcjE0MDAwMjM=",
-                                        "login": "dandelionmane"
+                                        "login": "decentralion"
                                     },
                                     "body": "It seems apropos to reference something from a pull request comment... eg: #2 ",
                                     "id": "MDEyOklzc3VlQ29tbWVudDM2OTE2MjIyMg==",
@@ -197,7 +197,7 @@
                         "author": {
                             "__typename": "User",
                             "id": "MDQ6VXNlcjE0MDAwMjM=",
-                            "login": "dandelionmane"
+                            "login": "decentralion"
                         },
                         "body": "@wchargin could you please do the following:\r\n- add a commit comment\r\n- add a review comment requesting some trivial change\r\n- i'll change it\r\n- then approve the pr",
                         "comments": {


### PR DESCRIPTION
Summary:
This was created by re-crawling the GitHub repo via `fetchGithubRepo`,
and then updating Jest snapshots.

Test Plan:
Note that `fetchGithubRepoTest.sh` passes, so the data is now up to
date.

Inspect the snapshot, and note that the only changes are to change login
names from `dandelionmane` to `decentralion`. To do so automatically:
```bash
set -eu
diff_contents() {
    git difftool HEAD^ HEAD --extcmd=diff --no-prompt
}
! diff_contents | grep '^<' | grep -vF '"dandelionmane"'
! diff_contents | grep '^>' | grep -vF '"decentralion"'
```

wchargin-branch: decentralion-data