### PR TITLE
Add options to not rebuild on shell script tests

### DIFF
--- a/src/plugins/git/loadRepositoryTest.sh
+++ b/src/plugins/git/loadRepositoryTest.sh
@@ -9,12 +9,14 @@ usage() {
   printf 'Flags:\n'
   printf '  -u|--updateSnapshot\n'
   printf '      Update the stored file instead of checking its contents\n'
+  printf ' --[no-]build\n'
+  printf '      Whether to run "yarn backend" before the test.\n'
+  printf '      Default is --build.\n'
   printf '  --help\n'
   printf '      Show this message\n'
 }
 
 fetch() {
-  yarn backend >&2
   tmpdir="$(mktemp -d)"
   node bin/createExampleRepo.js "${tmpdir}"
   node bin/loadAndPrintGitRepository.js "${tmpdir}"
@@ -33,21 +35,31 @@ update() {
 }
 
 main() {
-  cd "$(git rev-parse --show-toplevel)"
-  if [ $# -eq 0 ]; then
-    check
-  elif [ $# -eq 1 ]; then
-    if [ "$1" = "-u" ] || [ "$1" = "--updateSnapshot" ]; then
-      update
-    elif [ "$1" = "--help" ]; then
+  UPDATE=
+  BUILD=1
+  while [ $# -gt 0 ]; do
+    if [ "$1" = "--help" ]; then
       usage
+      return 0
+    elif [ "$1" = "-u" ] || [ "$1" = "--updateSnapshot" ]; then
+      UPDATE=1
+    elif [ "$1" = "--build" ]; then
+      BUILD=1
+    elif [ "$1" = "--no-build" ]; then
+      BUILD=
     else
       usage >&2
       return 1
     fi
+    shift
+  done
+  if [ -n "${BUILD}" ]; then
+    yarn backend
+  fi
+  if [ -n "${UPDATE}" ]; then
+    update
   else
-    usage >&2
-    return 1
+    check
   fi
 }
 

--- a/src/plugins/github/fetchGithubRepoTest.sh
+++ b/src/plugins/github/fetchGithubRepoTest.sh
@@ -5,12 +5,15 @@ set -eu
 data_file=src/plugins/github/demoData/example-repo.json
 
 usage() {
-  printf 'usage: %s [-u|--updateSnapshot] [--help]\n' "$0"
+  printf 'usage: %s [-u|--updateSnapshot] [--[no-]build] [--help]\n' "$0"
   printf 'Required environment variables:\n'
   printf '  GITHUB_TOKEN: A 40-character hex string API token.\n'
   printf 'Flags:\n'
   printf '  -u|--updateSnapshot\n'
   printf '      Update the stored file instead of checking its contents\n'
+  printf ' --[no-]build\n'
+  printf '      Whether to run "yarn backend" before the test.\n'
+  printf '      Default is --build.\n'
   printf '  --help\n'
   printf '      Show this message\n'
 }
@@ -21,7 +24,6 @@ fetch() {
     printf >&2 'to a 40-character hex string API token from GitHub.\n'
     return 1
   fi
-  yarn backend >&2
   node bin/fetchAndPrintGithubRepo.js \
     sourcecred example-repo "${GITHUB_TOKEN}"
 }
@@ -39,20 +41,31 @@ update() {
 
 main() {
   cd "$(git rev-parse --show-toplevel)"
-  if [ $# -eq 0 ]; then
-    check
-  elif [ $# -eq 1 ]; then
-    if [ "$1" = "-u" ] || [ "$1" = "--updateSnapshot" ]; then
-      update
-    elif [ "$1" = "--help" ]; then
+  UPDATE=
+  BUILD=1
+  while [ $# -gt 0 ]; do
+    if [ "$1" = "--help" ]; then
       usage
+      return 0
+    elif [ "$1" = "-u" ] || [ "$1" = "--updateSnapshot" ]; then
+      UPDATE=1
+    elif [ "$1" = "--build" ]; then
+      BUILD=1
+    elif [ "$1" = "--no-build" ]; then
+      BUILD=
     else
       usage >&2
       return 1
     fi
+    shift
+  done
+  if [ -n "${BUILD}" ]; then
+    yarn backend
+  fi
+  if [ -n "${UPDATE}" ]; then
+    update
   else
-    usage >&2
-    return 1
+    check
   fi
 }
 


### PR DESCRIPTION
Summary:
This can be useful for speed, but it can also be important for
correctness (at least theoretically): if we run both these scripts
concurrently, then we don’t want one of them to squash the `bin`
directory while the other is about to invoke an executable therein.

One might note that the diffs to the two files in this commit are
virtually identical, and indeed the files themselves are quite similar.
I’d prefer to keep the duplication for now; if we really need a Bash
snapshot testing framework, we can factor one out.

Test Plan:
Run each script with `--help`, with `--build` and `--no-build`, and with
and without `-u`.

wchargin-branch: optional-rebuild