### PR TITLE
Get urls for all GitHub objects

### DIFF
--- a/src/plugins/artifact/editor/adapters/__snapshots__/githubPluginAdapter.test.js.snap
+++ b/src/plugins/artifact/editor/adapters/__snapshots__/githubPluginAdapter.test.js.snap
@@ -7,6 +7,7 @@ Array [
     "payload": Object {
       "body": "I'm sold",
       "state": "APPROVED",
+      "url": "https://github.com/sourcecred/example-repo/pull/5#pullrequestreview-100314038",
     },
     "rendered": <div>
       type: 
@@ -21,6 +22,7 @@ Array [
     "payload": Object {
       "body": "hmmm.jpg",
       "state": "CHANGES_REQUESTED",
+      "url": "https://github.com/sourcecred/example-repo/pull/5#pullrequestreview-100313899",
     },
     "rendered": <div>
       type: 
@@ -36,6 +38,7 @@ Array [
       "body": "Oh look, it's a pull request.",
       "number": 3,
       "title": "Add README, merge via PR.",
+      "url": "https://github.com/sourcecred/example-repo/pull/3",
     },
     "rendered": <div>
       type: 
@@ -55,6 +58,7 @@ Array [
 - then approve the pr",
       "number": 5,
       "title": "This pull request will be more contentious. I can feel it...",
+      "url": "https://github.com/sourcecred/example-repo/pull/5",
     },
     "rendered": <div>
       type: 
@@ -181,6 +185,7 @@ https://github.com/sourcecred/example-repo/issues/6#issuecomment-373768538",
       "body": "This is just an example issue.",
       "number": 1,
       "title": "An example issue.",
+      "url": "https://github.com/sourcecred/example-repo/issues/1",
     },
     "rendered": <div>
       type: 
@@ -196,6 +201,7 @@ https://github.com/sourcecred/example-repo/issues/6#issuecomment-373768538",
       "body": "This issue references another issue, namely #1",
       "number": 2,
       "title": "A referencing issue.",
+      "url": "https://github.com/sourcecred/example-repo/issues/2",
     },
     "rendered": <div>
       type: 
@@ -211,6 +217,7 @@ https://github.com/sourcecred/example-repo/issues/6#issuecomment-373768538",
       "body": "Alas, its life as an open issue had only just begun.",
       "number": 4,
       "title": "A closed pull request",
+      "url": "https://github.com/sourcecred/example-repo/issues/4",
     },
     "rendered": <div>
       type: 
@@ -226,6 +233,7 @@ https://github.com/sourcecred/example-repo/issues/6#issuecomment-373768538",
       "body": "This issue shall shortly have a few comments.",
       "number": 6,
       "title": "An issue with comments",
+      "url": "https://github.com/sourcecred/example-repo/issues/6",
     },
     "rendered": <div>
       type: 
@@ -241,6 +249,7 @@ https://github.com/sourcecred/example-repo/issues/6#issuecomment-373768538",
       "body": "Deal with this, naive string display algorithms!!!!!",
       "number": 7,
       "title": "An issue with an extremely long title, which even has a VerySuperFragicalisticialiManyCharacterUberLongTriplePlusGood word in it, and should really be truncated intelligently or something",
+      "url": "https://github.com/sourcecred/example-repo/issues/7",
     },
     "rendered": <div>
       type: 
@@ -257,6 +266,7 @@ https://github.com/sourcecred/example-repo/issues/6#issuecomment-373768538",
 Issue with Unicode: ȴሲ𣐳楢👍 :heart: 𐤔𐤁𐤀𐤑𐤍𐤉𐤔𐤌𐤄𐤍𐤍 ❤️",
       "number": 8,
       "title": "Issue with Unicode: ȴሲ𣐳楢👍 :heart: 𐤔𐤁𐤀𐤑𐤍𐤉𐤔𐤌𐤄𐤍𐤍 ❤️",
+      "url": "https://github.com/sourcecred/example-repo/issues/8",
     },
     "rendered": <div>
       type: 

