### PR TITLE
Store `TreeEntry` metadata in non-string form

### DIFF
--- a/src/plugins/git/__snapshots__/createGraph.test.js.snap
+++ b/src/plugins/git/__snapshots__/createGraph.test.js.snap
@@ -1234,13 +1234,11 @@ Object {
     "{\\"id\\":\\"2f7155e359fd0ecb96ffdca66fa45b6ed5792809:README.txt\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"repositoryName\\":\\"sourcecred/example-git\\",\\"type\\":\\"TREE_ENTRY\\"}": Object {
       "payload": Object {
         "name": "README.txt",
-        "tree": "2f7155e359fd0ecb96ffdca66fa45b6ed5792809",
       },
     },
     "{\\"id\\":\\"2f7155e359fd0ecb96ffdca66fa45b6ed5792809:science.txt\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"repositoryName\\":\\"sourcecred/example-git\\",\\"type\\":\\"TREE_ENTRY\\"}": Object {
       "payload": Object {
         "name": "science.txt",
-        "tree": "2f7155e359fd0ecb96ffdca66fa45b6ed5792809",
       },
     },
     "{\\"id\\":\\"3715ddfb8d4c4fd2a6f6af75488c82f84c92ec2f\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"repositoryName\\":\\"sourcecred/example-git\\",\\"type\\":\\"COMMIT\\"}": Object {
@@ -1252,25 +1250,21 @@ Object {
     "{\\"id\\":\\"3dfb84795e07341b05fad3a0d5a55f8304b2d7d8:.gitmodules\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"repositoryName\\":\\"sourcecred/example-git\\",\\"type\\":\\"TREE_ENTRY\\"}": Object {
       "payload": Object {
         "name": ".gitmodules",
-        "tree": "3dfb84795e07341b05fad3a0d5a55f8304b2d7d8",
       },
     },
     "{\\"id\\":\\"3dfb84795e07341b05fad3a0d5a55f8304b2d7d8:README.txt\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"repositoryName\\":\\"sourcecred/example-git\\",\\"type\\":\\"TREE_ENTRY\\"}": Object {
       "payload": Object {
         "name": "README.txt",
-        "tree": "3dfb84795e07341b05fad3a0d5a55f8304b2d7d8",
       },
     },
     "{\\"id\\":\\"3dfb84795e07341b05fad3a0d5a55f8304b2d7d8:pygravitydefier\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"repositoryName\\":\\"sourcecred/example-git\\",\\"type\\":\\"TREE_ENTRY\\"}": Object {
       "payload": Object {
         "name": "pygravitydefier",
-        "tree": "3dfb84795e07341b05fad3a0d5a55f8304b2d7d8",
       },
     },
     "{\\"id\\":\\"3dfb84795e07341b05fad3a0d5a55f8304b2d7d8:science.txt\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"repositoryName\\":\\"sourcecred/example-git\\",\\"type\\":\\"TREE_ENTRY\\"}": Object {
       "payload": Object {
         "name": "science.txt",
-        "tree": "3dfb84795e07341b05fad3a0d5a55f8304b2d7d8",
       },
     },
     "{\\"id\\":\\"569e1d383759903134df75230d63c0090196d4cb\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"repositoryName\\":\\"sourcecred/example-git\\",\\"type\\":\\"TREE\\"}": Object {
@@ -1279,37 +1273,31 @@ Object {
     "{\\"id\\":\\"569e1d383759903134df75230d63c0090196d4cb:.gitmodules\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"repositoryName\\":\\"sourcecred/example-git\\",\\"type\\":\\"TREE_ENTRY\\"}": Object {
       "payload": Object {
         "name": ".gitmodules",
-        "tree": "569e1d383759903134df75230d63c0090196d4cb",
       },
     },
     "{\\"id\\":\\"569e1d383759903134df75230d63c0090196d4cb:README.txt\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"repositoryName\\":\\"sourcecred/example-git\\",\\"type\\":\\"TREE_ENTRY\\"}": Object {
       "payload": Object {
         "name": "README.txt",
-        "tree": "569e1d383759903134df75230d63c0090196d4cb",
       },
     },
     "{\\"id\\":\\"569e1d383759903134df75230d63c0090196d4cb:TODOS.txt\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"repositoryName\\":\\"sourcecred/example-git\\",\\"type\\":\\"TREE_ENTRY\\"}": Object {
       "payload": Object {
         "name": "TODOS.txt",
-        "tree": "569e1d383759903134df75230d63c0090196d4cb",
       },
     },
     "{\\"id\\":\\"569e1d383759903134df75230d63c0090196d4cb:pygravitydefier\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"repositoryName\\":\\"sourcecred/example-git\\",\\"type\\":\\"TREE_ENTRY\\"}": Object {
       "payload": Object {
         "name": "pygravitydefier",
-        "tree": "569e1d383759903134df75230d63c0090196d4cb",
       },
     },
     "{\\"id\\":\\"569e1d383759903134df75230d63c0090196d4cb:science.txt\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"repositoryName\\":\\"sourcecred/example-git\\",\\"type\\":\\"TREE_ENTRY\\"}": Object {
       "payload": Object {
         "name": "science.txt",
-        "tree": "569e1d383759903134df75230d63c0090196d4cb",
       },
     },
     "{\\"id\\":\\"569e1d383759903134df75230d63c0090196d4cb:src\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"repositoryName\\":\\"sourcecred/example-git\\",\\"type\\":\\"TREE_ENTRY\\"}": Object {
       "payload": Object {
         "name": "src",
-        "tree": "569e1d383759903134df75230d63c0090196d4cb",
       },
     },
     "{\\"id\\":\\"674b0b476989384510304846248b3acd16206782\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"repositoryName\\":\\"sourcecred/example-git\\",\\"type\\":\\"BLOB\\"}": Object {
@@ -1324,13 +1312,11 @@ Object {
     "{\\"id\\":\\"78fc9c83023386854c6bfdc5761c0e58f68e226f:index.py\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"repositoryName\\":\\"sourcecred/example-git\\",\\"type\\":\\"TREE_ENTRY\\"}": Object {
       "payload": Object {
         "name": "index.py",
-        "tree": "78fc9c83023386854c6bfdc5761c0e58f68e226f",
       },
     },
     "{\\"id\\":\\"78fc9c83023386854c6bfdc5761c0e58f68e226f:quantum_gravity.py\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"repositoryName\\":\\"sourcecred/example-git\\",\\"type\\":\\"TREE_ENTRY\\"}": Object {
       "payload": Object {
         "name": "quantum_gravity.py",
-        "tree": "78fc9c83023386854c6bfdc5761c0e58f68e226f",
       },
     },
     "{\\"id\\":\\"7b79d579b62994faba3b69fdf8aa442586c32681\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"repositoryName\\":\\"sourcecred/example-git\\",\\"type\\":\\"TREE\\"}": Object {
