### PR TITLE
Add `Graph.getAdjacentEdges` for in and out edges

### DIFF
--- a/src/core/graph.js
+++ b/src/core/graph.js
@@ -220,6 +220,18 @@ export class Graph<NP, EP> {
     return result;
   }
 
+  getAdjacentEdges(
+    nodeAddress: Address,
+    typeOptions?: {+nodeType?: string, +edgeType?: string}
+  ): Edge<EP>[] {
+    const inEdges = this.getInEdges(nodeAddress, typeOptions);
+    // If there are self-reference edges, avoid double counting them.
+    const outEdges = this.getOutEdges(nodeAddress, typeOptions).filter(
+      (e) => !deepEqual(e.src, e.dst)
+    );
+    return [].concat(inEdges, outEdges);
+  }
+
   /**
    * Gets all nodes in the graph, in unspecified order.
    */


### PR DESCRIPTION
Some consumers of the graph may prefer to treat it as an undirected
graph. For example, when finding the author of an issue, it is wholly
sufficient to find an edge with the `AUTHORS` type; the caller may
prefer not to be bothered with remembering which end of the `AUTHORS`
end is considered the `src` and which is the `dst`.

The `getAdjacentEdges` call enables that, by combining the output of
`getInEdges` and `getOutEdges`.

Test plan:
The new tests are pretty comprehensive.