### PR TITLE
Create nodes for submodule commits

### DIFF
--- a/src/plugins/git/__snapshots__/createGraph.test.js.snap
+++ b/src/plugins/git/__snapshots__/createGraph.test.js.snap
@@ -588,6 +588,21 @@ Object {
         "type": "TREE_ENTRY",
       },
     },
+    "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"3dfb84795e07341b05fad3a0d5a55f8304b2d7d8:pygravitydefier\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/git-beta\\\\\\",\\\\\\"repositoryName\\\\\\":\\\\\\"sourcecred/example-git\\\\\\",\\\\\\"type\\\\\\":\\\\\\"TREE_ENTRY\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-git-submodule.git@762c062fbdc7ec198cd693e95d55b374a08ff3e3\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/git-beta\\\\\\",\\\\\\"repositoryName\\\\\\":\\\\\\"sourcecred/example-git\\\\\\",\\\\\\"type\\\\\\":\\\\\\"SUBMODULE_COMMIT\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"repositoryName\\":\\"sourcecred/example-git\\",\\"type\\":\\"HAS_CONTENTS\\"}": Object {
+      "dst": Object {
+        "id": "https://github.com/sourcecred/example-git-submodule.git@762c062fbdc7ec198cd693e95d55b374a08ff3e3",
+        "pluginName": "sourcecred/git-beta",
+        "repositoryName": "sourcecred/example-git",
+        "type": "SUBMODULE_COMMIT",
+      },
+      "payload": Object {},
+      "src": Object {
+        "id": "3dfb84795e07341b05fad3a0d5a55f8304b2d7d8:pygravitydefier",
+        "pluginName": "sourcecred/git-beta",
+        "repositoryName": "sourcecred/example-git",
+        "type": "TREE_ENTRY",
+      },
+    },
     "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"3dfb84795e07341b05fad3a0d5a55f8304b2d7d8:science.txt\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/git-beta\\\\\\",\\\\\\"repositoryName\\\\\\":\\\\\\"sourcecred/example-git\\\\\\",\\\\\\"type\\\\\\":\\\\\\"TREE_ENTRY\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"f1f2514ca6d7a6a1a0511957021b1995bf9ace1c\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/git-beta\\\\\\",\\\\\\"repositoryName\\\\\\":\\\\\\"sourcecred/example-git\\\\\\",\\\\\\"type\\\\\\":\\\\\\"BLOB\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"repositoryName\\":\\"sourcecred/example-git\\",\\"type\\":\\"HAS_CONTENTS\\"}": Object {
       "dst": Object {
         "id": "f1f2514ca6d7a6a1a0511957021b1995bf9ace1c",
@@ -643,6 +658,21 @@ Object {
       "payload": Object {},
       "src": Object {
         "id": "569e1d383759903134df75230d63c0090196d4cb:TODOS.txt",
+        "pluginName": "sourcecred/git-beta",
+        "repositoryName": "sourcecred/example-git",
+        "type": "TREE_ENTRY",
+      },
+    },
+    "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"569e1d383759903134df75230d63c0090196d4cb:pygravitydefier\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/git-beta\\\\\\",\\\\\\"repositoryName\\\\\\":\\\\\\"sourcecred/example-git\\\\\\",\\\\\\"type\\\\\\":\\\\\\"TREE_ENTRY\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-git-submodule.git@762c062fbdc7ec198cd693e95d55b374a08ff3e3\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/git-beta\\\\\\",\\\\\\"repositoryName\\\\\\":\\\\\\"sourcecred/example-git\\\\\\",\\\\\\"type\\\\\\":\\\\\\"SUBMODULE_COMMIT\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"repositoryName\\":\\"sourcecred/example-git\\",\\"type\\":\\"HAS_CONTENTS\\"}": Object {
+      "dst": Object {
+        "id": "https://github.com/sourcecred/example-git-submodule.git@762c062fbdc7ec198cd693e95d55b374a08ff3e3",
+        "pluginName": "sourcecred/git-beta",
+        "repositoryName": "sourcecred/example-git",
+        "type": "SUBMODULE_COMMIT",
+      },
+      "payload": Object {},
+      "src": Object {
+        "id": "569e1d383759903134df75230d63c0090196d4cb:pygravitydefier",
         "pluginName": "sourcecred/git-beta",
         "repositoryName": "sourcecred/example-git",
         "type": "TREE_ENTRY",
@@ -783,6 +813,21 @@ Object {
         "type": "TREE_ENTRY",
       },
     },
+    "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"7be3ecfee5314ffa9b2d93fc4377792b2d6d70ed:pygravitydefier\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/git-beta\\\\\\",\\\\\\"repositoryName\\\\\\":\\\\\\"sourcecred/example-git\\\\\\",\\\\\\"type\\\\\\":\\\\\\"TREE_ENTRY\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-git-submodule.git@29ef158bc982733e2ba429fcf73e2f7562244188\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/git-beta\\\\\\",\\\\\\"repositoryName\\\\\\":\\\\\\"sourcecred/example-git\\\\\\",\\\\\\"type\\\\\\":\\\\\\"SUBMODULE_COMMIT\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"repositoryName\\":\\"sourcecred/example-git\\",\\"type\\":\\"HAS_CONTENTS\\"}": Object {
+      "dst": Object {
+        "id": "https://github.com/sourcecred/example-git-submodule.git@29ef158bc982733e2ba429fcf73e2f7562244188",
+        "pluginName": "sourcecred/git-beta",
+        "repositoryName": "sourcecred/example-git",
+        "type": "SUBMODULE_COMMIT",
+      },
+      "payload": Object {},
+      "src": Object {
+        "id": "7be3ecfee5314ffa9b2d93fc4377792b2d6d70ed:pygravitydefier",
+        "pluginName": "sourcecred/git-beta",
+        "repositoryName": "sourcecred/example-git",
+        "type": "TREE_ENTRY",
+      },
+    },
     "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"7be3ecfee5314ffa9b2d93fc4377792b2d6d70ed:science.txt\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/git-beta\\\\\\",\\\\\\"repositoryName\\\\\\":\\\\\\"sourcecred/example-git\\\\\\",\\\\\\"type\\\\\\":\\\\\\"TREE_ENTRY\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"f1f2514ca6d7a6a1a0511957021b1995bf9ace1c\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/git-beta\\\\\\",\\\\\\"repositoryName\\\\\\":\\\\\\"sourcecred/example-git\\\\\\",\\\\\\"type\\\\\\":\\\\\\"BLOB\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"repositoryName\\":\\"sourcecred/example-git\\",\\"type\\":\\"HAS_CONTENTS\\"}": Object {
       "dst": Object {
         "id": "f1f2514ca6d7a6a1a0511957021b1995bf9ace1c",
@@ -853,6 +898,21 @@ Object {
       "payload": Object {},
       "src": Object {
         "id": "819fc546cea489476ce8dc90785e9ba7753d0a8f:TODOS.txt",
+        "pluginName": "sourcecred/git-beta",
+        "repositoryName": "sourcecred/example-git",
+        "type": "TREE_ENTRY",
+      },
+    },
+    "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"819fc546cea489476ce8dc90785e9ba7753d0a8f:pygravitydefier\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/git-beta\\\\\\",\\\\\\"repositoryName\\\\\\":\\\\\\"sourcecred/example-git\\\\\\",\\\\\\"type\\\\\\":\\\\\\"TREE_ENTRY\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-git-submodule.git@29ef158bc982733e2ba429fcf73e2f7562244188\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/git-beta\\\\\\",\\\\\\"repositoryName\\\\\\":\\\\\\"sourcecred/example-git\\\\\\",\\\\\\"type\\\\\\":\\\\\\"SUBMODULE_COMMIT\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"repositoryName\\":\\"sourcecred/example-git\\",\\"type\\":\\"HAS_CONTENTS\\"}": Object {
+      "dst": Object {
+        "id": "https://github.com/sourcecred/example-git-submodule.git@29ef158bc982733e2ba429fcf73e2f7562244188",
+        "pluginName": "sourcecred/git-beta",
+        "repositoryName": "sourcecred/example-git",
+        "type": "SUBMODULE_COMMIT",
+      },
+      "payload": Object {},
+      "src": Object {
+        "id": "819fc546cea489476ce8dc90785e9ba7753d0a8f:pygravitydefier",
         "pluginName": "sourcecred/git-beta",
         "repositoryName": "sourcecred/example-git",
         "type": "TREE_ENTRY",
@@ -943,6 +1003,21 @@ Object {
       "payload": Object {},
       "src": Object {
         "id": "bbf3b8b3d26a4f884b5c022d46851f593d329192:TODOS.txt",
+        "pluginName": "sourcecred/git-beta",
+        "repositoryName": "sourcecred/example-git",
+        "type": "TREE_ENTRY",
+      },
+    },
+    "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"bbf3b8b3d26a4f884b5c022d46851f593d329192:pygravitydefier\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/git-beta\\\\\\",\\\\\\"repositoryName\\\\\\":\\\\\\"sourcecred/example-git\\\\\\",\\\\\\"type\\\\\\":\\\\\\"TREE_ENTRY\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-git-submodule.git@29ef158bc982733e2ba429fcf73e2f7562244188\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/git-beta\\\\\\",\\\\\\"repositoryName\\\\\\":\\\\\\"sourcecred/example-git\\\\\\",\\\\\\"type\\\\\\":\\\\\\"SUBMODULE_COMMIT\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"repositoryName\\":\\"sourcecred/example-git\\",\\"type\\":\\"HAS_CONTENTS\\"}": Object {
+      "dst": Object {
+        "id": "https://github.com/sourcecred/example-git-submodule.git@29ef158bc982733e2ba429fcf73e2f7562244188",
+        "pluginName": "sourcecred/git-beta",
+        "repositoryName": "sourcecred/example-git",
+        "type": "SUBMODULE_COMMIT",
+      },
+      "payload": Object {},
+      "src": Object {
+        "id": "bbf3b8b3d26a4f884b5c022d46851f593d329192:pygravitydefier",
         "pluginName": "sourcecred/git-beta",
         "repositoryName": "sourcecred/example-git",
         "type": "TREE_ENTRY",
@@ -1463,6 +1538,18 @@ Object {
     },
     "{\\"id\\":\\"f1f2514ca6d7a6a1a0511957021b1995bf9ace1c\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"repositoryName\\":\\"sourcecred/example-git\\",\\"type\\":\\"BLOB\\"}": Object {
       "payload": Object {},
+    },
+    "{\\"id\\":\\"https://github.com/sourcecred/example-git-submodule.git@29ef158bc982733e2ba429fcf73e2f7562244188\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"repositoryName\\":\\"sourcecred/example-git\\",\\"type\\":\\"SUBMODULE_COMMIT\\"}": Object {
+      "payload": Object {
+        "hash": "29ef158bc982733e2ba429fcf73e2f7562244188",
+        "url": "https://github.com/sourcecred/example-git-submodule.git",
+      },
+    },
+    "{\\"id\\":\\"https://github.com/sourcecred/example-git-submodule.git@762c062fbdc7ec198cd693e95d55b374a08ff3e3\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"repositoryName\\":\\"sourcecred/example-git\\",\\"type\\":\\"SUBMODULE_COMMIT\\"}": Object {
+      "payload": Object {
+        "hash": "762c062fbdc7ec198cd693e95d55b374a08ff3e3",
+        "url": "https://github.com/sourcecred/example-git-submodule.git",
+      },
     },
   },
 }

