### PR TITLE
Add url to author payloads

### DIFF
--- a/src/plugins/artifact/editor/adapters/__snapshots__/githubPluginAdapter.test.js.snap
+++ b/src/plugins/artifact/editor/adapters/__snapshots__/githubPluginAdapter.test.js.snap
@@ -157,6 +157,7 @@ https://github.com/sourcecred/example-repo/issues/6#issuecomment-373768538",
     "id": "MDQ6VXNlcjE0MDAwMjM=",
     "payload": Object {
       "login": "decentralion",
+      "url": "https://github.com/decentralion",
     },
     "rendered": <div>
       type: 
@@ -170,6 +171,7 @@ https://github.com/sourcecred/example-repo/issues/6#issuecomment-373768538",
     "id": "MDQ6VXNlcjQzMTc4MDY=",
     "payload": Object {
       "login": "wchargin",
+      "url": "https://github.com/wchargin",
     },
     "rendered": <div>
       type: 

--- a/src/plugins/github/__snapshots__/githubPlugin.test.js.snap
+++ b/src/plugins/github/__snapshots__/githubPlugin.test.js.snap
@@ -23,6 +23,7 @@ Object {
     "{\\"id\\":\\"MDQ6VXNlcjE0MDAwMjM=\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"repositoryName\\":\\"sourcecred/example-repo\\",\\"type\\":\\"USER\\"}": Object {
       "payload": Object {
         "login": "decentralion",
+        "url": "https://github.com/decentralion",
       },
     },
     "{\\"id\\":\\"MDU6SXNzdWUzMDA5MzQ4MTg=\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"repositoryName\\":\\"sourcecred/example-repo\\",\\"type\\":\\"ISSUE\\"}": Object {
@@ -132,6 +133,7 @@ Object {
     "{\\"id\\":\\"MDQ6VXNlcjE0MDAwMjM=\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"repositoryName\\":\\"sourcecred/example-repo\\",\\"type\\":\\"USER\\"}": Object {
       "payload": Object {
         "login": "decentralion",
+        "url": "https://github.com/decentralion",
       },
     },
     "{\\"id\\":\\"MDU6SXNzdWUzMDU5OTM3NzM=\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"repositoryName\\":\\"sourcecred/example-repo\\",\\"type\\":\\"ISSUE\\"}": Object {
@@ -291,11 +293,13 @@ Object {
     "{\\"id\\":\\"MDQ6VXNlcjE0MDAwMjM=\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"repositoryName\\":\\"sourcecred/example-repo\\",\\"type\\":\\"USER\\"}": Object {
       "payload": Object {
         "login": "decentralion",
+        "url": "https://github.com/decentralion",
       },
     },
     "{\\"id\\":\\"MDQ6VXNlcjQzMTc4MDY=\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"repositoryName\\":\\"sourcecred/example-repo\\",\\"type\\":\\"USER\\"}": Object {
       "payload": Object {
         "login": "wchargin",
+        "url": "https://github.com/wchargin",
       },
     },
   },
@@ -369,6 +373,7 @@ Object {
     "{\\"id\\":\\"MDQ6VXNlcjE0MDAwMjM=\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"repositoryName\\":\\"sourcecred/example-repo\\",\\"type\\":\\"USER\\"}": Object {
       "payload": Object {
         "login": "decentralion",
+        "url": "https://github.com/decentralion",
       },
     },
   },
@@ -814,11 +819,13 @@ https://github.com/sourcecred/example-repo/issues/6#issuecomment-373768538",
     "{\\"id\\":\\"MDQ6VXNlcjE0MDAwMjM=\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"repositoryName\\":\\"sourcecred/example-repo\\",\\"type\\":\\"USER\\"}": Object {
       "payload": Object {
         "login": "decentralion",
+        "url": "https://github.com/decentralion",
       },
     },
     "{\\"id\\":\\"MDQ6VXNlcjQzMTc4MDY=\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"repositoryName\\":\\"sourcecred/example-repo\\",\\"type\\":\\"USER\\"}": Object {
       "payload": Object {
         "login": "wchargin",
+        "url": "https://github.com/wchargin",
       },
     },
     "{\\"id\\":\\"MDU6SXNzdWUzMDA5MzQ4MTg=\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"repositoryName\\":\\"sourcecred/example-repo\\",\\"type\\":\\"ISSUE\\"}": Object {

--- a/src/plugins/github/githubPlugin.js
+++ b/src/plugins/github/githubPlugin.js
@@ -57,16 +57,19 @@ export type PullRequestReviewCommentNodePayload = {|
 export const USER_NODE_TYPE: "USER" = "USER";
 export type UserNodePayload = {|
   +login: string,
+  +url: string,
 |};
 
 export const BOT_NODE_TYPE: "BOT" = "BOT";
 export type BotNodePayload = {|
   +login: string,
+  +url: string,
 |};
 
 export const ORGANIZATION_NODE_TYPE: "ORGANIZATION" = "ORGANIZATION";
 export type OrganizationNodePayload = {|
   +login: string,
+  +url: string,
 |};
 
 export type AuthorNodeType =
@@ -208,7 +211,10 @@ export class GithubParser {
     >,
     authorJson: *
   ) {
-    let authorPayload: AuthorNodePayload = {login: authorJson.login};
+    let authorPayload: AuthorNodePayload = {
+      login: authorJson.login,
+      url: authorJson.url,
+    };
     let authorType: NodeType;
     switch (authorJson.__typename) {
       case "User":


### PR DESCRIPTION
We fetch urls for every type of author (organization, user, bot). For consistency, this commit adds urls to the author node payloads, so that every GitHub node payload has a url.

Test plan:
Check that snapshot changes consist entirely of adding urls, and that
the urls are appropraite.