### PR TITLE
Extract repository types to a separate module

### DIFF
--- a/src/plugins/git/loadRepository.js
+++ b/src/plugins/git/loadRepository.js
@@ -11,6 +11,8 @@
 
 import {execFileSync} from "child_process";
 
+import type {Repository, Hash, Commit, Tree, TreeEntry} from "./types";
+
 export type GitDriver = (args: string[], options?: ExecOptions) => string;
 type ExecOptions = Object; // close enough
 export function localGit(repositoryPath: string): GitDriver {
@@ -23,25 +25,6 @@ export function localGit(repositoryPath: string): GitDriver {
     ).toString();
   };
 }
-
-export type Repository = {|
-  +commits: Map<Hash, Commit>,
-  +trees: Map<Hash, Tree>,
-|};
-export type Hash = string;
-export type Commit = {|
-  +hash: Hash,
-  +treeHash: Hash,
-|};
-export type Tree = {|
-  +hash: Hash,
-  +entries: Map<string, TreeEntry>, // map from name
-|};
-export type TreeEntry = {|
-  +type: "blob" | "commit" | "tree",
-  +name: string,
-  +hash: Hash,
-|};
 
 /**
  * Load a Git repository from disk into memory. The `rootRef` should be

--- a/src/plugins/git/types.js
+++ b/src/plugins/git/types.js
@@ -1,0 +1,20 @@
+// @flow
+
+export type Repository = {|
+  +commits: Map<Hash, Commit>,
+  +trees: Map<Hash, Tree>,
+|};
+export type Hash = string;
+export type Commit = {|
+  +hash: Hash,
+  +treeHash: Hash,
+|};
+export type Tree = {|
+  +hash: Hash,
+  +entries: Map<string, TreeEntry>, // map from name
+|};
+export type TreeEntry = {|
+  +type: "blob" | "commit" | "tree",
+  +name: string,
+  +hash: Hash,
+|};


### PR DESCRIPTION
Summary:
We should be able to get the types without depending on the function to
load a Git repo from disk, and in particular without depending on
`child_process`.

Test Plan:
Flow and tests are sufficient.

wchargin-branch: extract-repository-types