@@ -1339,13 +1325,11 @@ Object {
     "{\\"id\\":\\"7b79d579b62994faba3b69fdf8aa442586c32681:index.py\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"repositoryName\\":\\"sourcecred/example-git\\",\\"type\\":\\"TREE_ENTRY\\"}": Object {
       "payload": Object {
         "name": "index.py",
-        "tree": "7b79d579b62994faba3b69fdf8aa442586c32681",
       },
     },
     "{\\"id\\":\\"7b79d579b62994faba3b69fdf8aa442586c32681:quantum_gravity.py\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"repositoryName\\":\\"sourcecred/example-git\\",\\"type\\":\\"TREE_ENTRY\\"}": Object {
       "payload": Object {
         "name": "quantum_gravity.py",
-        "tree": "7b79d579b62994faba3b69fdf8aa442586c32681",
       },
     },
     "{\\"id\\":\\"7be3ecfee5314ffa9b2d93fc4377792b2d6d70ed\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"repositoryName\\":\\"sourcecred/example-git\\",\\"type\\":\\"TREE\\"}": Object {
@@ -1354,31 +1338,26 @@ Object {
     "{\\"id\\":\\"7be3ecfee5314ffa9b2d93fc4377792b2d6d70ed:.gitmodules\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"repositoryName\\":\\"sourcecred/example-git\\",\\"type\\":\\"TREE_ENTRY\\"}": Object {
       "payload": Object {
         "name": ".gitmodules",
-        "tree": "7be3ecfee5314ffa9b2d93fc4377792b2d6d70ed",
       },
     },
     "{\\"id\\":\\"7be3ecfee5314ffa9b2d93fc4377792b2d6d70ed:README.txt\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"repositoryName\\":\\"sourcecred/example-git\\",\\"type\\":\\"TREE_ENTRY\\"}": Object {
       "payload": Object {
         "name": "README.txt",
-        "tree": "7be3ecfee5314ffa9b2d93fc4377792b2d6d70ed",
       },
     },
     "{\\"id\\":\\"7be3ecfee5314ffa9b2d93fc4377792b2d6d70ed:pygravitydefier\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"repositoryName\\":\\"sourcecred/example-git\\",\\"type\\":\\"TREE_ENTRY\\"}": Object {
       "payload": Object {
         "name": "pygravitydefier",
-        "tree": "7be3ecfee5314ffa9b2d93fc4377792b2d6d70ed",
       },
     },
     "{\\"id\\":\\"7be3ecfee5314ffa9b2d93fc4377792b2d6d70ed:science.txt\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"repositoryName\\":\\"sourcecred/example-git\\",\\"type\\":\\"TREE_ENTRY\\"}": Object {
       "payload": Object {
         "name": "science.txt",
-        "tree": "7be3ecfee5314ffa9b2d93fc4377792b2d6d70ed",
       },
     },
     "{\\"id\\":\\"7be3ecfee5314ffa9b2d93fc4377792b2d6d70ed:src\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"repositoryName\\":\\"sourcecred/example-git\\",\\"type\\":\\"TREE_ENTRY\\"}": Object {
       "payload": Object {
         "name": "src",
-        "tree": "7be3ecfee5314ffa9b2d93fc4377792b2d6d70ed",
       },
     },
     "{\\"id\\":\\"819fc546cea489476ce8dc90785e9ba7753d0a8f\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"repositoryName\\":\\"sourcecred/example-git\\",\\"type\\":\\"TREE\\"}": Object {
@@ -1387,37 +1366,31 @@ Object {
     "{\\"id\\":\\"819fc546cea489476ce8dc90785e9ba7753d0a8f:.gitmodules\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"repositoryName\\":\\"sourcecred/example-git\\",\\"type\\":\\"TREE_ENTRY\\"}": Object {
       "payload": Object {
         "name": ".gitmodules",
-        "tree": "819fc546cea489476ce8dc90785e9ba7753d0a8f",
       },
     },
     "{\\"id\\":\\"819fc546cea489476ce8dc90785e9ba7753d0a8f:README.txt\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"repositoryName\\":\\"sourcecred/example-git\\",\\"type\\":\\"TREE_ENTRY\\"}": Object {
       "payload": Object {
         "name": "README.txt",
-        "tree": "819fc546cea489476ce8dc90785e9ba7753d0a8f",
       },
     },
     "{\\"id\\":\\"819fc546cea489476ce8dc90785e9ba7753d0a8f:TODOS.txt\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"repositoryName\\":\\"sourcecred/example-git\\",\\"type\\":\\"TREE_ENTRY\\"}": Object {
       "payload": Object {
         "name": "TODOS.txt",
-        "tree": "819fc546cea489476ce8dc90785e9ba7753d0a8f",
       },
     },
     "{\\"id\\":\\"819fc546cea489476ce8dc90785e9ba7753d0a8f:pygravitydefier\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"repositoryName\\":\\"sourcecred/example-git\\",\\"type\\":\\"TREE_ENTRY\\"}": Object {
       "payload": Object {
         "name": "pygravitydefier",
-        "tree": "819fc546cea489476ce8dc90785e9ba7753d0a8f",
       },
     },
     "{\\"id\\":\\"819fc546cea489476ce8dc90785e9ba7753d0a8f:science.txt\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"repositoryName\\":\\"sourcecred/example-git\\",\\"type\\":\\"TREE_ENTRY\\"}": Object {
       "payload": Object {
         "name": "science.txt",
-        "tree": "819fc546cea489476ce8dc90785e9ba7753d0a8f",
       },
     },
     "{\\"id\\":\\"819fc546cea489476ce8dc90785e9ba7753d0a8f:src\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"repositoryName\\":\\"sourcecred/example-git\\",\\"type\\":\\"TREE_ENTRY\\"}": Object {
       "payload": Object {
         "name": "src",
-        "tree": "819fc546cea489476ce8dc90785e9ba7753d0a8f",
       },
     },
     "{\\"id\\":\\"887ad856bbc1373da146106c86cb581ad78cdafe\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"repositoryName\\":\\"sourcecred/example-git\\",\\"type\\":\\"BLOB\\"}": Object {
