### PR TITLE
Load commit parent hashes into memory

### DIFF
--- a/src/plugins/git/demoData/example-git.json
+++ b/src/plugins/git/demoData/example-git.json
@@ -2,30 +2,50 @@
     "commits": {
         "3715ddfb8d4c4fd2a6f6af75488c82f84c92ec2f": {
             "hash": "3715ddfb8d4c4fd2a6f6af75488c82f84c92ec2f",
+            "parentHashes": [
+                "69c5aad50eec8f2a0a07c988c3b283a6490eb45b"
+            ],
             "treeHash": "7be3ecfee5314ffa9b2d93fc4377792b2d6d70ed"
         },
         "69c5aad50eec8f2a0a07c988c3b283a6490eb45b": {
             "hash": "69c5aad50eec8f2a0a07c988c3b283a6490eb45b",
+            "parentHashes": [
+                "e8b7a8f19701cd5a25e4a097d513ead60e5f8bcc"
+            ],
             "treeHash": "bbf3b8b3d26a4f884b5c022d46851f593d329192"
         },
         "8d287c3bfbf8455ef30187bf5153ffc1b6eef268": {
             "hash": "8d287c3bfbf8455ef30187bf5153ffc1b6eef268",
+            "parentHashes": [
+                "c08ee3a4edea384d5291ffcbf06724a13ed72325"
+            ],
             "treeHash": "3dfb84795e07341b05fad3a0d5a55f8304b2d7d8"
         },
         "c08ee3a4edea384d5291ffcbf06724a13ed72325": {
             "hash": "c08ee3a4edea384d5291ffcbf06724a13ed72325",
+            "parentHashes": [
+                "c2b51945e7457546912a8ce158ed9d294558d294"
+            ],
             "treeHash": "2f7155e359fd0ecb96ffdca66fa45b6ed5792809"
         },
         "c2b51945e7457546912a8ce158ed9d294558d294": {
             "hash": "c2b51945e7457546912a8ce158ed9d294558d294",
+            "parentHashes": [
+            ],
             "treeHash": "bdff5d94193170015d6cbb549b7b630649428b1f"
         },
         "d160cca97611e9dfed642522ad44408d0292e8ea": {
             "hash": "d160cca97611e9dfed642522ad44408d0292e8ea",
+            "parentHashes": [
+                "8d287c3bfbf8455ef30187bf5153ffc1b6eef268"
+            ],
             "treeHash": "569e1d383759903134df75230d63c0090196d4cb"
         },
         "e8b7a8f19701cd5a25e4a097d513ead60e5f8bcc": {
             "hash": "e8b7a8f19701cd5a25e4a097d513ead60e5f8bcc",
+            "parentHashes": [
+                "d160cca97611e9dfed642522ad44408d0292e8ea"
+            ],
             "treeHash": "819fc546cea489476ce8dc90785e9ba7753d0a8f"
         }
     },

--- a/src/plugins/git/loadRepository.js
+++ b/src/plugins/git/loadRepository.js
@@ -38,12 +38,12 @@ function objectMap<T: {+hash: Hash}>(ts: $ReadOnlyArray<T>): {[Hash]: T} {
 }
 
 function findCommits(git: GitDriver, rootRef: string): Commit[] {
-  return git(["log", "--oneline", "--pretty=%H %T", rootRef])
+  return git(["log", "--oneline", "--pretty=%H %T %P", rootRef])
     .split("\n")
     .filter((line) => line.length > 0)
     .map((line) => {
-      const [hash, treeHash] = line.split(" ");
-      return {hash, treeHash};
+      const [hash, treeHash, ...parentHashes] = line.trim().split(" ");
+      return {hash, parentHashes, treeHash};
     });
 }
 

--- a/src/plugins/git/types.js
+++ b/src/plugins/git/types.js
@@ -10,6 +10,7 @@ export type Repository = {|
 export type Hash = string;
 export type Commit = {|
   +hash: Hash,
+  +parentHashes: $ReadOnlyArray<Hash>,
   +treeHash: Hash,
 |};
 export type Tree = {|


### PR DESCRIPTION
Test Plan:
Snapshot updated with `./src/plugins/git/loadRepositoryTest.sh -u`; unit
tests suffice.

wchargin-branch: load-commit-parents