### PR TITLE
Exclude punctuation surrounding URL references

### DIFF
--- a/src/plugins/github/findReferences.js
+++ b/src/plugins/github/findReferences.js
@@ -35,20 +35,24 @@ function findUsernameReferences(body: string): string[] {
 }
 
 function findGithubUrlReferences(body: string): string[] {
-  const githubNamePart = /([a-zA-Z0-9_-]+)/.source;
+  const githubNamePart = /(?:[a-zA-Z0-9_-]+)/.source;
   const urlRegex = new RegExp(
     "" +
-      /(?:\W|^)http(?:s)?:\/\/github.com\//.source +
+      /(?:\W|^)/.source +
+      "(" +
+      /http(?:s)?:\/\/github.com\//.source +
       githubNamePart +
       "(?:" +
       /\//.source +
       githubNamePart +
-      /\/(issues|pull)\//.source +
-      /(\d+)/.source +
-      /(#(issue|issuecomment|pullrequestreview|discussion_r)-?(\d+))?/.source +
+      /\/(?:issues|pull)\//.source +
+      /(?:\d+)/.source +
+      /(?:#(?:issue|issuecomment|pullrequestreview|discussion_r)-?(?:\d+))?/
+        .source +
       ")?" +
+      ")" +
       /(?:[^\w/]|$)/.source,
     "gm"
   );
-  return findAllMatches(urlRegex, body).map((match) => match[0].trim());
+  return findAllMatches(urlRegex, body).map((match) => match[1]);
 }

--- a/src/plugins/github/findReferences.test.js
+++ b/src/plugins/github/findReferences.test.js
@@ -91,6 +91,13 @@ https://github.com/sourcecred/example-repo/pull/3#issuecomment-369162222
     ).toHaveLength(1);
   });
 
+  it("allows but excludes leading and trailing punctuation", () => {
+    const base = "https://github.com/sourcecred/sourcecred/pull/94";
+    expect(findReferences(`!${base}`)).toEqual([base]);
+    expect(findReferences(`${base}!`)).toEqual([base]);
+    expect(findReferences(`!${base}!`)).toEqual([base]);
+  });
+
   it("finds username references", () => {
     expect(findReferences("hello to @wchargin from @decentralion!")).toEqual([
       "@wchargin",


### PR DESCRIPTION
Summary:
To avoid confusion, we simultaneously remove unused capturing groups.
This is not strictly necessary, but it makes the code less brittle.

Test Plan:
The newly added test fails before the change to `findReferences.js`.

wchargin-branch: url-punctuation