### PR TITLE
Run npm scripts with `--silent` in CI

### DIFF
--- a/config/travis.js
+++ b/config/travis.js
@@ -197,29 +197,29 @@ function makeTasks(mode /*: "BASIC" | "FULL" */) {
   const basicTasks = [
     {
       id: "check-pretty",
-      cmd: ["npm", "run", "check-pretty"],
+      cmd: ["npm", "run", "--silent", "check-pretty"],
       deps: [],
     },
     {
       id: "lint",
-      cmd: ["npm", "run", "lint"],
+      cmd: ["npm", "run", "--silent", "lint"],
       deps: [],
     },
     {
       id: "flow",
-      cmd: ["npm", "run", "flow"],
+      cmd: ["npm", "run", "--silent", "flow"],
       deps: [],
     },
     {
       id: "ci-test",
-      cmd: ["npm", "run", "ci-test"],
+      cmd: ["npm", "run", "--silent", "ci-test"],
       deps: [],
     },
   ];
   const extraTasks = [
     {
       id: "backend",
-      cmd: ["npm", "run", "backend"],
+      cmd: ["npm", "run", "--silent", "backend"],
       deps: [],
     },
     {


### PR DESCRIPTION
Summary:
This prevents the boilerplate output of the form
```

> sourcecred-explorer@0.1.0 check-pretty /home/wchargin/git/sourcecred
> prettier --list-different '**/*.js'

```
(superfluous linebreaks included). In the case that a script fails, it
also omits the giant “this is most likely not a problem with npm” block.

The downside to this is that it suppresses any errors in npm-run-script
itself. For instance, `npm run wat` produces “missing script: wat”,
while `npm run --silent wat` just silently exits with 1. This does not
silence the actual scripts themselves, so things like lint errors or
test failures will still appear.

Test Plan:
Run `yarn travis` before and after this commit, and note that the
resulting build log is prettier after.

wchargin-branch: ci-silent