### PR TITLE
Move `localGit`/`GitDriver` into Git utils

### DIFF
--- a/src/plugins/git/loadRepository.js
+++ b/src/plugins/git/loadRepository.js
@@ -9,22 +9,9 @@
  */
 // @flow
 
-import {execFileSync} from "child_process";
-
+import type {GitDriver} from "./gitUtils";
 import type {Repository, Hash, Commit, Tree, TreeEntry} from "./types";
-
-export type GitDriver = (args: string[], options?: ExecOptions) => string;
-type ExecOptions = Object; // close enough
-export function localGit(repositoryPath: string): GitDriver {
-  return function git(args: string[], options?: ExecOptions): string {
-    // Throws an Error on shell failure.
-    return execFileSync(
-      "git",
-      ["-C", repositoryPath, ...args],
-      options
-    ).toString();
-  };
-}
+import {localGit} from "./gitUtils";
 
 /**
  * Load a Git repository from disk into memory. The `rootRef` should be


### PR DESCRIPTION
Summary:
A few reasons for this:
 1. This _is_ a utility, so it makes sense semantically.
 2. This unifies the utilities API; clients like `loadRepository.test`
    don’t have to keep around both a `git` and a `gitUtils`.
 3. Most importantly, further scripts and tests shouldn’t depend on
    `loadRepository` just for `localGit`. Depending on `gitUtils` makes
    much more sense.

(Note that `makeUtils` is no longer dependency-injectable, but that’s
okay; I considered this and favored YAGNI on this one.)

Test Plan:
Existing unit tests pass.

wchargin-branch: move-localgit