--- a/src/plugins/github/__snapshots__/githubPlugin.test.js.snap
+++ b/src/plugins/github/__snapshots__/githubPlugin.test.js.snap
@@ -30,6 +30,7 @@ Object {
         "body": "This is just an example issue.",
         "number": 1,
         "title": "An example issue.",
+        "url": "https://github.com/sourcecred/example-repo/issues/1",
       },
     },
   },
@@ -138,6 +139,7 @@ Object {
         "body": "This issue shall shortly have a few comments.",
         "number": 6,
         "title": "An issue with comments",
+        "url": "https://github.com/sourcecred/example-repo/issues/6",
       },
     },
   },
@@ -258,12 +260,14 @@ Object {
       "payload": Object {
         "body": "I'm sold",
         "state": "APPROVED",
+        "url": "https://github.com/sourcecred/example-repo/pull/5#pullrequestreview-100314038",
       },
     },
     "{\\"id\\":\\"MDE3OlB1bGxSZXF1ZXN0UmV2aWV3MTAwMzEzODk5\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"repositoryName\\":\\"sourcecred/example-repo\\",\\"type\\":\\"PULL_REQUEST_REVIEW\\"}": Object {
       "payload": Object {
         "body": "hmmm.jpg",
         "state": "CHANGES_REQUESTED",
+        "url": "https://github.com/sourcecred/example-repo/pull/5#pullrequestreview-100313899",
       },
     },
     "{\\"id\\":\\"MDExOlB1bGxSZXF1ZXN0MTcxODg4NTIy\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"repositoryName\\":\\"sourcecred/example-repo\\",\\"type\\":\\"PULL_REQUEST\\"}": Object {
@@ -275,6 +279,7 @@ Object {
 - then approve the pr",
         "number": 5,
         "title": "This pull request will be more contentious. I can feel it...",
+        "url": "https://github.com/sourcecred/example-repo/pull/5",
       },
     },
     "{\\"id\\":\\"MDI0OlB1bGxSZXF1ZXN0UmV2aWV3Q29tbWVudDE3MTQ2MDE5OA==\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"repositoryName\\":\\"sourcecred/example-repo\\",\\"type\\":\\"PULL_REQUEST_REVIEW_COMMENT\\"}": Object {
@@ -352,6 +357,7 @@ Object {
         "body": "Oh look, it's a pull request.",
         "number": 3,
         "title": "Add README, merge via PR.",
+        "url": "https://github.com/sourcecred/example-repo/pull/3",
       },
     },
     "{\\"id\\":\\"MDEyOklzc3VlQ29tbWVudDM2OTE2MjIyMg==\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"repositoryName\\":\\"sourcecred/example-repo\\",\\"type\\":\\"COMMENT\\"}": Object {
@@ -738,12 +744,14 @@ Object {
       "payload": Object {
         "body": "I'm sold",
         "state": "APPROVED",
+        "url": "https://github.com/sourcecred/example-repo/pull/5#pullrequestreview-100314038",
       },
     },
     "{\\"id\\":\\"MDE3OlB1bGxSZXF1ZXN0UmV2aWV3MTAwMzEzODk5\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"repositoryName\\":\\"sourcecred/example-repo\\",\\"type\\":\\"PULL_REQUEST_REVIEW\\"}": Object {
       "payload": Object {
         "body": "hmmm.jpg",
         "state": "CHANGES_REQUESTED",
+        "url": "https://github.com/sourcecred/example-repo/pull/5#pullrequestreview-100313899",
       },
     },
     "{\\"id\\":\\"MDExOlB1bGxSZXF1ZXN0MTcxODg3NzQx\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"repositoryName\\":\\"sourcecred/example-repo\\",\\"type\\":\\"PULL_REQUEST\\"}": Object {
@@ -751,6 +759,7 @@ Object {
         "body": "Oh look, it's a pull request.",
         "number": 3,
         "title": "Add README, merge via PR.",
+        "url": "https://github.com/sourcecred/example-repo/pull/3",
       },
     },
     "{\\"id\\":\\"MDExOlB1bGxSZXF1ZXN0MTcxODg4NTIy\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"repositoryName\\":\\"sourcecred/example-repo\\",\\"type\\":\\"PULL_REQUEST\\"}": Object {