@@ -1438,37 +1411,31 @@ Object {
     "{\\"id\\":\\"bbf3b8b3d26a4f884b5c022d46851f593d329192:.gitmodules\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"repositoryName\\":\\"sourcecred/example-git\\",\\"type\\":\\"TREE_ENTRY\\"}": Object {
       "payload": Object {
         "name": ".gitmodules",
-        "tree": "bbf3b8b3d26a4f884b5c022d46851f593d329192",
       },
     },
     "{\\"id\\":\\"bbf3b8b3d26a4f884b5c022d46851f593d329192:README.txt\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"repositoryName\\":\\"sourcecred/example-git\\",\\"type\\":\\"TREE_ENTRY\\"}": Object {
       "payload": Object {
         "name": "README.txt",
-        "tree": "bbf3b8b3d26a4f884b5c022d46851f593d329192",
       },
     },
     "{\\"id\\":\\"bbf3b8b3d26a4f884b5c022d46851f593d329192:TODOS.txt\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"repositoryName\\":\\"sourcecred/example-git\\",\\"type\\":\\"TREE_ENTRY\\"}": Object {
       "payload": Object {
         "name": "TODOS.txt",
-        "tree": "bbf3b8b3d26a4f884b5c022d46851f593d329192",
       },
     },
     "{\\"id\\":\\"bbf3b8b3d26a4f884b5c022d46851f593d329192:pygravitydefier\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"repositoryName\\":\\"sourcecred/example-git\\",\\"type\\":\\"TREE_ENTRY\\"}": Object {
       "payload": Object {
         "name": "pygravitydefier",
-        "tree": "bbf3b8b3d26a4f884b5c022d46851f593d329192",
       },
     },
     "{\\"id\\":\\"bbf3b8b3d26a4f884b5c022d46851f593d329192:science.txt\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"repositoryName\\":\\"sourcecred/example-git\\",\\"type\\":\\"TREE_ENTRY\\"}": Object {
       "payload": Object {
         "name": "science.txt",
-        "tree": "bbf3b8b3d26a4f884b5c022d46851f593d329192",
       },
     },
     "{\\"id\\":\\"bbf3b8b3d26a4f884b5c022d46851f593d329192:src\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"repositoryName\\":\\"sourcecred/example-git\\",\\"type\\":\\"TREE_ENTRY\\"}": Object {
       "payload": Object {
         "name": "src",
-        "tree": "bbf3b8b3d26a4f884b5c022d46851f593d329192",
       },
     },
     "{\\"id\\":\\"bdff5d94193170015d6cbb549b7b630649428b1f\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"repositoryName\\":\\"sourcecred/example-git\\",\\"type\\":\\"TREE\\"}": Object {
@@ -1477,7 +1444,6 @@ Object {
     "{\\"id\\":\\"bdff5d94193170015d6cbb549b7b630649428b1f:README.txt\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"repositoryName\\":\\"sourcecred/example-git\\",\\"type\\":\\"TREE_ENTRY\\"}": Object {
       "payload": Object {
         "name": "README.txt",
-        "tree": "bdff5d94193170015d6cbb549b7b630649428b1f",
       },
     },
     "{\\"id\\":\\"c08ee3a4edea384d5291ffcbf06724a13ed72325\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"repositoryName\\":\\"sourcecred/example-git\\",\\"type\\":\\"COMMIT\\"}": Object {

--- a/src/plugins/git/__snapshots__/createGraph.test.js.snap
+++ b/src/plugins/git/__snapshots__/createGraph.test.js.snap
@@ -10,7 +10,9 @@ Object {
         "repositoryName": "sourcecred/example-git",
         "type": "TREE_ENTRY",
       },