--- a/src/plugins/git/createGraph.js
+++ b/src/plugins/git/createGraph.js
@@ -3,29 +3,36 @@
 import type {Address} from "../../core/address";
 import type {Edge, Node} from "../../core/graph";
 import type {
+  BlobNodePayload,
   Commit,
   EdgePayload,
   EdgeType,
+  HasContentsEdgePayload,
+  Hash,
   IncludesEdgePayload,
   NodePayload,
   NodeType,
   Repository,
+  SubmoduleCommitPayload,
   Tree,
   TreeEntryNodePayload,
+  TreeNodePayload,
 } from "./types";
 import {Graph, edgeID} from "../../core/graph";
 import {
   BLOB_NODE_TYPE,
   COMMIT_NODE_TYPE,
-  TREE_NODE_TYPE,
-  TREE_ENTRY_NODE_TYPE,
-  INCLUDES_EDGE_TYPE,
+  GIT_PLUGIN_NAME,
   HAS_CONTENTS_EDGE_TYPE,
   HAS_PARENT_EDGE_TYPE,
   HAS_TREE_EDGE_TYPE,
-  GIT_PLUGIN_NAME,
+  INCLUDES_EDGE_TYPE,
+  SUBMODULE_COMMIT_NODE_TYPE,
+  TREE_ENTRY_NODE_TYPE,
+  TREE_NODE_TYPE,
   hasParentEdgeId,
   includesEdgeId,
+  submoduleCommitId,
   treeEntryId,
 } from "./types";
 