@@ -762,6 +771,7 @@ Object {
 - then approve the pr",
         "number": 5,
         "title": "This pull request will be more contentious. I can feel it...",
+        "url": "https://github.com/sourcecred/example-repo/pull/5",
       },
     },
     "{\\"id\\":\\"MDEyOklzc3VlQ29tbWVudDM2OTE2MjIyMg==\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"repositoryName\\":\\"sourcecred/example-repo\\",\\"type\\":\\"COMMENT\\"}": Object {
@@ -816,6 +826,7 @@ https://github.com/sourcecred/example-repo/issues/6#issuecomment-373768538",
         "body": "This is just an example issue.",
         "number": 1,
         "title": "An example issue.",
+        "url": "https://github.com/sourcecred/example-repo/issues/1",
       },
     },
     "{\\"id\\":\\"MDU6SXNzdWUzMDA5MzQ5ODA=\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"repositoryName\\":\\"sourcecred/example-repo\\",\\"type\\":\\"ISSUE\\"}": Object {
@@ -823,6 +834,7 @@ https://github.com/sourcecred/example-repo/issues/6#issuecomment-373768538",
         "body": "This issue references another issue, namely #1",
         "number": 2,
         "title": "A referencing issue.",
+        "url": "https://github.com/sourcecred/example-repo/issues/2",
       },
     },
     "{\\"id\\":\\"MDU6SXNzdWUzMDA5MzYzNzQ=\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"repositoryName\\":\\"sourcecred/example-repo\\",\\"type\\":\\"ISSUE\\"}": Object {
@@ -830,6 +842,7 @@ https://github.com/sourcecred/example-repo/issues/6#issuecomment-373768538",
         "body": "Alas, its life as an open issue had only just begun.",
         "number": 4,
         "title": "A closed pull request",
+        "url": "https://github.com/sourcecred/example-repo/issues/4",
       },
     },
     "{\\"id\\":\\"MDU6SXNzdWUzMDU5OTM3NzM=\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"repositoryName\\":\\"sourcecred/example-repo\\",\\"type\\":\\"ISSUE\\"}": Object {
@@ -837,6 +850,7 @@ https://github.com/sourcecred/example-repo/issues/6#issuecomment-373768538",
         "body": "This issue shall shortly have a few comments.",
         "number": 6,
         "title": "An issue with comments",
+        "url": "https://github.com/sourcecred/example-repo/issues/6",
       },
     },
     "{\\"id\\":\\"MDU6SXNzdWUzMDY5ODM1NTI=\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"repositoryName\\":\\"sourcecred/example-repo\\",\\"type\\":\\"ISSUE\\"}": Object {
@@ -844,6 +858,7 @@ https://github.com/sourcecred/example-repo/issues/6#issuecomment-373768538",
         "body": "Deal with this, naive string display algorithms!!!!!",
         "number": 7,
         "title": "An issue with an extremely long title, which even has a VerySuperFragicalisticialiManyCharacterUberLongTriplePlusGood word in it, and should really be truncated intelligently or something",
+        "url": "https://github.com/sourcecred/example-repo/issues/7",
       },
     },
     "{\\"id\\":\\"MDU6SXNzdWUzMDY5ODUzNjc=\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"repositoryName\\":\\"sourcecred/example-repo\\",\\"type\\":\\"ISSUE\\"}": Object {
@@ -852,6 +867,7 @@ https://github.com/sourcecred/example-repo/issues/6#issuecomment-373768538",
 Issue with Unicode: ȴሲ𣐳楢👍 :heart: 𐤔𐤁𐤀𐤑𐤍𐤉𐤔𐤌𐤄𐤍𐤍 ❤️",
         "number": 8,
         "title": "Issue with Unicode: ȴሲ𣐳楢👍 :heart: 𐤔𐤁𐤀𐤑𐤍𐤉𐤔𐤌𐤄𐤍𐤍 ❤️",
