### PR TITLE
Fix Git plugin `NodePayload` definition

### DIFF
--- a/src/plugins/git/types.js
+++ b/src/plugins/git/types.js
@@ -44,7 +44,7 @@ export type NodePayload =
   | CommitNodePayload
   | TreeNodePayload
   | TreeEntryNodePayload
-  | HasContentsEdgePayload;
+  | BlobNodePayload;
 
 export type NodeType =
   | typeof COMMIT_NODE_TYPE


### PR DESCRIPTION
Summary:
Flow didn’t catch this because all the payloads are `{}` anyway.

Test Plan:
Note that every node and edge payload is now listed exactly once in the
correct spot for each of `{Node,Edge}{Type,Payload}`.

wchargin-branch: git-nodepayload