### PR TITLE
Remove `address.sortedByAddress`

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "json-stable-stringify": "^1.0.1",
     "lint-staged": "^6.1.1",
     "lodash.isequal": "^4.5.0",
+    "lodash.sortby": "^4.7.0",
     "object-assign": "4.1.1",
     "postcss-flexbugs-fixes": "3.2.0",
     "postcss-loader": "2.0.8",

--- a/src/core/address.js
+++ b/src/core/address.js
@@ -111,21 +111,6 @@ export class AddressMap<T: Addressable> {
   }
 }
 
-/**
- * Create a copy of the given array and sort its elements by their
- * addresses. The original array and its elements are not modified.
- */
-export function sortedByAddress<T: Addressable>(xs: T[]) {
-  function cmp(x1: T, x2: T): -1 | 0 | 1 {
-    // TODO(@wchargin): This can be replaced by four string-comparisons
-    // to avoid stringifying.
-    const a1 = toString(x1.address);
-    const a2 = toString(x2.address);
-    return a1 > a2 ? 1 : a1 < a2 ? -1 : 0;
-  }
-  return xs.slice().sort(cmp);
-}
-
 export function toString(x: Address): string {
   return stringify(x);
 }

--- a/src/core/address.test.js
+++ b/src/core/address.test.js
@@ -1,7 +1,10 @@
 // @flow
 
+import sortBy from "lodash.sortby";
+import stringify from "json-stable-stringify";
+
 import type {Address} from "./address";
-import {AddressMap, fromString, sortedByAddress, toString} from "./address";
+import {AddressMap, fromString, toString} from "./address";
 
 describe("address", () => {
   // Some test data using objects that have addresses, like houses.
@@ -51,7 +54,8 @@ describe("address", () => {
     it("gets all objects, in some order", () => {
       const actual = makeMap().getAll();
       const expected = [mansion(), mattressStore()];
-      expect(sortedByAddress(actual)).toEqual(sortedByAddress(expected));
+      const sort = (xs) => sortBy(xs, (x) => stringify(x.address));
+      expect(sort(actual)).toEqual(sort(actual));
     });
 
     it("removes objects by key", () => {
@@ -134,34 +138,6 @@ describe("address", () => {
           expect(() => makeMap().add(element)).toThrow(message);
         });
       });
-    });
-  });
-
-  describe("sortedByAddress", () => {
-    it("sorts the empty array", () => {
-      expect(sortedByAddress([])).toEqual([]);
-    });
-    it("sorts a sorted array", () => {
-      const input = () => [mansion(), mattressStore()];
-      const output = () => [mansion(), mattressStore()];
-      expect(sortedByAddress(input())).toEqual(output());
-    });
-    it("sorts a reverse-sorted array", () => {
-      const input = () => [mattressStore(), mansion()];
-      const output = () => [mansion(), mattressStore()];
-      expect(sortedByAddress(input())).toEqual(output());
-    });
-    it("sorts an array with duplicates", () => {
-      const input = () => [mattressStore(), mansion(), mattressStore()];
-      const output = () => [mansion(), mattressStore(), mattressStore()];
-      expect(sortedByAddress(input())).toEqual(output());
-    });
-    it("doesn't mutate its input", () => {
-      const input = () => [mattressStore(), mansion()];
-      const x = input();
-      expect(x).toEqual(input());
-      expect(sortedByAddress(x)).not.toEqual(input());
-      expect(x).toEqual(input());
     });
   });
 

--- a/src/core/graph.test.js
+++ b/src/core/graph.test.js
@@ -1,9 +1,10 @@
 // @flow
 
 import deepEqual from "lodash.isequal";
+import sortBy from "lodash.sortby";
+import stringify from "json-stable-stringify";
 
 import type {Address, Addressable} from "./address";
-import {sortedByAddress} from "./address";
 import type {Node, Edge} from "./graph";
 import {Graph} from "./graph";
 import * as demoData from "./graphDemoData";
@@ -14,7 +15,8 @@ describe("graph", () => {
     // array with undefined order. We canonicalize the ordering so that
     // we can then test equality with `expect(...).toEqual(...)`.
     function expectSameSorted<T: Addressable>(xs: T[], ys: T[]) {
-      expect(sortedByAddress(xs)).toEqual(sortedByAddress(ys));
+      const sort = (xs) => sortBy(xs, (x) => stringify(x.address));
+      expect(sort(xs)).toEqual(sort(ys));
     }
 
     describe("construction", () => {
@@ -671,16 +673,16 @@ describe("graph", () => {
       it("is idempotent in terms of in-edges", () => {
         const g1 = originalGraph();
         const g2 = modifiedGraph();
-        const e1 = sortedByAddress(g1.getInEdges(targetEdge().address));
-        const e2 = sortedByAddress(g2.getInEdges(targetEdge().address));
-        expect(e1).toEqual(e2);
+        const e1 = g1.getInEdges(targetEdge().address);
+        const e2 = g2.getInEdges(targetEdge().address);
+        expectSameSorted(e1, e2);
       });
       it("is idempotent in terms of out-edges", () => {
         const g1 = originalGraph();
         const g2 = modifiedGraph();
-        const e1 = sortedByAddress(g1.getOutEdges(targetEdge().address));
-        const e2 = sortedByAddress(g2.getOutEdges(targetEdge().address));
-        expect(e1).toEqual(e2);
+        const e1 = g1.getOutEdges(targetEdge().address);
+        const e2 = g2.getOutEdges(targetEdge().address);
+        expectSameSorted(e1, e2);
       });
     });
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -4302,6 +4302,10 @@ lodash.memoize@^4.1.2:
   version "4.1.2"
   resolved "https://registry.yarnpkg.com/lodash.memoize/-/lodash.memoize-4.1.2.tgz#bcc6c49a42a2840ed997f323eada5ecd182e0bfe"
 
+lodash.sortby@^4.7.0:
+  version "4.7.0"
+  resolved "https://registry.yarnpkg.com/lodash.sortby/-/lodash.sortby-4.7.0.tgz#edd14c824e2cc9c1e0b0a1b42bb5210516a42438"
+
 lodash.template@^4.4.0:
   version "4.4.0"
   resolved "https://registry.yarnpkg.com/lodash.template/-/lodash.template-4.4.0.tgz#e73a0385c8355591746e020b99679c690e68fba0"


### PR DESCRIPTION
Previously, the address module exported `sortedByAddress`, a utility
function that sorts an array of `Addressable`s. This function was only
used in test code.

This commit replaces it with generic usage of `lodash.sortBy`. This
reduces the API surface area of the module, and removes test-only code
from the exported api.

New dependency added: `lodash.sortby`
https://www.npmjs.com/package/lodash.sortby