+        "url": "https://github.com/sourcecred/example-repo/issues/8",
       },
     },
   },

--- a/src/plugins/github/demoData/example-repo.json
+++ b/src/plugins/github/demoData/example-repo.json
@@ -8,7 +8,8 @@
                         "author": {
                             "__typename": "User",
                             "id": "MDQ6VXNlcjE0MDAwMjM=",
-                            "login": "decentralion"
+                            "login": "decentralion",
+                            "url": "https://github.com/decentralion"
                         },
                         "body": "This is just an example issue.",
                         "comments": {
@@ -21,13 +22,15 @@
                         },
                         "id": "MDU6SXNzdWUzMDA5MzQ4MTg=",
                         "number": 1,
-                        "title": "An example issue."
+                        "title": "An example issue.",
+                        "url": "https://github.com/sourcecred/example-repo/issues/1"
                     },
                     {
                         "author": {
                             "__typename": "User",
                             "id": "MDQ6VXNlcjE0MDAwMjM=",
-                            "login": "decentralion"
+                            "login": "decentralion",
+                            "url": "https://github.com/decentralion"
                         },
                         "body": "This issue references another issue, namely #1",
                         "comments": {
@@ -36,7 +39,8 @@
                                     "author": {
                                         "__typename": "User",
                                         "id": "MDQ6VXNlcjE0MDAwMjM=",
-                                        "login": "decentralion"
+                                        "login": "decentralion",
+                                        "url": "https://github.com/decentralion"
                                     },
                                     "body": "It should also be possible to reference by exact url: https://github.com/sourcecred/example-repo/issues/6",
                                     "id": "MDEyOklzc3VlQ29tbWVudDM3Mzc2ODcwMw==",
@@ -46,7 +50,8 @@
                                     "author": {
                                         "__typename": "User",
                                         "id": "MDQ6VXNlcjE0MDAwMjM=",
-                                        "login": "decentralion"
+                                        "login": "decentralion",
+                                        "url": "https://github.com/decentralion"
                                     },
                                     "body": "We might also reference individual comments directly.\r\nhttps://github.com/sourcecred/example-repo/issues/6#issuecomment-373768538",
                                     "id": "MDEyOklzc3VlQ29tbWVudDM3Mzc2ODg1MA==",
@@ -60,13 +65,15 @@
                         },
                         "id": "MDU6SXNzdWUzMDA5MzQ5ODA=",
                         "number": 2,
-                        "title": "A referencing issue."
+                        "title": "A referencing issue.",
+                        "url": "https://github.com/sourcecred/example-repo/issues/2"
                     },
                     {
                         "author": {
                             "__typename": "User",
                             "id": "MDQ6VXNlcjE0MDAwMjM=",
-                            "login": "decentralion"
+                            "login": "decentralion",
+                            "url": "https://github.com/decentralion"
                         },
                         "body": "Alas, its life as an open issue had only just begun.",
                         "comments": {
@@ -79,13 +86,15 @@
                         },
                         "id": "MDU6SXNzdWUzMDA5MzYzNzQ=",
                         "number": 4,
-                        "title": "A closed pull request"
+                        "title": "A closed pull request",
+                        "url": "https://github.com/sourcecred/example-repo/issues/4"
                     },
                     {
                         "author": {
                             "__typename": "User",
                             "id": "MDQ6VXNlcjE0MDAwMjM=",
-                            "login": "decentralion"
+                            "login": "decentralion",
+                            "url": "https://github.com/decentralion"
                         },
                         "body": "This issue shall shortly have a few comments.",
                         "comments": {
@@ -94,7 +103,8 @@
                                     "author": {
                                         "__typename": "User",
                                         "id": "MDQ6VXNlcjE0MDAwMjM=",
-                                        "login": "decentralion"
+                                        "login": "decentralion",
+                                        "url": "https://github.com/decentralion"
                                     },
                                     "body": "A wild COMMENT appeared!",
                                     "id": "MDEyOklzc3VlQ29tbWVudDM3Mzc2ODQ0Mg==",
@@ -104,7 +114,8 @@
                                     "author": {
                                         "__typename": "User",
                                         "id": "MDQ6VXNlcjE0MDAwMjM=",
-                                        "login": "decentralion"
+                                        "login": "decentralion",
+                                        "url": "https://github.com/decentralion"
                                     },
                                     "body": "And the maintainer said, \"Let there be comments!\"",
                                     "id": "MDEyOklzc3VlQ29tbWVudDM3Mzc2ODUzOA==",
@@ -118,13 +129,15 @@
                         },
                         "id": "MDU6SXNzdWUzMDU5OTM3NzM=",
                         "number": 6,
-                        "title": "An issue with comments"
+                        "title": "An issue with comments",
+                        "url": "https://github.com/sourcecred/example-repo/issues/6"
                     },
                     {
                         "author": {
                             "__typename": "User",
                             "id": "MDQ6VXNlcjE0MDAwMjM=",
-                            "login": "decentralion"
+                            "login": "decentralion",
+                            "url": "https://github.com/decentralion"
                         },
                         "body": "Deal with this, naive string display algorithms!!!!!",
                         "comments": {
@@ -137,13 +150,15 @@
                         },
                         "id": "MDU6SXNzdWUzMDY5ODM1NTI=",
                         "number": 7,
-                        "title": "An issue with an extremely long title, which even has a VerySuperFragicalisticialiManyCharacterUberLongTriplePlusGood word in it, and should really be truncated intelligently or something"
+                        "title": "An issue with an extremely long title, which even has a VerySuperFragicalisticialiManyCharacterUberLongTriplePlusGood word in it, and should really be truncated intelligently or something",
+                        "url": "https://github.com/sourcecred/example-repo/issues/7"
                     },
                     {
                         "author": {
                             "__typename": "User",
                             "id": "MDQ6VXNlcjE0MDAwMjM=",
-                            "login": "decentralion"
+                            "login": "decentralion",
+                            "url": "https://github.com/decentralion"
                         },
                         "body": "Issue with Unicode: ȴሲ𣐳楢👍 :heart: 𐤔𐤁𐤀𐤑𐤍𐤉𐤔𐤌𐤄𐤍𐤍 ❤️\r\nIssue with Unicode: ȴሲ𣐳楢👍 :heart: 𐤔𐤁𐤀𐤑𐤍𐤉𐤔𐤌𐤄𐤍𐤍 ❤️",
                         "comments": {
@@ -156,7 +171,8 @@
                         },
                         "id": "MDU6SXNzdWUzMDY5ODUzNjc=",
                         "number": 8,
-                        "title": "Issue with Unicode: ȴሲ𣐳楢👍 :heart: 𐤔𐤁𐤀𐤑𐤍𐤉𐤔𐤌𐤄𐤍𐤍 ❤️"
+                        "title": "Issue with Unicode: ȴሲ𣐳楢👍 :heart: 𐤔𐤁𐤀𐤑𐤍𐤉𐤔𐤌𐤄𐤍𐤍 ❤️",
+                        "url": "https://github.com/sourcecred/example-repo/issues/8"
                     }
                 ],
                 "pageInfo": {
@@ -170,7 +186,8 @@
                         "author": {
                             "__typename": "User",
                             "id": "MDQ6VXNlcjE0MDAwMjM=",
-                            "login": "decentralion"
+                            "login": "decentralion",
+                            "url": "https://github.com/decentralion"
                         },
                         "body": "Oh look, it's a pull request.",
                         "comments": {
@@ -179,7 +196,8 @@
                                     "author": {
                                         "__typename": "User",
                                         "id": "MDQ6VXNlcjE0MDAwMjM=",
-                                        "login": "decentralion"
+                                        "login": "decentralion",
+                                        "url": "https://github.com/decentralion"
                                     },
                                     "body": "It seems apropos to reference something from a pull request comment... eg: #2 ",
                                     "id": "MDEyOklzc3VlQ29tbWVudDM2OTE2MjIyMg==",
@@ -201,13 +219,15 @@
                                 "hasNextPage": false
                             }
                         },
