### PR TITLE
Create an example submodule repository

### DIFF
--- a/src/plugins/git/demoData/__snapshots__/exampleRepo.test.js.snap
+++ b/src/plugins/git/demoData/__snapshots__/exampleRepo.test.js.snap
@@ -8,3 +8,10 @@ Array [
   "677b340674bde17fdaac3b5f5eef929139ef2a52",
 ]
 `;
+
+exports[`createExampleSubmoduleRepo is deterministic 1`] = `
+Array [
+  "762c062fbdc7ec198cd693e95d55b374a08ff3e3",
+  "29ef158bc982733e2ba429fcf73e2f7562244188",
+]
+`;

--- a/src/plugins/git/demoData/exampleRepo.js
+++ b/src/plugins/git/demoData/exampleRepo.js
@@ -44,3 +44,37 @@ export function createExampleRepo(intoDirectory: string): RepositoryInfo {
 
   return {path: repositoryPath, commits};
 }
+
+/**
+ * Create the example repository that should be included as a submodule
+ * in a larger repository. (This repository does not itself have
+ * submodules.)
+ */
+export function createExampleSubmoduleRepo(
+  intoDirectory: string
+): RepositoryInfo {
+  const repositoryPath = intoDirectory;
+  mkdirp(repositoryPath);
+  const git = makeUtils(repositoryPath);
+  const commits = [];
+
+  git.exec(["init"]);
+
+  git.writeAndStage(
+    "README.txt",
+    [
+      "example-git-submodule\n",
+      "---------------------\n\n",
+      "This simple repository serves no purpose other than to be included as\n",
+      "a submodule in a larger repository.\n",
+    ].join("")
+  );
+  git.deterministicCommit("Initial commit");
+  commits.push(git.head());
+
+  git.writeAndStage("useless.txt", "Nothing to see here; move along.\n");
+  git.deterministicCommit("Add a file, so that we have multiple commits");
+  commits.push(git.head());
+
+  return {path: repositoryPath, commits};
+}

--- a/src/plugins/git/demoData/exampleRepo.test.js
+++ b/src/plugins/git/demoData/exampleRepo.test.js
@@ -2,7 +2,7 @@
 
 import tmp from "tmp";
 
-import {createExampleRepo} from "./exampleRepo";
+import {createExampleRepo, createExampleSubmoduleRepo} from "./exampleRepo";
 
 const cleanups: (() => void)[] = [];
 afterAll(() => {
@@ -20,5 +20,11 @@ function mkdtemp() {
 describe("createExampleRepo", () => {
   it("is deterministic", () => {
     expect(createExampleRepo(mkdtemp()).commits).toMatchSnapshot();
+  });
+});
+
+describe("createExampleSubmoduleRepo", () => {
+  it("is deterministic", () => {
+    expect(createExampleSubmoduleRepo(mkdtemp()).commits).toMatchSnapshot();
   });
 });


### PR DESCRIPTION
Summary:
We want our main repository to include submodules so that we can test
submodule support. Here, we create a repository to be included as a
submodule.

wchargin-branch: example-submodule-repository