### PR TITLE
Add a command-line script to create example repos

### DIFF
--- a/config/paths.js
+++ b/config/paths.js
@@ -62,5 +62,6 @@ module.exports = {
     fetchAndPrintGithubRepo: resolveApp(
       "src/plugins/github/bin/fetchAndPrintGithubRepo.js"
     ),
+    createExampleRepo: resolveApp("src/plugins/git/bin/createExampleRepo.js"),
   },
 };

--- a/src/plugins/git/bin/createExampleRepo.js
+++ b/src/plugins/git/bin/createExampleRepo.js
@@ -1,0 +1,74 @@
+// @flow
+
+import fs from "fs";
+
+import {
+  createExampleRepo,
+  createExampleSubmoduleRepo,
+} from "../demoData/exampleRepo";
+
+function parseArgs() {
+  const argv = process.argv.slice(2);
+  const fail = () => {
+    const invocation = process.argv.slice(0, 2).join(" ");
+    throw new Error(`Usage: ${invocation} [--[no-]submodule] TARGET_DIRECTORY`);
+  };
+
+  let submodule: boolean = false;
+  let target: ?string = null;
+
+  for (const arg of argv) {
+    if (arg === "--submodule") {
+      submodule = true;
+    } else if (arg === "--no-submodule") {
+      submodule = false;
+    } else {
+      if (target == null) {
+        target = arg;
+      } else {
+        fail();
+      }
+    }
+  }
+
+  if (target == null) {
+    fail();
+    throw new Error("Unreachable"); // for Flow
+  }
+  return {
+    submodule,
+    target: (target: string),
+  };
+}
+
+function ensureEmptyDirectoryOrNonexistent(target: string) {
+  const files = (() => {
+    try {
+      return fs.readdirSync(target);
+    } catch (e) {
+      if (e.code === "ENOTDIR") {
+        throw new Error("Target exists, but is not a directory.");
+      } else if (e.code === "ENOENT") {
+        // No problem. We'll create it.
+        return [];
+      } else {
+        throw e;
+      }
+    }
+  })();
+  if (files.length > 0) {
+    throw new Error("Target directory exists, but is nonempty.");
+  }
+}
+
+function main() {
+  const args = parseArgs();
+  ensureEmptyDirectoryOrNonexistent(args.target);
+  if (args.submodule) {
+    createExampleSubmoduleRepo(args.target);
+  } else {
+    createExampleRepo(args.target);
+  }
+}
+
+main();


### PR DESCRIPTION
Summary:
We’ll use this to create the repositories on disk and then push them to
GitHub.

Test Plan:
Generate both kinds of repository, and check out the SHAs:
```shell
$ yarn backend
$ node bin/createExampleRepo.js /tmp/repo
$ node bin/createExampleRepo.js --submodule /tmp/repo-submodule
$ node bin/createExampleRepo.js --no-submodule /tmp/repo-no-submodule
$ # (first and third lines do the same thing)
$ git -C /tmp/repo rev-parse HEAD
677b340674bde17fdaac3b5f5eef929139ef2a52
$ git -C /tmp/repo-submodule rev-parse HEAD
29ef158bc982733e2ba429fcf73e2f7562244188
$ git -C /tmp/repo-no-submodule rev-parse HEAD
677b340674bde17fdaac3b5f5eef929139ef2a52
```
Then, note that these SHAs are expected per the snapshot file in
`exampleRepo.test.js.snap`.

wchargin-branch: create-example-repo-command