-                        "title": "Add README, merge via PR."
+                        "title": "Add README, merge via PR.",
+                        "url": "https://github.com/sourcecred/example-repo/pull/3"
                     },
                     {
                         "author": {
                             "__typename": "User",
                             "id": "MDQ6VXNlcjE0MDAwMjM=",
-                            "login": "decentralion"
+                            "login": "decentralion",
+                            "url": "https://github.com/decentralion"
                         },
                         "body": "@wchargin could you please do the following:\r\n- add a commit comment\r\n- add a review comment requesting some trivial change\r\n- i'll change it\r\n- then approve the pr",
                         "comments": {
@@ -226,7 +246,8 @@
                                     "author": {
                                         "__typename": "User",
                                         "id": "MDQ6VXNlcjQzMTc4MDY=",
-                                        "login": "wchargin"
+                                        "login": "wchargin",
+                                        "url": "https://github.com/wchargin"
                                     },
                                     "body": "hmmm.jpg",
                                     "comments": {
@@ -235,7 +256,8 @@
                                                 "author": {
                                                     "__typename": "User",
                                                     "id": "MDQ6VXNlcjQzMTc4MDY=",
-                                                    "login": "wchargin"
+                                                    "login": "wchargin",
+                                                    "url": "https://github.com/wchargin"
                                                 },
                                                 "body": "seems a bit capricious",
                                                 "id": "MDI0OlB1bGxSZXF1ZXN0UmV2aWV3Q29tbWVudDE3MTQ2MDE5OA==",
@@ -248,13 +270,15 @@
                                         }
                                     },
                                     "id": "MDE3OlB1bGxSZXF1ZXN0UmV2aWV3MTAwMzEzODk5",
-                                    "state": "CHANGES_REQUESTED"
+                                    "state": "CHANGES_REQUESTED",
+                                    "url": "https://github.com/sourcecred/example-repo/pull/5#pullrequestreview-100313899"
                                 },
                                 {
                                     "author": {
                                         "__typename": "User",
                                         "id": "MDQ6VXNlcjQzMTc4MDY=",
-                                        "login": "wchargin"
+                                        "login": "wchargin",
+                                        "url": "https://github.com/wchargin"
                                     },
                                     "body": "I'm sold",
                                     "comments": {
@@ -266,15 +290,17 @@
                                         }
                                     },
                                     "id": "MDE3OlB1bGxSZXF1ZXN0UmV2aWV3MTAwMzE0MDM4",
