### PR TITLE
Graph: type filter for `nodes()` and `edges()`

### DIFF
--- a/src/core/graph.js
+++ b/src/core/graph.js
@@ -244,17 +244,31 @@ export class Graph<NP, EP> {
   }
 
   /**
-   * Gets all nodes in the graph, in unspecified order.
+   * Get nodes in the graph, in unspecified order.
+   *
+   * If filter is provided, it will return only nodes with the requested type.
    */
-  nodes(): Node<NP>[] {
-    return this._nodes.getAll();
+  nodes(filter?: {type?: string}): Node<NP>[] {
+    let nodes = this._nodes.getAll();
+    if (filter != null && filter.type != null) {
+      const typeFilter = filter.type;
+      nodes = nodes.filter((n) => n.address.type === typeFilter);
+    }
+    return nodes;
   }
 
   /**
-   * Gets all edges in the graph, in unspecified order.
+   * Gets edges in the graph, in unspecified order.
+   *
+   * If filter is provided, it will return only edges with the requested type.
    */
-  edges(): Edge<EP>[] {
-    return this._edges.getAll();
+  edges(filter?: {type?: string}): Edge<EP>[] {
+    let edges = this._edges.getAll();
+    if (filter != null && filter.type != null) {
+      const typeFilter = filter.type;
+      edges = edges.filter((e) => e.address.type === typeFilter);
+    }
+    return edges;
   }
 
   /**

--- a/src/core/graph.test.js
+++ b/src/core/graph.test.js
@@ -165,6 +165,24 @@ describe("graph", () => {
         expectSameSorted(expected, actual);
       });
 
+      it("can filter nodes", () => {
+        const typeAndExpectedNodes = [
+          {type: "PC", nodes: [demoData.heroNode()]},
+          {
+            type: "FOOD",
+            nodes: [
+              demoData.bananasNode(),
+              demoData.crabNode(),
+              demoData.mealNode(),
+            ],
+          },
+        ];
+        typeAndExpectedNodes.forEach(({type, nodes}) => {
+          const actual = demoData.advancedMealGraph().nodes({type});
+          expectSameSorted(actual, nodes);
+        });
+      });
+
       it("gets all edges", () => {
         const expected = [
           demoData.pickEdge(),
@@ -178,6 +196,41 @@ describe("graph", () => {
         ];
         const actual = demoData.advancedMealGraph().edges();
         expectSameSorted(expected, actual);
+      });
+
+      it("can filter edges", () => {
+        const typeAndExpectedEdges = [
+          {
+            type: "ACTION",
+            edges: [
+              demoData.pickEdge(),
+              demoData.grabEdge(),
+              demoData.cookEdge(),
+              demoData.duplicateCookEdge(),
+              demoData.eatEdge(),
+            ],
+          },
+          {
+            type: "INGREDIENT",
+            edges: [
+              demoData.bananasIngredientEdge(),
+              demoData.crabIngredientEdge(),
+            ],
+          },
+          {
+            type: "SILLY",
+            edges: [demoData.crabLoopEdge()],
+          },
+        ];
+        typeAndExpectedEdges.forEach(({type, edges}) => {
+          const actual = demoData.advancedMealGraph().edges({type});
+          expectSameSorted(actual, edges);
+        });
+      });
+      it("filter args are optional", () => {
+        const graph = demoData.advancedMealGraph();
+        expectSameSorted(graph.edges(), graph.edges({}));
+        expectSameSorted(graph.nodes(), graph.nodes({}));
       });
     });
 


### PR DESCRIPTION
When requesting nodes and edges from the graph, it is convenient to
filter them by their type.

In the future, we should add plugin filtering as well, as we
expect type names to collide across plugins.

We may also want to consider keeping a cache of nodes and edges by type
to speed up these calls, if they become performance bottlenecks. (The
implementation in this commit naively iterates over every node/edge.)

Test plan:
Verify that the unit tests are appropriate.