### PR TITLE
Add one-way GitHub sync for Git example repos

### DIFF
--- a/src/plugins/git/demoData/synchronizeToGithub.sh
+++ b/src/plugins/git/demoData/synchronizeToGithub.sh
@@ -1,0 +1,41 @@
+#!/bin/bash
+
+set -eu
+
+main() {
+    if [ "${1:-}" = "-n" ] || [ "${1:-}" = "--dry-run" ]; then
+        DRY_RUN=1
+    fi
+    cd "$(git rev-parse --show-toplevel)"
+    yarn backend
+    printf '\n'
+    printf 'Synchronizing: example-git\n'
+    synchronize \
+        --no-submodule 'git@github.com:sourcecred/example-git.git'
+    printf '\n'
+    printf 'Synchronizing: example-git-submodule\n'
+    synchronize \
+        --submodule 'git@github.com:sourcecred/example-git-submodule.git'
+    printf '\n'
+    printf 'Done.\n'
+}
+
+synchronize() (
+    submodule_flag="$1"  # --submodule | --no-submodule
+    remote_url="$2"
+    tmpdir="$(mktemp -d)"
+    node bin/createExampleRepo.js "${submodule_flag}" "${tmpdir}"
+    (
+        cd "${tmpdir}"
+        git remote add upstream "${remote_url}"
+        git fetch upstream --quiet
+        args=( git push --force-with-lease upstream HEAD:master )
+        if [ -n "${DRY_RUN:-}" ]; then
+            args+=( --dry-run )
+        fi
+        "${args[@]}"
+    )
+    rm -rf "${tmpdir}"
+)
+
+main "$@"


### PR DESCRIPTION
Test Plan:
Run the script with `--dry-run`, which currently prints
```shell
$ src/plugins/git/demoData/synchronizeToGithub.sh -n
yarn run v1.5.1
[build output truncated]
Build completed; results in 'bin'.
Done in 3.30s.

Synchronizing: example-git
warning: no common commits
To github.com:sourcecred/example-git.git
 + 3507b7c...3715ddf HEAD -> master (forced update)

Synchronizing: example-git-submodule
Everything up-to-date

Done.
```
This reflects the correct state of affairs, because #158 changed the
example repository. Note that the `3715ddf` SHA in the output of the
above script matches the SHA in the `exampleRepo.test.js.snap` snapshot.

wchargin-branch: sync-git-example-repos