### PR TITLE
Add richer types to graphDemoData

### DIFF
--- a/src/core/__snapshots__/graph.test.js.snap
+++ b/src/core/__snapshots__/graph.test.js.snap
@@ -3,12 +3,12 @@
 exports[`graph #Graph JSON functions should serialize a simple graph 1`] = `
 Object {
   "edges": Object {
-    "{\\"id\\":\\"crab-self-assessment\\",\\"pluginName\\":\\"hill_cooking_pot\\",\\"repositoryName\\":\\"sourcecred/eventide\\",\\"type\\":\\"demoType\\"}": Object {
+    "{\\"id\\":\\"crab-self-assessment\\",\\"pluginName\\":\\"hill_cooking_pot\\",\\"repositoryName\\":\\"sourcecred/eventide\\",\\"type\\":\\"SILLY\\"}": Object {
       "dst": Object {
         "id": "razorclaw_crab#2",
         "pluginName": "hill_cooking_pot",
         "repositoryName": "sourcecred/eventide",
-        "type": "demoType",
+        "type": "FOOD",
       },
       "payload": Object {
         "evaluation": "not effective at avoiding hero",
@@ -17,15 +17,15 @@ Object {
         "id": "razorclaw_crab#2",
         "pluginName": "hill_cooking_pot",
         "repositoryName": "sourcecred/eventide",
-        "type": "demoType",
+        "type": "FOOD",
       },
     },
-    "{\\"id\\":\\"hero_of_time#0@again_cooks@seafood_fruit_mix#3\\",\\"pluginName\\":\\"hill_cooking_pot\\",\\"repositoryName\\":\\"sourcecred/eventide\\",\\"type\\":\\"demoType\\"}": Object {
+    "{\\"id\\":\\"hero_of_time#0@again_cooks@seafood_fruit_mix#3\\",\\"pluginName\\":\\"hill_cooking_pot\\",\\"repositoryName\\":\\"sourcecred/eventide\\",\\"type\\":\\"ACTION\\"}": Object {
       "dst": Object {
         "id": "hero_of_time#0",
         "pluginName": "hill_cooking_pot",
         "repositoryName": "sourcecred/eventide",
-        "type": "demoType",
+        "type": "PC",
       },
       "payload": Object {
         "crit": true,
@@ -35,15 +35,15 @@ Object {
         "id": "seafood_fruit_mix#3",
         "pluginName": "hill_cooking_pot",
         "repositoryName": "sourcecred/eventide",
-        "type": "demoType",
+        "type": "FOOD",
       },
     },
-    "{\\"id\\":\\"hero_of_time#0@cooks@seafood_fruit_mix#3\\",\\"pluginName\\":\\"hill_cooking_pot\\",\\"repositoryName\\":\\"sourcecred/eventide\\",\\"type\\":\\"demoType\\"}": Object {
+    "{\\"id\\":\\"hero_of_time#0@cooks@seafood_fruit_mix#3\\",\\"pluginName\\":\\"hill_cooking_pot\\",\\"repositoryName\\":\\"sourcecred/eventide\\",\\"type\\":\\"ACTION\\"}": Object {
       "dst": Object {
         "id": "hero_of_time#0",
         "pluginName": "hill_cooking_pot",
         "repositoryName": "sourcecred/eventide",
-        "type": "demoType",
+        "type": "PC",
       },
       "payload": Object {
         "crit": false,
@@ -52,96 +52,96 @@ Object {
         "id": "seafood_fruit_mix#3",
         "pluginName": "hill_cooking_pot",
         "repositoryName": "sourcecred/eventide",
-        "type": "demoType",
+        "type": "FOOD",
       },
     },
-    "{\\"id\\":\\"hero_of_time#0@eats@seafood_fruit_mix#3\\",\\"pluginName\\":\\"hill_cooking_pot\\",\\"repositoryName\\":\\"sourcecred/eventide\\",\\"type\\":\\"demoType\\"}": Object {
+    "{\\"id\\":\\"hero_of_time#0@eats@seafood_fruit_mix#3\\",\\"pluginName\\":\\"hill_cooking_pot\\",\\"repositoryName\\":\\"sourcecred/eventide\\",\\"type\\":\\"ACTION\\"}": Object {
       "dst": Object {
         "id": "seafood_fruit_mix#3",
         "pluginName": "hill_cooking_pot",
         "repositoryName": "sourcecred/eventide",
-        "type": "demoType",
+        "type": "FOOD",
       },
       "payload": Object {},
       "src": Object {
         "id": "hero_of_time#0",
         "pluginName": "hill_cooking_pot",
         "repositoryName": "sourcecred/eventide",
-        "type": "demoType",
+        "type": "PC",
       },
     },
-    "{\\"id\\":\\"hero_of_time#0@grabs@razorclaw_crab#2\\",\\"pluginName\\":\\"hill_cooking_pot\\",\\"repositoryName\\":\\"sourcecred/eventide\\",\\"type\\":\\"demoType\\"}": Object {
+    "{\\"id\\":\\"hero_of_time#0@grabs@razorclaw_crab#2\\",\\"pluginName\\":\\"hill_cooking_pot\\",\\"repositoryName\\":\\"sourcecred/eventide\\",\\"type\\":\\"ACTION\\"}": Object {
       "dst": Object {
         "id": "hero_of_time#0",
         "pluginName": "hill_cooking_pot",
         "repositoryName": "sourcecred/eventide",
-        "type": "demoType",
+        "type": "PC",
       },
       "payload": Object {},
       "src": Object {
         "id": "razorclaw_crab#2",
         "pluginName": "hill_cooking_pot",
         "repositoryName": "sourcecred/eventide",
-        "type": "demoType",
+        "type": "FOOD",
       },
     },
-    "{\\"id\\":\\"hero_of_time#0@picks@mighty_bananas#1\\",\\"pluginName\\":\\"hill_cooking_pot\\",\\"repositoryName\\":\\"sourcecred/eventide\\",\\"type\\":\\"demoType\\"}": Object {
+    "{\\"id\\":\\"hero_of_time#0@picks@mighty_bananas#1\\",\\"pluginName\\":\\"hill_cooking_pot\\",\\"repositoryName\\":\\"sourcecred/eventide\\",\\"type\\":\\"ACTION\\"}": Object {
       "dst": Object {
         "id": "hero_of_time#0",
         "pluginName": "hill_cooking_pot",
         "repositoryName": "sourcecred/eventide",
-        "type": "demoType",
+        "type": "PC",
       },
       "payload": Object {},
       "src": Object {
         "id": "mighty_bananas#1",
         "pluginName": "hill_cooking_pot",
         "repositoryName": "sourcecred/eventide",
-        "type": "demoType",
+        "type": "FOOD",
       },
     },
-    "{\\"id\\":\\"mighty_bananas#1@included_in@seafood_fruit_mix#3\\",\\"pluginName\\":\\"hill_cooking_pot\\",\\"repositoryName\\":\\"sourcecred/eventide\\",\\"type\\":\\"demoType\\"}": Object {
+    "{\\"id\\":\\"mighty_bananas#1@included_in@seafood_fruit_mix#3\\",\\"pluginName\\":\\"hill_cooking_pot\\",\\"repositoryName\\":\\"sourcecred/eventide\\",\\"type\\":\\"INGREDIENT\\"}": Object {
       "dst": Object {
         "id": "mighty_bananas#1",
         "pluginName": "hill_cooking_pot",
         "repositoryName": "sourcecred/eventide",
-        "type": "demoType",
+        "type": "FOOD",
       },
       "payload": Object {},
       "src": Object {
         "id": "seafood_fruit_mix#3",
         "pluginName": "hill_cooking_pot",
         "repositoryName": "sourcecred/eventide",
-        "type": "demoType",
+        "type": "FOOD",
       },
     },
-    "{\\"id\\":\\"razorclaw_crab#2@included_in@seafood_fruit_mix#3\\",\\"pluginName\\":\\"hill_cooking_pot\\",\\"repositoryName\\":\\"sourcecred/eventide\\",\\"type\\":\\"demoType\\"}": Object {
+    "{\\"id\\":\\"razorclaw_crab#2@included_in@seafood_fruit_mix#3\\",\\"pluginName\\":\\"hill_cooking_pot\\",\\"repositoryName\\":\\"sourcecred/eventide\\",\\"type\\":\\"INGREDIENT\\"}": Object {
       "dst": Object {
         "id": "razorclaw_crab#2",
         "pluginName": "hill_cooking_pot",
         "repositoryName": "sourcecred/eventide",
-        "type": "demoType",
+        "type": "FOOD",
       },
       "payload": Object {},
       "src": Object {
         "id": "seafood_fruit_mix#3",
         "pluginName": "hill_cooking_pot",
         "repositoryName": "sourcecred/eventide",
-        "type": "demoType",
+        "type": "FOOD",
       },
     },
   },
   "nodes": Object {
-    "{\\"id\\":\\"hero_of_time#0\\",\\"pluginName\\":\\"hill_cooking_pot\\",\\"repositoryName\\":\\"sourcecred/eventide\\",\\"type\\":\\"demoType\\"}": Object {
+    "{\\"id\\":\\"hero_of_time#0\\",\\"pluginName\\":\\"hill_cooking_pot\\",\\"repositoryName\\":\\"sourcecred/eventide\\",\\"type\\":\\"PC\\"}": Object {
       "payload": Object {},
     },
-    "{\\"id\\":\\"mighty_bananas#1\\",\\"pluginName\\":\\"hill_cooking_pot\\",\\"repositoryName\\":\\"sourcecred/eventide\\",\\"type\\":\\"demoType\\"}": Object {
+    "{\\"id\\":\\"mighty_bananas#1\\",\\"pluginName\\":\\"hill_cooking_pot\\",\\"repositoryName\\":\\"sourcecred/eventide\\",\\"type\\":\\"FOOD\\"}": Object {
       "payload": Object {},
     },
-    "{\\"id\\":\\"razorclaw_crab#2\\",\\"pluginName\\":\\"hill_cooking_pot\\",\\"repositoryName\\":\\"sourcecred/eventide\\",\\"type\\":\\"demoType\\"}": Object {
+    "{\\"id\\":\\"razorclaw_crab#2\\",\\"pluginName\\":\\"hill_cooking_pot\\",\\"repositoryName\\":\\"sourcecred/eventide\\",\\"type\\":\\"FOOD\\"}": Object {
       "payload": Object {},
     },
-    "{\\"id\\":\\"seafood_fruit_mix#3\\",\\"pluginName\\":\\"hill_cooking_pot\\",\\"repositoryName\\":\\"sourcecred/eventide\\",\\"type\\":\\"demoType\\"}": Object {
+    "{\\"id\\":\\"seafood_fruit_mix#3\\",\\"pluginName\\":\\"hill_cooking_pot\\",\\"repositoryName\\":\\"sourcecred/eventide\\",\\"type\\":\\"FOOD\\"}": Object {
       "payload": Object {
         "effect": Array [
           "attack_power",

--- a/src/core/graphDemoData.js
+++ b/src/core/graphDemoData.js
@@ -7,46 +7,46 @@
 import type {Address} from "./address";
 import {Graph} from "./graph";
 
-export function makeAddress(id: string): Address {
+export function makeAddress(id: string, type: string): Address {
   return {
     repositoryName: "sourcecred/eventide",
     pluginName: "hill_cooking_pot",
-    type: "demoType",
     id,
+    type,
   };
 }
 export const heroNode = () => ({
-  address: makeAddress("hero_of_time#0"),
+  address: makeAddress("hero_of_time#0", "PC"),
   payload: {},
 });
 export const bananasNode = () => ({
-  address: makeAddress("mighty_bananas#1"),
+  address: makeAddress("mighty_bananas#1", "FOOD"),
   payload: {},
 });
 export const crabNode = () => ({
-  address: makeAddress("razorclaw_crab#2"),
+  address: makeAddress("razorclaw_crab#2", "FOOD"),
   payload: {},
 });
 export const mealNode = () => ({
-  address: makeAddress("seafood_fruit_mix#3"),
+  address: makeAddress("seafood_fruit_mix#3", "FOOD"),
   payload: {
     effect: ["attack_power", 1],
   },
 });
 export const pickEdge = () => ({
-  address: makeAddress("hero_of_time#0@picks@mighty_bananas#1"),
+  address: makeAddress("hero_of_time#0@picks@mighty_bananas#1", "ACTION"),
   src: bananasNode().address,
   dst: heroNode().address,
   payload: {},
 });
 export const grabEdge = () => ({
-  address: makeAddress("hero_of_time#0@grabs@razorclaw_crab#2"),
+  address: makeAddress("hero_of_time#0@grabs@razorclaw_crab#2", "ACTION"),
   src: crabNode().address,
   dst: heroNode().address,
   payload: {},
 });
 export const cookEdge = () => ({
-  address: makeAddress("hero_of_time#0@cooks@seafood_fruit_mix#3"),
+  address: makeAddress("hero_of_time#0@cooks@seafood_fruit_mix#3", "ACTION"),
   src: mealNode().address,
   dst: heroNode().address,
   payload: {
@@ -54,19 +54,25 @@ export const cookEdge = () => ({
   },
 });
 export const bananasIngredientEdge = () => ({
-  address: makeAddress("mighty_bananas#1@included_in@seafood_fruit_mix#3"),
+  address: makeAddress(
+    "mighty_bananas#1@included_in@seafood_fruit_mix#3",
+    "INGREDIENT"
+  ),
   src: mealNode().address,
   dst: bananasNode().address,
   payload: {},
 });
 export const crabIngredientEdge = () => ({
-  address: makeAddress("razorclaw_crab#2@included_in@seafood_fruit_mix#3"),
+  address: makeAddress(
+    "razorclaw_crab#2@included_in@seafood_fruit_mix#3",
+    "INGREDIENT"
+  ),
   src: mealNode().address,
   dst: crabNode().address,
   payload: {},
 });
 export const eatEdge = () => ({
-  address: makeAddress("hero_of_time#0@eats@seafood_fruit_mix#3"),
+  address: makeAddress("hero_of_time#0@eats@seafood_fruit_mix#3", "ACTION"),
   src: heroNode().address,
   dst: mealNode().address,
   payload: {},
@@ -85,14 +91,17 @@ export const simpleMealGraph = () =>
     .addEdge(eatEdge());
 
 export const crabLoopEdge = () => ({
-  address: makeAddress("crab-self-assessment"),
+  address: makeAddress("crab-self-assessment", "SILLY"),
   src: crabNode().address,
   dst: crabNode().address,
   payload: {evaluation: "not effective at avoiding hero"},
 });
 
 export const duplicateCookEdge = () => ({
-  address: makeAddress("hero_of_time#0@again_cooks@seafood_fruit_mix#3"),
+  address: makeAddress(
+    "hero_of_time#0@again_cooks@seafood_fruit_mix#3",
+    "ACTION"
+  ),
   src: mealNode().address,
   dst: heroNode().address,
   payload: {


### PR DESCRIPTION
In preparation for using type info in the Graph apis, it is helpful to
have richer type info in the graph demo data.

Test plan: Check that the snapshot changes only consist of type changes,
and that CI passes.