-      "payload": Object {},
+      "payload": Object {
+        "name": "README.txt",
+      },
       "src": Object {
         "id": "2f7155e359fd0ecb96ffdca66fa45b6ed5792809",
         "pluginName": "sourcecred/git-beta",
@@ -25,7 +27,9 @@ Object {
         "repositoryName": "sourcecred/example-git",
         "type": "TREE_ENTRY",
       },
-      "payload": Object {},
+      "payload": Object {
+        "name": "science.txt",
+      },
       "src": Object {
         "id": "2f7155e359fd0ecb96ffdca66fa45b6ed5792809",
         "pluginName": "sourcecred/git-beta",
@@ -57,7 +61,9 @@ Object {
         "repositoryName": "sourcecred/example-git",
         "type": "TREE_ENTRY",
       },
-      "payload": Object {},
+      "payload": Object {
+        "name": ".gitmodules",
+      },
       "src": Object {
         "id": "3dfb84795e07341b05fad3a0d5a55f8304b2d7d8",
         "pluginName": "sourcecred/git-beta",
@@ -72,7 +78,9 @@ Object {
         "repositoryName": "sourcecred/example-git",
         "type": "TREE_ENTRY",
       },
-      "payload": Object {},
+      "payload": Object {
+        "name": "README.txt",
+      },
       "src": Object {
         "id": "3dfb84795e07341b05fad3a0d5a55f8304b2d7d8",
         "pluginName": "sourcecred/git-beta",
@@ -87,7 +95,9 @@ Object {
         "repositoryName": "sourcecred/example-git",
         "type": "TREE_ENTRY",
       },
-      "payload": Object {},
+      "payload": Object {
+        "name": "pygravitydefier",
+      },
       "src": Object {
         "id": "3dfb84795e07341b05fad3a0d5a55f8304b2d7d8",
         "pluginName": "sourcecred/git-beta",
@@ -102,7 +112,9 @@ Object {
         "repositoryName": "sourcecred/example-git",
         "type": "TREE_ENTRY",
       },
-      "payload": Object {},
+      "payload": Object {
+        "name": "science.txt",
+      },
       "src": Object {
         "id": "3dfb84795e07341b05fad3a0d5a55f8304b2d7d8",
         "pluginName": "sourcecred/git-beta",
@@ -117,7 +129,9 @@ Object {
         "repositoryName": "sourcecred/example-git",
         "type": "TREE_ENTRY",
       },
-      "payload": Object {},
+      "payload": Object {
+        "name": ".gitmodules",
+      },
       "src": Object {
         "id": "569e1d383759903134df75230d63c0090196d4cb",
         "pluginName": "sourcecred/git-beta",
@@ -132,7 +146,9 @@ Object {
         "repositoryName": "sourcecred/example-git",
         "type": "TREE_ENTRY",
       },
-      "payload": Object {},
+      "payload": Object {
+        "name": "README.txt",
+      },
       "src": Object {
         "id": "569e1d383759903134df75230d63c0090196d4cb",
         "pluginName": "sourcecred/git-beta",
@@ -147,7 +163,9 @@ Object {
         "repositoryName": "sourcecred/example-git",
         "type": "TREE_ENTRY",
       },
-      "payload": Object {},
+      "payload": Object {
+        "name": "TODOS.txt",
+      },
       "src": Object {
         "id": "569e1d383759903134df75230d63c0090196d4cb",
         "pluginName": "sourcecred/git-beta",
@@ -162,7 +180,9 @@ Object {
         "repositoryName": "sourcecred/example-git",
         "type": "TREE_ENTRY",
       },
-      "payload": Object {},
+      "payload": Object {
+        "name": "pygravitydefier",
+      },
       "src": Object {
         "id": "569e1d383759903134df75230d63c0090196d4cb",
         "pluginName": "sourcecred/git-beta",
@@ -177,7 +197,9 @@ Object {
         "repositoryName": "sourcecred/example-git",
         "type": "TREE_ENTRY",
       },
-      "payload": Object {},
+      "payload": Object {
+        "name": "science.txt",
+      },
       "src": Object {
         "id": "569e1d383759903134df75230d63c0090196d4cb",
         "pluginName": "sourcecred/git-beta",
@@ -192,7 +214,9 @@ Object {
         "repositoryName": "sourcecred/example-git",
         "type": "TREE_ENTRY",
       },
-      "payload": Object {},
+      "payload": Object {
+        "name": "src",
+      },
       "src": Object {
         "id": "569e1d383759903134df75230d63c0090196d4cb",
         "pluginName": "sourcecred/git-beta",
@@ -224,7 +248,9 @@ Object {
         "repositoryName": "sourcecred/example-git",
         "type": "TREE_ENTRY",
       },
-      "payload": Object {},
+      "payload": Object {
+        "name": "index.py",
+      },
       "src": Object {
         "id": "78fc9c83023386854c6bfdc5761c0e58f68e226f",
         "pluginName": "sourcecred/git-beta",
@@ -239,7 +265,9 @@ Object {
         "repositoryName": "sourcecred/example-git",
         "type": "TREE_ENTRY",
       },
-      "payload": Object {},
+      "payload": Object {
+        "name": "quantum_gravity.py",
+      },
       "src": Object {
         "id": "78fc9c83023386854c6bfdc5761c0e58f68e226f",
         "pluginName": "sourcecred/git-beta",
@@ -254,7 +282,9 @@ Object {
         "repositoryName": "sourcecred/example-git",
         "type": "TREE_ENTRY",
       },
-      "payload": Object {},
+      "payload": Object {
+        "name": "index.py",
+      },
       "src": Object {
         "id": "7b79d579b62994faba3b69fdf8aa442586c32681",
         "pluginName": "sourcecred/git-beta",
@@ -269,7 +299,9 @@ Object {
         "repositoryName": "sourcecred/example-git",
         "type": "TREE_ENTRY",
       },
-      "payload": Object {},
+      "payload": Object {
+        "name": "quantum_gravity.py",
+      },
       "src": Object {
         "id": "7b79d579b62994faba3b69fdf8aa442586c32681",
         "pluginName": "sourcecred/git-beta",
@@ -284,7 +316,9 @@ Object {
         "repositoryName": "sourcecred/example-git",
         "type": "TREE_ENTRY",
       },
-      "payload": Object {},
+      "payload": Object {
+        "name": ".gitmodules",
+      },
       "src": Object {
         "id": "7be3ecfee5314ffa9b2d93fc4377792b2d6d70ed",
         "pluginName": "sourcecred/git-beta",
@@ -299,7 +333,9 @@ Object {
         "repositoryName": "sourcecred/example-git",
         "type": "TREE_ENTRY",
       },
-      "payload": Object {},
+      "payload": Object {
+        "name": "README.txt",
+      },
       "src": Object {
         "id": "7be3ecfee5314ffa9b2d93fc4377792b2d6d70ed",
         "pluginName": "sourcecred/git-beta",
@@ -314,7 +350,9 @@ Object {
         "repositoryName": "sourcecred/example-git",
         "type": "TREE_ENTRY",
       },
-      "payload": Object {},
+      "payload": Object {
+        "name": "pygravitydefier",
+      },
       "src": Object {
         "id": "7be3ecfee5314ffa9b2d93fc4377792b2d6d70ed",
         "pluginName": "sourcecred/git-beta",
@@ -329,7 +367,9 @@ Object {
         "repositoryName": "sourcecred/example-git",
         "type": "TREE_ENTRY",
       },
-      "payload": Object {},
+      "payload": Object {
+        "name": "science.txt",
+      },
       "src": Object {
         "id": "7be3ecfee5314ffa9b2d93fc4377792b2d6d70ed",
         "pluginName": "sourcecred/git-beta",
@@ -344,7 +384,9 @@ Object {
         "repositoryName": "sourcecred/example-git",
         "type": "TREE_ENTRY",
       },
-      "payload": Object {},
+      "payload": Object {
+        "name": "src",
+      },
       "src": Object {
         "id": "7be3ecfee5314ffa9b2d93fc4377792b2d6d70ed",
         "pluginName": "sourcecred/git-beta",
@@ -359,7 +401,9 @@ Object {
         "repositoryName": "sourcecred/example-git",
         "type": "TREE_ENTRY",
       },
-      "payload": Object {},
+      "payload": Object {
+        "name": ".gitmodules",
+      },
       "src": Object {
         "id": "819fc546cea489476ce8dc90785e9ba7753d0a8f",
         "pluginName": "sourcecred/git-beta",
@@ -374,7 +418,9 @@ Object {
         "repositoryName": "sourcecred/example-git",
         "type": "TREE_ENTRY",
       },
-      "payload": Object {},
+      "payload": Object {
+        "name": "README.txt",
+      },
       "src": Object {
         "id": "819fc546cea489476ce8dc90785e9ba7753d0a8f",
         "pluginName": "sourcecred/git-beta",
@@ -389,7 +435,9 @@ Object {
         "repositoryName": "sourcecred/example-git",
         "type": "TREE_ENTRY",
       },
-      "payload": Object {},
+      "payload": Object {
+        "name": "TODOS.txt",
+      },
       "src": Object {
         "id": "819fc546cea489476ce8dc90785e9ba7753d0a8f",
         "pluginName": "sourcecred/git-beta",
@@ -404,7 +452,9 @@ Object {
         "repositoryName": "sourcecred/example-git",
         "type": "TREE_ENTRY",
       },
-      "payload": Object {},
+      "payload": Object {
+        "name": "pygravitydefier",
+      },
       "src": Object {
         "id": "819fc546cea489476ce8dc90785e9ba7753d0a8f",
         "pluginName": "sourcecred/git-beta",
@@ -419,7 +469,9 @@ Object {
         "repositoryName": "sourcecred/example-git",
         "type": "TREE_ENTRY",
       },
-      "payload": Object {},
+      "payload": Object {
+        "name": "science.txt",
+      },
       "src": Object {
         "id": "819fc546cea489476ce8dc90785e9ba7753d0a8f",
         "pluginName": "sourcecred/git-beta",
@@ -434,7 +486,9 @@ Object {
         "repositoryName": "sourcecred/example-git",
         "type": "TREE_ENTRY",
       },
-      "payload": Object {},
+      "payload": Object {
+        "name": "src",
+      },
       "src": Object {
         "id": "819fc546cea489476ce8dc90785e9ba7753d0a8f",
         "pluginName": "sourcecred/git-beta",
@@ -1006,7 +1060,9 @@ Object {
         "repositoryName": "sourcecred/example-git",
         "type": "TREE_ENTRY",
       },
-      "payload": Object {},
+      "payload": Object {
+        "name": ".gitmodules",
+      },
       "src": Object {
         "id": "bbf3b8b3d26a4f884b5c022d46851f593d329192",
         "pluginName": "sourcecred/git-beta",
@@ -1021,7 +1077,9 @@ Object {
         "repositoryName": "sourcecred/example-git",
         "type": "TREE_ENTRY",
       },
-      "payload": Object {},
+      "payload": Object {
+        "name": "README.txt",
+      },
       "src": Object {
         "id": "bbf3b8b3d26a4f884b5c022d46851f593d329192",
         "pluginName": "sourcecred/git-beta",
@@ -1036,7 +1094,9 @@ Object {
         "repositoryName": "sourcecred/example-git",
         "type": "TREE_ENTRY",
       },
-      "payload": Object {},
+      "payload": Object {
+        "name": "TODOS.txt",
+      },
       "src": Object {
         "id": "bbf3b8b3d26a4f884b5c022d46851f593d329192",
         "pluginName": "sourcecred/git-beta",
@@ -1051,7 +1111,9 @@ Object {
         "repositoryName": "sourcecred/example-git",
         "type": "TREE_ENTRY",
       },
-      "payload": Object {},
+      "payload": Object {
+        "name": "pygravitydefier",
+      },
       "src": Object {
         "id": "bbf3b8b3d26a4f884b5c022d46851f593d329192",
         "pluginName": "sourcecred/git-beta",
@@ -1066,7 +1128,9 @@ Object {
         "repositoryName": "sourcecred/example-git",
         "type": "TREE_ENTRY",
       },
-      "payload": Object {},
+      "payload": Object {
+        "name": "science.txt",
+      },
       "src": Object {
         "id": "bbf3b8b3d26a4f884b5c022d46851f593d329192",
         "pluginName": "sourcecred/git-beta",
@@ -1081,7 +1145,9 @@ Object {
         "repositoryName": "sourcecred/example-git",
         "type": "TREE_ENTRY",
       },
-      "payload": Object {},
+      "payload": Object {
+        "name": "src",
+      },
       "src": Object {
         "id": "bbf3b8b3d26a4f884b5c022d46851f593d329192",
         "pluginName": "sourcecred/git-beta",
@@ -1096,7 +1162,9 @@ Object {
         "repositoryName": "sourcecred/example-git",
         "type": "TREE_ENTRY",
       },
-      "payload": Object {},
+      "payload": Object {
+        "name": "README.txt",
+      },
       "src": Object {
         "id": "bdff5d94193170015d6cbb549b7b630649428b1f",
         "pluginName": "sourcecred/git-beta",
@@ -1164,10 +1232,16 @@ Object {
       "payload": Object {},
     },
     "{\\"id\\":\\"2f7155e359fd0ecb96ffdca66fa45b6ed5792809:README.txt\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"repositoryName\\":\\"sourcecred/example-git\\",\\"type\\":\\"TREE_ENTRY\\"}": Object {
-      "payload": Object {},
+      "payload": Object {
+        "name": "README.txt",
+        "tree": "2f7155e359fd0ecb96ffdca66fa45b6ed5792809",
+      },
     },
     "{\\"id\\":\\"2f7155e359fd0ecb96ffdca66fa45b6ed5792809:science.txt\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"repositoryName\\":\\"sourcecred/example-git\\",\\"type\\":\\"TREE_ENTRY\\"}": Object {
-      "payload": Object {},
+      "payload": Object {
+        "name": "science.txt",
+        "tree": "2f7155e359fd0ecb96ffdca66fa45b6ed5792809",
+      },
     },
     "{\\"id\\":\\"3715ddfb8d4c4fd2a6f6af75488c82f84c92ec2f\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"repositoryName\\":\\"sourcecred/example-git\\",\\"type\\":\\"COMMIT\\"}": Object {
       "payload": Object {},
@@ -1176,37 +1250,67 @@ Object {
       "payload": Object {},
     },
     "{\\"id\\":\\"3dfb84795e07341b05fad3a0d5a55f8304b2d7d8:.gitmodules\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"repositoryName\\":\\"sourcecred/example-git\\",\\"type\\":\\"TREE_ENTRY\\"}": Object {
-      "payload": Object {},
+      "payload": Object {
+        "name": ".gitmodules",
+        "tree": "3dfb84795e07341b05fad3a0d5a55f8304b2d7d8",
+      },
     },
     "{\\"id\\":\\"3dfb84795e07341b05fad3a0d5a55f8304b2d7d8:README.txt\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"repositoryName\\":\\"sourcecred/example-git\\",\\"type\\":\\"TREE_ENTRY\\"}": Object {
-      "payload": Object {},
+      "payload": Object {
+        "name": "README.txt",
+        "tree": "3dfb84795e07341b05fad3a0d5a55f8304b2d7d8",
+      },
     },
     "{\\"id\\":\\"3dfb84795e07341b05fad3a0d5a55f8304b2d7d8:pygravitydefier\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"repositoryName\\":\\"sourcecred/example-git\\",\\"type\\":\\"TREE_ENTRY\\"}": Object {
-      "payload": Object {},
+      "payload": Object {
+        "name": "pygravitydefier",
+        "tree": "3dfb84795e07341b05fad3a0d5a55f8304b2d7d8",
+      },
     },
     "{\\"id\\":\\"3dfb84795e07341b05fad3a0d5a55f8304b2d7d8:science.txt\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"repositoryName\\":\\"sourcecred/example-git\\",\\"type\\":\\"TREE_ENTRY\\"}": Object {
-      "payload": Object {},
+      "payload": Object {
+        "name": "science.txt",
+        "tree": "3dfb84795e07341b05fad3a0d5a55f8304b2d7d8",
+      },
     },
     "{\\"id\\":\\"569e1d383759903134df75230d63c0090196d4cb\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"repositoryName\\":\\"sourcecred/example-git\\",\\"type\\":\\"TREE\\"}": Object {
       "payload": Object {},
     },
     "{\\"id\\":\\"569e1d383759903134df75230d63c0090196d4cb:.gitmodules\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"repositoryName\\":\\"sourcecred/example-git\\",\\"type\\":\\"TREE_ENTRY\\"}": Object {
-      "payload": Object {},
+      "payload": Object {
+        "name": ".gitmodules",
+        "tree": "569e1d383759903134df75230d63c0090196d4cb",
+      },
     },
     "{\\"id\\":\\"569e1d383759903134df75230d63c0090196d4cb:README.txt\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"repositoryName\\":\\"sourcecred/example-git\\",\\"type\\":\\"TREE_ENTRY\\"}": Object {
-      "payload": Object {},
+      "payload": Object {
+        "name": "README.txt",
+        "tree": "569e1d383759903134df75230d63c0090196d4cb",
+      },
     },
     "{\\"id\\":\\"569e1d383759903134df75230d63c0090196d4cb:TODOS.txt\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"repositoryName\\":\\"sourcecred/example-git\\",\\"type\\":\\"TREE_ENTRY\\"}": Object {
-      "payload": Object {},
+      "payload": Object {
+        "name": "TODOS.txt",
+        "tree": "569e1d383759903134df75230d63c0090196d4cb",
+      },
     },
     "{\\"id\\":\\"569e1d383759903134df75230d63c0090196d4cb:pygravitydefier\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"repositoryName\\":\\"sourcecred/example-git\\",\\"type\\":\\"TREE_ENTRY\\"}": Object {
-      "payload": Object {},
+      "payload": Object {
+        "name": "pygravitydefier",
+        "tree": "569e1d383759903134df75230d63c0090196d4cb",
+      },
     },
     "{\\"id\\":\\"569e1d383759903134df75230d63c0090196d4cb:science.txt\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"repositoryName\\":\\"sourcecred/example-git\\",\\"type\\":\\"TREE_ENTRY\\"}": Object {
-      "payload": Object {},
+      "payload": Object {
+        "name": "science.txt",
+        "tree": "569e1d383759903134df75230d63c0090196d4cb",
+      },
     },
     "{\\"id\\":\\"569e1d383759903134df75230d63c0090196d4cb:src\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"repositoryName\\":\\"sourcecred/example-git\\",\\"type\\":\\"TREE_ENTRY\\"}": Object {
-      "payload": Object {},
+      "payload": Object {
+        "name": "src",
+        "tree": "569e1d383759903134df75230d63c0090196d4cb",
+      },
     },
     "{\\"id\\":\\"674b0b476989384510304846248b3acd16206782\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"repositoryName\\":\\"sourcecred/example-git\\",\\"type\\":\\"BLOB\\"}": Object {
       "payload": Object {},
@@ -1218,58 +1322,103 @@ Object {
       "payload": Object {},
     },
     "{\\"id\\":\\"78fc9c83023386854c6bfdc5761c0e58f68e226f:index.py\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"repositoryName\\":\\"sourcecred/example-git\\",\\"type\\":\\"TREE_ENTRY\\"}": Object {
-      "payload": Object {},
+      "payload": Object {
+        "name": "index.py",
+        "tree": "78fc9c83023386854c6bfdc5761c0e58f68e226f",
+      },
     },
     "{\\"id\\":\\"78fc9c83023386854c6bfdc5761c0e58f68e226f:quantum_gravity.py\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"repositoryName\\":\\"sourcecred/example-git\\",\\"type\\":\\"TREE_ENTRY\\"}": Object {
-      "payload": Object {},
+      "payload": Object {
+        "name": "quantum_gravity.py",
+        "tree": "78fc9c83023386854c6bfdc5761c0e58f68e226f",
+      },
     },
     "{\\"id\\":\\"7b79d579b62994faba3b69fdf8aa442586c32681\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"repositoryName\\":\\"sourcecred/example-git\\",\\"type\\":\\"TREE\\"}": Object {
       "payload": Object {},
     },
     "{\\"id\\":\\"7b79d579b62994faba3b69fdf8aa442586c32681:index.py\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"repositoryName\\":\\"sourcecred/example-git\\",\\"type\\":\\"TREE_ENTRY\\"}": Object {