@@ -46,15 +53,50 @@ class GitGraphCreator {
   }
 
   createGraph(repository: Repository): Graph<NodePayload, EdgePayload> {
+    const treeAndNameToSubmoduleUrls = this.treeAndNameToSubmoduleUrls(
+      repository
+    );
     const graphs = [
       ...Object.keys(repository.commits).map((hash) =>
         this.commitGraph(repository.commits[hash])
       ),
       ...Object.keys(repository.trees).map((hash) =>
-        this.treeGraph(repository.trees[hash])
+        this.treeGraph(repository.trees[hash], treeAndNameToSubmoduleUrls)
       ),
     ];
     return graphs.reduce((g, h) => Graph.mergeConservative(g, h), new Graph());
+  }
+
+  treeAndNameToSubmoduleUrls(repository: Repository) {
+    const result: {[tree: Hash]: {[name: string]: string[]}} = {};
+    Object.keys(repository.commits).forEach((commitHash) => {
+      const {treeHash: rootTreeHash, submoduleUrls} = repository.commits[
+        commitHash
+      ];
+      Object.keys(submoduleUrls).forEach((path) => {
+        const parts = path.split("/");
+        const [treePath, name] = [
+          parts.slice(0, parts.length - 1),
+          parts[parts.length - 1],
+        ];
+        let tree = repository.trees[rootTreeHash];
+        for (const pathComponent of treePath) {
+          tree = repository.trees[tree.entries[pathComponent].hash];
+          if (tree == null) {
+            return;
+          }
+        }
+        if (result[tree.hash] == null) {
+          result[tree.hash] = {};
+        }
+        const url = submoduleUrls[path];
+        if (result[tree.hash][name] == null) {
+          result[tree.hash][name] = [];
+        }
+        result[tree.hash][name].push(url);
+      });
+    });
+    return result;
   }
 
   commitGraph(commit: Commit) {
@@ -98,7 +140,7 @@ class GitGraphCreator {
     return result;
   }
 
-  treeGraph(tree: Tree) {
+  treeGraph(tree: Tree, treeAndNameToSubmoduleUrls) {
     const treeNode = {
       address: this.makeAddress(TREE_NODE_TYPE, tree.hash),
       payload: {},
@@ -123,34 +165,50 @@ class GitGraphCreator {
         payload: {name},
       };
       result.addNode(entryNode).addEdge(entryEdge);
-      if (entry.type === "commit") {
-        // We don't represent subproject commits in the graph.
-      } else {
-        let contentsNodeType;
-        if (entry.type === "tree") {
-          contentsNodeType = TREE_NODE_TYPE;
-        } else if (entry.type === "blob") {
-          contentsNodeType = BLOB_NODE_TYPE;
+      const contentsNodes: Node<NodePayload>[] = (() => {
+        if (entry.type !== "commit") {
+          let contentsNodeType;
+          if (entry.type === "tree") {
+            contentsNodeType = TREE_NODE_TYPE;
+          } else if (entry.type === "blob") {
+            contentsNodeType = BLOB_NODE_TYPE;
+          } else {
+            // eslint-disable-next-line no-unused-expressions
+            (entry.type: empty);
+            throw new Error(`Unknown entry type: ${entry.type}`);
+          }
+          const contentsNode: Node<TreeNodePayload> | Node<BlobNodePayload> = {
+            address: this.makeAddress(contentsNodeType, entry.hash),
+            payload: (({}: any): {||}),
+          };
+          return [contentsNode];
         } else {
-          // eslint-disable-next-line no-unused-expressions
-          (entry.type: empty);
-          throw new Error(`Unknown entry type: ${entry.type}`);
+          // One entry for each possible URL.
+          const urls = treeAndNameToSubmoduleUrls[tree.hash][name];
+          return urls.map((url): Node<SubmoduleCommitPayload> => ({
+            address: this.makeAddress(
+              SUBMODULE_COMMIT_NODE_TYPE,
+              submoduleCommitId(entry.hash, url)
+            ),
+            payload: {
+              hash: entry.hash,
+              url,
+            },
+          }));
         }
-        const contentsNode = {
-          address: this.makeAddress(contentsNodeType, entry.hash),
-          payload: {},
-        };
-        const contentsEdge = {
+      })();
+      contentsNodes.forEach((contentsNode) => {
+        const contentsEdge: Edge<HasContentsEdgePayload> = {
           address: this.makeAddress(
             HAS_CONTENTS_EDGE_TYPE,
             edgeID(entryNode.address, contentsNode.address)
           ),
           src: entryNode.address,
           dst: contentsNode.address,
-          payload: {},
+          payload: (({}: any): {||}),
         };
         result.addNode(contentsNode).addEdge(contentsEdge);
-      }
+      });
     });
     return result;
   }

--- a/src/plugins/git/types.js
+++ b/src/plugins/git/types.js
@@ -36,6 +36,21 @@ export type TreeNodePayload = {||};
 export const BLOB_NODE_TYPE: "BLOB" = "BLOB";
 export type BlobNodePayload = {||}; // we do not store the content
 
+// In Git, a tree may point to a commit directly; in our graph, we have
+// an explicit notion of "submodule commit", because, a priori, we do
+// not know the repository to which the commit belongs. A submodule
+// commit node stores the hash of the referent commit, as well as the
+// URL to the subproject as listed in the .gitmodules file.
+export const SUBMODULE_COMMIT_NODE_TYPE: "SUBMODULE_COMMIT" =
+  "SUBMODULE_COMMIT";
+export function submoduleCommitId(hash: Hash, submoduleUrl: string) {
+  return `${submoduleUrl}@${hash}`;
+}
+export type SubmoduleCommitPayload = {|
+  +hash: Hash,
+  +url: string, // from .gitmodules file
+|};
+
 export const TREE_ENTRY_NODE_TYPE: "TREE_ENTRY" = "TREE_ENTRY";
 export type TreeEntryNodePayload = {|
   +name: string,
@@ -45,16 +60,18 @@ export function treeEntryId(tree: Hash, name: string): string {
 }
 
 export type NodePayload =
+  | BlobNodePayload
   | CommitNodePayload
-  | TreeNodePayload
+  | SubmoduleCommitPayload
   | TreeEntryNodePayload
-  | BlobNodePayload;
+  | TreeNodePayload;
 
 export type NodeType =
+  | typeof BLOB_NODE_TYPE
   | typeof COMMIT_NODE_TYPE
-  | typeof TREE_NODE_TYPE
+  | typeof SUBMODULE_COMMIT_NODE_TYPE
   | typeof TREE_ENTRY_NODE_TYPE
-  | typeof BLOB_NODE_TYPE;
+  | typeof TREE_NODE_TYPE;
 
 // Edges
 


### PR DESCRIPTION
Summary:
Previously, a tree entry had exactly one `HAS_CONTENTS` edge, unless the
tree entry corresponded to a submodule commit, in which case we had no
information at all. Now, submodule commit tree entries point to zero or
more `SUBMODULE_COMMIT` nodes. In the vast majority of cases, there will
be exactly one such node—however, it is possible that a particular tree
entry could correspond to multiple submodules (clone two identical
submodules with different URLs) or none at all (some manually edited
`.gitmodules` or other corruption).

Test Plan:
The snapshot changes are easy enough to read and verify (two new nodes
and five new edges). Additionally, the path-to-submodule `createGraph`
test has been updated.

wchargin-branch: graph-submodule-urls