### PR TITLE
Switch in-memory Git types from Maps to objects

### DIFF
--- a/src/plugins/git/__snapshots__/loadRepository.test.js.snap
+++ b/src/plugins/git/__snapshots__/loadRepository.test.js.snap
@@ -2,205 +2,45 @@
 
 exports[`loadRepository loads from HEAD 1`] = `
 Object {
-  "commits": Map {
-    "3715ddfb8d4c4fd2a6f6af75488c82f84c92ec2f" => Object {
+  "commits": Object {
+    "3715ddfb8d4c4fd2a6f6af75488c82f84c92ec2f": Object {
       "hash": "3715ddfb8d4c4fd2a6f6af75488c82f84c92ec2f",
       "treeHash": "7be3ecfee5314ffa9b2d93fc4377792b2d6d70ed",
     },
-    "69c5aad50eec8f2a0a07c988c3b283a6490eb45b" => Object {
+    "69c5aad50eec8f2a0a07c988c3b283a6490eb45b": Object {
       "hash": "69c5aad50eec8f2a0a07c988c3b283a6490eb45b",
       "treeHash": "bbf3b8b3d26a4f884b5c022d46851f593d329192",
     },
-    "e8b7a8f19701cd5a25e4a097d513ead60e5f8bcc" => Object {
-      "hash": "e8b7a8f19701cd5a25e4a097d513ead60e5f8bcc",
-      "treeHash": "819fc546cea489476ce8dc90785e9ba7753d0a8f",
-    },
-    "d160cca97611e9dfed642522ad44408d0292e8ea" => Object {
-      "hash": "d160cca97611e9dfed642522ad44408d0292e8ea",
-      "treeHash": "569e1d383759903134df75230d63c0090196d4cb",
-    },
-    "8d287c3bfbf8455ef30187bf5153ffc1b6eef268" => Object {
+    "8d287c3bfbf8455ef30187bf5153ffc1b6eef268": Object {
       "hash": "8d287c3bfbf8455ef30187bf5153ffc1b6eef268",
       "treeHash": "3dfb84795e07341b05fad3a0d5a55f8304b2d7d8",
     },
-    "c08ee3a4edea384d5291ffcbf06724a13ed72325" => Object {
+    "c08ee3a4edea384d5291ffcbf06724a13ed72325": Object {
       "hash": "c08ee3a4edea384d5291ffcbf06724a13ed72325",
       "treeHash": "2f7155e359fd0ecb96ffdca66fa45b6ed5792809",
     },
-    "c2b51945e7457546912a8ce158ed9d294558d294" => Object {
+    "c2b51945e7457546912a8ce158ed9d294558d294": Object {
       "hash": "c2b51945e7457546912a8ce158ed9d294558d294",
       "treeHash": "bdff5d94193170015d6cbb549b7b630649428b1f",
     },
+    "d160cca97611e9dfed642522ad44408d0292e8ea": Object {
+      "hash": "d160cca97611e9dfed642522ad44408d0292e8ea",
+      "treeHash": "569e1d383759903134df75230d63c0090196d4cb",
+    },
+    "e8b7a8f19701cd5a25e4a097d513ead60e5f8bcc": Object {
+      "hash": "e8b7a8f19701cd5a25e4a097d513ead60e5f8bcc",
+      "treeHash": "819fc546cea489476ce8dc90785e9ba7753d0a8f",
+    },
   },
-  "trees": Map {
-    "7be3ecfee5314ffa9b2d93fc4377792b2d6d70ed" => Object {
-      "entries": Map {
-        ".gitmodules" => Object {
-          "hash": "8c6cac301e763aa6d36466e0a775eb804be2c311",
-          "name": ".gitmodules",
-          "type": "blob",
-        },
-        "README.txt" => Object {
+  "trees": Object {
+    "2f7155e359fd0ecb96ffdca66fa45b6ed5792809": Object {
+      "entries": Object {
+        "README.txt": Object {
           "hash": "0fb31858c8e3710be77e1dbb8880acf8a5543d82",
           "name": "README.txt",
           "type": "blob",
         },
-        "pygravitydefier" => Object {
-          "hash": "29ef158bc982733e2ba429fcf73e2f7562244188",
-          "name": "pygravitydefier",
-          "type": "commit",
-        },
-        "science.txt" => Object {
-          "hash": "f1f2514ca6d7a6a1a0511957021b1995bf9ace1c",
-          "name": "science.txt",
-          "type": "blob",
-        },
-        "src" => Object {
-          "hash": "78fc9c83023386854c6bfdc5761c0e58f68e226f",
-          "name": "src",
-          "type": "tree",
-        },
-      },
-      "hash": "7be3ecfee5314ffa9b2d93fc4377792b2d6d70ed",
-    },
-    "bbf3b8b3d26a4f884b5c022d46851f593d329192" => Object {
-      "entries": Map {
-        ".gitmodules" => Object {
-          "hash": "8c6cac301e763aa6d36466e0a775eb804be2c311",
-          "name": ".gitmodules",
-          "type": "blob",
-        },
-        "README.txt" => Object {
-          "hash": "0fb31858c8e3710be77e1dbb8880acf8a5543d82",
-          "name": "README.txt",
-          "type": "blob",
-        },
-        "TODOS.txt" => Object {
-          "hash": "ddec7477206c30c31b81482e56b877a0b3c2638b",
-          "name": "TODOS.txt",
-          "type": "blob",
-        },
-        "pygravitydefier" => Object {
-          "hash": "29ef158bc982733e2ba429fcf73e2f7562244188",
-          "name": "pygravitydefier",
-          "type": "commit",
-        },
-        "science.txt" => Object {
-          "hash": "f1f2514ca6d7a6a1a0511957021b1995bf9ace1c",
-          "name": "science.txt",
-          "type": "blob",
-        },
-        "src" => Object {
-          "hash": "78fc9c83023386854c6bfdc5761c0e58f68e226f",
-          "name": "src",
-          "type": "tree",
-        },
-      },
-      "hash": "bbf3b8b3d26a4f884b5c022d46851f593d329192",
-    },
-    "819fc546cea489476ce8dc90785e9ba7753d0a8f" => Object {
-      "entries": Map {
-        ".gitmodules" => Object {
-          "hash": "8c6cac301e763aa6d36466e0a775eb804be2c311",
-          "name": ".gitmodules",
-          "type": "blob",
-        },
-        "README.txt" => Object {
-          "hash": "0fb31858c8e3710be77e1dbb8880acf8a5543d82",
-          "name": "README.txt",
-          "type": "blob",
-        },
-        "TODOS.txt" => Object {
-          "hash": "ddec7477206c30c31b81482e56b877a0b3c2638b",
-          "name": "TODOS.txt",
-          "type": "blob",
-        },
-        "pygravitydefier" => Object {
-          "hash": "29ef158bc982733e2ba429fcf73e2f7562244188",
-          "name": "pygravitydefier",
-          "type": "commit",
-        },
-        "science.txt" => Object {
-          "hash": "f1f2514ca6d7a6a1a0511957021b1995bf9ace1c",
-          "name": "science.txt",
-          "type": "blob",
-        },
-        "src" => Object {
-          "hash": "7b79d579b62994faba3b69fdf8aa442586c32681",
-          "name": "src",
-          "type": "tree",
-        },
-      },
-      "hash": "819fc546cea489476ce8dc90785e9ba7753d0a8f",
-    },
-    "569e1d383759903134df75230d63c0090196d4cb" => Object {
-      "entries": Map {
-        ".gitmodules" => Object {
-          "hash": "8c6cac301e763aa6d36466e0a775eb804be2c311",
-          "name": ".gitmodules",
-          "type": "blob",
-        },
-        "README.txt" => Object {
-          "hash": "0fb31858c8e3710be77e1dbb8880acf8a5543d82",
-          "name": "README.txt",
-          "type": "blob",
-        },
-        "TODOS.txt" => Object {
-          "hash": "ddec7477206c30c31b81482e56b877a0b3c2638b",
-          "name": "TODOS.txt",
-          "type": "blob",
-        },
-        "pygravitydefier" => Object {
-          "hash": "762c062fbdc7ec198cd693e95d55b374a08ff3e3",
-          "name": "pygravitydefier",
-          "type": "commit",
-        },
-        "science.txt" => Object {
-          "hash": "f1f2514ca6d7a6a1a0511957021b1995bf9ace1c",
-          "name": "science.txt",
-          "type": "blob",
-        },
-        "src" => Object {
-          "hash": "7b79d579b62994faba3b69fdf8aa442586c32681",
-          "name": "src",
-          "type": "tree",
-        },
-      },
-      "hash": "569e1d383759903134df75230d63c0090196d4cb",
-    },
-    "3dfb84795e07341b05fad3a0d5a55f8304b2d7d8" => Object {
-      "entries": Map {
-        ".gitmodules" => Object {
-          "hash": "8c6cac301e763aa6d36466e0a775eb804be2c311",
-          "name": ".gitmodules",
-          "type": "blob",
-        },
-        "README.txt" => Object {
-          "hash": "0fb31858c8e3710be77e1dbb8880acf8a5543d82",
-          "name": "README.txt",
-          "type": "blob",
-        },
-        "pygravitydefier" => Object {
-          "hash": "762c062fbdc7ec198cd693e95d55b374a08ff3e3",
-          "name": "pygravitydefier",
-          "type": "commit",
-        },
-        "science.txt" => Object {
-          "hash": "f1f2514ca6d7a6a1a0511957021b1995bf9ace1c",
-          "name": "science.txt",
-          "type": "blob",
-        },
-      },
-      "hash": "3dfb84795e07341b05fad3a0d5a55f8304b2d7d8",
-    },
-    "2f7155e359fd0ecb96ffdca66fa45b6ed5792809" => Object {
-      "entries": Map {
-        "README.txt" => Object {
-          "hash": "0fb31858c8e3710be77e1dbb8880acf8a5543d82",
-          "name": "README.txt",
-          "type": "blob",
-        },
-        "science.txt" => Object {
+        "science.txt": Object {
           "hash": "f1f2514ca6d7a6a1a0511957021b1995bf9ace1c",
           "name": "science.txt",
           "type": "blob",
@@ -208,24 +48,74 @@ Object {
       },
       "hash": "2f7155e359fd0ecb96ffdca66fa45b6ed5792809",
     },
-    "bdff5d94193170015d6cbb549b7b630649428b1f" => Object {
-      "entries": Map {
-        "README.txt" => Object {
+    "3dfb84795e07341b05fad3a0d5a55f8304b2d7d8": Object {
+      "entries": Object {
+        ".gitmodules": Object {
+          "hash": "8c6cac301e763aa6d36466e0a775eb804be2c311",
+          "name": ".gitmodules",
+          "type": "blob",
+        },
+        "README.txt": Object {
           "hash": "0fb31858c8e3710be77e1dbb8880acf8a5543d82",
           "name": "README.txt",
           "type": "blob",
         },
+        "pygravitydefier": Object {
+          "hash": "762c062fbdc7ec198cd693e95d55b374a08ff3e3",
+          "name": "pygravitydefier",
+          "type": "commit",
+        },
+        "science.txt": Object {
+          "hash": "f1f2514ca6d7a6a1a0511957021b1995bf9ace1c",
+          "name": "science.txt",
+          "type": "blob",
+        },
       },
-      "hash": "bdff5d94193170015d6cbb549b7b630649428b1f",
+      "hash": "3dfb84795e07341b05fad3a0d5a55f8304b2d7d8",
     },
-    "78fc9c83023386854c6bfdc5761c0e58f68e226f" => Object {
-      "entries": Map {
-        "index.py" => Object {
+    "569e1d383759903134df75230d63c0090196d4cb": Object {
+      "entries": Object {
+        ".gitmodules": Object {
+          "hash": "8c6cac301e763aa6d36466e0a775eb804be2c311",
+          "name": ".gitmodules",
+          "type": "blob",
+        },
+        "README.txt": Object {
+          "hash": "0fb31858c8e3710be77e1dbb8880acf8a5543d82",
+          "name": "README.txt",
+          "type": "blob",
+        },
+        "TODOS.txt": Object {
+          "hash": "ddec7477206c30c31b81482e56b877a0b3c2638b",
+          "name": "TODOS.txt",
+          "type": "blob",
+        },
+        "pygravitydefier": Object {
+          "hash": "762c062fbdc7ec198cd693e95d55b374a08ff3e3",
+          "name": "pygravitydefier",
+          "type": "commit",
+        },
+        "science.txt": Object {
+          "hash": "f1f2514ca6d7a6a1a0511957021b1995bf9ace1c",
+          "name": "science.txt",
+          "type": "blob",
+        },
+        "src": Object {
+          "hash": "7b79d579b62994faba3b69fdf8aa442586c32681",
+          "name": "src",
+          "type": "tree",
+        },
+      },
+      "hash": "569e1d383759903134df75230d63c0090196d4cb",
+    },
+    "78fc9c83023386854c6bfdc5761c0e58f68e226f": Object {
+      "entries": Object {
+        "index.py": Object {
           "hash": "674b0b476989384510304846248b3acd16206782",
           "name": "index.py",
           "type": "blob",
         },
-        "quantum_gravity.py" => Object {
+        "quantum_gravity.py": Object {
           "hash": "aea4f28abb23abde151b0ead4063227f8bf6c0b0",
           "name": "quantum_gravity.py",
           "type": "blob",
@@ -233,20 +123,130 @@ Object {
       },
       "hash": "78fc9c83023386854c6bfdc5761c0e58f68e226f",
     },
-    "7b79d579b62994faba3b69fdf8aa442586c32681" => Object {
-      "entries": Map {
-        "index.py" => Object {
+    "7b79d579b62994faba3b69fdf8aa442586c32681": Object {
+      "entries": Object {
+        "index.py": Object {
           "hash": "674b0b476989384510304846248b3acd16206782",
           "name": "index.py",
           "type": "blob",
         },
-        "quantum_gravity.py" => Object {
+        "quantum_gravity.py": Object {
           "hash": "887ad856bbc1373da146106c86cb581ad78cdafe",
           "name": "quantum_gravity.py",
           "type": "blob",
         },
       },
       "hash": "7b79d579b62994faba3b69fdf8aa442586c32681",
+    },
+    "7be3ecfee5314ffa9b2d93fc4377792b2d6d70ed": Object {
+      "entries": Object {
+        ".gitmodules": Object {
+          "hash": "8c6cac301e763aa6d36466e0a775eb804be2c311",
+          "name": ".gitmodules",
+          "type": "blob",
+        },
+        "README.txt": Object {
+          "hash": "0fb31858c8e3710be77e1dbb8880acf8a5543d82",
+          "name": "README.txt",
+          "type": "blob",
+        },
+        "pygravitydefier": Object {
+          "hash": "29ef158bc982733e2ba429fcf73e2f7562244188",
+          "name": "pygravitydefier",
+          "type": "commit",
+        },
+        "science.txt": Object {
+          "hash": "f1f2514ca6d7a6a1a0511957021b1995bf9ace1c",
+          "name": "science.txt",
+          "type": "blob",
+        },
+        "src": Object {
+          "hash": "78fc9c83023386854c6bfdc5761c0e58f68e226f",
+          "name": "src",
+          "type": "tree",
+        },
+      },
+      "hash": "7be3ecfee5314ffa9b2d93fc4377792b2d6d70ed",
+    },
+    "819fc546cea489476ce8dc90785e9ba7753d0a8f": Object {
+      "entries": Object {
+        ".gitmodules": Object {
+          "hash": "8c6cac301e763aa6d36466e0a775eb804be2c311",
+          "name": ".gitmodules",
+          "type": "blob",
+        },
+        "README.txt": Object {
+          "hash": "0fb31858c8e3710be77e1dbb8880acf8a5543d82",
+          "name": "README.txt",
+          "type": "blob",
+        },
+        "TODOS.txt": Object {
+          "hash": "ddec7477206c30c31b81482e56b877a0b3c2638b",
+          "name": "TODOS.txt",
+          "type": "blob",
+        },
+        "pygravitydefier": Object {
+          "hash": "29ef158bc982733e2ba429fcf73e2f7562244188",
+          "name": "pygravitydefier",
+          "type": "commit",
+        },
+        "science.txt": Object {
+          "hash": "f1f2514ca6d7a6a1a0511957021b1995bf9ace1c",
+          "name": "science.txt",
+          "type": "blob",
+        },
+        "src": Object {
+          "hash": "7b79d579b62994faba3b69fdf8aa442586c32681",
+          "name": "src",
+          "type": "tree",
+        },
+      },
+      "hash": "819fc546cea489476ce8dc90785e9ba7753d0a8f",
+    },
+    "bbf3b8b3d26a4f884b5c022d46851f593d329192": Object {
+      "entries": Object {
+        ".gitmodules": Object {
+          "hash": "8c6cac301e763aa6d36466e0a775eb804be2c311",
+          "name": ".gitmodules",
+          "type": "blob",
+        },
+        "README.txt": Object {
+          "hash": "0fb31858c8e3710be77e1dbb8880acf8a5543d82",
+          "name": "README.txt",
+          "type": "blob",
+        },
+        "TODOS.txt": Object {
+          "hash": "ddec7477206c30c31b81482e56b877a0b3c2638b",
+          "name": "TODOS.txt",
+          "type": "blob",
+        },
+        "pygravitydefier": Object {
+          "hash": "29ef158bc982733e2ba429fcf73e2f7562244188",
+          "name": "pygravitydefier",
+          "type": "commit",
+        },
+        "science.txt": Object {
+          "hash": "f1f2514ca6d7a6a1a0511957021b1995bf9ace1c",
+          "name": "science.txt",
+          "type": "blob",
+        },
+        "src": Object {
+          "hash": "78fc9c83023386854c6bfdc5761c0e58f68e226f",
+          "name": "src",
+          "type": "tree",
+        },
+      },
+      "hash": "bbf3b8b3d26a4f884b5c022d46851f593d329192",
+    },
+    "bdff5d94193170015d6cbb549b7b630649428b1f": Object {
+      "entries": Object {
+        "README.txt": Object {
+          "hash": "0fb31858c8e3710be77e1dbb8880acf8a5543d82",
+          "name": "README.txt",
+          "type": "blob",
+        },
+      },
+      "hash": "bdff5d94193170015d6cbb549b7b630649428b1f",
     },
   },
 }

--- a/src/plugins/git/loadRepository.test.js
+++ b/src/plugins/git/loadRepository.test.js
@@ -31,17 +31,17 @@ describe("loadRepository", () => {
     const part = loadRepository(repository.path, repository.commits[1]);
 
     // Check that `part` is a subset of `whole`...
-    for (const hash of part.commits.keys()) {
-      expect(part.commits.get(hash)).toEqual(whole.commits.get(hash));
-    }
-    for (const hash of part.trees.keys()) {
-      expect(part.trees.get(hash)).toEqual(whole.trees.get(hash));
-    }
+    Object.keys(part.commits).forEach((hash) => {
+      expect(part.commits[hash]).toEqual(whole.commits[hash]);
+    });
+    Object.keys(part.trees).forEach((hash) => {
+      expect(part.trees[hash]).toEqual(whole.trees[hash]);
+    });
 
     // ...and that it's the right subset.
     expect({
-      commits: new Set(part.commits.keys()),
-      trees: new Set(part.trees.keys()),
+      commits: new Set(Object.keys(part.commits)),
+      trees: new Set(Object.keys(part.trees)),
     }).toMatchSnapshot();
   });
 });

--- a/src/plugins/git/types.js
+++ b/src/plugins/git/types.js
@@ -1,8 +1,8 @@
 // @flow
 
 export type Repository = {|
-  +commits: Map<Hash, Commit>,
-  +trees: Map<Hash, Tree>,
+  +commits: {[Hash]: Commit},
+  +trees: {[Hash]: Tree},
 |};
 export type Hash = string;
 export type Commit = {|
@@ -11,7 +11,7 @@ export type Commit = {|
 |};
 export type Tree = {|
   +hash: Hash,
-  +entries: Map<string, TreeEntry>, // map from name
+  +entries: {[name: string]: TreeEntry},
 |};
 export type TreeEntry = {|
   +type: "blob" | "commit" | "tree",


### PR DESCRIPTION
Summary:
I’d like to use `Map`s whenever the keys are homogeneous (i.e.,
dictionaries, not structs). But this has proven infeasible. The primary
issue at this point is that `JSON.stringify(anyMap)` is `"{}"`—not
entirely unreasonable given that maps can have non-string keys, but
frustrating enough to not use them.

Test Plan:
Jest appears to order the snapshot keys differently for `Map`s and
objects (the former by insertion order and the latter alphabetical),
which makes the snapshot change harder to read. I verified that the
general structure is okay, and hand-verified some of the individual
changes. Noting that the number of lines added and deleted in the
snapshot is a good sanity check.

wchargin-branch: map-to-object