-      "payload": Object {},
+      "payload": Object {
+        "name": "index.py",
+        "tree": "7b79d579b62994faba3b69fdf8aa442586c32681",
+      },
     },
     "{\\"id\\":\\"7b79d579b62994faba3b69fdf8aa442586c32681:quantum_gravity.py\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"repositoryName\\":\\"sourcecred/example-git\\",\\"type\\":\\"TREE_ENTRY\\"}": Object {
-      "payload": Object {},
+      "payload": Object {
+        "name": "quantum_gravity.py",
+        "tree": "7b79d579b62994faba3b69fdf8aa442586c32681",
+      },
     },
     "{\\"id\\":\\"7be3ecfee5314ffa9b2d93fc4377792b2d6d70ed\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"repositoryName\\":\\"sourcecred/example-git\\",\\"type\\":\\"TREE\\"}": Object {
       "payload": Object {},
     },
     "{\\"id\\":\\"7be3ecfee5314ffa9b2d93fc4377792b2d6d70ed:.gitmodules\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"repositoryName\\":\\"sourcecred/example-git\\",\\"type\\":\\"TREE_ENTRY\\"}": Object {
-      "payload": Object {},
+      "payload": Object {
+        "name": ".gitmodules",
+        "tree": "7be3ecfee5314ffa9b2d93fc4377792b2d6d70ed",
+      },
     },
     "{\\"id\\":\\"7be3ecfee5314ffa9b2d93fc4377792b2d6d70ed:README.txt\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"repositoryName\\":\\"sourcecred/example-git\\",\\"type\\":\\"TREE_ENTRY\\"}": Object {
