### PR TITLE
Add return type info for fetchGithubRepo

### DIFF
--- a/src/plugins/artifact/editor/GithubGraphFetcher.js
+++ b/src/plugins/artifact/editor/GithubGraphFetcher.js
@@ -33,7 +33,7 @@ export class GithubGraphFetcher extends React.Component<Props> {
     fetchGithubRepo(repoOwner, repoName, githubApiToken)
       .then((json) => {
         const parser = new GithubParser(`${repoOwner}/${repoName}`);
-        parser.addData(json.data);
+        parser.addData(json);
         return Promise.resolve(parser.graph);
       })
       .then((graph) => {

--- a/src/plugins/github/fetchGithubRepo.js
+++ b/src/plugins/github/fetchGithubRepo.js
@@ -8,6 +8,7 @@ import fetch from "isomorphic-fetch";
 
 import {stringify, inlineLayout} from "../../graphql/queries";
 import {createQuery, createVariables, postQueryExhaustive} from "./graphql";
+import type {RepositoryJSON} from "./graphql";
 
 /**
  * Scrape data from a GitHub repo using the GitHub API.
@@ -28,7 +29,7 @@ export default function fetchGithubRepo(
   repoOwner: string,
   repoName: string,
   token: string
-): Promise<Object> {
+): Promise<RepositoryJSON> {
   repoOwner = String(repoOwner);
   repoName = String(repoName);
   token = String(token);
@@ -51,7 +52,7 @@ export default function fetchGithubRepo(
   return postQueryExhaustive(
     (somePayload) => postQuery(somePayload, token),
     payload
-  ).then((x) => {
+  ).then((x: RepositoryJSON) => {
     ensureNoMorePages(x);
     return x;
   });
@@ -80,7 +81,7 @@ function postQuery({body, variables}, token) {
     });
 }
 
-function ensureNoMorePages(result, path = []) {
+function ensureNoMorePages(result: any, path = []) {
   if (result == null) {
     return;
   }


### PR DESCRIPTION
Once the type was added, flow correctly discovered a bug in
GithubGraphFetcher.js, which resulted in broken graph fetching in the
ArtifactEditor. Oops! / Good work Flow!

I made `ensureNoMorePages` expect the result it is testing to be an
`any`, which is appropriate for how the function is written (i.e. it is
written in a way that is agnostic to the actual result).