### PR TITLE
Artifact plugin logs presence of dangling edges

### DIFF
--- a/src/plugins/artifact/editor/GithubGraphFetcher.js
+++ b/src/plugins/artifact/editor/GithubGraphFetcher.js
@@ -34,6 +34,15 @@ export class GithubGraphFetcher extends React.Component<Props> {
       .then((json) => {
         const parser = new GithubParser(`${repoOwner}/${repoName}`);
         parser.addData(json.data);
+
+        const dangling = parser.danglingReferences();
+        if (dangling.length !== 0) {
+          console.log(
+            `Warning: detected ${dangling.length} dangling references:`
+          );
+          console.log(dangling);
+        }
+
         return Promise.resolve(parser.graph);
       })
       .then((graph) => {


### PR DESCRIPTION
If there are any dangling edges leftover from a graph parse, the
artifact plugin will now record that fact in the console.

I think this will be mildly useful for debugging; note it only generates
noise in the exception case.

Test plan:
No tests were added. We don't depend on this behavior at all, I just
think it will be nice to make it discoverable when this happens.