-      "payload": Object {},
+      "payload": Object {
+        "name": "README.txt",
+        "tree": "7be3ecfee5314ffa9b2d93fc4377792b2d6d70ed",
+      },
     },
     "{\\"id\\":\\"7be3ecfee5314ffa9b2d93fc4377792b2d6d70ed:pygravitydefier\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"repositoryName\\":\\"sourcecred/example-git\\",\\"type\\":\\"TREE_ENTRY\\"}": Object {
-      "payload": Object {},
+      "payload": Object {
+        "name": "pygravitydefier",
+        "tree": "7be3ecfee5314ffa9b2d93fc4377792b2d6d70ed",
+      },
     },
     "{\\"id\\":\\"7be3ecfee5314ffa9b2d93fc4377792b2d6d70ed:science.txt\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"repositoryName\\":\\"sourcecred/example-git\\",\\"type\\":\\"TREE_ENTRY\\"}": Object {
-      "payload": Object {},
+      "payload": Object {
+        "name": "science.txt",
+        "tree": "7be3ecfee5314ffa9b2d93fc4377792b2d6d70ed",
+      },
     },
     "{\\"id\\":\\"7be3ecfee5314ffa9b2d93fc4377792b2d6d70ed:src\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"repositoryName\\":\\"sourcecred/example-git\\",\\"type\\":\\"TREE_ENTRY\\"}": Object {