-                                    "state": "APPROVED"
+                                    "state": "APPROVED",
+                                    "url": "https://github.com/sourcecred/example-repo/pull/5#pullrequestreview-100314038"
                                 }
                             ],
                             "pageInfo": {
-                                "endCursor": "Y3Vyc29yOnYyOpO5MjAxOC0wMi0yOFQyMDoyNDo1Ni0wODowMLkyMDE4LTAyLTI4VDIwOjI0OjU2LTA4OjAwzgX6q7Y=",
+                                "endCursor": "Y3Vyc29yOnYyOpO5MjAxOC0wMy0wMVQwNjoyNDo1NiswMjowMLkyMDE4LTAzLTAxVDA2OjI0OjU2KzAyOjAwzgX6q7Y=",
                                 "hasNextPage": false
                             }
                         },
-                        "title": "This pull request will be more contentious. I can feel it..."
+                        "title": "This pull request will be more contentious. I can feel it...",
+                        "url": "https://github.com/sourcecred/example-repo/pull/5"
                     }
                 ],
                 "pageInfo": {

--- a/src/plugins/github/githubPlugin.js
+++ b/src/plugins/github/githubPlugin.js
@@ -10,6 +10,7 @@ export const GITHUB_PLUGIN_NAME = "sourcecred/github-beta";
 /** Node Types */
 export const ISSUE_NODE_TYPE: "ISSUE" = "ISSUE";
 export type IssueNodePayload = {|
+  +url: string,
   +title: string,
   +number: number,
   +body: string,
@@ -17,6 +18,7 @@ export type IssueNodePayload = {|
 
 export const PULL_REQUEST_NODE_TYPE: "PULL_REQUEST" = "PULL_REQUEST";
 export type PullRequestNodePayload = {|
+  +url: string,
   +title: string,
   +number: number,
   +body: string,
@@ -31,6 +33,7 @@ export type PullRequestReviewState =
 export const PULL_REQUEST_REVIEW_NODE_TYPE: "PULL_REQUEST_REVIEW" =
   "PULL_REQUEST_REVIEW";
 export type PullRequestReviewNodePayload = {|
+  +url: string,
   +body: string,
   +state: PullRequestReviewState,
 |};
@@ -308,6 +311,7 @@ export class GithubParser {
 
   addIssue(issueJson: *) {
     const issuePayload: IssueNodePayload = {
+      url: issueJson.url,
       number: issueJson.number,
       title: issueJson.title,
       body: issueJson.body,
@@ -325,6 +329,7 @@ export class GithubParser {
 
   addPullRequest(prJson: *) {
     const pullRequestPayload: PullRequestNodePayload = {
+      url: prJson.url,
       number: prJson.number,
       title: prJson.title,
       body: prJson.body,
@@ -348,6 +353,7 @@ export class GithubParser {
     reviewJson: *
   ) {
     const reviewPayload: PullRequestReviewNodePayload = {
+      url: reviewJson.url,
       state: reviewJson.state,
       body: reviewJson.body,
     };

--- a/src/plugins/github/graphql.js
+++ b/src/plugins/github/graphql.js
@@ -620,6 +620,7 @@ export function createFragments(): FragmentDefinition[] {
     b.fragment("whoami", "Actor", [
       b.field("__typename"),
       b.field("login"),
+      b.field("url"),
       b.inlineFragment("User", [b.field("id")]),
       b.inlineFragment("Organization", [b.field("id")]),
       b.inlineFragment("Bot", [b.field("id")]),
@@ -628,6 +629,7 @@ export function createFragments(): FragmentDefinition[] {
       makePageInfo(),
       b.field("nodes", {}, [
         b.field("id"),
+        b.field("url"),
         b.field("title"),
         b.field("body"),
         b.field("number"),
@@ -641,6 +643,7 @@ export function createFragments(): FragmentDefinition[] {
       makePageInfo(),
       b.field("nodes", {}, [
         b.field("id"),
+        b.field("url"),
         b.field("title"),
         b.field("body"),
         b.field("number"),
@@ -658,6 +661,7 @@ export function createFragments(): FragmentDefinition[] {
       makePageInfo(),
       b.field("nodes", {}, [
         b.field("id"),
+        b.field("url"),
         makeAuthor(),
         b.field("body"),
         b.field("url"),
@@ -667,6 +671,7 @@ export function createFragments(): FragmentDefinition[] {
       makePageInfo(),
       b.field("nodes", {}, [
         b.field("id"),
+        b.field("url"),
         b.field("body"),
         makeAuthor(),
         b.field("state"),
@@ -679,8 +684,8 @@ export function createFragments(): FragmentDefinition[] {
       makePageInfo(),
       b.field("nodes", {}, [
         b.field("id"),
-        b.field("body"),
         b.field("url"),
+        b.field("body"),
         makeAuthor(),
       ]),
     ]),


### PR DESCRIPTION
This commit modifies our GitHub graphql query so that we request urls
for all objects (e.g. users, pull requests, pull request review
comments). Some change along these lines is necessary so that we can
correctly represent URL reference edges to e.g. issue comments. (It
might be possible to do without by reverse-enginering from the ids, but
we are resolved to treat ids as opaque).

Strictly speaking, we don't need to collect urls for users, issues, and
pull requests - they are generated via simple schema. However, for
consistency, I think it's better to just take URLs on everything.

Test plan: The example-repo.json has been regenerated. The diffs are as
expected.