### PR TITLE
Run `flow check` instead of `flow` in CI

### DIFF
--- a/config/travis.js
+++ b/config/travis.js
@@ -206,8 +206,8 @@ function makeTasks(mode /*: "BASIC" | "FULL" */) {
       deps: [],
     },
     {
-      id: "flow",
-      cmd: ["npm", "run", "--silent", "flow"],
+      id: "flow-check",
+      cmd: ["npm", "run", "--silent", "flow", "check"],
       deps: [],
     },
     {


### PR DESCRIPTION
Summary:
This means that Flow will check from scratch, instead of merging in
incremental stages and talking to an existing server.

This improves test isolation. If your existing Flow server is in a
different state than a new Flow server would be, then without this patch
you might not get correct results. (This can happen if, for instance,
you add additional `flow-typed` declarations.)

A side benefit is that it gets rid of the dozens of lines of log spam of
the form, “Please wait. Server is initializing (parsed files 12345)”.

A minor benefit is that this fixes a memory leak on CI—previously, the
Travis instance would have a useless Flow server running in the
background after checks complete. But I’m sure that Travis doesn’t
actually care, so this isn’t very important.

A downside of this change is that it will often make `yarn travis`
slower when run locally. Build times on a Travis instance should not be
affected, because Travis has to start a server either way, and that’s
the slow part. For me, a `yarn flow check` takes about 11s, so the build
must take at least that long.

[1]: https://stackoverflow.com/questions/38902752/

Test Plan:
Run `yarn travis` and note that it still passes. Then, introduce a Flow
error and note that the build properly fails.

wchargin-branch: ci-flow-check