### PR TITLE
findReferences now finds url references to users

### DIFF
--- a/src/plugins/github/findReferences.js
+++ b/src/plugins/github/findReferences.js
@@ -40,12 +40,14 @@ function findGithubUrlReferences(body: string): string[] {
     "" +
       /(?:\W|^)http(?:s)?:\/\/github.com\//.source +
       githubNamePart +
+      "(?:" +
       /\//.source +
       githubNamePart +
       /\/(issues|pull)\//.source +
       /(\d+)/.source +
       /(#(issue|issuecomment|pullrequestreview|discussion_r)-?(\d+))?/.source +
-      /(?:\W|$)/.source,
+      ")?" +
+      /(?:[^\w/]|$)/.source,
     "gm"
   );
   return findAllMatches(urlRegex, body).map((match) => match[0].trim());

--- a/src/plugins/github/findReferences.test.js
+++ b/src/plugins/github/findReferences.test.js
@@ -104,6 +104,12 @@ https://github.com/sourcecred/example-repo/pull/3#issuecomment-369162222
     );
   });
 
+  it("finds username references by exact url", () => {
+    expect(findReferences("greetings https://github.com/wchargin")).toEqual([
+      "https://github.com/wchargin",
+    ]);
+  });
+
   it("finds a mix of reference types", () => {
     expect(
       findReferences(


### PR DESCRIPTION
For example, `https://github.com/decentralion` is now a valid url
reference to a GitHub author.

Test plan: Check the added test case.