### PR TITLE
Clean up temporary directories in tests

### DIFF
--- a/src/plugins/git/loadRepository.test.js
+++ b/src/plugins/git/loadRepository.test.js
@@ -13,7 +13,7 @@ afterAll(() => {
 });
 
 function mkdtemp() {
-  const result = tmp.dirSync();
+  const result = tmp.dirSync({unsafeCleanup: true});
   cleanups.push(() => result.removeCallback());
   return result.name;
 }


### PR DESCRIPTION
Summary:
The `loadRepository` test tries to clean up temporary directories, but
failed to do so because the directories were not empty. The cleanup hook
threw an error, but this error was silenced by Jest due to [a known
bug][1] that was fixed a few days ago. We can fix this by asking `tmp`
to clean up directories even if they are not empty, using the
`unsafeCleanup` option.

[1]: https://github.com/facebook/jest/issues/3266

Test Plan:
While running `watch -n 0.1 'ls /tmp | grep "tmp-.*" | wc -l'`, run
tests. Note that the number increases by five and then drops down again;
before this patch, it would increase by 5 and then stay there.

wchargin-branch: clean-up-tmpdirs