### PR TITLE
Find GitHub username references

### DIFF
--- a/src/plugins/github/findReferences.js
+++ b/src/plugins/github/findReferences.js
@@ -17,11 +17,21 @@ export function findReferences(body: string): string[] {
   // Note to maintainer: If it becomes necessary to encode references in a
   // richer format, consider implementing the type signature described in
   // https://github.com/sourcecred/sourcecred/pull/130#pullrequestreview-113849998
-  return [...findNumericReferences(body), ...findGithubUrlReferences(body)];
+  return [
+    ...findNumericReferences(body),
+    ...findGithubUrlReferences(body),
+    ...findUsernameReferences(body),
+  ];
 }
 
 function findNumericReferences(body: string): string[] {
   return findAllMatches(/(?:\W|^)(#\d+)(?:\W|$)/g, body).map((x) => x[1]);
+}
+
+function findUsernameReferences(body: string): string[] {
+  return findAllMatches(/(?:\W|^)(@[a-zA-Z0-9-]+)(?:\W|$)/g, body).map(
+    (x) => x[1]
+  );
 }
 
 function findGithubUrlReferences(body: string): string[] {

--- a/src/plugins/github/findReferences.test.js
+++ b/src/plugins/github/findReferences.test.js
@@ -91,6 +91,19 @@ https://github.com/sourcecred/example-repo/pull/3#issuecomment-369162222
     ).toHaveLength(1);
   });
 
+  it("finds username references", () => {
+    expect(findReferences("hello to @wchargin from @decentralion!")).toEqual([
+      "@wchargin",
+      "@decentralion",
+    ]);
+  });
+
+  it("finds usernames with hypens and numbers", () => {
+    expect(findReferences("@paddy-hack and @0x00 are valid usernames")).toEqual(
+      ["@paddy-hack", "@0x00"]
+    );
+  });
+
   it("finds a mix of reference types", () => {
     expect(
       findReferences(
@@ -99,6 +112,7 @@ https://github.com/sourcecred/example-repo/pull/3#issuecomment-369162222
     ).toEqual([
       "#125",
       "https://github.com/sourcecred/sourcecred/pull/125#pullrequestreview-113402856",
+      "@wchargin",
     ]);
   });
 });


### PR DESCRIPTION
Add logic to findReferences for finding GitHub username references,
e.g. `Hello, @wchargin!`. The API is unchanged.

Test plan:
There are new unit tests that verify this behavior works as expected.