-      "payload": Object {},
+      "payload": Object {
+        "name": "src",
+        "tree": "7be3ecfee5314ffa9b2d93fc4377792b2d6d70ed",
+      },
     },
     "{\\"id\\":\\"819fc546cea489476ce8dc90785e9ba7753d0a8f\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"repositoryName\\":\\"sourcecred/example-git\\",\\"type\\":\\"TREE\\"}": Object {
       "payload": Object {},
     },
     "{\\"id\\":\\"819fc546cea489476ce8dc90785e9ba7753d0a8f:.gitmodules\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"repositoryName\\":\\"sourcecred/example-git\\",\\"type\\":\\"TREE_ENTRY\\"}": Object {
-      "payload": Object {},
+      "payload": Object {
+        "name": ".gitmodules",
+        "tree": "819fc546cea489476ce8dc90785e9ba7753d0a8f",
+      },
     },
     "{\\"id\\":\\"819fc546cea489476ce8dc90785e9ba7753d0a8f:README.txt\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"repositoryName\\":\\"sourcecred/example-git\\",\\"type\\":\\"TREE_ENTRY\\"}": Object {
-      "payload": Object {},
+      "payload": Object {
+        "name": "README.txt",
+        "tree": "819fc546cea489476ce8dc90785e9ba7753d0a8f",
+      },
     },
     "{\\"id\\":\\"819fc546cea489476ce8dc90785e9ba7753d0a8f:TODOS.txt\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"repositoryName\\":\\"sourcecred/example-git\\",\\"type\\":\\"TREE_ENTRY\\"}": Object {
-      "payload": Object {},
+      "payload": Object {
+        "name": "TODOS.txt",
+        "tree": "819fc546cea489476ce8dc90785e9ba7753d0a8f",
+      },
     },
     "{\\"id\\":\\"819fc546cea489476ce8dc90785e9ba7753d0a8f:pygravitydefier\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"repositoryName\\":\\"sourcecred/example-git\\",\\"type\\":\\"TREE_ENTRY\\"}": Object {
-      "payload": Object {},
+      "payload": Object {
+        "name": "pygravitydefier",
+        "tree": "819fc546cea489476ce8dc90785e9ba7753d0a8f",
+      },
     },
     "{\\"id\\":\\"819fc546cea489476ce8dc90785e9ba7753d0a8f:science.txt\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"repositoryName\\":\\"sourcecred/example-git\\",\\"type\\":\\"TREE_ENTRY\\"}": Object {
-      "payload": Object {},
+      "payload": Object {
+        "name": "science.txt",
+        "tree": "819fc546cea489476ce8dc90785e9ba7753d0a8f",
+      },
     },
     "{\\"id\\":\\"819fc546cea489476ce8dc90785e9ba7753d0a8f:src\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"repositoryName\\":\\"sourcecred/example-git\\",\\"type\\":\\"TREE_ENTRY\\"}": Object {
-      "payload": Object {},
+      "payload": Object {
+        "name": "src",
+        "tree": "819fc546cea489476ce8dc90785e9ba7753d0a8f",
+      },
     },
     "{\\"id\\":\\"887ad856bbc1373da146106c86cb581ad78cdafe\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"repositoryName\\":\\"sourcecred/example-git\\",\\"type\\":\\"BLOB\\"}": Object {
       "payload": Object {},
@@ -1287,28 +1436,49 @@ Object {
       "payload": Object {},
     },
     "{\\"id\\":\\"bbf3b8b3d26a4f884b5c022d46851f593d329192:.gitmodules\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"repositoryName\\":\\"sourcecred/example-git\\",\\"type\\":\\"TREE_ENTRY\\"}": Object {
-      "payload": Object {},
+      "payload": Object {
+        "name": ".gitmodules",
+        "tree": "bbf3b8b3d26a4f884b5c022d46851f593d329192",
+      },
     },
     "{\\"id\\":\\"bbf3b8b3d26a4f884b5c022d46851f593d329192:README.txt\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"repositoryName\\":\\"sourcecred/example-git\\",\\"type\\":\\"TREE_ENTRY\\"}": Object {
-      "payload": Object {},
+      "payload": Object {
+        "name": "README.txt",
+        "tree": "bbf3b8b3d26a4f884b5c022d46851f593d329192",
+      },
     },
     "{\\"id\\":\\"bbf3b8b3d26a4f884b5c022d46851f593d329192:TODOS.txt\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"repositoryName\\":\\"sourcecred/example-git\\",\\"type\\":\\"TREE_ENTRY\\"}": Object {
-      "payload": Object {},
+      "payload": Object {
+        "name": "TODOS.txt",
+        "tree": "bbf3b8b3d26a4f884b5c022d46851f593d329192",
+      },
     },
     "{\\"id\\":\\"bbf3b8b3d26a4f884b5c022d46851f593d329192:pygravitydefier\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"repositoryName\\":\\"sourcecred/example-git\\",\\"type\\":\\"TREE_ENTRY\\"}": Object {
-      "payload": Object {},
+      "payload": Object {
+        "name": "pygravitydefier",
+        "tree": "bbf3b8b3d26a4f884b5c022d46851f593d329192",
+      },
     },
     "{\\"id\\":\\"bbf3b8b3d26a4f884b5c022d46851f593d329192:science.txt\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"repositoryName\\":\\"sourcecred/example-git\\",\\"type\\":\\"TREE_ENTRY\\"}": Object {
-      "payload": Object {},
+      "payload": Object {
+        "name": "science.txt",
+        "tree": "bbf3b8b3d26a4f884b5c022d46851f593d329192",
+      },
     },
     "{\\"id\\":\\"bbf3b8b3d26a4f884b5c022d46851f593d329192:src\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"repositoryName\\":\\"sourcecred/example-git\\",\\"type\\":\\"TREE_ENTRY\\"}": Object {
-      "payload": Object {},
+      "payload": Object {
+        "name": "src",
+        "tree": "bbf3b8b3d26a4f884b5c022d46851f593d329192",
+      },
     },
     "{\\"id\\":\\"bdff5d94193170015d6cbb549b7b630649428b1f\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"repositoryName\\":\\"sourcecred/example-git\\",\\"type\\":\\"TREE\\"}": Object {
       "payload": Object {},
     },
     "{\\"id\\":\\"bdff5d94193170015d6cbb549b7b630649428b1f:README.txt\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"repositoryName\\":\\"sourcecred/example-git\\",\\"type\\":\\"TREE_ENTRY\\"}": Object {
-      "payload": Object {},
+      "payload": Object {
+        "name": "README.txt",
+        "tree": "bdff5d94193170015d6cbb549b7b630649428b1f",
+      },
     },
     "{\\"id\\":\\"c08ee3a4edea384d5291ffcbf06724a13ed72325\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"repositoryName\\":\\"sourcecred/example-git\\",\\"type\\":\\"COMMIT\\"}": Object {
       "payload": Object {},

--- a/src/plugins/git/createGraph.js
+++ b/src/plugins/git/createGraph.js
@@ -1,14 +1,17 @@
 // @flow
 
 import type {Address} from "../../core/address";
+import type {Edge, Node} from "../../core/graph";
 import type {
-  Repository,
   Commit,
-  Tree,
-  NodePayload,
   EdgePayload,
-  NodeType,
   EdgeType,
+  IncludesEdgePayload,
+  NodePayload,
+  NodeType,
+  Repository,
+  Tree,
+  TreeEntryNodePayload,
 } from "./types";
 import {Graph, edgeID} from "../../core/graph";
 import {
@@ -103,21 +106,21 @@ class GitGraphCreator {
     const result = new Graph().addNode(treeNode);
     Object.keys(tree.entries).forEach((name) => {
       const entry = tree.entries[name];
-      const entryNode = {
+      const entryNode: Node<TreeEntryNodePayload> = {
         address: this.makeAddress(
           TREE_ENTRY_NODE_TYPE,
           treeEntryId(tree.hash, entry.name)
         ),
-        payload: {},
+        payload: {tree: tree.hash, name},
       };
-      const entryEdge = {
+      const entryEdge: Edge<IncludesEdgePayload> = {
         address: this.makeAddress(
           INCLUDES_EDGE_TYPE,
           includesEdgeId(tree.hash, entry.name)
         ),
         src: treeNode.address,
         dst: entryNode.address,
-        payload: {},
+        payload: {name},
       };
       result.addNode(entryNode).addEdge(entryEdge);
       if (entry.type === "commit") {

--- a/src/plugins/git/createGraph.js
+++ b/src/plugins/git/createGraph.js
@@ -111,7 +111,7 @@ class GitGraphCreator {
           TREE_ENTRY_NODE_TYPE,
           treeEntryId(tree.hash, entry.name)
         ),
-        payload: {tree: tree.hash, name},
+        payload: {name},
       };
       const entryEdge: Edge<IncludesEdgePayload> = {
         address: this.makeAddress(

--- a/src/plugins/git/types.js
+++ b/src/plugins/git/types.js
@@ -36,9 +36,12 @@ export const BLOB_NODE_TYPE: "BLOB" = "BLOB";
 export type BlobNodePayload = {||}; // we do not store the content
 
 export const TREE_ENTRY_NODE_TYPE: "TREE_ENTRY" = "TREE_ENTRY";
-export type TreeEntryNodePayload = {||};
-export function treeEntryId(treeSha: string, name: string): string {
-  return `${treeSha}:${name}`;
+export type TreeEntryNodePayload = {|
+  +tree: Hash,
+  +name: string,
+|};
+export function treeEntryId(tree: Hash, name: string): string {
+  return `${tree}:${name}`;
 }
 
 export type NodePayload =
@@ -83,7 +86,9 @@ export type HasTreeEdgePayload = {||};
 
 // TreeNode -> TreeEntryNode
 export const INCLUDES_EDGE_TYPE: "INCLUDES" = "INCLUDES";
-export type IncludesEdgePayload = {||};
+export type IncludesEdgePayload = {|
+  +name: string,
+|};
 export function includesEdgeId(treeSha: string, name: string): string {
   return `${treeSha}:${name}`;
 }

--- a/src/plugins/git/types.js
+++ b/src/plugins/git/types.js
@@ -37,7 +37,6 @@ export type BlobNodePayload = {||}; // we do not store the content
 
 export const TREE_ENTRY_NODE_TYPE: "TREE_ENTRY" = "TREE_ENTRY";
 export type TreeEntryNodePayload = {|
-  +tree: Hash,
   +name: string,
 |};
 export function treeEntryId(tree: Hash, name: string): string {


### PR DESCRIPTION
Summary:
Prior to this commit, given a `Tree` node with an edge to a `TreeEntry`
node, there was no way to tell what the entry name was other than
parsing the ID (which should never be required). This adds appropriate
data to the payload of a `TreeEntry`, and also to the inclusion edge (so
that if you only have the edge, you don’t have to fetch the entry).

Test Plan:
Snapshot changes are readable.

wchargin-branch: treeentry-metadata