### PR TITLE
Remove the `repositoryName` field from Addresses

### DIFF
--- a/src/core/__snapshots__/address.test.js.snap
+++ b/src/core/__snapshots__/address.test.js.snap
@@ -2,11 +2,11 @@
 
 exports[`address AddressMap stringifies to JSON 1`] = `
 Object {
-  "{\\"id\\":\\"mansion\\",\\"pluginName\\":\\"houseville\\",\\"repositoryName\\":\\"sourcecred/suburbia\\",\\"type\\":\\"HOME\\"}": Object {
+  "{\\"id\\":\\"mansion\\",\\"pluginName\\":\\"houseville\\",\\"type\\":\\"HOME\\"}": Object {
     "baths": 5,
     "beds": 10,
   },
-  "{\\"id\\":\\"mattressStore\\",\\"pluginName\\":\\"houseville\\",\\"repositoryName\\":\\"sourcecred/suburbia\\",\\"type\\":\\"BUSINESS\\"}": Object {
+  "{\\"id\\":\\"mattressStore\\",\\"pluginName\\":\\"houseville\\",\\"type\\":\\"BUSINESS\\"}": Object {
     "baths": 1,
     "beds": 99,
   },
@@ -19,28 +19,25 @@ Array [
     Object {
       "id": "mansion",
       "pluginName": "houseville",
-      "repositoryName": "sourcecred/suburbia",
       "type": "HOME",
     },
-    "{\\"id\\":\\"mansion\\",\\"pluginName\\":\\"houseville\\",\\"repositoryName\\":\\"sourcecred/suburbia\\",\\"type\\":\\"HOME\\"}",
+    "{\\"id\\":\\"mansion\\",\\"pluginName\\":\\"houseville\\",\\"type\\":\\"HOME\\"}",
   ],
   Array [
     Object {
       "id": "mansion",
       "pluginName": "houseville",
-      "repositoryName": "sourcecred/suburbia",
       "type": "HOME",
     },
-    "{\\"id\\":\\"mansion\\",\\"pluginName\\":\\"houseville\\",\\"repositoryName\\":\\"sourcecred/suburbia\\",\\"type\\":\\"HOME\\"}",
+    "{\\"id\\":\\"mansion\\",\\"pluginName\\":\\"houseville\\",\\"type\\":\\"HOME\\"}",
   ],
   Array [
     Object {
       "id": "mattressStore",
       "pluginName": "houseville",
-      "repositoryName": "sourcecred/suburbia",
       "type": "BUSINESS",
     },
-    "{\\"id\\":\\"mattressStore\\",\\"pluginName\\":\\"houseville\\",\\"repositoryName\\":\\"sourcecred/suburbia\\",\\"type\\":\\"BUSINESS\\"}",
+    "{\\"id\\":\\"mattressStore\\",\\"pluginName\\":\\"houseville\\",\\"type\\":\\"BUSINESS\\"}",
   ],
 ]
 `;

--- a/src/core/__snapshots__/graph.test.js.snap
+++ b/src/core/__snapshots__/graph.test.js.snap
@@ -3,11 +3,10 @@
 exports[`graph #Graph JSON functions should serialize a simple graph 1`] = `
 Object {
   "edges": Object {
-    "{\\"id\\":\\"crab-self-assessment\\",\\"pluginName\\":\\"hill_cooking_pot\\",\\"repositoryName\\":\\"sourcecred/eventide\\",\\"type\\":\\"SILLY\\"}": Object {
+    "{\\"id\\":\\"crab-self-assessment\\",\\"pluginName\\":\\"hill_cooking_pot\\",\\"type\\":\\"SILLY\\"}": Object {
       "dst": Object {
         "id": "razorclaw_crab#2",
         "pluginName": "hill_cooking_pot",
-        "repositoryName": "sourcecred/eventide",
         "type": "FOOD",
       },
       "payload": Object {
@@ -16,15 +15,13 @@ Object {
       "src": Object {
         "id": "razorclaw_crab#2",
         "pluginName": "hill_cooking_pot",
-        "repositoryName": "sourcecred/eventide",
         "type": "FOOD",
       },
     },
-    "{\\"id\\":\\"hero_of_time#0@again_cooks@seafood_fruit_mix#3\\",\\"pluginName\\":\\"hill_cooking_pot\\",\\"repositoryName\\":\\"sourcecred/eventide\\",\\"type\\":\\"ACTION\\"}": Object {
+    "{\\"id\\":\\"hero_of_time#0@again_cooks@seafood_fruit_mix#3\\",\\"pluginName\\":\\"hill_cooking_pot\\",\\"type\\":\\"ACTION\\"}": Object {
       "dst": Object {
         "id": "hero_of_time#0",
         "pluginName": "hill_cooking_pot",
-        "repositoryName": "sourcecred/eventide",
         "type": "PC",
       },
       "payload": Object {
@@ -34,15 +31,13 @@ Object {
       "src": Object {
         "id": "seafood_fruit_mix#3",
         "pluginName": "hill_cooking_pot",
-        "repositoryName": "sourcecred/eventide",
         "type": "FOOD",
       },
     },
-    "{\\"id\\":\\"hero_of_time#0@cooks@seafood_fruit_mix#3\\",\\"pluginName\\":\\"hill_cooking_pot\\",\\"repositoryName\\":\\"sourcecred/eventide\\",\\"type\\":\\"ACTION\\"}": Object {
+    "{\\"id\\":\\"hero_of_time#0@cooks@seafood_fruit_mix#3\\",\\"pluginName\\":\\"hill_cooking_pot\\",\\"type\\":\\"ACTION\\"}": Object {
       "dst": Object {
         "id": "hero_of_time#0",
         "pluginName": "hill_cooking_pot",
-        "repositoryName": "sourcecred/eventide",
         "type": "PC",
       },
       "payload": Object {
@@ -51,97 +46,86 @@ Object {
       "src": Object {
         "id": "seafood_fruit_mix#3",
         "pluginName": "hill_cooking_pot",
-        "repositoryName": "sourcecred/eventide",
         "type": "FOOD",
       },
     },
-    "{\\"id\\":\\"hero_of_time#0@eats@seafood_fruit_mix#3\\",\\"pluginName\\":\\"hill_cooking_pot\\",\\"repositoryName\\":\\"sourcecred/eventide\\",\\"type\\":\\"ACTION\\"}": Object {
+    "{\\"id\\":\\"hero_of_time#0@eats@seafood_fruit_mix#3\\",\\"pluginName\\":\\"hill_cooking_pot\\",\\"type\\":\\"ACTION\\"}": Object {
       "dst": Object {
         "id": "seafood_fruit_mix#3",
         "pluginName": "hill_cooking_pot",
-        "repositoryName": "sourcecred/eventide",
         "type": "FOOD",
       },
       "payload": Object {},
       "src": Object {
         "id": "hero_of_time#0",
         "pluginName": "hill_cooking_pot",
-        "repositoryName": "sourcecred/eventide",
         "type": "PC",
       },
     },
-    "{\\"id\\":\\"hero_of_time#0@grabs@razorclaw_crab#2\\",\\"pluginName\\":\\"hill_cooking_pot\\",\\"repositoryName\\":\\"sourcecred/eventide\\",\\"type\\":\\"ACTION\\"}": Object {
+    "{\\"id\\":\\"hero_of_time#0@grabs@razorclaw_crab#2\\",\\"pluginName\\":\\"hill_cooking_pot\\",\\"type\\":\\"ACTION\\"}": Object {
       "dst": Object {
         "id": "hero_of_time#0",
         "pluginName": "hill_cooking_pot",
-        "repositoryName": "sourcecred/eventide",
         "type": "PC",
       },
       "payload": Object {},
       "src": Object {
         "id": "razorclaw_crab#2",
         "pluginName": "hill_cooking_pot",
-        "repositoryName": "sourcecred/eventide",
         "type": "FOOD",
       },
     },
-    "{\\"id\\":\\"hero_of_time#0@picks@mighty_bananas#1\\",\\"pluginName\\":\\"hill_cooking_pot\\",\\"repositoryName\\":\\"sourcecred/eventide\\",\\"type\\":\\"ACTION\\"}": Object {
+    "{\\"id\\":\\"hero_of_time#0@picks@mighty_bananas#1\\",\\"pluginName\\":\\"hill_cooking_pot\\",\\"type\\":\\"ACTION\\"}": Object {
       "dst": Object {
         "id": "hero_of_time#0",
         "pluginName": "hill_cooking_pot",
-        "repositoryName": "sourcecred/eventide",
         "type": "PC",
       },
       "payload": Object {},
       "src": Object {
         "id": "mighty_bananas#1",
         "pluginName": "hill_cooking_pot",
-        "repositoryName": "sourcecred/eventide",
         "type": "FOOD",
       },
     },
-    "{\\"id\\":\\"mighty_bananas#1@included_in@seafood_fruit_mix#3\\",\\"pluginName\\":\\"hill_cooking_pot\\",\\"repositoryName\\":\\"sourcecred/eventide\\",\\"type\\":\\"INGREDIENT\\"}": Object {
+    "{\\"id\\":\\"mighty_bananas#1@included_in@seafood_fruit_mix#3\\",\\"pluginName\\":\\"hill_cooking_pot\\",\\"type\\":\\"INGREDIENT\\"}": Object {
       "dst": Object {
         "id": "mighty_bananas#1",
         "pluginName": "hill_cooking_pot",
-        "repositoryName": "sourcecred/eventide",
         "type": "FOOD",
       },
       "payload": Object {},
       "src": Object {
         "id": "seafood_fruit_mix#3",
         "pluginName": "hill_cooking_pot",
-        "repositoryName": "sourcecred/eventide",
         "type": "FOOD",
       },
     },
-    "{\\"id\\":\\"razorclaw_crab#2@included_in@seafood_fruit_mix#3\\",\\"pluginName\\":\\"hill_cooking_pot\\",\\"repositoryName\\":\\"sourcecred/eventide\\",\\"type\\":\\"INGREDIENT\\"}": Object {
+    "{\\"id\\":\\"razorclaw_crab#2@included_in@seafood_fruit_mix#3\\",\\"pluginName\\":\\"hill_cooking_pot\\",\\"type\\":\\"INGREDIENT\\"}": Object {
       "dst": Object {
         "id": "razorclaw_crab#2",
         "pluginName": "hill_cooking_pot",
-        "repositoryName": "sourcecred/eventide",
         "type": "FOOD",
       },
       "payload": Object {},
       "src": Object {
         "id": "seafood_fruit_mix#3",
         "pluginName": "hill_cooking_pot",
-        "repositoryName": "sourcecred/eventide",
         "type": "FOOD",
       },
     },
   },
   "nodes": Object {
-    "{\\"id\\":\\"hero_of_time#0\\",\\"pluginName\\":\\"hill_cooking_pot\\",\\"repositoryName\\":\\"sourcecred/eventide\\",\\"type\\":\\"PC\\"}": Object {
+    "{\\"id\\":\\"hero_of_time#0\\",\\"pluginName\\":\\"hill_cooking_pot\\",\\"type\\":\\"PC\\"}": Object {
       "payload": Object {},
     },
-    "{\\"id\\":\\"mighty_bananas#1\\",\\"pluginName\\":\\"hill_cooking_pot\\",\\"repositoryName\\":\\"sourcecred/eventide\\",\\"type\\":\\"FOOD\\"}": Object {
+    "{\\"id\\":\\"mighty_bananas#1\\",\\"pluginName\\":\\"hill_cooking_pot\\",\\"type\\":\\"FOOD\\"}": Object {
       "payload": Object {},
     },
-    "{\\"id\\":\\"razorclaw_crab#2\\",\\"pluginName\\":\\"hill_cooking_pot\\",\\"repositoryName\\":\\"sourcecred/eventide\\",\\"type\\":\\"FOOD\\"}": Object {
+    "{\\"id\\":\\"razorclaw_crab#2\\",\\"pluginName\\":\\"hill_cooking_pot\\",\\"type\\":\\"FOOD\\"}": Object {
       "payload": Object {},
     },
-    "{\\"id\\":\\"seafood_fruit_mix#3\\",\\"pluginName\\":\\"hill_cooking_pot\\",\\"repositoryName\\":\\"sourcecred/eventide\\",\\"type\\":\\"FOOD\\"}": Object {
+    "{\\"id\\":\\"seafood_fruit_mix#3\\",\\"pluginName\\":\\"hill_cooking_pot\\",\\"type\\":\\"FOOD\\"}": Object {
       "payload": Object {
         "effect": Array [
           "attack_power",

--- a/src/core/address.js
+++ b/src/core/address.js
@@ -4,7 +4,6 @@ import deepEqual from "lodash.isequal";
 import stringify from "json-stable-stringify";
 
 export type Address = {|
-  +repositoryName: string,
   +pluginName: string,
   +id: string,
   +type: string,

--- a/src/core/address.test.js
+++ b/src/core/address.test.js
@@ -15,7 +15,6 @@ describe("address", () => {
   |};
   function makeAddress(type: "HOME" | "BUSINESS", id: string): Address {
     return {
-      repositoryName: "sourcecred/suburbia",
       pluginName: "houseville",
       id,
       type,
@@ -160,12 +159,10 @@ describe("address", () => {
         pluginName: "foo",
         type: "bar",
         id: "zoombat",
-        repositoryName: "oregano",
       };
       const a2 = {
         id: "zoombat",
         type: "bar",
-        repositoryName: "oregano",
         pluginName: "foo",
       };
       expect(toString(a1)).toEqual(toString(a2));

--- a/src/core/graph.test.js
+++ b/src/core/graph.test.js
@@ -416,7 +416,6 @@ describe("graph", () => {
               id,
               type,
               pluginName: "graph-test",
-              repositoryName: "sourcecred",
             };
           }
 

--- a/src/core/graphDemoData.js
+++ b/src/core/graphDemoData.js
@@ -9,7 +9,6 @@ import {Graph} from "./graph";
 
 export function makeAddress(id: string, type: string): Address {
   return {
-    repositoryName: "sourcecred/eventide",
     pluginName: "hill_cooking_pot",
     id,
     type,

--- a/src/plugins/artifact/artifactPlugin.js
+++ b/src/plugins/artifact/artifactPlugin.js
@@ -28,10 +28,10 @@ export function artifactAddress(
   repoName: string,
   artifactName: string
 ): Address {
-  const baseId = artifactName.toLowerCase().replace(NON_SLUG_CHARACTER, "-");
+  const baseName = artifactName.toLowerCase().replace(NON_SLUG_CHARACTER, "-");
+  const baseId = `${repoOwner}/${repoName}/${baseName}`;
   function address(id) {
     return {
-      repositoryName: `${repoOwner}/${repoName}`,
       pluginName: ARTIFACT_PLUGIN_NAME,
       id,
       type: ARTIFACT_NODE_TYPE,

--- a/src/plugins/artifact/artifactPlugin.test.js
+++ b/src/plugins/artifact/artifactPlugin.test.js
@@ -5,14 +5,14 @@ import {artifactAddress} from "./artifactPlugin";
 
 describe("artifactPlugin", () => {
   describe("artifactAddress", () => {
-    it("formats the repository name", () => {
+    it("repositoryName included in id", () => {
       const a = artifactAddress(
         new Graph(),
         "not-sourcecred",
         "not-artifact-plugin",
         "Sample artifact!"
       );
-      expect(a.repositoryName).toEqual("not-sourcecred/not-artifact-plugin");
+      expect(a.id.startsWith("not-sourcecred/not-artifact-plugin")).toBe(true);
     });
 
     it("slugifies the artifact name", () => {
@@ -22,7 +22,9 @@ describe("artifactPlugin", () => {
         "not-artifact-plugin",
         "Sample artifact!"
       );
-      expect(a.id).toEqual("sample-artifact-");
+      expect(a.id).toEqual(
+        "not-sourcecred/not-artifact-plugin/sample-artifact-"
+      );
     });
 
     it("resolves collisions", () => {
@@ -42,9 +44,9 @@ describe("artifactPlugin", () => {
         });
       }
       expect(ids).toEqual([
-        "sample-artifact-",
-        "sample-artifact--0",
-        "sample-artifact--1",
+        "not-sourcecred/not-artifact-plugin/sample-artifact-",
+        "not-sourcecred/not-artifact-plugin/sample-artifact--0",
+        "not-sourcecred/not-artifact-plugin/sample-artifact--1",
       ]);
     });
   });

--- a/src/plugins/artifact/editor/ContributionList.test.js
+++ b/src/plugins/artifact/editor/ContributionList.test.js
@@ -32,7 +32,6 @@ function createTestData(): * {
     id: string
   ): Address {
     return {
-      repositoryName: "sourcecred/tests",
       pluginName,
       id,
       type,

--- a/src/plugins/artifact/editor/GithubGraphFetcher.js
+++ b/src/plugins/artifact/editor/GithubGraphFetcher.js
@@ -32,7 +32,7 @@ export class GithubGraphFetcher extends React.Component<Props> {
     const {repoOwner, repoName, githubApiToken} = this.props.settings;
     fetchGithubRepo(repoOwner, repoName, githubApiToken)
       .then((json) => {
-        return Promise.resolve(parse(`${repoOwner}/${repoName}`, json));
+        return Promise.resolve(parse(json));
       })
       .then((graph) => {
         this.props.onCreateGraph(graph);

--- a/src/plugins/artifact/editor/__snapshots__/ContributionList.test.js.snap
+++ b/src/plugins/artifact/editor/__snapshots__/ContributionList.test.js.snap
@@ -75,7 +75,7 @@ exports[`ContributionList renders some test data in the default state 1`] = `
     </thead>
     <tbody>
       <tr
-        key="{\\"repositoryName\\":\\"sourcecred/tests\\",\\"pluginName\\":\\"sourcecred/example-plugin-a\\",\\"id\\":\\"one\\",\\"type\\":\\"small\\"}"
+        key="{\\"pluginName\\":\\"sourcecred/example-plugin-a\\",\\"id\\":\\"one\\",\\"type\\":\\"small\\"}"
       >
         <td>
           the number 111
@@ -88,7 +88,7 @@ exports[`ContributionList renders some test data in the default state 1`] = `
         </td>
       </tr>
       <tr
-        key="{\\"repositoryName\\":\\"sourcecred/tests\\",\\"pluginName\\":\\"sourcecred/example-plugin-a\\",\\"id\\":\\"two\\",\\"type\\":\\"small\\"}"
+        key="{\\"pluginName\\":\\"sourcecred/example-plugin-a\\",\\"id\\":\\"two\\",\\"type\\":\\"small\\"}"
       >
         <td>
           the number 234
@@ -101,7 +101,7 @@ exports[`ContributionList renders some test data in the default state 1`] = `
         </td>
       </tr>
       <tr
-        key="{\\"repositoryName\\":\\"sourcecred/tests\\",\\"pluginName\\":\\"sourcecred/example-plugin-a\\",\\"id\\":\\"three\\",\\"type\\":\\"big\\"}"
+        key="{\\"pluginName\\":\\"sourcecred/example-plugin-a\\",\\"id\\":\\"three\\",\\"type\\":\\"big\\"}"
       >
         <td>
           the number 616
@@ -114,7 +114,7 @@ exports[`ContributionList renders some test data in the default state 1`] = `
         </td>
       </tr>
       <tr
-        key="{\\"repositoryName\\":\\"sourcecred/tests\\",\\"pluginName\\":\\"sourcecred/example-plugin-b\\",\\"id\\":\\"four\\",\\"type\\":\\"very true\\"}"
+        key="{\\"pluginName\\":\\"sourcecred/example-plugin-b\\",\\"id\\":\\"four\\",\\"type\\":\\"very true\\"}"
       >
         <td>
           TRUE!
@@ -127,7 +127,7 @@ exports[`ContributionList renders some test data in the default state 1`] = `
         </td>
       </tr>
       <tr
-        key="{\\"repositoryName\\":\\"sourcecred/tests\\",\\"pluginName\\":\\"sourcecred/example-plugin-c\\",\\"id\\":\\"five\\",\\"type\\":\\"ctype\\"}"
+        key="{\\"pluginName\\":\\"sourcecred/example-plugin-c\\",\\"id\\":\\"five\\",\\"type\\":\\"ctype\\"}"
       >
         <td
           colSpan={3}
@@ -220,7 +220,7 @@ exports[`ContributionList updates the node table when a filter is selected 1`] =
     </thead>
     <tbody>
       <tr
-        key="{\\"repositoryName\\":\\"sourcecred/tests\\",\\"pluginName\\":\\"sourcecred/example-plugin-a\\",\\"id\\":\\"one\\",\\"type\\":\\"small\\"}"
+        key="{\\"pluginName\\":\\"sourcecred/example-plugin-a\\",\\"id\\":\\"one\\",\\"type\\":\\"small\\"}"
       >
         <td>
           the number 111
@@ -233,7 +233,7 @@ exports[`ContributionList updates the node table when a filter is selected 1`] =
         </td>
       </tr>
       <tr
-        key="{\\"repositoryName\\":\\"sourcecred/tests\\",\\"pluginName\\":\\"sourcecred/example-plugin-a\\",\\"id\\":\\"two\\",\\"type\\":\\"small\\"}"
+        key="{\\"pluginName\\":\\"sourcecred/example-plugin-a\\",\\"id\\":\\"two\\",\\"type\\":\\"small\\"}"
       >
         <td>
           the number 234

--- a/src/plugins/artifact/editor/adapters/githubPluginAdapter.test.js
+++ b/src/plugins/artifact/editor/adapters/githubPluginAdapter.test.js
@@ -13,7 +13,7 @@ require("../testUtil").configureEnzyme();
 
 describe("githubPluginAdapter", () => {
   it("operates on the example repo", () => {
-    const graph = parse("sourcecred/example-repo", exampleRepoData);
+    const graph = parse(exampleRepoData);
 
     const result = graph
       .nodes()

--- a/src/plugins/git/__snapshots__/createGraph.test.js.snap
+++ b/src/plugins/git/__snapshots__/createGraph.test.js.snap
@@ -3,11 +3,10 @@
 exports[`createGraph processes a simple repository 1`] = `
 Object {
   "edges": Object {
-    "{\\"id\\":\\"2f7155e359fd0ecb96ffdca66fa45b6ed5792809:README.txt\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"repositoryName\\":\\"sourcecred/example-git\\",\\"type\\":\\"INCLUDES\\"}": Object {
+    "{\\"id\\":\\"2f7155e359fd0ecb96ffdca66fa45b6ed5792809:README.txt\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"type\\":\\"INCLUDES\\"}": Object {
       "dst": Object {
         "id": "2f7155e359fd0ecb96ffdca66fa45b6ed5792809:README.txt",
         "pluginName": "sourcecred/git-beta",
-        "repositoryName": "sourcecred/example-git",
         "type": "TREE_ENTRY",
       },
       "payload": Object {
@@ -16,15 +15,13 @@ Object {
       "src": Object {
         "id": "2f7155e359fd0ecb96ffdca66fa45b6ed5792809",
         "pluginName": "sourcecred/git-beta",
-        "repositoryName": "sourcecred/example-git",
         "type": "TREE",
       },
     },
-    "{\\"id\\":\\"2f7155e359fd0ecb96ffdca66fa45b6ed5792809:science.txt\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"repositoryName\\":\\"sourcecred/example-git\\",\\"type\\":\\"INCLUDES\\"}": Object {
+    "{\\"id\\":\\"2f7155e359fd0ecb96ffdca66fa45b6ed5792809:science.txt\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"type\\":\\"INCLUDES\\"}": Object {
       "dst": Object {
         "id": "2f7155e359fd0ecb96ffdca66fa45b6ed5792809:science.txt",
         "pluginName": "sourcecred/git-beta",
-        "repositoryName": "sourcecred/example-git",
         "type": "TREE_ENTRY",
       },
       "payload": Object {
@@ -33,15 +30,13 @@ Object {
       "src": Object {
         "id": "2f7155e359fd0ecb96ffdca66fa45b6ed5792809",
         "pluginName": "sourcecred/git-beta",
-        "repositoryName": "sourcecred/example-git",
         "type": "TREE",
       },
     },
-    "{\\"id\\":\\"3715ddfb8d4c4fd2a6f6af75488c82f84c92ec2f^1\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"repositoryName\\":\\"sourcecred/example-git\\",\\"type\\":\\"HAS_PARENT\\"}": Object {
+    "{\\"id\\":\\"3715ddfb8d4c4fd2a6f6af75488c82f84c92ec2f^1\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"type\\":\\"HAS_PARENT\\"}": Object {
       "dst": Object {
         "id": "69c5aad50eec8f2a0a07c988c3b283a6490eb45b",
         "pluginName": "sourcecred/git-beta",
-        "repositoryName": "sourcecred/example-git",
         "type": "COMMIT",
       },
       "payload": Object {
@@ -50,15 +45,13 @@ Object {
       "src": Object {
         "id": "3715ddfb8d4c4fd2a6f6af75488c82f84c92ec2f",
         "pluginName": "sourcecred/git-beta",
-        "repositoryName": "sourcecred/example-git",
         "type": "COMMIT",
       },
     },
-    "{\\"id\\":\\"3dfb84795e07341b05fad3a0d5a55f8304b2d7d8:.gitmodules\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"repositoryName\\":\\"sourcecred/example-git\\",\\"type\\":\\"INCLUDES\\"}": Object {
+    "{\\"id\\":\\"3dfb84795e07341b05fad3a0d5a55f8304b2d7d8:.gitmodules\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"type\\":\\"INCLUDES\\"}": Object {
       "dst": Object {
         "id": "3dfb84795e07341b05fad3a0d5a55f8304b2d7d8:.gitmodules",
         "pluginName": "sourcecred/git-beta",
-        "repositoryName": "sourcecred/example-git",
         "type": "TREE_ENTRY",
       },
       "payload": Object {
@@ -67,15 +60,13 @@ Object {
       "src": Object {
         "id": "3dfb84795e07341b05fad3a0d5a55f8304b2d7d8",
         "pluginName": "sourcecred/git-beta",
-        "repositoryName": "sourcecred/example-git",
         "type": "TREE",
       },
     },
-    "{\\"id\\":\\"3dfb84795e07341b05fad3a0d5a55f8304b2d7d8:README.txt\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"repositoryName\\":\\"sourcecred/example-git\\",\\"type\\":\\"INCLUDES\\"}": Object {
+    "{\\"id\\":\\"3dfb84795e07341b05fad3a0d5a55f8304b2d7d8:README.txt\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"type\\":\\"INCLUDES\\"}": Object {
       "dst": Object {
         "id": "3dfb84795e07341b05fad3a0d5a55f8304b2d7d8:README.txt",
         "pluginName": "sourcecred/git-beta",
-        "repositoryName": "sourcecred/example-git",
         "type": "TREE_ENTRY",
       },
       "payload": Object {
@@ -84,15 +75,13 @@ Object {
       "src": Object {
         "id": "3dfb84795e07341b05fad3a0d5a55f8304b2d7d8",
         "pluginName": "sourcecred/git-beta",
-        "repositoryName": "sourcecred/example-git",
         "type": "TREE",
       },
     },
-    "{\\"id\\":\\"3dfb84795e07341b05fad3a0d5a55f8304b2d7d8:pygravitydefier\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"repositoryName\\":\\"sourcecred/example-git\\",\\"type\\":\\"INCLUDES\\"}": Object {
+    "{\\"id\\":\\"3dfb84795e07341b05fad3a0d5a55f8304b2d7d8:pygravitydefier\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"type\\":\\"INCLUDES\\"}": Object {
       "dst": Object {
         "id": "3dfb84795e07341b05fad3a0d5a55f8304b2d7d8:pygravitydefier",
         "pluginName": "sourcecred/git-beta",
-        "repositoryName": "sourcecred/example-git",
         "type": "TREE_ENTRY",
       },
       "payload": Object {
@@ -101,15 +90,13 @@ Object {
       "src": Object {
         "id": "3dfb84795e07341b05fad3a0d5a55f8304b2d7d8",
         "pluginName": "sourcecred/git-beta",
-        "repositoryName": "sourcecred/example-git",
         "type": "TREE",
       },
     },
-    "{\\"id\\":\\"3dfb84795e07341b05fad3a0d5a55f8304b2d7d8:science.txt\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"repositoryName\\":\\"sourcecred/example-git\\",\\"type\\":\\"INCLUDES\\"}": Object {
+    "{\\"id\\":\\"3dfb84795e07341b05fad3a0d5a55f8304b2d7d8:science.txt\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"type\\":\\"INCLUDES\\"}": Object {
       "dst": Object {
         "id": "3dfb84795e07341b05fad3a0d5a55f8304b2d7d8:science.txt",
         "pluginName": "sourcecred/git-beta",
-        "repositoryName": "sourcecred/example-git",
         "type": "TREE_ENTRY",
       },
       "payload": Object {
@@ -118,15 +105,13 @@ Object {
       "src": Object {
         "id": "3dfb84795e07341b05fad3a0d5a55f8304b2d7d8",
         "pluginName": "sourcecred/git-beta",
-        "repositoryName": "sourcecred/example-git",
         "type": "TREE",
       },
     },
-    "{\\"id\\":\\"569e1d383759903134df75230d63c0090196d4cb:.gitmodules\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"repositoryName\\":\\"sourcecred/example-git\\",\\"type\\":\\"INCLUDES\\"}": Object {
+    "{\\"id\\":\\"569e1d383759903134df75230d63c0090196d4cb:.gitmodules\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"type\\":\\"INCLUDES\\"}": Object {
       "dst": Object {
         "id": "569e1d383759903134df75230d63c0090196d4cb:.gitmodules",
         "pluginName": "sourcecred/git-beta",
-        "repositoryName": "sourcecred/example-git",
         "type": "TREE_ENTRY",
       },
       "payload": Object {
@@ -135,15 +120,13 @@ Object {
       "src": Object {
         "id": "569e1d383759903134df75230d63c0090196d4cb",
         "pluginName": "sourcecred/git-beta",
-        "repositoryName": "sourcecred/example-git",
         "type": "TREE",
       },
     },
-    "{\\"id\\":\\"569e1d383759903134df75230d63c0090196d4cb:README.txt\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"repositoryName\\":\\"sourcecred/example-git\\",\\"type\\":\\"INCLUDES\\"}": Object {
+    "{\\"id\\":\\"569e1d383759903134df75230d63c0090196d4cb:README.txt\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"type\\":\\"INCLUDES\\"}": Object {
       "dst": Object {
         "id": "569e1d383759903134df75230d63c0090196d4cb:README.txt",
         "pluginName": "sourcecred/git-beta",
-        "repositoryName": "sourcecred/example-git",
         "type": "TREE_ENTRY",
       },
       "payload": Object {
@@ -152,15 +135,13 @@ Object {
       "src": Object {
         "id": "569e1d383759903134df75230d63c0090196d4cb",
         "pluginName": "sourcecred/git-beta",
-        "repositoryName": "sourcecred/example-git",
         "type": "TREE",
       },
     },
-    "{\\"id\\":\\"569e1d383759903134df75230d63c0090196d4cb:TODOS.txt\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"repositoryName\\":\\"sourcecred/example-git\\",\\"type\\":\\"INCLUDES\\"}": Object {
+    "{\\"id\\":\\"569e1d383759903134df75230d63c0090196d4cb:TODOS.txt\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"type\\":\\"INCLUDES\\"}": Object {
       "dst": Object {
         "id": "569e1d383759903134df75230d63c0090196d4cb:TODOS.txt",
         "pluginName": "sourcecred/git-beta",
-        "repositoryName": "sourcecred/example-git",
         "type": "TREE_ENTRY",
       },
       "payload": Object {
@@ -169,15 +150,13 @@ Object {
       "src": Object {
         "id": "569e1d383759903134df75230d63c0090196d4cb",
         "pluginName": "sourcecred/git-beta",
-        "repositoryName": "sourcecred/example-git",
         "type": "TREE",
       },
     },
-    "{\\"id\\":\\"569e1d383759903134df75230d63c0090196d4cb:pygravitydefier\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"repositoryName\\":\\"sourcecred/example-git\\",\\"type\\":\\"INCLUDES\\"}": Object {
+    "{\\"id\\":\\"569e1d383759903134df75230d63c0090196d4cb:pygravitydefier\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"type\\":\\"INCLUDES\\"}": Object {
       "dst": Object {
         "id": "569e1d383759903134df75230d63c0090196d4cb:pygravitydefier",
         "pluginName": "sourcecred/git-beta",
-        "repositoryName": "sourcecred/example-git",
         "type": "TREE_ENTRY",
       },
       "payload": Object {
@@ -186,15 +165,13 @@ Object {
       "src": Object {
         "id": "569e1d383759903134df75230d63c0090196d4cb",
         "pluginName": "sourcecred/git-beta",
-        "repositoryName": "sourcecred/example-git",
         "type": "TREE",
       },
     },
-    "{\\"id\\":\\"569e1d383759903134df75230d63c0090196d4cb:science.txt\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"repositoryName\\":\\"sourcecred/example-git\\",\\"type\\":\\"INCLUDES\\"}": Object {
+    "{\\"id\\":\\"569e1d383759903134df75230d63c0090196d4cb:science.txt\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"type\\":\\"INCLUDES\\"}": Object {
       "dst": Object {
         "id": "569e1d383759903134df75230d63c0090196d4cb:science.txt",
         "pluginName": "sourcecred/git-beta",
-        "repositoryName": "sourcecred/example-git",
         "type": "TREE_ENTRY",
       },
       "payload": Object {
@@ -203,15 +180,13 @@ Object {
       "src": Object {
         "id": "569e1d383759903134df75230d63c0090196d4cb",
         "pluginName": "sourcecred/git-beta",
-        "repositoryName": "sourcecred/example-git",
         "type": "TREE",
       },
     },
-    "{\\"id\\":\\"569e1d383759903134df75230d63c0090196d4cb:src\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"repositoryName\\":\\"sourcecred/example-git\\",\\"type\\":\\"INCLUDES\\"}": Object {
+    "{\\"id\\":\\"569e1d383759903134df75230d63c0090196d4cb:src\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"type\\":\\"INCLUDES\\"}": Object {
       "dst": Object {
         "id": "569e1d383759903134df75230d63c0090196d4cb:src",
         "pluginName": "sourcecred/git-beta",
-        "repositoryName": "sourcecred/example-git",
         "type": "TREE_ENTRY",
       },
       "payload": Object {
@@ -220,15 +195,13 @@ Object {
       "src": Object {
         "id": "569e1d383759903134df75230d63c0090196d4cb",
         "pluginName": "sourcecred/git-beta",
-        "repositoryName": "sourcecred/example-git",
         "type": "TREE",
       },
     },
-    "{\\"id\\":\\"69c5aad50eec8f2a0a07c988c3b283a6490eb45b^1\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"repositoryName\\":\\"sourcecred/example-git\\",\\"type\\":\\"HAS_PARENT\\"}": Object {
+    "{\\"id\\":\\"69c5aad50eec8f2a0a07c988c3b283a6490eb45b^1\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"type\\":\\"HAS_PARENT\\"}": Object {
       "dst": Object {
         "id": "e8b7a8f19701cd5a25e4a097d513ead60e5f8bcc",
         "pluginName": "sourcecred/git-beta",
-        "repositoryName": "sourcecred/example-git",
         "type": "COMMIT",
       },
       "payload": Object {
@@ -237,15 +210,13 @@ Object {
       "src": Object {
         "id": "69c5aad50eec8f2a0a07c988c3b283a6490eb45b",
         "pluginName": "sourcecred/git-beta",
-        "repositoryName": "sourcecred/example-git",
         "type": "COMMIT",
       },
     },
-    "{\\"id\\":\\"78fc9c83023386854c6bfdc5761c0e58f68e226f:index.py\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"repositoryName\\":\\"sourcecred/example-git\\",\\"type\\":\\"INCLUDES\\"}": Object {
+    "{\\"id\\":\\"78fc9c83023386854c6bfdc5761c0e58f68e226f:index.py\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"type\\":\\"INCLUDES\\"}": Object {
       "dst": Object {
         "id": "78fc9c83023386854c6bfdc5761c0e58f68e226f:index.py",
         "pluginName": "sourcecred/git-beta",
-        "repositoryName": "sourcecred/example-git",
         "type": "TREE_ENTRY",
       },
       "payload": Object {
@@ -254,15 +225,13 @@ Object {
       "src": Object {
         "id": "78fc9c83023386854c6bfdc5761c0e58f68e226f",
         "pluginName": "sourcecred/git-beta",
-        "repositoryName": "sourcecred/example-git",
         "type": "TREE",
       },
     },
-    "{\\"id\\":\\"78fc9c83023386854c6bfdc5761c0e58f68e226f:quantum_gravity.py\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"repositoryName\\":\\"sourcecred/example-git\\",\\"type\\":\\"INCLUDES\\"}": Object {
+    "{\\"id\\":\\"78fc9c83023386854c6bfdc5761c0e58f68e226f:quantum_gravity.py\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"type\\":\\"INCLUDES\\"}": Object {
       "dst": Object {
         "id": "78fc9c83023386854c6bfdc5761c0e58f68e226f:quantum_gravity.py",
         "pluginName": "sourcecred/git-beta",
-        "repositoryName": "sourcecred/example-git",
         "type": "TREE_ENTRY",
       },
       "payload": Object {
@@ -271,15 +240,13 @@ Object {
       "src": Object {
         "id": "78fc9c83023386854c6bfdc5761c0e58f68e226f",
         "pluginName": "sourcecred/git-beta",
-        "repositoryName": "sourcecred/example-git",
         "type": "TREE",
       },
     },
-    "{\\"id\\":\\"7b79d579b62994faba3b69fdf8aa442586c32681:index.py\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"repositoryName\\":\\"sourcecred/example-git\\",\\"type\\":\\"INCLUDES\\"}": Object {
+    "{\\"id\\":\\"7b79d579b62994faba3b69fdf8aa442586c32681:index.py\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"type\\":\\"INCLUDES\\"}": Object {
       "dst": Object {
         "id": "7b79d579b62994faba3b69fdf8aa442586c32681:index.py",
         "pluginName": "sourcecred/git-beta",
-        "repositoryName": "sourcecred/example-git",
         "type": "TREE_ENTRY",
       },
       "payload": Object {
@@ -288,15 +255,13 @@ Object {
       "src": Object {
         "id": "7b79d579b62994faba3b69fdf8aa442586c32681",
         "pluginName": "sourcecred/git-beta",
-        "repositoryName": "sourcecred/example-git",
         "type": "TREE",
       },
     },
-    "{\\"id\\":\\"7b79d579b62994faba3b69fdf8aa442586c32681:quantum_gravity.py\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"repositoryName\\":\\"sourcecred/example-git\\",\\"type\\":\\"INCLUDES\\"}": Object {
+    "{\\"id\\":\\"7b79d579b62994faba3b69fdf8aa442586c32681:quantum_gravity.py\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"type\\":\\"INCLUDES\\"}": Object {
       "dst": Object {
         "id": "7b79d579b62994faba3b69fdf8aa442586c32681:quantum_gravity.py",
         "pluginName": "sourcecred/git-beta",
-        "repositoryName": "sourcecred/example-git",
         "type": "TREE_ENTRY",
       },
       "payload": Object {
@@ -305,15 +270,13 @@ Object {
       "src": Object {
         "id": "7b79d579b62994faba3b69fdf8aa442586c32681",
         "pluginName": "sourcecred/git-beta",
-        "repositoryName": "sourcecred/example-git",
         "type": "TREE",
       },
     },
-    "{\\"id\\":\\"7be3ecfee5314ffa9b2d93fc4377792b2d6d70ed:.gitmodules\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"repositoryName\\":\\"sourcecred/example-git\\",\\"type\\":\\"INCLUDES\\"}": Object {
+    "{\\"id\\":\\"7be3ecfee5314ffa9b2d93fc4377792b2d6d70ed:.gitmodules\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"type\\":\\"INCLUDES\\"}": Object {
       "dst": Object {
         "id": "7be3ecfee5314ffa9b2d93fc4377792b2d6d70ed:.gitmodules",
         "pluginName": "sourcecred/git-beta",
-        "repositoryName": "sourcecred/example-git",
         "type": "TREE_ENTRY",
       },
       "payload": Object {
@@ -322,15 +285,13 @@ Object {
       "src": Object {
         "id": "7be3ecfee5314ffa9b2d93fc4377792b2d6d70ed",
         "pluginName": "sourcecred/git-beta",
-        "repositoryName": "sourcecred/example-git",
         "type": "TREE",
       },
     },
-    "{\\"id\\":\\"7be3ecfee5314ffa9b2d93fc4377792b2d6d70ed:README.txt\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"repositoryName\\":\\"sourcecred/example-git\\",\\"type\\":\\"INCLUDES\\"}": Object {
+    "{\\"id\\":\\"7be3ecfee5314ffa9b2d93fc4377792b2d6d70ed:README.txt\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"type\\":\\"INCLUDES\\"}": Object {
       "dst": Object {
         "id": "7be3ecfee5314ffa9b2d93fc4377792b2d6d70ed:README.txt",
         "pluginName": "sourcecred/git-beta",
-        "repositoryName": "sourcecred/example-git",
         "type": "TREE_ENTRY",
       },
       "payload": Object {
@@ -339,15 +300,13 @@ Object {
       "src": Object {
         "id": "7be3ecfee5314ffa9b2d93fc4377792b2d6d70ed",
         "pluginName": "sourcecred/git-beta",
-        "repositoryName": "sourcecred/example-git",
         "type": "TREE",
       },
     },
-    "{\\"id\\":\\"7be3ecfee5314ffa9b2d93fc4377792b2d6d70ed:pygravitydefier\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"repositoryName\\":\\"sourcecred/example-git\\",\\"type\\":\\"INCLUDES\\"}": Object {
+    "{\\"id\\":\\"7be3ecfee5314ffa9b2d93fc4377792b2d6d70ed:pygravitydefier\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"type\\":\\"INCLUDES\\"}": Object {
       "dst": Object {
         "id": "7be3ecfee5314ffa9b2d93fc4377792b2d6d70ed:pygravitydefier",
         "pluginName": "sourcecred/git-beta",
-        "repositoryName": "sourcecred/example-git",
         "type": "TREE_ENTRY",
       },
       "payload": Object {
@@ -356,15 +315,13 @@ Object {
       "src": Object {
         "id": "7be3ecfee5314ffa9b2d93fc4377792b2d6d70ed",
         "pluginName": "sourcecred/git-beta",
-        "repositoryName": "sourcecred/example-git",
         "type": "TREE",
       },
     },
-    "{\\"id\\":\\"7be3ecfee5314ffa9b2d93fc4377792b2d6d70ed:science.txt\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"repositoryName\\":\\"sourcecred/example-git\\",\\"type\\":\\"INCLUDES\\"}": Object {
+    "{\\"id\\":\\"7be3ecfee5314ffa9b2d93fc4377792b2d6d70ed:science.txt\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"type\\":\\"INCLUDES\\"}": Object {
       "dst": Object {
         "id": "7be3ecfee5314ffa9b2d93fc4377792b2d6d70ed:science.txt",
         "pluginName": "sourcecred/git-beta",
-        "repositoryName": "sourcecred/example-git",
         "type": "TREE_ENTRY",
       },
       "payload": Object {
@@ -373,15 +330,13 @@ Object {
       "src": Object {
         "id": "7be3ecfee5314ffa9b2d93fc4377792b2d6d70ed",
         "pluginName": "sourcecred/git-beta",
-        "repositoryName": "sourcecred/example-git",
         "type": "TREE",
       },
     },
-    "{\\"id\\":\\"7be3ecfee5314ffa9b2d93fc4377792b2d6d70ed:src\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"repositoryName\\":\\"sourcecred/example-git\\",\\"type\\":\\"INCLUDES\\"}": Object {
+    "{\\"id\\":\\"7be3ecfee5314ffa9b2d93fc4377792b2d6d70ed:src\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"type\\":\\"INCLUDES\\"}": Object {
       "dst": Object {
         "id": "7be3ecfee5314ffa9b2d93fc4377792b2d6d70ed:src",
         "pluginName": "sourcecred/git-beta",
-        "repositoryName": "sourcecred/example-git",
         "type": "TREE_ENTRY",
       },
       "payload": Object {
@@ -390,15 +345,13 @@ Object {
       "src": Object {
         "id": "7be3ecfee5314ffa9b2d93fc4377792b2d6d70ed",
         "pluginName": "sourcecred/git-beta",
-        "repositoryName": "sourcecred/example-git",
         "type": "TREE",
       },
     },
-    "{\\"id\\":\\"819fc546cea489476ce8dc90785e9ba7753d0a8f:.gitmodules\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"repositoryName\\":\\"sourcecred/example-git\\",\\"type\\":\\"INCLUDES\\"}": Object {
+    "{\\"id\\":\\"819fc546cea489476ce8dc90785e9ba7753d0a8f:.gitmodules\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"type\\":\\"INCLUDES\\"}": Object {
       "dst": Object {
         "id": "819fc546cea489476ce8dc90785e9ba7753d0a8f:.gitmodules",
         "pluginName": "sourcecred/git-beta",
-        "repositoryName": "sourcecred/example-git",
         "type": "TREE_ENTRY",
       },
       "payload": Object {
@@ -407,15 +360,13 @@ Object {
       "src": Object {
         "id": "819fc546cea489476ce8dc90785e9ba7753d0a8f",
         "pluginName": "sourcecred/git-beta",
-        "repositoryName": "sourcecred/example-git",
         "type": "TREE",
       },
     },
-    "{\\"id\\":\\"819fc546cea489476ce8dc90785e9ba7753d0a8f:README.txt\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"repositoryName\\":\\"sourcecred/example-git\\",\\"type\\":\\"INCLUDES\\"}": Object {
+    "{\\"id\\":\\"819fc546cea489476ce8dc90785e9ba7753d0a8f:README.txt\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"type\\":\\"INCLUDES\\"}": Object {
       "dst": Object {
         "id": "819fc546cea489476ce8dc90785e9ba7753d0a8f:README.txt",
         "pluginName": "sourcecred/git-beta",
-        "repositoryName": "sourcecred/example-git",
         "type": "TREE_ENTRY",
       },
       "payload": Object {
@@ -424,15 +375,13 @@ Object {
       "src": Object {
         "id": "819fc546cea489476ce8dc90785e9ba7753d0a8f",
         "pluginName": "sourcecred/git-beta",
-        "repositoryName": "sourcecred/example-git",
         "type": "TREE",
       },
     },
-    "{\\"id\\":\\"819fc546cea489476ce8dc90785e9ba7753d0a8f:TODOS.txt\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"repositoryName\\":\\"sourcecred/example-git\\",\\"type\\":\\"INCLUDES\\"}": Object {
+    "{\\"id\\":\\"819fc546cea489476ce8dc90785e9ba7753d0a8f:TODOS.txt\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"type\\":\\"INCLUDES\\"}": Object {
       "dst": Object {
         "id": "819fc546cea489476ce8dc90785e9ba7753d0a8f:TODOS.txt",
         "pluginName": "sourcecred/git-beta",
-        "repositoryName": "sourcecred/example-git",
         "type": "TREE_ENTRY",
       },
       "payload": Object {
@@ -441,15 +390,13 @@ Object {
       "src": Object {
         "id": "819fc546cea489476ce8dc90785e9ba7753d0a8f",
         "pluginName": "sourcecred/git-beta",
-        "repositoryName": "sourcecred/example-git",
         "type": "TREE",
       },
     },
-    "{\\"id\\":\\"819fc546cea489476ce8dc90785e9ba7753d0a8f:pygravitydefier\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"repositoryName\\":\\"sourcecred/example-git\\",\\"type\\":\\"INCLUDES\\"}": Object {
+    "{\\"id\\":\\"819fc546cea489476ce8dc90785e9ba7753d0a8f:pygravitydefier\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"type\\":\\"INCLUDES\\"}": Object {
       "dst": Object {
         "id": "819fc546cea489476ce8dc90785e9ba7753d0a8f:pygravitydefier",
         "pluginName": "sourcecred/git-beta",
-        "repositoryName": "sourcecred/example-git",
         "type": "TREE_ENTRY",
       },
       "payload": Object {
@@ -458,15 +405,13 @@ Object {
       "src": Object {
         "id": "819fc546cea489476ce8dc90785e9ba7753d0a8f",
         "pluginName": "sourcecred/git-beta",
-        "repositoryName": "sourcecred/example-git",
         "type": "TREE",
       },
     },
-    "{\\"id\\":\\"819fc546cea489476ce8dc90785e9ba7753d0a8f:science.txt\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"repositoryName\\":\\"sourcecred/example-git\\",\\"type\\":\\"INCLUDES\\"}": Object {
+    "{\\"id\\":\\"819fc546cea489476ce8dc90785e9ba7753d0a8f:science.txt\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"type\\":\\"INCLUDES\\"}": Object {
       "dst": Object {
         "id": "819fc546cea489476ce8dc90785e9ba7753d0a8f:science.txt",
         "pluginName": "sourcecred/git-beta",
-        "repositoryName": "sourcecred/example-git",
         "type": "TREE_ENTRY",
       },
       "payload": Object {
@@ -475,15 +420,13 @@ Object {
       "src": Object {
         "id": "819fc546cea489476ce8dc90785e9ba7753d0a8f",
         "pluginName": "sourcecred/git-beta",
-        "repositoryName": "sourcecred/example-git",
         "type": "TREE",
       },
     },
-    "{\\"id\\":\\"819fc546cea489476ce8dc90785e9ba7753d0a8f:src\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"repositoryName\\":\\"sourcecred/example-git\\",\\"type\\":\\"INCLUDES\\"}": Object {
+    "{\\"id\\":\\"819fc546cea489476ce8dc90785e9ba7753d0a8f:src\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"type\\":\\"INCLUDES\\"}": Object {
       "dst": Object {
         "id": "819fc546cea489476ce8dc90785e9ba7753d0a8f:src",
         "pluginName": "sourcecred/git-beta",
-        "repositoryName": "sourcecred/example-git",
         "type": "TREE_ENTRY",
       },
       "payload": Object {
@@ -492,15 +435,13 @@ Object {
       "src": Object {
         "id": "819fc546cea489476ce8dc90785e9ba7753d0a8f",
         "pluginName": "sourcecred/git-beta",
-        "repositoryName": "sourcecred/example-git",
         "type": "TREE",
       },
     },
-    "{\\"id\\":\\"8d287c3bfbf8455ef30187bf5153ffc1b6eef268^1\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"repositoryName\\":\\"sourcecred/example-git\\",\\"type\\":\\"HAS_PARENT\\"}": Object {
+    "{\\"id\\":\\"8d287c3bfbf8455ef30187bf5153ffc1b6eef268^1\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"type\\":\\"HAS_PARENT\\"}": Object {
       "dst": Object {
         "id": "c08ee3a4edea384d5291ffcbf06724a13ed72325",
         "pluginName": "sourcecred/git-beta",
-        "repositoryName": "sourcecred/example-git",
         "type": "COMMIT",
       },
       "payload": Object {
@@ -509,630 +450,546 @@ Object {
       "src": Object {
         "id": "8d287c3bfbf8455ef30187bf5153ffc1b6eef268",
         "pluginName": "sourcecred/git-beta",
-        "repositoryName": "sourcecred/example-git",
         "type": "COMMIT",
       },
     },
-    "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"2f7155e359fd0ecb96ffdca66fa45b6ed5792809:README.txt\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/git-beta\\\\\\",\\\\\\"repositoryName\\\\\\":\\\\\\"sourcecred/example-git\\\\\\",\\\\\\"type\\\\\\":\\\\\\"TREE_ENTRY\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"0fb31858c8e3710be77e1dbb8880acf8a5543d82\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/git-beta\\\\\\",\\\\\\"repositoryName\\\\\\":\\\\\\"sourcecred/example-git\\\\\\",\\\\\\"type\\\\\\":\\\\\\"BLOB\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"repositoryName\\":\\"sourcecred/example-git\\",\\"type\\":\\"HAS_CONTENTS\\"}": Object {
+    "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"2f7155e359fd0ecb96ffdca66fa45b6ed5792809:README.txt\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/git-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"TREE_ENTRY\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"0fb31858c8e3710be77e1dbb8880acf8a5543d82\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/git-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"BLOB\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"type\\":\\"HAS_CONTENTS\\"}": Object {
       "dst": Object {
         "id": "0fb31858c8e3710be77e1dbb8880acf8a5543d82",
         "pluginName": "sourcecred/git-beta",
-        "repositoryName": "sourcecred/example-git",
         "type": "BLOB",
       },
       "payload": Object {},
       "src": Object {
         "id": "2f7155e359fd0ecb96ffdca66fa45b6ed5792809:README.txt",
         "pluginName": "sourcecred/git-beta",
-        "repositoryName": "sourcecred/example-git",
         "type": "TREE_ENTRY",
       },
     },
-    "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"2f7155e359fd0ecb96ffdca66fa45b6ed5792809:science.txt\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/git-beta\\\\\\",\\\\\\"repositoryName\\\\\\":\\\\\\"sourcecred/example-git\\\\\\",\\\\\\"type\\\\\\":\\\\\\"TREE_ENTRY\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"f1f2514ca6d7a6a1a0511957021b1995bf9ace1c\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/git-beta\\\\\\",\\\\\\"repositoryName\\\\\\":\\\\\\"sourcecred/example-git\\\\\\",\\\\\\"type\\\\\\":\\\\\\"BLOB\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"repositoryName\\":\\"sourcecred/example-git\\",\\"type\\":\\"HAS_CONTENTS\\"}": Object {
+    "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"2f7155e359fd0ecb96ffdca66fa45b6ed5792809:science.txt\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/git-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"TREE_ENTRY\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"f1f2514ca6d7a6a1a0511957021b1995bf9ace1c\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/git-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"BLOB\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"type\\":\\"HAS_CONTENTS\\"}": Object {
       "dst": Object {
         "id": "f1f2514ca6d7a6a1a0511957021b1995bf9ace1c",
         "pluginName": "sourcecred/git-beta",
-        "repositoryName": "sourcecred/example-git",
         "type": "BLOB",
       },
       "payload": Object {},
       "src": Object {
         "id": "2f7155e359fd0ecb96ffdca66fa45b6ed5792809:science.txt",
         "pluginName": "sourcecred/git-beta",
-        "repositoryName": "sourcecred/example-git",
         "type": "TREE_ENTRY",
       },
     },
-    "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"3715ddfb8d4c4fd2a6f6af75488c82f84c92ec2f\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/git-beta\\\\\\",\\\\\\"repositoryName\\\\\\":\\\\\\"sourcecred/example-git\\\\\\",\\\\\\"type\\\\\\":\\\\\\"COMMIT\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"7be3ecfee5314ffa9b2d93fc4377792b2d6d70ed\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/git-beta\\\\\\",\\\\\\"repositoryName\\\\\\":\\\\\\"sourcecred/example-git\\\\\\",\\\\\\"type\\\\\\":\\\\\\"TREE\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"repositoryName\\":\\"sourcecred/example-git\\",\\"type\\":\\"HAS_TREE\\"}": Object {
+    "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"3715ddfb8d4c4fd2a6f6af75488c82f84c92ec2f\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/git-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"COMMIT\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"7be3ecfee5314ffa9b2d93fc4377792b2d6d70ed\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/git-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"TREE\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"type\\":\\"HAS_TREE\\"}": Object {
       "dst": Object {
         "id": "7be3ecfee5314ffa9b2d93fc4377792b2d6d70ed",
         "pluginName": "sourcecred/git-beta",
-        "repositoryName": "sourcecred/example-git",
         "type": "TREE",
       },
       "payload": Object {},
       "src": Object {
         "id": "3715ddfb8d4c4fd2a6f6af75488c82f84c92ec2f",
         "pluginName": "sourcecred/git-beta",
-        "repositoryName": "sourcecred/example-git",
         "type": "COMMIT",
       },
     },
-    "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"3dfb84795e07341b05fad3a0d5a55f8304b2d7d8:.gitmodules\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/git-beta\\\\\\",\\\\\\"repositoryName\\\\\\":\\\\\\"sourcecred/example-git\\\\\\",\\\\\\"type\\\\\\":\\\\\\"TREE_ENTRY\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"8c6cac301e763aa6d36466e0a775eb804be2c311\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/git-beta\\\\\\",\\\\\\"repositoryName\\\\\\":\\\\\\"sourcecred/example-git\\\\\\",\\\\\\"type\\\\\\":\\\\\\"BLOB\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"repositoryName\\":\\"sourcecred/example-git\\",\\"type\\":\\"HAS_CONTENTS\\"}": Object {
+    "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"3dfb84795e07341b05fad3a0d5a55f8304b2d7d8:.gitmodules\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/git-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"TREE_ENTRY\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"8c6cac301e763aa6d36466e0a775eb804be2c311\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/git-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"BLOB\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"type\\":\\"HAS_CONTENTS\\"}": Object {
       "dst": Object {
         "id": "8c6cac301e763aa6d36466e0a775eb804be2c311",
         "pluginName": "sourcecred/git-beta",
-        "repositoryName": "sourcecred/example-git",
         "type": "BLOB",
       },
       "payload": Object {},
       "src": Object {
         "id": "3dfb84795e07341b05fad3a0d5a55f8304b2d7d8:.gitmodules",
         "pluginName": "sourcecred/git-beta",
-        "repositoryName": "sourcecred/example-git",
         "type": "TREE_ENTRY",
       },
     },
-    "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"3dfb84795e07341b05fad3a0d5a55f8304b2d7d8:README.txt\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/git-beta\\\\\\",\\\\\\"repositoryName\\\\\\":\\\\\\"sourcecred/example-git\\\\\\",\\\\\\"type\\\\\\":\\\\\\"TREE_ENTRY\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"0fb31858c8e3710be77e1dbb8880acf8a5543d82\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/git-beta\\\\\\",\\\\\\"repositoryName\\\\\\":\\\\\\"sourcecred/example-git\\\\\\",\\\\\\"type\\\\\\":\\\\\\"BLOB\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"repositoryName\\":\\"sourcecred/example-git\\",\\"type\\":\\"HAS_CONTENTS\\"}": Object {
+    "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"3dfb84795e07341b05fad3a0d5a55f8304b2d7d8:README.txt\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/git-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"TREE_ENTRY\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"0fb31858c8e3710be77e1dbb8880acf8a5543d82\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/git-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"BLOB\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"type\\":\\"HAS_CONTENTS\\"}": Object {
       "dst": Object {
         "id": "0fb31858c8e3710be77e1dbb8880acf8a5543d82",
         "pluginName": "sourcecred/git-beta",
-        "repositoryName": "sourcecred/example-git",
         "type": "BLOB",
       },
       "payload": Object {},
       "src": Object {
         "id": "3dfb84795e07341b05fad3a0d5a55f8304b2d7d8:README.txt",
         "pluginName": "sourcecred/git-beta",
-        "repositoryName": "sourcecred/example-git",
         "type": "TREE_ENTRY",
       },
     },
-    "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"3dfb84795e07341b05fad3a0d5a55f8304b2d7d8:pygravitydefier\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/git-beta\\\\\\",\\\\\\"repositoryName\\\\\\":\\\\\\"sourcecred/example-git\\\\\\",\\\\\\"type\\\\\\":\\\\\\"TREE_ENTRY\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-git-submodule.git@762c062fbdc7ec198cd693e95d55b374a08ff3e3\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/git-beta\\\\\\",\\\\\\"repositoryName\\\\\\":\\\\\\"sourcecred/example-git\\\\\\",\\\\\\"type\\\\\\":\\\\\\"SUBMODULE_COMMIT\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"repositoryName\\":\\"sourcecred/example-git\\",\\"type\\":\\"HAS_CONTENTS\\"}": Object {
+    "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"3dfb84795e07341b05fad3a0d5a55f8304b2d7d8:pygravitydefier\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/git-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"TREE_ENTRY\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-git-submodule.git@762c062fbdc7ec198cd693e95d55b374a08ff3e3\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/git-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"SUBMODULE_COMMIT\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"type\\":\\"HAS_CONTENTS\\"}": Object {
       "dst": Object {
         "id": "https://github.com/sourcecred/example-git-submodule.git@762c062fbdc7ec198cd693e95d55b374a08ff3e3",
         "pluginName": "sourcecred/git-beta",
-        "repositoryName": "sourcecred/example-git",
         "type": "SUBMODULE_COMMIT",
       },
       "payload": Object {},
       "src": Object {
         "id": "3dfb84795e07341b05fad3a0d5a55f8304b2d7d8:pygravitydefier",
         "pluginName": "sourcecred/git-beta",
-        "repositoryName": "sourcecred/example-git",
         "type": "TREE_ENTRY",
       },
     },
-    "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"3dfb84795e07341b05fad3a0d5a55f8304b2d7d8:science.txt\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/git-beta\\\\\\",\\\\\\"repositoryName\\\\\\":\\\\\\"sourcecred/example-git\\\\\\",\\\\\\"type\\\\\\":\\\\\\"TREE_ENTRY\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"f1f2514ca6d7a6a1a0511957021b1995bf9ace1c\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/git-beta\\\\\\",\\\\\\"repositoryName\\\\\\":\\\\\\"sourcecred/example-git\\\\\\",\\\\\\"type\\\\\\":\\\\\\"BLOB\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"repositoryName\\":\\"sourcecred/example-git\\",\\"type\\":\\"HAS_CONTENTS\\"}": Object {
+    "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"3dfb84795e07341b05fad3a0d5a55f8304b2d7d8:science.txt\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/git-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"TREE_ENTRY\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"f1f2514ca6d7a6a1a0511957021b1995bf9ace1c\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/git-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"BLOB\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"type\\":\\"HAS_CONTENTS\\"}": Object {
       "dst": Object {
         "id": "f1f2514ca6d7a6a1a0511957021b1995bf9ace1c",
         "pluginName": "sourcecred/git-beta",
-        "repositoryName": "sourcecred/example-git",
         "type": "BLOB",
       },
       "payload": Object {},
       "src": Object {
         "id": "3dfb84795e07341b05fad3a0d5a55f8304b2d7d8:science.txt",
         "pluginName": "sourcecred/git-beta",
-        "repositoryName": "sourcecred/example-git",
         "type": "TREE_ENTRY",
       },
     },
-    "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"569e1d383759903134df75230d63c0090196d4cb:.gitmodules\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/git-beta\\\\\\",\\\\\\"repositoryName\\\\\\":\\\\\\"sourcecred/example-git\\\\\\",\\\\\\"type\\\\\\":\\\\\\"TREE_ENTRY\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"8c6cac301e763aa6d36466e0a775eb804be2c311\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/git-beta\\\\\\",\\\\\\"repositoryName\\\\\\":\\\\\\"sourcecred/example-git\\\\\\",\\\\\\"type\\\\\\":\\\\\\"BLOB\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"repositoryName\\":\\"sourcecred/example-git\\",\\"type\\":\\"HAS_CONTENTS\\"}": Object {
+    "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"569e1d383759903134df75230d63c0090196d4cb:.gitmodules\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/git-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"TREE_ENTRY\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"8c6cac301e763aa6d36466e0a775eb804be2c311\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/git-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"BLOB\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"type\\":\\"HAS_CONTENTS\\"}": Object {
       "dst": Object {
         "id": "8c6cac301e763aa6d36466e0a775eb804be2c311",
         "pluginName": "sourcecred/git-beta",
-        "repositoryName": "sourcecred/example-git",
         "type": "BLOB",
       },
       "payload": Object {},
       "src": Object {
         "id": "569e1d383759903134df75230d63c0090196d4cb:.gitmodules",
         "pluginName": "sourcecred/git-beta",
-        "repositoryName": "sourcecred/example-git",
         "type": "TREE_ENTRY",
       },
     },
-    "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"569e1d383759903134df75230d63c0090196d4cb:README.txt\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/git-beta\\\\\\",\\\\\\"repositoryName\\\\\\":\\\\\\"sourcecred/example-git\\\\\\",\\\\\\"type\\\\\\":\\\\\\"TREE_ENTRY\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"0fb31858c8e3710be77e1dbb8880acf8a5543d82\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/git-beta\\\\\\",\\\\\\"repositoryName\\\\\\":\\\\\\"sourcecred/example-git\\\\\\",\\\\\\"type\\\\\\":\\\\\\"BLOB\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"repositoryName\\":\\"sourcecred/example-git\\",\\"type\\":\\"HAS_CONTENTS\\"}": Object {
+    "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"569e1d383759903134df75230d63c0090196d4cb:README.txt\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/git-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"TREE_ENTRY\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"0fb31858c8e3710be77e1dbb8880acf8a5543d82\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/git-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"BLOB\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"type\\":\\"HAS_CONTENTS\\"}": Object {
       "dst": Object {
         "id": "0fb31858c8e3710be77e1dbb8880acf8a5543d82",
         "pluginName": "sourcecred/git-beta",
-        "repositoryName": "sourcecred/example-git",
         "type": "BLOB",
       },
       "payload": Object {},
       "src": Object {
         "id": "569e1d383759903134df75230d63c0090196d4cb:README.txt",
         "pluginName": "sourcecred/git-beta",
-        "repositoryName": "sourcecred/example-git",
         "type": "TREE_ENTRY",
       },
     },
-    "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"569e1d383759903134df75230d63c0090196d4cb:TODOS.txt\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/git-beta\\\\\\",\\\\\\"repositoryName\\\\\\":\\\\\\"sourcecred/example-git\\\\\\",\\\\\\"type\\\\\\":\\\\\\"TREE_ENTRY\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"ddec7477206c30c31b81482e56b877a0b3c2638b\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/git-beta\\\\\\",\\\\\\"repositoryName\\\\\\":\\\\\\"sourcecred/example-git\\\\\\",\\\\\\"type\\\\\\":\\\\\\"BLOB\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"repositoryName\\":\\"sourcecred/example-git\\",\\"type\\":\\"HAS_CONTENTS\\"}": Object {
+    "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"569e1d383759903134df75230d63c0090196d4cb:TODOS.txt\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/git-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"TREE_ENTRY\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"ddec7477206c30c31b81482e56b877a0b3c2638b\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/git-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"BLOB\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"type\\":\\"HAS_CONTENTS\\"}": Object {
       "dst": Object {
         "id": "ddec7477206c30c31b81482e56b877a0b3c2638b",
         "pluginName": "sourcecred/git-beta",
-        "repositoryName": "sourcecred/example-git",
         "type": "BLOB",
       },
       "payload": Object {},
       "src": Object {
         "id": "569e1d383759903134df75230d63c0090196d4cb:TODOS.txt",
         "pluginName": "sourcecred/git-beta",
-        "repositoryName": "sourcecred/example-git",
         "type": "TREE_ENTRY",
       },
     },
-    "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"569e1d383759903134df75230d63c0090196d4cb:pygravitydefier\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/git-beta\\\\\\",\\\\\\"repositoryName\\\\\\":\\\\\\"sourcecred/example-git\\\\\\",\\\\\\"type\\\\\\":\\\\\\"TREE_ENTRY\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-git-submodule.git@762c062fbdc7ec198cd693e95d55b374a08ff3e3\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/git-beta\\\\\\",\\\\\\"repositoryName\\\\\\":\\\\\\"sourcecred/example-git\\\\\\",\\\\\\"type\\\\\\":\\\\\\"SUBMODULE_COMMIT\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"repositoryName\\":\\"sourcecred/example-git\\",\\"type\\":\\"HAS_CONTENTS\\"}": Object {
+    "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"569e1d383759903134df75230d63c0090196d4cb:pygravitydefier\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/git-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"TREE_ENTRY\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-git-submodule.git@762c062fbdc7ec198cd693e95d55b374a08ff3e3\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/git-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"SUBMODULE_COMMIT\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"type\\":\\"HAS_CONTENTS\\"}": Object {
       "dst": Object {
         "id": "https://github.com/sourcecred/example-git-submodule.git@762c062fbdc7ec198cd693e95d55b374a08ff3e3",
         "pluginName": "sourcecred/git-beta",
-        "repositoryName": "sourcecred/example-git",
         "type": "SUBMODULE_COMMIT",
       },
       "payload": Object {},
       "src": Object {
         "id": "569e1d383759903134df75230d63c0090196d4cb:pygravitydefier",
         "pluginName": "sourcecred/git-beta",
-        "repositoryName": "sourcecred/example-git",
         "type": "TREE_ENTRY",
       },
     },
-    "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"569e1d383759903134df75230d63c0090196d4cb:science.txt\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/git-beta\\\\\\",\\\\\\"repositoryName\\\\\\":\\\\\\"sourcecred/example-git\\\\\\",\\\\\\"type\\\\\\":\\\\\\"TREE_ENTRY\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"f1f2514ca6d7a6a1a0511957021b1995bf9ace1c\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/git-beta\\\\\\",\\\\\\"repositoryName\\\\\\":\\\\\\"sourcecred/example-git\\\\\\",\\\\\\"type\\\\\\":\\\\\\"BLOB\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"repositoryName\\":\\"sourcecred/example-git\\",\\"type\\":\\"HAS_CONTENTS\\"}": Object {
+    "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"569e1d383759903134df75230d63c0090196d4cb:science.txt\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/git-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"TREE_ENTRY\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"f1f2514ca6d7a6a1a0511957021b1995bf9ace1c\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/git-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"BLOB\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"type\\":\\"HAS_CONTENTS\\"}": Object {
       "dst": Object {
         "id": "f1f2514ca6d7a6a1a0511957021b1995bf9ace1c",
         "pluginName": "sourcecred/git-beta",
-        "repositoryName": "sourcecred/example-git",
         "type": "BLOB",
       },
       "payload": Object {},
       "src": Object {
         "id": "569e1d383759903134df75230d63c0090196d4cb:science.txt",
         "pluginName": "sourcecred/git-beta",
-        "repositoryName": "sourcecred/example-git",
         "type": "TREE_ENTRY",
       },
     },
-    "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"569e1d383759903134df75230d63c0090196d4cb:src\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/git-beta\\\\\\",\\\\\\"repositoryName\\\\\\":\\\\\\"sourcecred/example-git\\\\\\",\\\\\\"type\\\\\\":\\\\\\"TREE_ENTRY\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"7b79d579b62994faba3b69fdf8aa442586c32681\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/git-beta\\\\\\",\\\\\\"repositoryName\\\\\\":\\\\\\"sourcecred/example-git\\\\\\",\\\\\\"type\\\\\\":\\\\\\"TREE\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"repositoryName\\":\\"sourcecred/example-git\\",\\"type\\":\\"HAS_CONTENTS\\"}": Object {
+    "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"569e1d383759903134df75230d63c0090196d4cb:src\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/git-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"TREE_ENTRY\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"7b79d579b62994faba3b69fdf8aa442586c32681\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/git-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"TREE\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"type\\":\\"HAS_CONTENTS\\"}": Object {
       "dst": Object {
         "id": "7b79d579b62994faba3b69fdf8aa442586c32681",
         "pluginName": "sourcecred/git-beta",
-        "repositoryName": "sourcecred/example-git",
         "type": "TREE",
       },
       "payload": Object {},
       "src": Object {
         "id": "569e1d383759903134df75230d63c0090196d4cb:src",
         "pluginName": "sourcecred/git-beta",
-        "repositoryName": "sourcecred/example-git",
         "type": "TREE_ENTRY",
       },
     },
-    "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"69c5aad50eec8f2a0a07c988c3b283a6490eb45b\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/git-beta\\\\\\",\\\\\\"repositoryName\\\\\\":\\\\\\"sourcecred/example-git\\\\\\",\\\\\\"type\\\\\\":\\\\\\"COMMIT\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"bbf3b8b3d26a4f884b5c022d46851f593d329192\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/git-beta\\\\\\",\\\\\\"repositoryName\\\\\\":\\\\\\"sourcecred/example-git\\\\\\",\\\\\\"type\\\\\\":\\\\\\"TREE\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"repositoryName\\":\\"sourcecred/example-git\\",\\"type\\":\\"HAS_TREE\\"}": Object {
+    "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"69c5aad50eec8f2a0a07c988c3b283a6490eb45b\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/git-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"COMMIT\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"bbf3b8b3d26a4f884b5c022d46851f593d329192\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/git-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"TREE\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"type\\":\\"HAS_TREE\\"}": Object {
       "dst": Object {
         "id": "bbf3b8b3d26a4f884b5c022d46851f593d329192",
         "pluginName": "sourcecred/git-beta",
-        "repositoryName": "sourcecred/example-git",
         "type": "TREE",
       },
       "payload": Object {},
       "src": Object {
         "id": "69c5aad50eec8f2a0a07c988c3b283a6490eb45b",
         "pluginName": "sourcecred/git-beta",
-        "repositoryName": "sourcecred/example-git",
         "type": "COMMIT",
       },
     },
-    "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"78fc9c83023386854c6bfdc5761c0e58f68e226f:index.py\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/git-beta\\\\\\",\\\\\\"repositoryName\\\\\\":\\\\\\"sourcecred/example-git\\\\\\",\\\\\\"type\\\\\\":\\\\\\"TREE_ENTRY\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"674b0b476989384510304846248b3acd16206782\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/git-beta\\\\\\",\\\\\\"repositoryName\\\\\\":\\\\\\"sourcecred/example-git\\\\\\",\\\\\\"type\\\\\\":\\\\\\"BLOB\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"repositoryName\\":\\"sourcecred/example-git\\",\\"type\\":\\"HAS_CONTENTS\\"}": Object {
+    "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"78fc9c83023386854c6bfdc5761c0e58f68e226f:index.py\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/git-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"TREE_ENTRY\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"674b0b476989384510304846248b3acd16206782\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/git-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"BLOB\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"type\\":\\"HAS_CONTENTS\\"}": Object {
       "dst": Object {
         "id": "674b0b476989384510304846248b3acd16206782",
         "pluginName": "sourcecred/git-beta",
-        "repositoryName": "sourcecred/example-git",
         "type": "BLOB",
       },
       "payload": Object {},
       "src": Object {
         "id": "78fc9c83023386854c6bfdc5761c0e58f68e226f:index.py",
         "pluginName": "sourcecred/git-beta",
-        "repositoryName": "sourcecred/example-git",
         "type": "TREE_ENTRY",
       },
     },
-    "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"78fc9c83023386854c6bfdc5761c0e58f68e226f:quantum_gravity.py\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/git-beta\\\\\\",\\\\\\"repositoryName\\\\\\":\\\\\\"sourcecred/example-git\\\\\\",\\\\\\"type\\\\\\":\\\\\\"TREE_ENTRY\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"aea4f28abb23abde151b0ead4063227f8bf6c0b0\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/git-beta\\\\\\",\\\\\\"repositoryName\\\\\\":\\\\\\"sourcecred/example-git\\\\\\",\\\\\\"type\\\\\\":\\\\\\"BLOB\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"repositoryName\\":\\"sourcecred/example-git\\",\\"type\\":\\"HAS_CONTENTS\\"}": Object {
+    "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"78fc9c83023386854c6bfdc5761c0e58f68e226f:quantum_gravity.py\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/git-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"TREE_ENTRY\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"aea4f28abb23abde151b0ead4063227f8bf6c0b0\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/git-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"BLOB\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"type\\":\\"HAS_CONTENTS\\"}": Object {
       "dst": Object {
         "id": "aea4f28abb23abde151b0ead4063227f8bf6c0b0",
         "pluginName": "sourcecred/git-beta",
-        "repositoryName": "sourcecred/example-git",
         "type": "BLOB",
       },
       "payload": Object {},
       "src": Object {
         "id": "78fc9c83023386854c6bfdc5761c0e58f68e226f:quantum_gravity.py",
         "pluginName": "sourcecred/git-beta",
-        "repositoryName": "sourcecred/example-git",
         "type": "TREE_ENTRY",
       },
     },
-    "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"7b79d579b62994faba3b69fdf8aa442586c32681:index.py\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/git-beta\\\\\\",\\\\\\"repositoryName\\\\\\":\\\\\\"sourcecred/example-git\\\\\\",\\\\\\"type\\\\\\":\\\\\\"TREE_ENTRY\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"674b0b476989384510304846248b3acd16206782\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/git-beta\\\\\\",\\\\\\"repositoryName\\\\\\":\\\\\\"sourcecred/example-git\\\\\\",\\\\\\"type\\\\\\":\\\\\\"BLOB\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"repositoryName\\":\\"sourcecred/example-git\\",\\"type\\":\\"HAS_CONTENTS\\"}": Object {
+    "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"7b79d579b62994faba3b69fdf8aa442586c32681:index.py\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/git-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"TREE_ENTRY\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"674b0b476989384510304846248b3acd16206782\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/git-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"BLOB\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"type\\":\\"HAS_CONTENTS\\"}": Object {
       "dst": Object {
         "id": "674b0b476989384510304846248b3acd16206782",
         "pluginName": "sourcecred/git-beta",
-        "repositoryName": "sourcecred/example-git",
         "type": "BLOB",
       },
       "payload": Object {},
       "src": Object {
         "id": "7b79d579b62994faba3b69fdf8aa442586c32681:index.py",
         "pluginName": "sourcecred/git-beta",
-        "repositoryName": "sourcecred/example-git",
         "type": "TREE_ENTRY",
       },
     },
-    "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"7b79d579b62994faba3b69fdf8aa442586c32681:quantum_gravity.py\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/git-beta\\\\\\",\\\\\\"repositoryName\\\\\\":\\\\\\"sourcecred/example-git\\\\\\",\\\\\\"type\\\\\\":\\\\\\"TREE_ENTRY\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"887ad856bbc1373da146106c86cb581ad78cdafe\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/git-beta\\\\\\",\\\\\\"repositoryName\\\\\\":\\\\\\"sourcecred/example-git\\\\\\",\\\\\\"type\\\\\\":\\\\\\"BLOB\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"repositoryName\\":\\"sourcecred/example-git\\",\\"type\\":\\"HAS_CONTENTS\\"}": Object {
+    "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"7b79d579b62994faba3b69fdf8aa442586c32681:quantum_gravity.py\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/git-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"TREE_ENTRY\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"887ad856bbc1373da146106c86cb581ad78cdafe\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/git-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"BLOB\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"type\\":\\"HAS_CONTENTS\\"}": Object {
       "dst": Object {
         "id": "887ad856bbc1373da146106c86cb581ad78cdafe",
         "pluginName": "sourcecred/git-beta",
-        "repositoryName": "sourcecred/example-git",
         "type": "BLOB",
       },
       "payload": Object {},
       "src": Object {
         "id": "7b79d579b62994faba3b69fdf8aa442586c32681:quantum_gravity.py",
         "pluginName": "sourcecred/git-beta",
-        "repositoryName": "sourcecred/example-git",
         "type": "TREE_ENTRY",
       },
     },
-    "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"7be3ecfee5314ffa9b2d93fc4377792b2d6d70ed:.gitmodules\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/git-beta\\\\\\",\\\\\\"repositoryName\\\\\\":\\\\\\"sourcecred/example-git\\\\\\",\\\\\\"type\\\\\\":\\\\\\"TREE_ENTRY\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"8c6cac301e763aa6d36466e0a775eb804be2c311\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/git-beta\\\\\\",\\\\\\"repositoryName\\\\\\":\\\\\\"sourcecred/example-git\\\\\\",\\\\\\"type\\\\\\":\\\\\\"BLOB\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"repositoryName\\":\\"sourcecred/example-git\\",\\"type\\":\\"HAS_CONTENTS\\"}": Object {
+    "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"7be3ecfee5314ffa9b2d93fc4377792b2d6d70ed:.gitmodules\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/git-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"TREE_ENTRY\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"8c6cac301e763aa6d36466e0a775eb804be2c311\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/git-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"BLOB\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"type\\":\\"HAS_CONTENTS\\"}": Object {
       "dst": Object {
         "id": "8c6cac301e763aa6d36466e0a775eb804be2c311",
         "pluginName": "sourcecred/git-beta",
-        "repositoryName": "sourcecred/example-git",
         "type": "BLOB",
       },
       "payload": Object {},
       "src": Object {
         "id": "7be3ecfee5314ffa9b2d93fc4377792b2d6d70ed:.gitmodules",
         "pluginName": "sourcecred/git-beta",
-        "repositoryName": "sourcecred/example-git",
         "type": "TREE_ENTRY",
       },
     },
-    "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"7be3ecfee5314ffa9b2d93fc4377792b2d6d70ed:README.txt\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/git-beta\\\\\\",\\\\\\"repositoryName\\\\\\":\\\\\\"sourcecred/example-git\\\\\\",\\\\\\"type\\\\\\":\\\\\\"TREE_ENTRY\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"0fb31858c8e3710be77e1dbb8880acf8a5543d82\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/git-beta\\\\\\",\\\\\\"repositoryName\\\\\\":\\\\\\"sourcecred/example-git\\\\\\",\\\\\\"type\\\\\\":\\\\\\"BLOB\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"repositoryName\\":\\"sourcecred/example-git\\",\\"type\\":\\"HAS_CONTENTS\\"}": Object {
+    "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"7be3ecfee5314ffa9b2d93fc4377792b2d6d70ed:README.txt\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/git-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"TREE_ENTRY\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"0fb31858c8e3710be77e1dbb8880acf8a5543d82\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/git-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"BLOB\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"type\\":\\"HAS_CONTENTS\\"}": Object {
       "dst": Object {
         "id": "0fb31858c8e3710be77e1dbb8880acf8a5543d82",
         "pluginName": "sourcecred/git-beta",
-        "repositoryName": "sourcecred/example-git",
         "type": "BLOB",
       },
       "payload": Object {},
       "src": Object {
         "id": "7be3ecfee5314ffa9b2d93fc4377792b2d6d70ed:README.txt",
         "pluginName": "sourcecred/git-beta",
-        "repositoryName": "sourcecred/example-git",
         "type": "TREE_ENTRY",
       },
     },
-    "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"7be3ecfee5314ffa9b2d93fc4377792b2d6d70ed:pygravitydefier\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/git-beta\\\\\\",\\\\\\"repositoryName\\\\\\":\\\\\\"sourcecred/example-git\\\\\\",\\\\\\"type\\\\\\":\\\\\\"TREE_ENTRY\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-git-submodule.git@29ef158bc982733e2ba429fcf73e2f7562244188\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/git-beta\\\\\\",\\\\\\"repositoryName\\\\\\":\\\\\\"sourcecred/example-git\\\\\\",\\\\\\"type\\\\\\":\\\\\\"SUBMODULE_COMMIT\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"repositoryName\\":\\"sourcecred/example-git\\",\\"type\\":\\"HAS_CONTENTS\\"}": Object {
+    "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"7be3ecfee5314ffa9b2d93fc4377792b2d6d70ed:pygravitydefier\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/git-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"TREE_ENTRY\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-git-submodule.git@29ef158bc982733e2ba429fcf73e2f7562244188\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/git-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"SUBMODULE_COMMIT\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"type\\":\\"HAS_CONTENTS\\"}": Object {
       "dst": Object {
         "id": "https://github.com/sourcecred/example-git-submodule.git@29ef158bc982733e2ba429fcf73e2f7562244188",
         "pluginName": "sourcecred/git-beta",
-        "repositoryName": "sourcecred/example-git",
         "type": "SUBMODULE_COMMIT",
       },
       "payload": Object {},
       "src": Object {
         "id": "7be3ecfee5314ffa9b2d93fc4377792b2d6d70ed:pygravitydefier",
         "pluginName": "sourcecred/git-beta",
-        "repositoryName": "sourcecred/example-git",
         "type": "TREE_ENTRY",
       },
     },
-    "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"7be3ecfee5314ffa9b2d93fc4377792b2d6d70ed:science.txt\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/git-beta\\\\\\",\\\\\\"repositoryName\\\\\\":\\\\\\"sourcecred/example-git\\\\\\",\\\\\\"type\\\\\\":\\\\\\"TREE_ENTRY\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"f1f2514ca6d7a6a1a0511957021b1995bf9ace1c\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/git-beta\\\\\\",\\\\\\"repositoryName\\\\\\":\\\\\\"sourcecred/example-git\\\\\\",\\\\\\"type\\\\\\":\\\\\\"BLOB\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"repositoryName\\":\\"sourcecred/example-git\\",\\"type\\":\\"HAS_CONTENTS\\"}": Object {
+    "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"7be3ecfee5314ffa9b2d93fc4377792b2d6d70ed:science.txt\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/git-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"TREE_ENTRY\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"f1f2514ca6d7a6a1a0511957021b1995bf9ace1c\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/git-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"BLOB\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"type\\":\\"HAS_CONTENTS\\"}": Object {
       "dst": Object {
         "id": "f1f2514ca6d7a6a1a0511957021b1995bf9ace1c",
         "pluginName": "sourcecred/git-beta",
-        "repositoryName": "sourcecred/example-git",
         "type": "BLOB",
       },
       "payload": Object {},
       "src": Object {
         "id": "7be3ecfee5314ffa9b2d93fc4377792b2d6d70ed:science.txt",
         "pluginName": "sourcecred/git-beta",
-        "repositoryName": "sourcecred/example-git",
         "type": "TREE_ENTRY",
       },
     },
-    "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"7be3ecfee5314ffa9b2d93fc4377792b2d6d70ed:src\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/git-beta\\\\\\",\\\\\\"repositoryName\\\\\\":\\\\\\"sourcecred/example-git\\\\\\",\\\\\\"type\\\\\\":\\\\\\"TREE_ENTRY\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"78fc9c83023386854c6bfdc5761c0e58f68e226f\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/git-beta\\\\\\",\\\\\\"repositoryName\\\\\\":\\\\\\"sourcecred/example-git\\\\\\",\\\\\\"type\\\\\\":\\\\\\"TREE\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"repositoryName\\":\\"sourcecred/example-git\\",\\"type\\":\\"HAS_CONTENTS\\"}": Object {
+    "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"7be3ecfee5314ffa9b2d93fc4377792b2d6d70ed:src\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/git-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"TREE_ENTRY\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"78fc9c83023386854c6bfdc5761c0e58f68e226f\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/git-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"TREE\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"type\\":\\"HAS_CONTENTS\\"}": Object {
       "dst": Object {
         "id": "78fc9c83023386854c6bfdc5761c0e58f68e226f",
         "pluginName": "sourcecred/git-beta",
-        "repositoryName": "sourcecred/example-git",
         "type": "TREE",
       },
       "payload": Object {},
       "src": Object {
         "id": "7be3ecfee5314ffa9b2d93fc4377792b2d6d70ed:src",
         "pluginName": "sourcecred/git-beta",
-        "repositoryName": "sourcecred/example-git",
         "type": "TREE_ENTRY",
       },
     },
-    "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"819fc546cea489476ce8dc90785e9ba7753d0a8f:.gitmodules\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/git-beta\\\\\\",\\\\\\"repositoryName\\\\\\":\\\\\\"sourcecred/example-git\\\\\\",\\\\\\"type\\\\\\":\\\\\\"TREE_ENTRY\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"8c6cac301e763aa6d36466e0a775eb804be2c311\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/git-beta\\\\\\",\\\\\\"repositoryName\\\\\\":\\\\\\"sourcecred/example-git\\\\\\",\\\\\\"type\\\\\\":\\\\\\"BLOB\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"repositoryName\\":\\"sourcecred/example-git\\",\\"type\\":\\"HAS_CONTENTS\\"}": Object {
+    "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"819fc546cea489476ce8dc90785e9ba7753d0a8f:.gitmodules\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/git-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"TREE_ENTRY\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"8c6cac301e763aa6d36466e0a775eb804be2c311\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/git-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"BLOB\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"type\\":\\"HAS_CONTENTS\\"}": Object {
       "dst": Object {
         "id": "8c6cac301e763aa6d36466e0a775eb804be2c311",
         "pluginName": "sourcecred/git-beta",
-        "repositoryName": "sourcecred/example-git",
         "type": "BLOB",
       },
       "payload": Object {},
       "src": Object {
         "id": "819fc546cea489476ce8dc90785e9ba7753d0a8f:.gitmodules",
         "pluginName": "sourcecred/git-beta",
-        "repositoryName": "sourcecred/example-git",
         "type": "TREE_ENTRY",
       },
     },
-    "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"819fc546cea489476ce8dc90785e9ba7753d0a8f:README.txt\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/git-beta\\\\\\",\\\\\\"repositoryName\\\\\\":\\\\\\"sourcecred/example-git\\\\\\",\\\\\\"type\\\\\\":\\\\\\"TREE_ENTRY\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"0fb31858c8e3710be77e1dbb8880acf8a5543d82\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/git-beta\\\\\\",\\\\\\"repositoryName\\\\\\":\\\\\\"sourcecred/example-git\\\\\\",\\\\\\"type\\\\\\":\\\\\\"BLOB\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"repositoryName\\":\\"sourcecred/example-git\\",\\"type\\":\\"HAS_CONTENTS\\"}": Object {
+    "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"819fc546cea489476ce8dc90785e9ba7753d0a8f:README.txt\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/git-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"TREE_ENTRY\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"0fb31858c8e3710be77e1dbb8880acf8a5543d82\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/git-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"BLOB\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"type\\":\\"HAS_CONTENTS\\"}": Object {
       "dst": Object {
         "id": "0fb31858c8e3710be77e1dbb8880acf8a5543d82",
         "pluginName": "sourcecred/git-beta",
-        "repositoryName": "sourcecred/example-git",
         "type": "BLOB",
       },
       "payload": Object {},
       "src": Object {
         "id": "819fc546cea489476ce8dc90785e9ba7753d0a8f:README.txt",
         "pluginName": "sourcecred/git-beta",
-        "repositoryName": "sourcecred/example-git",
         "type": "TREE_ENTRY",
       },
     },
-    "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"819fc546cea489476ce8dc90785e9ba7753d0a8f:TODOS.txt\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/git-beta\\\\\\",\\\\\\"repositoryName\\\\\\":\\\\\\"sourcecred/example-git\\\\\\",\\\\\\"type\\\\\\":\\\\\\"TREE_ENTRY\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"ddec7477206c30c31b81482e56b877a0b3c2638b\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/git-beta\\\\\\",\\\\\\"repositoryName\\\\\\":\\\\\\"sourcecred/example-git\\\\\\",\\\\\\"type\\\\\\":\\\\\\"BLOB\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"repositoryName\\":\\"sourcecred/example-git\\",\\"type\\":\\"HAS_CONTENTS\\"}": Object {
+    "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"819fc546cea489476ce8dc90785e9ba7753d0a8f:TODOS.txt\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/git-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"TREE_ENTRY\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"ddec7477206c30c31b81482e56b877a0b3c2638b\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/git-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"BLOB\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"type\\":\\"HAS_CONTENTS\\"}": Object {
       "dst": Object {
         "id": "ddec7477206c30c31b81482e56b877a0b3c2638b",
         "pluginName": "sourcecred/git-beta",
-        "repositoryName": "sourcecred/example-git",
         "type": "BLOB",
       },
       "payload": Object {},
       "src": Object {
         "id": "819fc546cea489476ce8dc90785e9ba7753d0a8f:TODOS.txt",
         "pluginName": "sourcecred/git-beta",
-        "repositoryName": "sourcecred/example-git",
         "type": "TREE_ENTRY",
       },
     },
-    "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"819fc546cea489476ce8dc90785e9ba7753d0a8f:pygravitydefier\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/git-beta\\\\\\",\\\\\\"repositoryName\\\\\\":\\\\\\"sourcecred/example-git\\\\\\",\\\\\\"type\\\\\\":\\\\\\"TREE_ENTRY\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-git-submodule.git@29ef158bc982733e2ba429fcf73e2f7562244188\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/git-beta\\\\\\",\\\\\\"repositoryName\\\\\\":\\\\\\"sourcecred/example-git\\\\\\",\\\\\\"type\\\\\\":\\\\\\"SUBMODULE_COMMIT\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"repositoryName\\":\\"sourcecred/example-git\\",\\"type\\":\\"HAS_CONTENTS\\"}": Object {
+    "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"819fc546cea489476ce8dc90785e9ba7753d0a8f:pygravitydefier\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/git-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"TREE_ENTRY\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-git-submodule.git@29ef158bc982733e2ba429fcf73e2f7562244188\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/git-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"SUBMODULE_COMMIT\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"type\\":\\"HAS_CONTENTS\\"}": Object {
       "dst": Object {
         "id": "https://github.com/sourcecred/example-git-submodule.git@29ef158bc982733e2ba429fcf73e2f7562244188",
         "pluginName": "sourcecred/git-beta",
-        "repositoryName": "sourcecred/example-git",
         "type": "SUBMODULE_COMMIT",
       },
       "payload": Object {},
       "src": Object {
         "id": "819fc546cea489476ce8dc90785e9ba7753d0a8f:pygravitydefier",
         "pluginName": "sourcecred/git-beta",
-        "repositoryName": "sourcecred/example-git",
         "type": "TREE_ENTRY",
       },
     },
-    "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"819fc546cea489476ce8dc90785e9ba7753d0a8f:science.txt\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/git-beta\\\\\\",\\\\\\"repositoryName\\\\\\":\\\\\\"sourcecred/example-git\\\\\\",\\\\\\"type\\\\\\":\\\\\\"TREE_ENTRY\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"f1f2514ca6d7a6a1a0511957021b1995bf9ace1c\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/git-beta\\\\\\",\\\\\\"repositoryName\\\\\\":\\\\\\"sourcecred/example-git\\\\\\",\\\\\\"type\\\\\\":\\\\\\"BLOB\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"repositoryName\\":\\"sourcecred/example-git\\",\\"type\\":\\"HAS_CONTENTS\\"}": Object {
+    "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"819fc546cea489476ce8dc90785e9ba7753d0a8f:science.txt\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/git-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"TREE_ENTRY\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"f1f2514ca6d7a6a1a0511957021b1995bf9ace1c\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/git-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"BLOB\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"type\\":\\"HAS_CONTENTS\\"}": Object {
       "dst": Object {
         "id": "f1f2514ca6d7a6a1a0511957021b1995bf9ace1c",
         "pluginName": "sourcecred/git-beta",
-        "repositoryName": "sourcecred/example-git",
         "type": "BLOB",
       },
       "payload": Object {},
       "src": Object {
         "id": "819fc546cea489476ce8dc90785e9ba7753d0a8f:science.txt",
         "pluginName": "sourcecred/git-beta",
-        "repositoryName": "sourcecred/example-git",
         "type": "TREE_ENTRY",
       },
     },
-    "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"819fc546cea489476ce8dc90785e9ba7753d0a8f:src\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/git-beta\\\\\\",\\\\\\"repositoryName\\\\\\":\\\\\\"sourcecred/example-git\\\\\\",\\\\\\"type\\\\\\":\\\\\\"TREE_ENTRY\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"7b79d579b62994faba3b69fdf8aa442586c32681\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/git-beta\\\\\\",\\\\\\"repositoryName\\\\\\":\\\\\\"sourcecred/example-git\\\\\\",\\\\\\"type\\\\\\":\\\\\\"TREE\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"repositoryName\\":\\"sourcecred/example-git\\",\\"type\\":\\"HAS_CONTENTS\\"}": Object {
+    "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"819fc546cea489476ce8dc90785e9ba7753d0a8f:src\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/git-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"TREE_ENTRY\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"7b79d579b62994faba3b69fdf8aa442586c32681\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/git-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"TREE\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"type\\":\\"HAS_CONTENTS\\"}": Object {
       "dst": Object {
         "id": "7b79d579b62994faba3b69fdf8aa442586c32681",
         "pluginName": "sourcecred/git-beta",
-        "repositoryName": "sourcecred/example-git",
         "type": "TREE",
       },
       "payload": Object {},
       "src": Object {
         "id": "819fc546cea489476ce8dc90785e9ba7753d0a8f:src",
         "pluginName": "sourcecred/git-beta",
-        "repositoryName": "sourcecred/example-git",
         "type": "TREE_ENTRY",
       },
     },
-    "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"8d287c3bfbf8455ef30187bf5153ffc1b6eef268\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/git-beta\\\\\\",\\\\\\"repositoryName\\\\\\":\\\\\\"sourcecred/example-git\\\\\\",\\\\\\"type\\\\\\":\\\\\\"COMMIT\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"3dfb84795e07341b05fad3a0d5a55f8304b2d7d8\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/git-beta\\\\\\",\\\\\\"repositoryName\\\\\\":\\\\\\"sourcecred/example-git\\\\\\",\\\\\\"type\\\\\\":\\\\\\"TREE\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"repositoryName\\":\\"sourcecred/example-git\\",\\"type\\":\\"HAS_TREE\\"}": Object {
+    "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"8d287c3bfbf8455ef30187bf5153ffc1b6eef268\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/git-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"COMMIT\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"3dfb84795e07341b05fad3a0d5a55f8304b2d7d8\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/git-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"TREE\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"type\\":\\"HAS_TREE\\"}": Object {
       "dst": Object {
         "id": "3dfb84795e07341b05fad3a0d5a55f8304b2d7d8",
         "pluginName": "sourcecred/git-beta",
-        "repositoryName": "sourcecred/example-git",
         "type": "TREE",
       },
       "payload": Object {},
       "src": Object {
         "id": "8d287c3bfbf8455ef30187bf5153ffc1b6eef268",
         "pluginName": "sourcecred/git-beta",
-        "repositoryName": "sourcecred/example-git",
         "type": "COMMIT",
       },
     },
-    "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"bbf3b8b3d26a4f884b5c022d46851f593d329192:.gitmodules\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/git-beta\\\\\\",\\\\\\"repositoryName\\\\\\":\\\\\\"sourcecred/example-git\\\\\\",\\\\\\"type\\\\\\":\\\\\\"TREE_ENTRY\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"8c6cac301e763aa6d36466e0a775eb804be2c311\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/git-beta\\\\\\",\\\\\\"repositoryName\\\\\\":\\\\\\"sourcecred/example-git\\\\\\",\\\\\\"type\\\\\\":\\\\\\"BLOB\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"repositoryName\\":\\"sourcecred/example-git\\",\\"type\\":\\"HAS_CONTENTS\\"}": Object {
+    "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"bbf3b8b3d26a4f884b5c022d46851f593d329192:.gitmodules\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/git-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"TREE_ENTRY\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"8c6cac301e763aa6d36466e0a775eb804be2c311\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/git-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"BLOB\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"type\\":\\"HAS_CONTENTS\\"}": Object {
       "dst": Object {
         "id": "8c6cac301e763aa6d36466e0a775eb804be2c311",
         "pluginName": "sourcecred/git-beta",
-        "repositoryName": "sourcecred/example-git",
         "type": "BLOB",
       },
       "payload": Object {},
       "src": Object {
         "id": "bbf3b8b3d26a4f884b5c022d46851f593d329192:.gitmodules",
         "pluginName": "sourcecred/git-beta",
-        "repositoryName": "sourcecred/example-git",
         "type": "TREE_ENTRY",
       },
     },
-    "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"bbf3b8b3d26a4f884b5c022d46851f593d329192:README.txt\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/git-beta\\\\\\",\\\\\\"repositoryName\\\\\\":\\\\\\"sourcecred/example-git\\\\\\",\\\\\\"type\\\\\\":\\\\\\"TREE_ENTRY\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"0fb31858c8e3710be77e1dbb8880acf8a5543d82\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/git-beta\\\\\\",\\\\\\"repositoryName\\\\\\":\\\\\\"sourcecred/example-git\\\\\\",\\\\\\"type\\\\\\":\\\\\\"BLOB\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"repositoryName\\":\\"sourcecred/example-git\\",\\"type\\":\\"HAS_CONTENTS\\"}": Object {
+    "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"bbf3b8b3d26a4f884b5c022d46851f593d329192:README.txt\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/git-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"TREE_ENTRY\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"0fb31858c8e3710be77e1dbb8880acf8a5543d82\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/git-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"BLOB\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"type\\":\\"HAS_CONTENTS\\"}": Object {
       "dst": Object {
         "id": "0fb31858c8e3710be77e1dbb8880acf8a5543d82",
         "pluginName": "sourcecred/git-beta",
-        "repositoryName": "sourcecred/example-git",
         "type": "BLOB",
       },
       "payload": Object {},
       "src": Object {
         "id": "bbf3b8b3d26a4f884b5c022d46851f593d329192:README.txt",
         "pluginName": "sourcecred/git-beta",
-        "repositoryName": "sourcecred/example-git",
         "type": "TREE_ENTRY",
       },
     },
-    "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"bbf3b8b3d26a4f884b5c022d46851f593d329192:TODOS.txt\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/git-beta\\\\\\",\\\\\\"repositoryName\\\\\\":\\\\\\"sourcecred/example-git\\\\\\",\\\\\\"type\\\\\\":\\\\\\"TREE_ENTRY\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"ddec7477206c30c31b81482e56b877a0b3c2638b\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/git-beta\\\\\\",\\\\\\"repositoryName\\\\\\":\\\\\\"sourcecred/example-git\\\\\\",\\\\\\"type\\\\\\":\\\\\\"BLOB\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"repositoryName\\":\\"sourcecred/example-git\\",\\"type\\":\\"HAS_CONTENTS\\"}": Object {
+    "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"bbf3b8b3d26a4f884b5c022d46851f593d329192:TODOS.txt\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/git-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"TREE_ENTRY\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"ddec7477206c30c31b81482e56b877a0b3c2638b\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/git-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"BLOB\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"type\\":\\"HAS_CONTENTS\\"}": Object {
       "dst": Object {
         "id": "ddec7477206c30c31b81482e56b877a0b3c2638b",
         "pluginName": "sourcecred/git-beta",
-        "repositoryName": "sourcecred/example-git",
         "type": "BLOB",
       },
       "payload": Object {},
       "src": Object {
         "id": "bbf3b8b3d26a4f884b5c022d46851f593d329192:TODOS.txt",
         "pluginName": "sourcecred/git-beta",
-        "repositoryName": "sourcecred/example-git",
         "type": "TREE_ENTRY",
       },
     },
-    "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"bbf3b8b3d26a4f884b5c022d46851f593d329192:pygravitydefier\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/git-beta\\\\\\",\\\\\\"repositoryName\\\\\\":\\\\\\"sourcecred/example-git\\\\\\",\\\\\\"type\\\\\\":\\\\\\"TREE_ENTRY\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-git-submodule.git@29ef158bc982733e2ba429fcf73e2f7562244188\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/git-beta\\\\\\",\\\\\\"repositoryName\\\\\\":\\\\\\"sourcecred/example-git\\\\\\",\\\\\\"type\\\\\\":\\\\\\"SUBMODULE_COMMIT\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"repositoryName\\":\\"sourcecred/example-git\\",\\"type\\":\\"HAS_CONTENTS\\"}": Object {
+    "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"bbf3b8b3d26a4f884b5c022d46851f593d329192:pygravitydefier\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/git-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"TREE_ENTRY\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-git-submodule.git@29ef158bc982733e2ba429fcf73e2f7562244188\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/git-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"SUBMODULE_COMMIT\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"type\\":\\"HAS_CONTENTS\\"}": Object {
       "dst": Object {
         "id": "https://github.com/sourcecred/example-git-submodule.git@29ef158bc982733e2ba429fcf73e2f7562244188",
         "pluginName": "sourcecred/git-beta",
-        "repositoryName": "sourcecred/example-git",
         "type": "SUBMODULE_COMMIT",
       },
       "payload": Object {},
       "src": Object {
         "id": "bbf3b8b3d26a4f884b5c022d46851f593d329192:pygravitydefier",
         "pluginName": "sourcecred/git-beta",
-        "repositoryName": "sourcecred/example-git",
         "type": "TREE_ENTRY",
       },
     },
-    "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"bbf3b8b3d26a4f884b5c022d46851f593d329192:science.txt\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/git-beta\\\\\\",\\\\\\"repositoryName\\\\\\":\\\\\\"sourcecred/example-git\\\\\\",\\\\\\"type\\\\\\":\\\\\\"TREE_ENTRY\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"f1f2514ca6d7a6a1a0511957021b1995bf9ace1c\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/git-beta\\\\\\",\\\\\\"repositoryName\\\\\\":\\\\\\"sourcecred/example-git\\\\\\",\\\\\\"type\\\\\\":\\\\\\"BLOB\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"repositoryName\\":\\"sourcecred/example-git\\",\\"type\\":\\"HAS_CONTENTS\\"}": Object {
+    "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"bbf3b8b3d26a4f884b5c022d46851f593d329192:science.txt\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/git-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"TREE_ENTRY\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"f1f2514ca6d7a6a1a0511957021b1995bf9ace1c\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/git-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"BLOB\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"type\\":\\"HAS_CONTENTS\\"}": Object {
       "dst": Object {
         "id": "f1f2514ca6d7a6a1a0511957021b1995bf9ace1c",
         "pluginName": "sourcecred/git-beta",
-        "repositoryName": "sourcecred/example-git",
         "type": "BLOB",
       },
       "payload": Object {},
       "src": Object {
         "id": "bbf3b8b3d26a4f884b5c022d46851f593d329192:science.txt",
         "pluginName": "sourcecred/git-beta",
-        "repositoryName": "sourcecred/example-git",
         "type": "TREE_ENTRY",
       },
     },
-    "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"bbf3b8b3d26a4f884b5c022d46851f593d329192:src\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/git-beta\\\\\\",\\\\\\"repositoryName\\\\\\":\\\\\\"sourcecred/example-git\\\\\\",\\\\\\"type\\\\\\":\\\\\\"TREE_ENTRY\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"78fc9c83023386854c6bfdc5761c0e58f68e226f\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/git-beta\\\\\\",\\\\\\"repositoryName\\\\\\":\\\\\\"sourcecred/example-git\\\\\\",\\\\\\"type\\\\\\":\\\\\\"TREE\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"repositoryName\\":\\"sourcecred/example-git\\",\\"type\\":\\"HAS_CONTENTS\\"}": Object {
+    "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"bbf3b8b3d26a4f884b5c022d46851f593d329192:src\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/git-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"TREE_ENTRY\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"78fc9c83023386854c6bfdc5761c0e58f68e226f\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/git-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"TREE\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"type\\":\\"HAS_CONTENTS\\"}": Object {
       "dst": Object {
         "id": "78fc9c83023386854c6bfdc5761c0e58f68e226f",
         "pluginName": "sourcecred/git-beta",
-        "repositoryName": "sourcecred/example-git",
         "type": "TREE",
       },
       "payload": Object {},
       "src": Object {
         "id": "bbf3b8b3d26a4f884b5c022d46851f593d329192:src",
         "pluginName": "sourcecred/git-beta",
-        "repositoryName": "sourcecred/example-git",
         "type": "TREE_ENTRY",
       },
     },
-    "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"bdff5d94193170015d6cbb549b7b630649428b1f:README.txt\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/git-beta\\\\\\",\\\\\\"repositoryName\\\\\\":\\\\\\"sourcecred/example-git\\\\\\",\\\\\\"type\\\\\\":\\\\\\"TREE_ENTRY\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"0fb31858c8e3710be77e1dbb8880acf8a5543d82\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/git-beta\\\\\\",\\\\\\"repositoryName\\\\\\":\\\\\\"sourcecred/example-git\\\\\\",\\\\\\"type\\\\\\":\\\\\\"BLOB\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"repositoryName\\":\\"sourcecred/example-git\\",\\"type\\":\\"HAS_CONTENTS\\"}": Object {
+    "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"bdff5d94193170015d6cbb549b7b630649428b1f:README.txt\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/git-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"TREE_ENTRY\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"0fb31858c8e3710be77e1dbb8880acf8a5543d82\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/git-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"BLOB\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"type\\":\\"HAS_CONTENTS\\"}": Object {
       "dst": Object {
         "id": "0fb31858c8e3710be77e1dbb8880acf8a5543d82",
         "pluginName": "sourcecred/git-beta",
-        "repositoryName": "sourcecred/example-git",
         "type": "BLOB",
       },
       "payload": Object {},
       "src": Object {
         "id": "bdff5d94193170015d6cbb549b7b630649428b1f:README.txt",
         "pluginName": "sourcecred/git-beta",
-        "repositoryName": "sourcecred/example-git",
         "type": "TREE_ENTRY",
       },
     },
-    "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"c08ee3a4edea384d5291ffcbf06724a13ed72325\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/git-beta\\\\\\",\\\\\\"repositoryName\\\\\\":\\\\\\"sourcecred/example-git\\\\\\",\\\\\\"type\\\\\\":\\\\\\"COMMIT\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"2f7155e359fd0ecb96ffdca66fa45b6ed5792809\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/git-beta\\\\\\",\\\\\\"repositoryName\\\\\\":\\\\\\"sourcecred/example-git\\\\\\",\\\\\\"type\\\\\\":\\\\\\"TREE\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"repositoryName\\":\\"sourcecred/example-git\\",\\"type\\":\\"HAS_TREE\\"}": Object {
+    "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"c08ee3a4edea384d5291ffcbf06724a13ed72325\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/git-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"COMMIT\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"2f7155e359fd0ecb96ffdca66fa45b6ed5792809\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/git-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"TREE\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"type\\":\\"HAS_TREE\\"}": Object {
       "dst": Object {
         "id": "2f7155e359fd0ecb96ffdca66fa45b6ed5792809",
         "pluginName": "sourcecred/git-beta",
-        "repositoryName": "sourcecred/example-git",
         "type": "TREE",
       },
       "payload": Object {},
       "src": Object {
         "id": "c08ee3a4edea384d5291ffcbf06724a13ed72325",
         "pluginName": "sourcecred/git-beta",
-        "repositoryName": "sourcecred/example-git",
         "type": "COMMIT",
       },
     },
-    "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"c2b51945e7457546912a8ce158ed9d294558d294\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/git-beta\\\\\\",\\\\\\"repositoryName\\\\\\":\\\\\\"sourcecred/example-git\\\\\\",\\\\\\"type\\\\\\":\\\\\\"COMMIT\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"bdff5d94193170015d6cbb549b7b630649428b1f\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/git-beta\\\\\\",\\\\\\"repositoryName\\\\\\":\\\\\\"sourcecred/example-git\\\\\\",\\\\\\"type\\\\\\":\\\\\\"TREE\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"repositoryName\\":\\"sourcecred/example-git\\",\\"type\\":\\"HAS_TREE\\"}": Object {
+    "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"c2b51945e7457546912a8ce158ed9d294558d294\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/git-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"COMMIT\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"bdff5d94193170015d6cbb549b7b630649428b1f\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/git-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"TREE\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"type\\":\\"HAS_TREE\\"}": Object {
       "dst": Object {
         "id": "bdff5d94193170015d6cbb549b7b630649428b1f",
         "pluginName": "sourcecred/git-beta",
-        "repositoryName": "sourcecred/example-git",
         "type": "TREE",
       },
       "payload": Object {},
       "src": Object {
         "id": "c2b51945e7457546912a8ce158ed9d294558d294",
         "pluginName": "sourcecred/git-beta",
-        "repositoryName": "sourcecred/example-git",
         "type": "COMMIT",
       },
     },
-    "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"d160cca97611e9dfed642522ad44408d0292e8ea\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/git-beta\\\\\\",\\\\\\"repositoryName\\\\\\":\\\\\\"sourcecred/example-git\\\\\\",\\\\\\"type\\\\\\":\\\\\\"COMMIT\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"569e1d383759903134df75230d63c0090196d4cb\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/git-beta\\\\\\",\\\\\\"repositoryName\\\\\\":\\\\\\"sourcecred/example-git\\\\\\",\\\\\\"type\\\\\\":\\\\\\"TREE\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"repositoryName\\":\\"sourcecred/example-git\\",\\"type\\":\\"HAS_TREE\\"}": Object {
+    "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"d160cca97611e9dfed642522ad44408d0292e8ea\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/git-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"COMMIT\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"569e1d383759903134df75230d63c0090196d4cb\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/git-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"TREE\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"type\\":\\"HAS_TREE\\"}": Object {
       "dst": Object {
         "id": "569e1d383759903134df75230d63c0090196d4cb",
         "pluginName": "sourcecred/git-beta",
-        "repositoryName": "sourcecred/example-git",
         "type": "TREE",
       },
       "payload": Object {},
       "src": Object {
         "id": "d160cca97611e9dfed642522ad44408d0292e8ea",
         "pluginName": "sourcecred/git-beta",
-        "repositoryName": "sourcecred/example-git",
         "type": "COMMIT",
       },
     },
-    "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"e8b7a8f19701cd5a25e4a097d513ead60e5f8bcc\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/git-beta\\\\\\",\\\\\\"repositoryName\\\\\\":\\\\\\"sourcecred/example-git\\\\\\",\\\\\\"type\\\\\\":\\\\\\"COMMIT\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"819fc546cea489476ce8dc90785e9ba7753d0a8f\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/git-beta\\\\\\",\\\\\\"repositoryName\\\\\\":\\\\\\"sourcecred/example-git\\\\\\",\\\\\\"type\\\\\\":\\\\\\"TREE\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"repositoryName\\":\\"sourcecred/example-git\\",\\"type\\":\\"HAS_TREE\\"}": Object {
+    "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"e8b7a8f19701cd5a25e4a097d513ead60e5f8bcc\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/git-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"COMMIT\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"819fc546cea489476ce8dc90785e9ba7753d0a8f\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/git-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"TREE\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"type\\":\\"HAS_TREE\\"}": Object {
       "dst": Object {
         "id": "819fc546cea489476ce8dc90785e9ba7753d0a8f",
         "pluginName": "sourcecred/git-beta",
-        "repositoryName": "sourcecred/example-git",
         "type": "TREE",
       },
       "payload": Object {},
       "src": Object {
         "id": "e8b7a8f19701cd5a25e4a097d513ead60e5f8bcc",
         "pluginName": "sourcecred/git-beta",
-        "repositoryName": "sourcecred/example-git",
         "type": "COMMIT",
       },
     },
-    "{\\"id\\":\\"bbf3b8b3d26a4f884b5c022d46851f593d329192:.gitmodules\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"repositoryName\\":\\"sourcecred/example-git\\",\\"type\\":\\"INCLUDES\\"}": Object {
+    "{\\"id\\":\\"bbf3b8b3d26a4f884b5c022d46851f593d329192:.gitmodules\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"type\\":\\"INCLUDES\\"}": Object {
       "dst": Object {
         "id": "bbf3b8b3d26a4f884b5c022d46851f593d329192:.gitmodules",
         "pluginName": "sourcecred/git-beta",
-        "repositoryName": "sourcecred/example-git",
         "type": "TREE_ENTRY",
       },
       "payload": Object {
@@ -1141,15 +998,13 @@ Object {
       "src": Object {
         "id": "bbf3b8b3d26a4f884b5c022d46851f593d329192",
         "pluginName": "sourcecred/git-beta",
-        "repositoryName": "sourcecred/example-git",
         "type": "TREE",
       },
     },
-    "{\\"id\\":\\"bbf3b8b3d26a4f884b5c022d46851f593d329192:README.txt\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"repositoryName\\":\\"sourcecred/example-git\\",\\"type\\":\\"INCLUDES\\"}": Object {
+    "{\\"id\\":\\"bbf3b8b3d26a4f884b5c022d46851f593d329192:README.txt\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"type\\":\\"INCLUDES\\"}": Object {
       "dst": Object {
         "id": "bbf3b8b3d26a4f884b5c022d46851f593d329192:README.txt",
         "pluginName": "sourcecred/git-beta",
-        "repositoryName": "sourcecred/example-git",
         "type": "TREE_ENTRY",
       },
       "payload": Object {
@@ -1158,15 +1013,13 @@ Object {
       "src": Object {
         "id": "bbf3b8b3d26a4f884b5c022d46851f593d329192",
         "pluginName": "sourcecred/git-beta",
-        "repositoryName": "sourcecred/example-git",
         "type": "TREE",
       },
     },
-    "{\\"id\\":\\"bbf3b8b3d26a4f884b5c022d46851f593d329192:TODOS.txt\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"repositoryName\\":\\"sourcecred/example-git\\",\\"type\\":\\"INCLUDES\\"}": Object {
+    "{\\"id\\":\\"bbf3b8b3d26a4f884b5c022d46851f593d329192:TODOS.txt\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"type\\":\\"INCLUDES\\"}": Object {
       "dst": Object {
         "id": "bbf3b8b3d26a4f884b5c022d46851f593d329192:TODOS.txt",
         "pluginName": "sourcecred/git-beta",
-        "repositoryName": "sourcecred/example-git",
         "type": "TREE_ENTRY",
       },
       "payload": Object {
@@ -1175,15 +1028,13 @@ Object {
       "src": Object {
         "id": "bbf3b8b3d26a4f884b5c022d46851f593d329192",
         "pluginName": "sourcecred/git-beta",
-        "repositoryName": "sourcecred/example-git",
         "type": "TREE",
       },
     },
-    "{\\"id\\":\\"bbf3b8b3d26a4f884b5c022d46851f593d329192:pygravitydefier\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"repositoryName\\":\\"sourcecred/example-git\\",\\"type\\":\\"INCLUDES\\"}": Object {
+    "{\\"id\\":\\"bbf3b8b3d26a4f884b5c022d46851f593d329192:pygravitydefier\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"type\\":\\"INCLUDES\\"}": Object {
       "dst": Object {
         "id": "bbf3b8b3d26a4f884b5c022d46851f593d329192:pygravitydefier",
         "pluginName": "sourcecred/git-beta",
-        "repositoryName": "sourcecred/example-git",
         "type": "TREE_ENTRY",
       },
       "payload": Object {
@@ -1192,15 +1043,13 @@ Object {
       "src": Object {
         "id": "bbf3b8b3d26a4f884b5c022d46851f593d329192",
         "pluginName": "sourcecred/git-beta",
-        "repositoryName": "sourcecred/example-git",
         "type": "TREE",
       },
     },
-    "{\\"id\\":\\"bbf3b8b3d26a4f884b5c022d46851f593d329192:science.txt\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"repositoryName\\":\\"sourcecred/example-git\\",\\"type\\":\\"INCLUDES\\"}": Object {
+    "{\\"id\\":\\"bbf3b8b3d26a4f884b5c022d46851f593d329192:science.txt\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"type\\":\\"INCLUDES\\"}": Object {
       "dst": Object {
         "id": "bbf3b8b3d26a4f884b5c022d46851f593d329192:science.txt",
         "pluginName": "sourcecred/git-beta",
-        "repositoryName": "sourcecred/example-git",
         "type": "TREE_ENTRY",
       },
       "payload": Object {
@@ -1209,15 +1058,13 @@ Object {
       "src": Object {
         "id": "bbf3b8b3d26a4f884b5c022d46851f593d329192",
         "pluginName": "sourcecred/git-beta",
-        "repositoryName": "sourcecred/example-git",
         "type": "TREE",
       },
     },
-    "{\\"id\\":\\"bbf3b8b3d26a4f884b5c022d46851f593d329192:src\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"repositoryName\\":\\"sourcecred/example-git\\",\\"type\\":\\"INCLUDES\\"}": Object {
+    "{\\"id\\":\\"bbf3b8b3d26a4f884b5c022d46851f593d329192:src\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"type\\":\\"INCLUDES\\"}": Object {
       "dst": Object {
         "id": "bbf3b8b3d26a4f884b5c022d46851f593d329192:src",
         "pluginName": "sourcecred/git-beta",
-        "repositoryName": "sourcecred/example-git",
         "type": "TREE_ENTRY",
       },
       "payload": Object {
@@ -1226,15 +1073,13 @@ Object {
       "src": Object {
         "id": "bbf3b8b3d26a4f884b5c022d46851f593d329192",
         "pluginName": "sourcecred/git-beta",
-        "repositoryName": "sourcecred/example-git",
         "type": "TREE",
       },
     },
-    "{\\"id\\":\\"bdff5d94193170015d6cbb549b7b630649428b1f:README.txt\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"repositoryName\\":\\"sourcecred/example-git\\",\\"type\\":\\"INCLUDES\\"}": Object {
+    "{\\"id\\":\\"bdff5d94193170015d6cbb549b7b630649428b1f:README.txt\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"type\\":\\"INCLUDES\\"}": Object {
       "dst": Object {
         "id": "bdff5d94193170015d6cbb549b7b630649428b1f:README.txt",
         "pluginName": "sourcecred/git-beta",
-        "repositoryName": "sourcecred/example-git",
         "type": "TREE_ENTRY",
       },
       "payload": Object {
@@ -1243,15 +1088,13 @@ Object {
       "src": Object {
         "id": "bdff5d94193170015d6cbb549b7b630649428b1f",
         "pluginName": "sourcecred/git-beta",
-        "repositoryName": "sourcecred/example-git",
         "type": "TREE",
       },
     },
-    "{\\"id\\":\\"c08ee3a4edea384d5291ffcbf06724a13ed72325^1\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"repositoryName\\":\\"sourcecred/example-git\\",\\"type\\":\\"HAS_PARENT\\"}": Object {
+    "{\\"id\\":\\"c08ee3a4edea384d5291ffcbf06724a13ed72325^1\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"type\\":\\"HAS_PARENT\\"}": Object {
       "dst": Object {
         "id": "c2b51945e7457546912a8ce158ed9d294558d294",
         "pluginName": "sourcecred/git-beta",
-        "repositoryName": "sourcecred/example-git",
         "type": "COMMIT",
       },
       "payload": Object {
@@ -1260,15 +1103,13 @@ Object {
       "src": Object {
         "id": "c08ee3a4edea384d5291ffcbf06724a13ed72325",
         "pluginName": "sourcecred/git-beta",
-        "repositoryName": "sourcecred/example-git",
         "type": "COMMIT",
       },
     },
-    "{\\"id\\":\\"d160cca97611e9dfed642522ad44408d0292e8ea^1\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"repositoryName\\":\\"sourcecred/example-git\\",\\"type\\":\\"HAS_PARENT\\"}": Object {
+    "{\\"id\\":\\"d160cca97611e9dfed642522ad44408d0292e8ea^1\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"type\\":\\"HAS_PARENT\\"}": Object {
       "dst": Object {
         "id": "8d287c3bfbf8455ef30187bf5153ffc1b6eef268",
         "pluginName": "sourcecred/git-beta",
-        "repositoryName": "sourcecred/example-git",
         "type": "COMMIT",
       },
       "payload": Object {
@@ -1277,15 +1118,13 @@ Object {
       "src": Object {
         "id": "d160cca97611e9dfed642522ad44408d0292e8ea",
         "pluginName": "sourcecred/git-beta",
-        "repositoryName": "sourcecred/example-git",
         "type": "COMMIT",
       },
     },
-    "{\\"id\\":\\"e8b7a8f19701cd5a25e4a097d513ead60e5f8bcc^1\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"repositoryName\\":\\"sourcecred/example-git\\",\\"type\\":\\"HAS_PARENT\\"}": Object {
+    "{\\"id\\":\\"e8b7a8f19701cd5a25e4a097d513ead60e5f8bcc^1\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"type\\":\\"HAS_PARENT\\"}": Object {
       "dst": Object {
         "id": "d160cca97611e9dfed642522ad44408d0292e8ea",
         "pluginName": "sourcecred/git-beta",
-        "repositoryName": "sourcecred/example-git",
         "type": "COMMIT",
       },
       "payload": Object {
@@ -1294,258 +1133,257 @@ Object {
       "src": Object {
         "id": "e8b7a8f19701cd5a25e4a097d513ead60e5f8bcc",
         "pluginName": "sourcecred/git-beta",
-        "repositoryName": "sourcecred/example-git",
         "type": "COMMIT",
       },
     },
   },
   "nodes": Object {
-    "{\\"id\\":\\"0fb31858c8e3710be77e1dbb8880acf8a5543d82\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"repositoryName\\":\\"sourcecred/example-git\\",\\"type\\":\\"BLOB\\"}": Object {
+    "{\\"id\\":\\"0fb31858c8e3710be77e1dbb8880acf8a5543d82\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"type\\":\\"BLOB\\"}": Object {
       "payload": Object {},
     },
-    "{\\"id\\":\\"2f7155e359fd0ecb96ffdca66fa45b6ed5792809\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"repositoryName\\":\\"sourcecred/example-git\\",\\"type\\":\\"TREE\\"}": Object {
+    "{\\"id\\":\\"2f7155e359fd0ecb96ffdca66fa45b6ed5792809\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"type\\":\\"TREE\\"}": Object {
       "payload": Object {},
     },
-    "{\\"id\\":\\"2f7155e359fd0ecb96ffdca66fa45b6ed5792809:README.txt\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"repositoryName\\":\\"sourcecred/example-git\\",\\"type\\":\\"TREE_ENTRY\\"}": Object {
+    "{\\"id\\":\\"2f7155e359fd0ecb96ffdca66fa45b6ed5792809:README.txt\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"type\\":\\"TREE_ENTRY\\"}": Object {
       "payload": Object {
         "name": "README.txt",
       },
     },
-    "{\\"id\\":\\"2f7155e359fd0ecb96ffdca66fa45b6ed5792809:science.txt\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"repositoryName\\":\\"sourcecred/example-git\\",\\"type\\":\\"TREE_ENTRY\\"}": Object {
+    "{\\"id\\":\\"2f7155e359fd0ecb96ffdca66fa45b6ed5792809:science.txt\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"type\\":\\"TREE_ENTRY\\"}": Object {
       "payload": Object {
         "name": "science.txt",
       },
     },
-    "{\\"id\\":\\"3715ddfb8d4c4fd2a6f6af75488c82f84c92ec2f\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"repositoryName\\":\\"sourcecred/example-git\\",\\"type\\":\\"COMMIT\\"}": Object {
+    "{\\"id\\":\\"3715ddfb8d4c4fd2a6f6af75488c82f84c92ec2f\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"type\\":\\"COMMIT\\"}": Object {
       "payload": Object {},
     },
-    "{\\"id\\":\\"3dfb84795e07341b05fad3a0d5a55f8304b2d7d8\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"repositoryName\\":\\"sourcecred/example-git\\",\\"type\\":\\"TREE\\"}": Object {
+    "{\\"id\\":\\"3dfb84795e07341b05fad3a0d5a55f8304b2d7d8\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"type\\":\\"TREE\\"}": Object {
       "payload": Object {},
     },
-    "{\\"id\\":\\"3dfb84795e07341b05fad3a0d5a55f8304b2d7d8:.gitmodules\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"repositoryName\\":\\"sourcecred/example-git\\",\\"type\\":\\"TREE_ENTRY\\"}": Object {
+    "{\\"id\\":\\"3dfb84795e07341b05fad3a0d5a55f8304b2d7d8:.gitmodules\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"type\\":\\"TREE_ENTRY\\"}": Object {
       "payload": Object {
         "name": ".gitmodules",
       },
     },
-    "{\\"id\\":\\"3dfb84795e07341b05fad3a0d5a55f8304b2d7d8:README.txt\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"repositoryName\\":\\"sourcecred/example-git\\",\\"type\\":\\"TREE_ENTRY\\"}": Object {
+    "{\\"id\\":\\"3dfb84795e07341b05fad3a0d5a55f8304b2d7d8:README.txt\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"type\\":\\"TREE_ENTRY\\"}": Object {
       "payload": Object {
         "name": "README.txt",
       },
     },
-    "{\\"id\\":\\"3dfb84795e07341b05fad3a0d5a55f8304b2d7d8:pygravitydefier\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"repositoryName\\":\\"sourcecred/example-git\\",\\"type\\":\\"TREE_ENTRY\\"}": Object {
+    "{\\"id\\":\\"3dfb84795e07341b05fad3a0d5a55f8304b2d7d8:pygravitydefier\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"type\\":\\"TREE_ENTRY\\"}": Object {
       "payload": Object {
         "name": "pygravitydefier",
       },
     },
-    "{\\"id\\":\\"3dfb84795e07341b05fad3a0d5a55f8304b2d7d8:science.txt\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"repositoryName\\":\\"sourcecred/example-git\\",\\"type\\":\\"TREE_ENTRY\\"}": Object {
+    "{\\"id\\":\\"3dfb84795e07341b05fad3a0d5a55f8304b2d7d8:science.txt\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"type\\":\\"TREE_ENTRY\\"}": Object {
       "payload": Object {
         "name": "science.txt",
       },
     },
-    "{\\"id\\":\\"569e1d383759903134df75230d63c0090196d4cb\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"repositoryName\\":\\"sourcecred/example-git\\",\\"type\\":\\"TREE\\"}": Object {
+    "{\\"id\\":\\"569e1d383759903134df75230d63c0090196d4cb\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"type\\":\\"TREE\\"}": Object {
       "payload": Object {},
     },
-    "{\\"id\\":\\"569e1d383759903134df75230d63c0090196d4cb:.gitmodules\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"repositoryName\\":\\"sourcecred/example-git\\",\\"type\\":\\"TREE_ENTRY\\"}": Object {
+    "{\\"id\\":\\"569e1d383759903134df75230d63c0090196d4cb:.gitmodules\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"type\\":\\"TREE_ENTRY\\"}": Object {
       "payload": Object {
         "name": ".gitmodules",
       },
     },
-    "{\\"id\\":\\"569e1d383759903134df75230d63c0090196d4cb:README.txt\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"repositoryName\\":\\"sourcecred/example-git\\",\\"type\\":\\"TREE_ENTRY\\"}": Object {
+    "{\\"id\\":\\"569e1d383759903134df75230d63c0090196d4cb:README.txt\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"type\\":\\"TREE_ENTRY\\"}": Object {
       "payload": Object {
         "name": "README.txt",
       },
     },
-    "{\\"id\\":\\"569e1d383759903134df75230d63c0090196d4cb:TODOS.txt\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"repositoryName\\":\\"sourcecred/example-git\\",\\"type\\":\\"TREE_ENTRY\\"}": Object {
+    "{\\"id\\":\\"569e1d383759903134df75230d63c0090196d4cb:TODOS.txt\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"type\\":\\"TREE_ENTRY\\"}": Object {
       "payload": Object {
         "name": "TODOS.txt",
       },
     },
-    "{\\"id\\":\\"569e1d383759903134df75230d63c0090196d4cb:pygravitydefier\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"repositoryName\\":\\"sourcecred/example-git\\",\\"type\\":\\"TREE_ENTRY\\"}": Object {
+    "{\\"id\\":\\"569e1d383759903134df75230d63c0090196d4cb:pygravitydefier\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"type\\":\\"TREE_ENTRY\\"}": Object {
       "payload": Object {
         "name": "pygravitydefier",
       },
     },
-    "{\\"id\\":\\"569e1d383759903134df75230d63c0090196d4cb:science.txt\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"repositoryName\\":\\"sourcecred/example-git\\",\\"type\\":\\"TREE_ENTRY\\"}": Object {
+    "{\\"id\\":\\"569e1d383759903134df75230d63c0090196d4cb:science.txt\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"type\\":\\"TREE_ENTRY\\"}": Object {
       "payload": Object {
         "name": "science.txt",
       },
     },
-    "{\\"id\\":\\"569e1d383759903134df75230d63c0090196d4cb:src\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"repositoryName\\":\\"sourcecred/example-git\\",\\"type\\":\\"TREE_ENTRY\\"}": Object {
+    "{\\"id\\":\\"569e1d383759903134df75230d63c0090196d4cb:src\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"type\\":\\"TREE_ENTRY\\"}": Object {
       "payload": Object {
         "name": "src",
       },
     },
-    "{\\"id\\":\\"674b0b476989384510304846248b3acd16206782\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"repositoryName\\":\\"sourcecred/example-git\\",\\"type\\":\\"BLOB\\"}": Object {
+    "{\\"id\\":\\"674b0b476989384510304846248b3acd16206782\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"type\\":\\"BLOB\\"}": Object {
       "payload": Object {},
     },
-    "{\\"id\\":\\"69c5aad50eec8f2a0a07c988c3b283a6490eb45b\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"repositoryName\\":\\"sourcecred/example-git\\",\\"type\\":\\"COMMIT\\"}": Object {
+    "{\\"id\\":\\"69c5aad50eec8f2a0a07c988c3b283a6490eb45b\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"type\\":\\"COMMIT\\"}": Object {
       "payload": Object {},
     },
-    "{\\"id\\":\\"78fc9c83023386854c6bfdc5761c0e58f68e226f\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"repositoryName\\":\\"sourcecred/example-git\\",\\"type\\":\\"TREE\\"}": Object {
+    "{\\"id\\":\\"78fc9c83023386854c6bfdc5761c0e58f68e226f\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"type\\":\\"TREE\\"}": Object {
       "payload": Object {},
     },
-    "{\\"id\\":\\"78fc9c83023386854c6bfdc5761c0e58f68e226f:index.py\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"repositoryName\\":\\"sourcecred/example-git\\",\\"type\\":\\"TREE_ENTRY\\"}": Object {
+    "{\\"id\\":\\"78fc9c83023386854c6bfdc5761c0e58f68e226f:index.py\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"type\\":\\"TREE_ENTRY\\"}": Object {
       "payload": Object {
         "name": "index.py",
       },
     },
-    "{\\"id\\":\\"78fc9c83023386854c6bfdc5761c0e58f68e226f:quantum_gravity.py\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"repositoryName\\":\\"sourcecred/example-git\\",\\"type\\":\\"TREE_ENTRY\\"}": Object {
+    "{\\"id\\":\\"78fc9c83023386854c6bfdc5761c0e58f68e226f:quantum_gravity.py\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"type\\":\\"TREE_ENTRY\\"}": Object {
       "payload": Object {
         "name": "quantum_gravity.py",
       },
     },
-    "{\\"id\\":\\"7b79d579b62994faba3b69fdf8aa442586c32681\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"repositoryName\\":\\"sourcecred/example-git\\",\\"type\\":\\"TREE\\"}": Object {
+    "{\\"id\\":\\"7b79d579b62994faba3b69fdf8aa442586c32681\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"type\\":\\"TREE\\"}": Object {
       "payload": Object {},
     },
-    "{\\"id\\":\\"7b79d579b62994faba3b69fdf8aa442586c32681:index.py\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"repositoryName\\":\\"sourcecred/example-git\\",\\"type\\":\\"TREE_ENTRY\\"}": Object {
+    "{\\"id\\":\\"7b79d579b62994faba3b69fdf8aa442586c32681:index.py\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"type\\":\\"TREE_ENTRY\\"}": Object {
       "payload": Object {
         "name": "index.py",
       },
     },
-    "{\\"id\\":\\"7b79d579b62994faba3b69fdf8aa442586c32681:quantum_gravity.py\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"repositoryName\\":\\"sourcecred/example-git\\",\\"type\\":\\"TREE_ENTRY\\"}": Object {
+    "{\\"id\\":\\"7b79d579b62994faba3b69fdf8aa442586c32681:quantum_gravity.py\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"type\\":\\"TREE_ENTRY\\"}": Object {
       "payload": Object {
         "name": "quantum_gravity.py",
       },
     },
-    "{\\"id\\":\\"7be3ecfee5314ffa9b2d93fc4377792b2d6d70ed\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"repositoryName\\":\\"sourcecred/example-git\\",\\"type\\":\\"TREE\\"}": Object {
+    "{\\"id\\":\\"7be3ecfee5314ffa9b2d93fc4377792b2d6d70ed\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"type\\":\\"TREE\\"}": Object {
       "payload": Object {},
     },
-    "{\\"id\\":\\"7be3ecfee5314ffa9b2d93fc4377792b2d6d70ed:.gitmodules\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"repositoryName\\":\\"sourcecred/example-git\\",\\"type\\":\\"TREE_ENTRY\\"}": Object {
+    "{\\"id\\":\\"7be3ecfee5314ffa9b2d93fc4377792b2d6d70ed:.gitmodules\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"type\\":\\"TREE_ENTRY\\"}": Object {
       "payload": Object {
         "name": ".gitmodules",
       },
     },
-    "{\\"id\\":\\"7be3ecfee5314ffa9b2d93fc4377792b2d6d70ed:README.txt\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"repositoryName\\":\\"sourcecred/example-git\\",\\"type\\":\\"TREE_ENTRY\\"}": Object {
+    "{\\"id\\":\\"7be3ecfee5314ffa9b2d93fc4377792b2d6d70ed:README.txt\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"type\\":\\"TREE_ENTRY\\"}": Object {
       "payload": Object {
         "name": "README.txt",
       },
     },
-    "{\\"id\\":\\"7be3ecfee5314ffa9b2d93fc4377792b2d6d70ed:pygravitydefier\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"repositoryName\\":\\"sourcecred/example-git\\",\\"type\\":\\"TREE_ENTRY\\"}": Object {
+    "{\\"id\\":\\"7be3ecfee5314ffa9b2d93fc4377792b2d6d70ed:pygravitydefier\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"type\\":\\"TREE_ENTRY\\"}": Object {
       "payload": Object {
         "name": "pygravitydefier",
       },
     },
-    "{\\"id\\":\\"7be3ecfee5314ffa9b2d93fc4377792b2d6d70ed:science.txt\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"repositoryName\\":\\"sourcecred/example-git\\",\\"type\\":\\"TREE_ENTRY\\"}": Object {
+    "{\\"id\\":\\"7be3ecfee5314ffa9b2d93fc4377792b2d6d70ed:science.txt\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"type\\":\\"TREE_ENTRY\\"}": Object {
       "payload": Object {
         "name": "science.txt",
       },
     },
-    "{\\"id\\":\\"7be3ecfee5314ffa9b2d93fc4377792b2d6d70ed:src\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"repositoryName\\":\\"sourcecred/example-git\\",\\"type\\":\\"TREE_ENTRY\\"}": Object {
+    "{\\"id\\":\\"7be3ecfee5314ffa9b2d93fc4377792b2d6d70ed:src\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"type\\":\\"TREE_ENTRY\\"}": Object {
       "payload": Object {
         "name": "src",
       },
     },
-    "{\\"id\\":\\"819fc546cea489476ce8dc90785e9ba7753d0a8f\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"repositoryName\\":\\"sourcecred/example-git\\",\\"type\\":\\"TREE\\"}": Object {
+    "{\\"id\\":\\"819fc546cea489476ce8dc90785e9ba7753d0a8f\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"type\\":\\"TREE\\"}": Object {
       "payload": Object {},
     },
-    "{\\"id\\":\\"819fc546cea489476ce8dc90785e9ba7753d0a8f:.gitmodules\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"repositoryName\\":\\"sourcecred/example-git\\",\\"type\\":\\"TREE_ENTRY\\"}": Object {
+    "{\\"id\\":\\"819fc546cea489476ce8dc90785e9ba7753d0a8f:.gitmodules\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"type\\":\\"TREE_ENTRY\\"}": Object {
       "payload": Object {
         "name": ".gitmodules",
       },
     },
-    "{\\"id\\":\\"819fc546cea489476ce8dc90785e9ba7753d0a8f:README.txt\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"repositoryName\\":\\"sourcecred/example-git\\",\\"type\\":\\"TREE_ENTRY\\"}": Object {
+    "{\\"id\\":\\"819fc546cea489476ce8dc90785e9ba7753d0a8f:README.txt\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"type\\":\\"TREE_ENTRY\\"}": Object {
       "payload": Object {
         "name": "README.txt",
       },
     },
-    "{\\"id\\":\\"819fc546cea489476ce8dc90785e9ba7753d0a8f:TODOS.txt\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"repositoryName\\":\\"sourcecred/example-git\\",\\"type\\":\\"TREE_ENTRY\\"}": Object {
+    "{\\"id\\":\\"819fc546cea489476ce8dc90785e9ba7753d0a8f:TODOS.txt\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"type\\":\\"TREE_ENTRY\\"}": Object {
       "payload": Object {
         "name": "TODOS.txt",
       },
     },
-    "{\\"id\\":\\"819fc546cea489476ce8dc90785e9ba7753d0a8f:pygravitydefier\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"repositoryName\\":\\"sourcecred/example-git\\",\\"type\\":\\"TREE_ENTRY\\"}": Object {
+    "{\\"id\\":\\"819fc546cea489476ce8dc90785e9ba7753d0a8f:pygravitydefier\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"type\\":\\"TREE_ENTRY\\"}": Object {
       "payload": Object {
         "name": "pygravitydefier",
       },
     },
-    "{\\"id\\":\\"819fc546cea489476ce8dc90785e9ba7753d0a8f:science.txt\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"repositoryName\\":\\"sourcecred/example-git\\",\\"type\\":\\"TREE_ENTRY\\"}": Object {
+    "{\\"id\\":\\"819fc546cea489476ce8dc90785e9ba7753d0a8f:science.txt\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"type\\":\\"TREE_ENTRY\\"}": Object {
       "payload": Object {
         "name": "science.txt",
       },
     },
-    "{\\"id\\":\\"819fc546cea489476ce8dc90785e9ba7753d0a8f:src\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"repositoryName\\":\\"sourcecred/example-git\\",\\"type\\":\\"TREE_ENTRY\\"}": Object {
+    "{\\"id\\":\\"819fc546cea489476ce8dc90785e9ba7753d0a8f:src\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"type\\":\\"TREE_ENTRY\\"}": Object {
       "payload": Object {
         "name": "src",
       },
     },
-    "{\\"id\\":\\"887ad856bbc1373da146106c86cb581ad78cdafe\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"repositoryName\\":\\"sourcecred/example-git\\",\\"type\\":\\"BLOB\\"}": Object {
+    "{\\"id\\":\\"887ad856bbc1373da146106c86cb581ad78cdafe\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"type\\":\\"BLOB\\"}": Object {
       "payload": Object {},
     },
-    "{\\"id\\":\\"8c6cac301e763aa6d36466e0a775eb804be2c311\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"repositoryName\\":\\"sourcecred/example-git\\",\\"type\\":\\"BLOB\\"}": Object {
+    "{\\"id\\":\\"8c6cac301e763aa6d36466e0a775eb804be2c311\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"type\\":\\"BLOB\\"}": Object {
       "payload": Object {},
     },
-    "{\\"id\\":\\"8d287c3bfbf8455ef30187bf5153ffc1b6eef268\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"repositoryName\\":\\"sourcecred/example-git\\",\\"type\\":\\"COMMIT\\"}": Object {
+    "{\\"id\\":\\"8d287c3bfbf8455ef30187bf5153ffc1b6eef268\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"type\\":\\"COMMIT\\"}": Object {
       "payload": Object {},
     },
-    "{\\"id\\":\\"aea4f28abb23abde151b0ead4063227f8bf6c0b0\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"repositoryName\\":\\"sourcecred/example-git\\",\\"type\\":\\"BLOB\\"}": Object {
+    "{\\"id\\":\\"aea4f28abb23abde151b0ead4063227f8bf6c0b0\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"type\\":\\"BLOB\\"}": Object {
       "payload": Object {},
     },
-    "{\\"id\\":\\"bbf3b8b3d26a4f884b5c022d46851f593d329192\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"repositoryName\\":\\"sourcecred/example-git\\",\\"type\\":\\"TREE\\"}": Object {
+    "{\\"id\\":\\"bbf3b8b3d26a4f884b5c022d46851f593d329192\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"type\\":\\"TREE\\"}": Object {
       "payload": Object {},
     },
-    "{\\"id\\":\\"bbf3b8b3d26a4f884b5c022d46851f593d329192:.gitmodules\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"repositoryName\\":\\"sourcecred/example-git\\",\\"type\\":\\"TREE_ENTRY\\"}": Object {
+    "{\\"id\\":\\"bbf3b8b3d26a4f884b5c022d46851f593d329192:.gitmodules\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"type\\":\\"TREE_ENTRY\\"}": Object {
       "payload": Object {
         "name": ".gitmodules",
       },
     },
-    "{\\"id\\":\\"bbf3b8b3d26a4f884b5c022d46851f593d329192:README.txt\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"repositoryName\\":\\"sourcecred/example-git\\",\\"type\\":\\"TREE_ENTRY\\"}": Object {
+    "{\\"id\\":\\"bbf3b8b3d26a4f884b5c022d46851f593d329192:README.txt\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"type\\":\\"TREE_ENTRY\\"}": Object {
       "payload": Object {
         "name": "README.txt",
       },
     },
-    "{\\"id\\":\\"bbf3b8b3d26a4f884b5c022d46851f593d329192:TODOS.txt\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"repositoryName\\":\\"sourcecred/example-git\\",\\"type\\":\\"TREE_ENTRY\\"}": Object {
+    "{\\"id\\":\\"bbf3b8b3d26a4f884b5c022d46851f593d329192:TODOS.txt\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"type\\":\\"TREE_ENTRY\\"}": Object {
       "payload": Object {
         "name": "TODOS.txt",
       },
     },
-    "{\\"id\\":\\"bbf3b8b3d26a4f884b5c022d46851f593d329192:pygravitydefier\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"repositoryName\\":\\"sourcecred/example-git\\",\\"type\\":\\"TREE_ENTRY\\"}": Object {
+    "{\\"id\\":\\"bbf3b8b3d26a4f884b5c022d46851f593d329192:pygravitydefier\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"type\\":\\"TREE_ENTRY\\"}": Object {
       "payload": Object {
         "name": "pygravitydefier",
       },
     },
-    "{\\"id\\":\\"bbf3b8b3d26a4f884b5c022d46851f593d329192:science.txt\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"repositoryName\\":\\"sourcecred/example-git\\",\\"type\\":\\"TREE_ENTRY\\"}": Object {
+    "{\\"id\\":\\"bbf3b8b3d26a4f884b5c022d46851f593d329192:science.txt\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"type\\":\\"TREE_ENTRY\\"}": Object {
       "payload": Object {
         "name": "science.txt",
       },
     },
-    "{\\"id\\":\\"bbf3b8b3d26a4f884b5c022d46851f593d329192:src\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"repositoryName\\":\\"sourcecred/example-git\\",\\"type\\":\\"TREE_ENTRY\\"}": Object {
+    "{\\"id\\":\\"bbf3b8b3d26a4f884b5c022d46851f593d329192:src\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"type\\":\\"TREE_ENTRY\\"}": Object {
       "payload": Object {
         "name": "src",
       },
     },
-    "{\\"id\\":\\"bdff5d94193170015d6cbb549b7b630649428b1f\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"repositoryName\\":\\"sourcecred/example-git\\",\\"type\\":\\"TREE\\"}": Object {
+    "{\\"id\\":\\"bdff5d94193170015d6cbb549b7b630649428b1f\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"type\\":\\"TREE\\"}": Object {
       "payload": Object {},
     },
-    "{\\"id\\":\\"bdff5d94193170015d6cbb549b7b630649428b1f:README.txt\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"repositoryName\\":\\"sourcecred/example-git\\",\\"type\\":\\"TREE_ENTRY\\"}": Object {
+    "{\\"id\\":\\"bdff5d94193170015d6cbb549b7b630649428b1f:README.txt\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"type\\":\\"TREE_ENTRY\\"}": Object {
       "payload": Object {
         "name": "README.txt",
       },
     },
-    "{\\"id\\":\\"c08ee3a4edea384d5291ffcbf06724a13ed72325\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"repositoryName\\":\\"sourcecred/example-git\\",\\"type\\":\\"COMMIT\\"}": Object {
+    "{\\"id\\":\\"c08ee3a4edea384d5291ffcbf06724a13ed72325\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"type\\":\\"COMMIT\\"}": Object {
       "payload": Object {},
     },
-    "{\\"id\\":\\"c2b51945e7457546912a8ce158ed9d294558d294\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"repositoryName\\":\\"sourcecred/example-git\\",\\"type\\":\\"COMMIT\\"}": Object {
+    "{\\"id\\":\\"c2b51945e7457546912a8ce158ed9d294558d294\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"type\\":\\"COMMIT\\"}": Object {
       "payload": Object {},
     },
-    "{\\"id\\":\\"d160cca97611e9dfed642522ad44408d0292e8ea\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"repositoryName\\":\\"sourcecred/example-git\\",\\"type\\":\\"COMMIT\\"}": Object {
+    "{\\"id\\":\\"d160cca97611e9dfed642522ad44408d0292e8ea\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"type\\":\\"COMMIT\\"}": Object {
       "payload": Object {},
     },
-    "{\\"id\\":\\"ddec7477206c30c31b81482e56b877a0b3c2638b\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"repositoryName\\":\\"sourcecred/example-git\\",\\"type\\":\\"BLOB\\"}": Object {
+    "{\\"id\\":\\"ddec7477206c30c31b81482e56b877a0b3c2638b\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"type\\":\\"BLOB\\"}": Object {
       "payload": Object {},
     },
-    "{\\"id\\":\\"e8b7a8f19701cd5a25e4a097d513ead60e5f8bcc\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"repositoryName\\":\\"sourcecred/example-git\\",\\"type\\":\\"COMMIT\\"}": Object {
+    "{\\"id\\":\\"e8b7a8f19701cd5a25e4a097d513ead60e5f8bcc\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"type\\":\\"COMMIT\\"}": Object {
       "payload": Object {},
     },
-    "{\\"id\\":\\"f1f2514ca6d7a6a1a0511957021b1995bf9ace1c\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"repositoryName\\":\\"sourcecred/example-git\\",\\"type\\":\\"BLOB\\"}": Object {
+    "{\\"id\\":\\"f1f2514ca6d7a6a1a0511957021b1995bf9ace1c\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"type\\":\\"BLOB\\"}": Object {
       "payload": Object {},
     },
-    "{\\"id\\":\\"https://github.com/sourcecred/example-git-submodule.git@29ef158bc982733e2ba429fcf73e2f7562244188\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"repositoryName\\":\\"sourcecred/example-git\\",\\"type\\":\\"SUBMODULE_COMMIT\\"}": Object {
+    "{\\"id\\":\\"https://github.com/sourcecred/example-git-submodule.git@29ef158bc982733e2ba429fcf73e2f7562244188\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"type\\":\\"SUBMODULE_COMMIT\\"}": Object {
       "payload": Object {
         "hash": "29ef158bc982733e2ba429fcf73e2f7562244188",
         "url": "https://github.com/sourcecred/example-git-submodule.git",
       },
     },
-    "{\\"id\\":\\"https://github.com/sourcecred/example-git-submodule.git@762c062fbdc7ec198cd693e95d55b374a08ff3e3\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"repositoryName\\":\\"sourcecred/example-git\\",\\"type\\":\\"SUBMODULE_COMMIT\\"}": Object {
+    "{\\"id\\":\\"https://github.com/sourcecred/example-git-submodule.git@762c062fbdc7ec198cd693e95d55b374a08ff3e3\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"type\\":\\"SUBMODULE_COMMIT\\"}": Object {
       "payload": Object {
         "hash": "762c062fbdc7ec198cd693e95d55b374a08ff3e3",
         "url": "https://github.com/sourcecred/example-git-submodule.git",

--- a/src/plugins/git/createGraph.js
+++ b/src/plugins/git/createGraph.js
@@ -37,16 +37,9 @@ import {
 } from "./types";
 
 class GitGraphCreator {
-  repositoryName: string;
-
-  constructor(repositoryName) {
-    this.repositoryName = repositoryName;
-  }
-
   makeAddress(type: NodeType | EdgeType, id: string): Address {
     return {
       pluginName: GIT_PLUGIN_NAME,
-      repositoryName: this.repositoryName,
       type,
       id,
     };
@@ -215,8 +208,7 @@ class GitGraphCreator {
 }
 
 export function createGraph(
-  repository: Repository,
-  repositoryName: string
+  repository: Repository
 ): Graph<NodePayload, EdgePayload> {
-  return new GitGraphCreator(repositoryName).createGraph(repository);
+  return new GitGraphCreator().createGraph(repository);
 }

--- a/src/plugins/git/createGraph.test.js
+++ b/src/plugins/git/createGraph.test.js
@@ -21,11 +21,11 @@ const makeData = () => cloneDeep(require("./demoData/example-git"));
 
 describe("createGraph", () => {
   it("processes a simple repository", () => {
-    expect(createGraph(makeData(), "sourcecred/example-git")).toMatchSnapshot();
+    expect(createGraph(makeData())).toMatchSnapshot();
   });
 
   it("has no dangling edges", () => {
-    const graph = createGraph(makeData(), "sourcecred/example-git");
+    const graph = createGraph(makeData());
     graph.edges().forEach((edge) => {
       expect(graph.node(edge.src)).toEqual(expect.anything());
       expect(graph.node(edge.dst)).toEqual(expect.anything());
@@ -34,11 +34,10 @@ describe("createGraph", () => {
 
   it("has all commits, each with correct edges", () => {
     const data = makeData();
-    const graph = createGraph(data, "sourcecred/example-git");
+    const graph = createGraph(data);
     Object.keys(data.commits).forEach((hash) => {
       const address = {
         pluginName: GIT_PLUGIN_NAME,
-        repositoryName: "sourcecred/example-git",
         type: COMMIT_NODE_TYPE,
         id: hash,
       };
@@ -64,11 +63,10 @@ describe("createGraph", () => {
 
   it("has all trees, each with correct edges", () => {
     const data = makeData();
-    const graph = createGraph(data, "sourcecred/example-git");
+    const graph = createGraph(data);
     Object.keys(data.trees).forEach((hash) => {
       const address = {
         pluginName: GIT_PLUGIN_NAME,
-        repositoryName: "sourcecred/example-git",
         type: TREE_NODE_TYPE,
         id: hash,
       };
@@ -105,12 +103,11 @@ describe("createGraph", () => {
 
   it("has all tree entries, each with correct edges", () => {
     const data = makeData();
-    const graph = createGraph(data, "sourcecred/example-git");
+    const graph = createGraph(data);
     Object.keys(data.trees).forEach((hash) => {
       const tree = data.trees[hash];
       const treeAddress = {
         pluginName: GIT_PLUGIN_NAME,
-        repositoryName: "sourcecred/example-git",
         type: TREE_NODE_TYPE,
         id: hash,
       };
@@ -121,7 +118,6 @@ describe("createGraph", () => {
       Object.keys(tree.entries).forEach((name) => {
         const entryAddress = {
           pluginName: GIT_PLUGIN_NAME,
-          repositoryName: "sourcecred/example-git",
           type: TREE_ENTRY_NODE_TYPE,
           id: treeEntryId(hash, name),
         };
@@ -192,11 +188,10 @@ describe("createGraph", () => {
 
     test("HEAD^{tree}:src/quantum_gravity.py with correct contents", () => {
       const data = makeData();
-      const graph = createGraph(data, "sourcecred/example-git");
+      const graph = createGraph(data);
 
       const headCommitAddress = {
         pluginName: GIT_PLUGIN_NAME,
-        repositoryName: "sourcecred/example-git",
         type: COMMIT_NODE_TYPE,
         id: headCommitHash,
       };
@@ -221,11 +216,10 @@ describe("createGraph", () => {
 
     test("HEAD^{tree}:pygravitydefier with no contents", () => {
       const data = makeData();
-      const graph = createGraph(data, "sourcecred/example-git");
+      const graph = createGraph(data);
 
       const headCommitAddress = {
         pluginName: GIT_PLUGIN_NAME,
-        repositoryName: "sourcecred/example-git",
         type: COMMIT_NODE_TYPE,
         id: headCommitHash,
       };

--- a/src/plugins/github/__snapshots__/api.test.js.snap
+++ b/src/plugins/github/__snapshots__/api.test.js.snap
@@ -7,7 +7,6 @@ Object {
   "address": Object {
     "id": "https://github.com/decentralion",
     "pluginName": "sourcecred/github-beta",
-    "repositoryName": "sourcecred/example-repo",
     "type": "AUTHOR",
   },
   "payload": Object {
@@ -25,7 +24,6 @@ Object {
   "address": Object {
     "id": "https://github.com/sourcecred/example-repo/issues/6#issuecomment-373768442",
     "pluginName": "sourcecred/github-beta",
-    "repositoryName": "sourcecred/example-repo",
     "type": "COMMENT",
   },
   "payload": Object {
@@ -40,7 +38,6 @@ Object {
   "address": Object {
     "id": "https://github.com/sourcecred/example-repo/issues/1",
     "pluginName": "sourcecred/github-beta",
-    "repositoryName": "sourcecred/example-repo",
     "type": "ISSUE",
   },
   "payload": Object {
@@ -57,7 +54,6 @@ Object {
   "address": Object {
     "id": "https://github.com/sourcecred/example-repo/pull/3",
     "pluginName": "sourcecred/github-beta",
-    "repositoryName": "sourcecred/example-repo",
     "type": "PULL_REQUEST",
   },
   "payload": Object {

--- a/src/plugins/github/__snapshots__/parser.test.js.snap
+++ b/src/plugins/github/__snapshots__/parser.test.js.snap
@@ -3,31 +3,29 @@
 exports[`GithubParser issue parsing parses a simple issue (https://github.com/sourcecred/example-repo/issues/1) 1`] = `
 Object {
   "edges": Object {
-    "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/decentralion\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"repositoryName\\\\\\":\\\\\\"sourcecred/example-repo\\\\\\",\\\\\\"type\\\\\\":\\\\\\"AUTHOR\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-repo/issues/1\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"repositoryName\\\\\\":\\\\\\"sourcecred/example-repo\\\\\\",\\\\\\"type\\\\\\":\\\\\\"ISSUE\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"repositoryName\\":\\"sourcecred/example-repo\\",\\"type\\":\\"AUTHORS\\"}": Object {
+    "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/decentralion\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"AUTHOR\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-repo/issues/1\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"ISSUE\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"AUTHORS\\"}": Object {
       "dst": Object {
         "id": "https://github.com/decentralion",
         "pluginName": "sourcecred/github-beta",
-        "repositoryName": "sourcecred/example-repo",
         "type": "AUTHOR",
       },
       "payload": Object {},
       "src": Object {
         "id": "https://github.com/sourcecred/example-repo/issues/1",
         "pluginName": "sourcecred/github-beta",
-        "repositoryName": "sourcecred/example-repo",
         "type": "ISSUE",
       },
     },
   },
   "nodes": Object {
-    "{\\"id\\":\\"https://github.com/decentralion\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"repositoryName\\":\\"sourcecred/example-repo\\",\\"type\\":\\"AUTHOR\\"}": Object {
+    "{\\"id\\":\\"https://github.com/decentralion\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"AUTHOR\\"}": Object {
       "payload": Object {
         "login": "decentralion",
         "subtype": "USER",
         "url": "https://github.com/decentralion",
       },
     },
-    "{\\"id\\":\\"https://github.com/sourcecred/example-repo/issues/1\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"repositoryName\\":\\"sourcecred/example-repo\\",\\"type\\":\\"ISSUE\\"}": Object {
+    "{\\"id\\":\\"https://github.com/sourcecred/example-repo/issues/1\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"ISSUE\\"}": Object {
       "payload": Object {
         "body": "This is just an example issue.",
         "number": 1,
@@ -42,121 +40,107 @@ Object {
 exports[`GithubParser issue parsing parses an issue with comments (https://github.com/sourcecred/example-repo/issues/6) 1`] = `
 Object {
   "edges": Object {
-    "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/decentralion\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"repositoryName\\\\\\":\\\\\\"sourcecred/example-repo\\\\\\",\\\\\\"type\\\\\\":\\\\\\"AUTHOR\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-repo/issues/6#issuecomment-373768442\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"repositoryName\\\\\\":\\\\\\"sourcecred/example-repo\\\\\\",\\\\\\"type\\\\\\":\\\\\\"COMMENT\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"repositoryName\\":\\"sourcecred/example-repo\\",\\"type\\":\\"AUTHORS\\"}": Object {
+    "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/decentralion\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"AUTHOR\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-repo/issues/6#issuecomment-373768442\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"COMMENT\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"AUTHORS\\"}": Object {
       "dst": Object {
         "id": "https://github.com/decentralion",
         "pluginName": "sourcecred/github-beta",
-        "repositoryName": "sourcecred/example-repo",
         "type": "AUTHOR",
       },
       "payload": Object {},
       "src": Object {
         "id": "https://github.com/sourcecred/example-repo/issues/6#issuecomment-373768442",
         "pluginName": "sourcecred/github-beta",
-        "repositoryName": "sourcecred/example-repo",
         "type": "COMMENT",
       },
     },
-    "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/decentralion\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"repositoryName\\\\\\":\\\\\\"sourcecred/example-repo\\\\\\",\\\\\\"type\\\\\\":\\\\\\"AUTHOR\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-repo/issues/6#issuecomment-373768538\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"repositoryName\\\\\\":\\\\\\"sourcecred/example-repo\\\\\\",\\\\\\"type\\\\\\":\\\\\\"COMMENT\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"repositoryName\\":\\"sourcecred/example-repo\\",\\"type\\":\\"AUTHORS\\"}": Object {
+    "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/decentralion\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"AUTHOR\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-repo/issues/6#issuecomment-373768538\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"COMMENT\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"AUTHORS\\"}": Object {
       "dst": Object {
         "id": "https://github.com/decentralion",
         "pluginName": "sourcecred/github-beta",
-        "repositoryName": "sourcecred/example-repo",
         "type": "AUTHOR",
       },
       "payload": Object {},
       "src": Object {
         "id": "https://github.com/sourcecred/example-repo/issues/6#issuecomment-373768538",
         "pluginName": "sourcecred/github-beta",
-        "repositoryName": "sourcecred/example-repo",
         "type": "COMMENT",
       },
     },
-    "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/decentralion\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"repositoryName\\\\\\":\\\\\\"sourcecred/example-repo\\\\\\",\\\\\\"type\\\\\\":\\\\\\"AUTHOR\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-repo/issues/6#issuecomment-385223316\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"repositoryName\\\\\\":\\\\\\"sourcecred/example-repo\\\\\\",\\\\\\"type\\\\\\":\\\\\\"COMMENT\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"repositoryName\\":\\"sourcecred/example-repo\\",\\"type\\":\\"AUTHORS\\"}": Object {
+    "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/decentralion\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"AUTHOR\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-repo/issues/6#issuecomment-385223316\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"COMMENT\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"AUTHORS\\"}": Object {
       "dst": Object {
         "id": "https://github.com/decentralion",
         "pluginName": "sourcecred/github-beta",
-        "repositoryName": "sourcecred/example-repo",
         "type": "AUTHOR",
       },
       "payload": Object {},
       "src": Object {
         "id": "https://github.com/sourcecred/example-repo/issues/6#issuecomment-385223316",
         "pluginName": "sourcecred/github-beta",
-        "repositoryName": "sourcecred/example-repo",
         "type": "COMMENT",
       },
     },
-    "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/decentralion\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"repositoryName\\\\\\":\\\\\\"sourcecred/example-repo\\\\\\",\\\\\\"type\\\\\\":\\\\\\"AUTHOR\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-repo/issues/6\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"repositoryName\\\\\\":\\\\\\"sourcecred/example-repo\\\\\\",\\\\\\"type\\\\\\":\\\\\\"ISSUE\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"repositoryName\\":\\"sourcecred/example-repo\\",\\"type\\":\\"AUTHORS\\"}": Object {
+    "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/decentralion\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"AUTHOR\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-repo/issues/6\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"ISSUE\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"AUTHORS\\"}": Object {
       "dst": Object {
         "id": "https://github.com/decentralion",
         "pluginName": "sourcecred/github-beta",
-        "repositoryName": "sourcecred/example-repo",
         "type": "AUTHOR",
       },
       "payload": Object {},
       "src": Object {
         "id": "https://github.com/sourcecred/example-repo/issues/6",
         "pluginName": "sourcecred/github-beta",
-        "repositoryName": "sourcecred/example-repo",
         "type": "ISSUE",
       },
     },
-    "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-repo/issues/6\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"repositoryName\\\\\\":\\\\\\"sourcecred/example-repo\\\\\\",\\\\\\"type\\\\\\":\\\\\\"ISSUE\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-repo/issues/6#issuecomment-373768442\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"repositoryName\\\\\\":\\\\\\"sourcecred/example-repo\\\\\\",\\\\\\"type\\\\\\":\\\\\\"COMMENT\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"repositoryName\\":\\"sourcecred/example-repo\\",\\"type\\":\\"CONTAINS\\"}": Object {
+    "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-repo/issues/6\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"ISSUE\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-repo/issues/6#issuecomment-373768442\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"COMMENT\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"CONTAINS\\"}": Object {
       "dst": Object {
         "id": "https://github.com/sourcecred/example-repo/issues/6#issuecomment-373768442",
         "pluginName": "sourcecred/github-beta",
-        "repositoryName": "sourcecred/example-repo",
         "type": "COMMENT",
       },
       "payload": Object {},
       "src": Object {
         "id": "https://github.com/sourcecred/example-repo/issues/6",
         "pluginName": "sourcecred/github-beta",
-        "repositoryName": "sourcecred/example-repo",
         "type": "ISSUE",
       },
     },
-    "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-repo/issues/6\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"repositoryName\\\\\\":\\\\\\"sourcecred/example-repo\\\\\\",\\\\\\"type\\\\\\":\\\\\\"ISSUE\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-repo/issues/6#issuecomment-373768538\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"repositoryName\\\\\\":\\\\\\"sourcecred/example-repo\\\\\\",\\\\\\"type\\\\\\":\\\\\\"COMMENT\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"repositoryName\\":\\"sourcecred/example-repo\\",\\"type\\":\\"CONTAINS\\"}": Object {
+    "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-repo/issues/6\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"ISSUE\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-repo/issues/6#issuecomment-373768538\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"COMMENT\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"CONTAINS\\"}": Object {
       "dst": Object {
         "id": "https://github.com/sourcecred/example-repo/issues/6#issuecomment-373768538",
         "pluginName": "sourcecred/github-beta",
-        "repositoryName": "sourcecred/example-repo",
         "type": "COMMENT",
       },
       "payload": Object {},
       "src": Object {
         "id": "https://github.com/sourcecred/example-repo/issues/6",
         "pluginName": "sourcecred/github-beta",
-        "repositoryName": "sourcecred/example-repo",
         "type": "ISSUE",
       },
     },
-    "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-repo/issues/6\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"repositoryName\\\\\\":\\\\\\"sourcecred/example-repo\\\\\\",\\\\\\"type\\\\\\":\\\\\\"ISSUE\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-repo/issues/6#issuecomment-385223316\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"repositoryName\\\\\\":\\\\\\"sourcecred/example-repo\\\\\\",\\\\\\"type\\\\\\":\\\\\\"COMMENT\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"repositoryName\\":\\"sourcecred/example-repo\\",\\"type\\":\\"CONTAINS\\"}": Object {
+    "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-repo/issues/6\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"ISSUE\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-repo/issues/6#issuecomment-385223316\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"COMMENT\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"CONTAINS\\"}": Object {
       "dst": Object {
         "id": "https://github.com/sourcecred/example-repo/issues/6#issuecomment-385223316",
         "pluginName": "sourcecred/github-beta",
-        "repositoryName": "sourcecred/example-repo",
         "type": "COMMENT",
       },
       "payload": Object {},
       "src": Object {
         "id": "https://github.com/sourcecred/example-repo/issues/6",
         "pluginName": "sourcecred/github-beta",
-        "repositoryName": "sourcecred/example-repo",
         "type": "ISSUE",
       },
     },
   },
   "nodes": Object {
-    "{\\"id\\":\\"https://github.com/decentralion\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"repositoryName\\":\\"sourcecred/example-repo\\",\\"type\\":\\"AUTHOR\\"}": Object {
+    "{\\"id\\":\\"https://github.com/decentralion\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"AUTHOR\\"}": Object {
       "payload": Object {
         "login": "decentralion",
         "subtype": "USER",
         "url": "https://github.com/decentralion",
       },
     },
-    "{\\"id\\":\\"https://github.com/sourcecred/example-repo/issues/6\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"repositoryName\\":\\"sourcecred/example-repo\\",\\"type\\":\\"ISSUE\\"}": Object {
+    "{\\"id\\":\\"https://github.com/sourcecred/example-repo/issues/6\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"ISSUE\\"}": Object {
       "payload": Object {
         "body": "This issue shall shortly have a few comments.",
         "number": 6,
@@ -164,19 +148,19 @@ Object {
         "url": "https://github.com/sourcecred/example-repo/issues/6",
       },
     },
-    "{\\"id\\":\\"https://github.com/sourcecred/example-repo/issues/6#issuecomment-373768442\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"repositoryName\\":\\"sourcecred/example-repo\\",\\"type\\":\\"COMMENT\\"}": Object {
+    "{\\"id\\":\\"https://github.com/sourcecred/example-repo/issues/6#issuecomment-373768442\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"COMMENT\\"}": Object {
       "payload": Object {
         "body": "A wild COMMENT appeared!",
         "url": "https://github.com/sourcecred/example-repo/issues/6#issuecomment-373768442",
       },
     },
-    "{\\"id\\":\\"https://github.com/sourcecred/example-repo/issues/6#issuecomment-373768538\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"repositoryName\\":\\"sourcecred/example-repo\\",\\"type\\":\\"COMMENT\\"}": Object {
+    "{\\"id\\":\\"https://github.com/sourcecred/example-repo/issues/6#issuecomment-373768538\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"COMMENT\\"}": Object {
       "payload": Object {
         "body": "And the maintainer said, \\"Let there be comments!\\"",
         "url": "https://github.com/sourcecred/example-repo/issues/6#issuecomment-373768538",
       },
     },
-    "{\\"id\\":\\"https://github.com/sourcecred/example-repo/issues/6#issuecomment-385223316\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"repositoryName\\":\\"sourcecred/example-repo\\",\\"type\\":\\"COMMENT\\"}": Object {
+    "{\\"id\\":\\"https://github.com/sourcecred/example-repo/issues/6#issuecomment-385223316\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"COMMENT\\"}": Object {
       "payload": Object {
         "body": "This comment references an #2, which itself references an issue. This comment is thus allows us to test that in-references are not included when requesting a Post's references.",
         "url": "https://github.com/sourcecred/example-repo/issues/6#issuecomment-385223316",
@@ -189,136 +173,120 @@ Object {
 exports[`GithubParser pull request parsing parses a pr with review comments (https://github.com/sourcecred/example-repo/pull/3) 1`] = `
 Object {
   "edges": Object {
-    "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/decentralion\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"repositoryName\\\\\\":\\\\\\"sourcecred/example-repo\\\\\\",\\\\\\"type\\\\\\":\\\\\\"AUTHOR\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-repo/pull/5\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"repositoryName\\\\\\":\\\\\\"sourcecred/example-repo\\\\\\",\\\\\\"type\\\\\\":\\\\\\"PULL_REQUEST\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"repositoryName\\":\\"sourcecred/example-repo\\",\\"type\\":\\"AUTHORS\\"}": Object {
+    "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/decentralion\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"AUTHOR\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-repo/pull/5\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"PULL_REQUEST\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"AUTHORS\\"}": Object {
       "dst": Object {
         "id": "https://github.com/decentralion",
         "pluginName": "sourcecred/github-beta",
-        "repositoryName": "sourcecred/example-repo",
         "type": "AUTHOR",
       },
       "payload": Object {},
       "src": Object {
         "id": "https://github.com/sourcecred/example-repo/pull/5",
         "pluginName": "sourcecred/github-beta",
-        "repositoryName": "sourcecred/example-repo",
         "type": "PULL_REQUEST",
       },
     },
-    "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-repo/pull/5#pullrequestreview-100313899\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"repositoryName\\\\\\":\\\\\\"sourcecred/example-repo\\\\\\",\\\\\\"type\\\\\\":\\\\\\"PULL_REQUEST_REVIEW\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-repo/pull/5#discussion_r171460198\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"repositoryName\\\\\\":\\\\\\"sourcecred/example-repo\\\\\\",\\\\\\"type\\\\\\":\\\\\\"PULL_REQUEST_REVIEW_COMMENT\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"repositoryName\\":\\"sourcecred/example-repo\\",\\"type\\":\\"CONTAINS\\"}": Object {
+    "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-repo/pull/5#pullrequestreview-100313899\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"PULL_REQUEST_REVIEW\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-repo/pull/5#discussion_r171460198\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"PULL_REQUEST_REVIEW_COMMENT\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"CONTAINS\\"}": Object {
       "dst": Object {
         "id": "https://github.com/sourcecred/example-repo/pull/5#discussion_r171460198",
         "pluginName": "sourcecred/github-beta",
-        "repositoryName": "sourcecred/example-repo",
         "type": "PULL_REQUEST_REVIEW_COMMENT",
       },
       "payload": Object {},
       "src": Object {
         "id": "https://github.com/sourcecred/example-repo/pull/5#pullrequestreview-100313899",
         "pluginName": "sourcecred/github-beta",
-        "repositoryName": "sourcecred/example-repo",
         "type": "PULL_REQUEST_REVIEW",
       },
     },
-    "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-repo/pull/5\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"repositoryName\\\\\\":\\\\\\"sourcecred/example-repo\\\\\\",\\\\\\"type\\\\\\":\\\\\\"PULL_REQUEST\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-repo/pull/5#pullrequestreview-100313899\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"repositoryName\\\\\\":\\\\\\"sourcecred/example-repo\\\\\\",\\\\\\"type\\\\\\":\\\\\\"PULL_REQUEST_REVIEW\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"repositoryName\\":\\"sourcecred/example-repo\\",\\"type\\":\\"CONTAINS\\"}": Object {
+    "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-repo/pull/5\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"PULL_REQUEST\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-repo/pull/5#pullrequestreview-100313899\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"PULL_REQUEST_REVIEW\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"CONTAINS\\"}": Object {
       "dst": Object {
         "id": "https://github.com/sourcecred/example-repo/pull/5#pullrequestreview-100313899",
         "pluginName": "sourcecred/github-beta",
-        "repositoryName": "sourcecred/example-repo",
         "type": "PULL_REQUEST_REVIEW",
       },
       "payload": Object {},
       "src": Object {
         "id": "https://github.com/sourcecred/example-repo/pull/5",
         "pluginName": "sourcecred/github-beta",
-        "repositoryName": "sourcecred/example-repo",
         "type": "PULL_REQUEST",
       },
     },
-    "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-repo/pull/5\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"repositoryName\\\\\\":\\\\\\"sourcecred/example-repo\\\\\\",\\\\\\"type\\\\\\":\\\\\\"PULL_REQUEST\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-repo/pull/5#pullrequestreview-100314038\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"repositoryName\\\\\\":\\\\\\"sourcecred/example-repo\\\\\\",\\\\\\"type\\\\\\":\\\\\\"PULL_REQUEST_REVIEW\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"repositoryName\\":\\"sourcecred/example-repo\\",\\"type\\":\\"CONTAINS\\"}": Object {
+    "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-repo/pull/5\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"PULL_REQUEST\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-repo/pull/5#pullrequestreview-100314038\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"PULL_REQUEST_REVIEW\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"CONTAINS\\"}": Object {
       "dst": Object {
         "id": "https://github.com/sourcecred/example-repo/pull/5#pullrequestreview-100314038",
         "pluginName": "sourcecred/github-beta",
-        "repositoryName": "sourcecred/example-repo",
         "type": "PULL_REQUEST_REVIEW",
       },
       "payload": Object {},
       "src": Object {
         "id": "https://github.com/sourcecred/example-repo/pull/5",
         "pluginName": "sourcecred/github-beta",
-        "repositoryName": "sourcecred/example-repo",
         "type": "PULL_REQUEST",
       },
     },
-    "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-repo/pull/5\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"repositoryName\\\\\\":\\\\\\"sourcecred/example-repo\\\\\\",\\\\\\"type\\\\\\":\\\\\\"PULL_REQUEST\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/wchargin\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"repositoryName\\\\\\":\\\\\\"sourcecred/example-repo\\\\\\",\\\\\\"type\\\\\\":\\\\\\"AUTHOR\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"repositoryName\\":\\"sourcecred/example-repo\\",\\"type\\":\\"REFERENCES\\"}": Object {
+    "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-repo/pull/5\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"PULL_REQUEST\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/wchargin\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"AUTHOR\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"REFERENCES\\"}": Object {
       "dst": Object {
         "id": "https://github.com/wchargin",
         "pluginName": "sourcecred/github-beta",
-        "repositoryName": "sourcecred/example-repo",
         "type": "AUTHOR",
       },
       "payload": Object {},
       "src": Object {
         "id": "https://github.com/sourcecred/example-repo/pull/5",
         "pluginName": "sourcecred/github-beta",
-        "repositoryName": "sourcecred/example-repo",
         "type": "PULL_REQUEST",
       },
     },
-    "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/wchargin\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"repositoryName\\\\\\":\\\\\\"sourcecred/example-repo\\\\\\",\\\\\\"type\\\\\\":\\\\\\"AUTHOR\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-repo/pull/5#discussion_r171460198\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"repositoryName\\\\\\":\\\\\\"sourcecred/example-repo\\\\\\",\\\\\\"type\\\\\\":\\\\\\"PULL_REQUEST_REVIEW_COMMENT\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"repositoryName\\":\\"sourcecred/example-repo\\",\\"type\\":\\"AUTHORS\\"}": Object {
+    "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/wchargin\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"AUTHOR\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-repo/pull/5#discussion_r171460198\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"PULL_REQUEST_REVIEW_COMMENT\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"AUTHORS\\"}": Object {
       "dst": Object {
         "id": "https://github.com/wchargin",
         "pluginName": "sourcecred/github-beta",
-        "repositoryName": "sourcecred/example-repo",
         "type": "AUTHOR",
       },
       "payload": Object {},
       "src": Object {
         "id": "https://github.com/sourcecred/example-repo/pull/5#discussion_r171460198",
         "pluginName": "sourcecred/github-beta",
-        "repositoryName": "sourcecred/example-repo",
         "type": "PULL_REQUEST_REVIEW_COMMENT",
       },
     },
-    "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/wchargin\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"repositoryName\\\\\\":\\\\\\"sourcecred/example-repo\\\\\\",\\\\\\"type\\\\\\":\\\\\\"AUTHOR\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-repo/pull/5#pullrequestreview-100313899\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"repositoryName\\\\\\":\\\\\\"sourcecred/example-repo\\\\\\",\\\\\\"type\\\\\\":\\\\\\"PULL_REQUEST_REVIEW\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"repositoryName\\":\\"sourcecred/example-repo\\",\\"type\\":\\"AUTHORS\\"}": Object {
+    "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/wchargin\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"AUTHOR\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-repo/pull/5#pullrequestreview-100313899\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"PULL_REQUEST_REVIEW\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"AUTHORS\\"}": Object {
       "dst": Object {
         "id": "https://github.com/wchargin",
         "pluginName": "sourcecred/github-beta",
-        "repositoryName": "sourcecred/example-repo",
         "type": "AUTHOR",
       },
       "payload": Object {},
       "src": Object {
         "id": "https://github.com/sourcecred/example-repo/pull/5#pullrequestreview-100313899",
         "pluginName": "sourcecred/github-beta",
-        "repositoryName": "sourcecred/example-repo",
         "type": "PULL_REQUEST_REVIEW",
       },
     },
-    "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/wchargin\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"repositoryName\\\\\\":\\\\\\"sourcecred/example-repo\\\\\\",\\\\\\"type\\\\\\":\\\\\\"AUTHOR\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-repo/pull/5#pullrequestreview-100314038\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"repositoryName\\\\\\":\\\\\\"sourcecred/example-repo\\\\\\",\\\\\\"type\\\\\\":\\\\\\"PULL_REQUEST_REVIEW\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"repositoryName\\":\\"sourcecred/example-repo\\",\\"type\\":\\"AUTHORS\\"}": Object {
+    "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/wchargin\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"AUTHOR\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-repo/pull/5#pullrequestreview-100314038\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"PULL_REQUEST_REVIEW\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"AUTHORS\\"}": Object {
       "dst": Object {
         "id": "https://github.com/wchargin",
         "pluginName": "sourcecred/github-beta",
-        "repositoryName": "sourcecred/example-repo",
         "type": "AUTHOR",
       },
       "payload": Object {},
       "src": Object {
         "id": "https://github.com/sourcecred/example-repo/pull/5#pullrequestreview-100314038",
         "pluginName": "sourcecred/github-beta",
-        "repositoryName": "sourcecred/example-repo",
         "type": "PULL_REQUEST_REVIEW",
       },
     },
   },
   "nodes": Object {
-    "{\\"id\\":\\"https://github.com/decentralion\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"repositoryName\\":\\"sourcecred/example-repo\\",\\"type\\":\\"AUTHOR\\"}": Object {
+    "{\\"id\\":\\"https://github.com/decentralion\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"AUTHOR\\"}": Object {
       "payload": Object {
         "login": "decentralion",
         "subtype": "USER",
         "url": "https://github.com/decentralion",
       },
     },
-    "{\\"id\\":\\"https://github.com/sourcecred/example-repo/pull/5\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"repositoryName\\":\\"sourcecred/example-repo\\",\\"type\\":\\"PULL_REQUEST\\"}": Object {
+    "{\\"id\\":\\"https://github.com/sourcecred/example-repo/pull/5\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"PULL_REQUEST\\"}": Object {
       "payload": Object {
         "body": "@wchargin could you please do the following:
 - add a commit comment
@@ -330,27 +298,27 @@ Object {
         "url": "https://github.com/sourcecred/example-repo/pull/5",
       },
     },
-    "{\\"id\\":\\"https://github.com/sourcecred/example-repo/pull/5#discussion_r171460198\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"repositoryName\\":\\"sourcecred/example-repo\\",\\"type\\":\\"PULL_REQUEST_REVIEW_COMMENT\\"}": Object {
+    "{\\"id\\":\\"https://github.com/sourcecred/example-repo/pull/5#discussion_r171460198\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"PULL_REQUEST_REVIEW_COMMENT\\"}": Object {
       "payload": Object {
         "body": "seems a bit capricious",
         "url": "https://github.com/sourcecred/example-repo/pull/5#discussion_r171460198",
       },
     },
-    "{\\"id\\":\\"https://github.com/sourcecred/example-repo/pull/5#pullrequestreview-100313899\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"repositoryName\\":\\"sourcecred/example-repo\\",\\"type\\":\\"PULL_REQUEST_REVIEW\\"}": Object {
+    "{\\"id\\":\\"https://github.com/sourcecred/example-repo/pull/5#pullrequestreview-100313899\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"PULL_REQUEST_REVIEW\\"}": Object {
       "payload": Object {
         "body": "hmmm.jpg",
         "state": "CHANGES_REQUESTED",
         "url": "https://github.com/sourcecred/example-repo/pull/5#pullrequestreview-100313899",
       },
     },
-    "{\\"id\\":\\"https://github.com/sourcecred/example-repo/pull/5#pullrequestreview-100314038\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"repositoryName\\":\\"sourcecred/example-repo\\",\\"type\\":\\"PULL_REQUEST_REVIEW\\"}": Object {
+    "{\\"id\\":\\"https://github.com/sourcecred/example-repo/pull/5#pullrequestreview-100314038\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"PULL_REQUEST_REVIEW\\"}": Object {
       "payload": Object {
         "body": "I'm sold",
         "state": "APPROVED",
         "url": "https://github.com/sourcecred/example-repo/pull/5#pullrequestreview-100314038",
       },
     },
-    "{\\"id\\":\\"https://github.com/wchargin\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"repositoryName\\":\\"sourcecred/example-repo\\",\\"type\\":\\"AUTHOR\\"}": Object {
+    "{\\"id\\":\\"https://github.com/wchargin\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"AUTHOR\\"}": Object {
       "payload": Object {
         "login": "wchargin",
         "subtype": "USER",
@@ -364,61 +332,55 @@ Object {
 exports[`GithubParser pull request parsing parses a simple pull request (https://github.com/sourcecred/example-repo/pull/3) 1`] = `
 Object {
   "edges": Object {
-    "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/decentralion\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"repositoryName\\\\\\":\\\\\\"sourcecred/example-repo\\\\\\",\\\\\\"type\\\\\\":\\\\\\"AUTHOR\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-repo/pull/3#issuecomment-369162222\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"repositoryName\\\\\\":\\\\\\"sourcecred/example-repo\\\\\\",\\\\\\"type\\\\\\":\\\\\\"COMMENT\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"repositoryName\\":\\"sourcecred/example-repo\\",\\"type\\":\\"AUTHORS\\"}": Object {
+    "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/decentralion\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"AUTHOR\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-repo/pull/3#issuecomment-369162222\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"COMMENT\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"AUTHORS\\"}": Object {
       "dst": Object {
         "id": "https://github.com/decentralion",
         "pluginName": "sourcecred/github-beta",
-        "repositoryName": "sourcecred/example-repo",
         "type": "AUTHOR",
       },
       "payload": Object {},
       "src": Object {
         "id": "https://github.com/sourcecred/example-repo/pull/3#issuecomment-369162222",
         "pluginName": "sourcecred/github-beta",
-        "repositoryName": "sourcecred/example-repo",
         "type": "COMMENT",
       },
     },
-    "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/decentralion\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"repositoryName\\\\\\":\\\\\\"sourcecred/example-repo\\\\\\",\\\\\\"type\\\\\\":\\\\\\"AUTHOR\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-repo/pull/3\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"repositoryName\\\\\\":\\\\\\"sourcecred/example-repo\\\\\\",\\\\\\"type\\\\\\":\\\\\\"PULL_REQUEST\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"repositoryName\\":\\"sourcecred/example-repo\\",\\"type\\":\\"AUTHORS\\"}": Object {
+    "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/decentralion\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"AUTHOR\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-repo/pull/3\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"PULL_REQUEST\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"AUTHORS\\"}": Object {
       "dst": Object {
         "id": "https://github.com/decentralion",
         "pluginName": "sourcecred/github-beta",
-        "repositoryName": "sourcecred/example-repo",
         "type": "AUTHOR",
       },
       "payload": Object {},
       "src": Object {
         "id": "https://github.com/sourcecred/example-repo/pull/3",
         "pluginName": "sourcecred/github-beta",
-        "repositoryName": "sourcecred/example-repo",
         "type": "PULL_REQUEST",
       },
     },
-    "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-repo/pull/3\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"repositoryName\\\\\\":\\\\\\"sourcecred/example-repo\\\\\\",\\\\\\"type\\\\\\":\\\\\\"PULL_REQUEST\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-repo/pull/3#issuecomment-369162222\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"repositoryName\\\\\\":\\\\\\"sourcecred/example-repo\\\\\\",\\\\\\"type\\\\\\":\\\\\\"COMMENT\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"repositoryName\\":\\"sourcecred/example-repo\\",\\"type\\":\\"CONTAINS\\"}": Object {
+    "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-repo/pull/3\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"PULL_REQUEST\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-repo/pull/3#issuecomment-369162222\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"COMMENT\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"CONTAINS\\"}": Object {
       "dst": Object {
         "id": "https://github.com/sourcecred/example-repo/pull/3#issuecomment-369162222",
         "pluginName": "sourcecred/github-beta",
-        "repositoryName": "sourcecred/example-repo",
         "type": "COMMENT",
       },
       "payload": Object {},
       "src": Object {
         "id": "https://github.com/sourcecred/example-repo/pull/3",
         "pluginName": "sourcecred/github-beta",
-        "repositoryName": "sourcecred/example-repo",
         "type": "PULL_REQUEST",
       },
     },
   },
   "nodes": Object {
-    "{\\"id\\":\\"https://github.com/decentralion\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"repositoryName\\":\\"sourcecred/example-repo\\",\\"type\\":\\"AUTHOR\\"}": Object {
+    "{\\"id\\":\\"https://github.com/decentralion\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"AUTHOR\\"}": Object {
       "payload": Object {
         "login": "decentralion",
         "subtype": "USER",
         "url": "https://github.com/decentralion",
       },
     },
-    "{\\"id\\":\\"https://github.com/sourcecred/example-repo/pull/3\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"repositoryName\\":\\"sourcecred/example-repo\\",\\"type\\":\\"PULL_REQUEST\\"}": Object {
+    "{\\"id\\":\\"https://github.com/sourcecred/example-repo/pull/3\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"PULL_REQUEST\\"}": Object {
       "payload": Object {
         "body": "Oh look, it's a pull request.",
         "number": 3,
@@ -426,7 +388,7 @@ Object {
         "url": "https://github.com/sourcecred/example-repo/pull/3",
       },
     },
-    "{\\"id\\":\\"https://github.com/sourcecred/example-repo/pull/3#issuecomment-369162222\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"repositoryName\\":\\"sourcecred/example-repo\\",\\"type\\":\\"COMMENT\\"}": Object {
+    "{\\"id\\":\\"https://github.com/sourcecred/example-repo/pull/3#issuecomment-369162222\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"COMMENT\\"}": Object {
       "payload": Object {
         "body": "It seems apropos to reference something from a pull request comment... eg: #2 ",
         "url": "https://github.com/sourcecred/example-repo/pull/3#issuecomment-369162222",
@@ -439,481 +401,419 @@ Object {
 exports[`GithubParser reference detection discovers a simple reference 1`] = `
 Object {
   "edges": Object {
-    "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/decentralion\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"repositoryName\\\\\\":\\\\\\"sourcecred/example-repo\\\\\\",\\\\\\"type\\\\\\":\\\\\\"AUTHOR\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-repo/issues/1\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"repositoryName\\\\\\":\\\\\\"sourcecred/example-repo\\\\\\",\\\\\\"type\\\\\\":\\\\\\"ISSUE\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"repositoryName\\":\\"sourcecred/example-repo\\",\\"type\\":\\"AUTHORS\\"}": Object {
+    "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/decentralion\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"AUTHOR\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-repo/issues/1\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"ISSUE\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"AUTHORS\\"}": Object {
       "dst": Object {
         "id": "https://github.com/decentralion",
         "pluginName": "sourcecred/github-beta",
-        "repositoryName": "sourcecred/example-repo",
         "type": "AUTHOR",
       },
       "payload": Object {},
       "src": Object {
         "id": "https://github.com/sourcecred/example-repo/issues/1",
         "pluginName": "sourcecred/github-beta",
-        "repositoryName": "sourcecred/example-repo",
         "type": "ISSUE",
       },
     },
-    "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/decentralion\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"repositoryName\\\\\\":\\\\\\"sourcecred/example-repo\\\\\\",\\\\\\"type\\\\\\":\\\\\\"AUTHOR\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-repo/issues/2#issuecomment-373768703\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"repositoryName\\\\\\":\\\\\\"sourcecred/example-repo\\\\\\",\\\\\\"type\\\\\\":\\\\\\"COMMENT\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"repositoryName\\":\\"sourcecred/example-repo\\",\\"type\\":\\"AUTHORS\\"}": Object {
+    "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/decentralion\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"AUTHOR\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-repo/issues/2#issuecomment-373768703\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"COMMENT\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"AUTHORS\\"}": Object {
       "dst": Object {
         "id": "https://github.com/decentralion",
         "pluginName": "sourcecred/github-beta",
-        "repositoryName": "sourcecred/example-repo",
         "type": "AUTHOR",
       },
       "payload": Object {},
       "src": Object {
         "id": "https://github.com/sourcecred/example-repo/issues/2#issuecomment-373768703",
         "pluginName": "sourcecred/github-beta",
-        "repositoryName": "sourcecred/example-repo",
         "type": "COMMENT",
       },
     },
-    "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/decentralion\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"repositoryName\\\\\\":\\\\\\"sourcecred/example-repo\\\\\\",\\\\\\"type\\\\\\":\\\\\\"AUTHOR\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-repo/issues/2#issuecomment-373768850\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"repositoryName\\\\\\":\\\\\\"sourcecred/example-repo\\\\\\",\\\\\\"type\\\\\\":\\\\\\"COMMENT\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"repositoryName\\":\\"sourcecred/example-repo\\",\\"type\\":\\"AUTHORS\\"}": Object {
+    "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/decentralion\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"AUTHOR\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-repo/issues/2#issuecomment-373768850\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"COMMENT\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"AUTHORS\\"}": Object {
       "dst": Object {
         "id": "https://github.com/decentralion",
         "pluginName": "sourcecred/github-beta",
-        "repositoryName": "sourcecred/example-repo",
         "type": "AUTHOR",
       },
       "payload": Object {},
       "src": Object {
         "id": "https://github.com/sourcecred/example-repo/issues/2#issuecomment-373768850",
         "pluginName": "sourcecred/github-beta",
-        "repositoryName": "sourcecred/example-repo",
         "type": "COMMENT",
       },
     },
-    "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/decentralion\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"repositoryName\\\\\\":\\\\\\"sourcecred/example-repo\\\\\\",\\\\\\"type\\\\\\":\\\\\\"AUTHOR\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-repo/issues/2#issuecomment-385576185\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"repositoryName\\\\\\":\\\\\\"sourcecred/example-repo\\\\\\",\\\\\\"type\\\\\\":\\\\\\"COMMENT\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"repositoryName\\":\\"sourcecred/example-repo\\",\\"type\\":\\"AUTHORS\\"}": Object {
+    "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/decentralion\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"AUTHOR\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-repo/issues/2#issuecomment-385576185\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"COMMENT\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"AUTHORS\\"}": Object {
       "dst": Object {
         "id": "https://github.com/decentralion",
         "pluginName": "sourcecred/github-beta",
-        "repositoryName": "sourcecred/example-repo",
         "type": "AUTHOR",
       },
       "payload": Object {},
       "src": Object {
         "id": "https://github.com/sourcecred/example-repo/issues/2#issuecomment-385576185",
         "pluginName": "sourcecred/github-beta",
-        "repositoryName": "sourcecred/example-repo",
         "type": "COMMENT",
       },
     },
-    "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/decentralion\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"repositoryName\\\\\\":\\\\\\"sourcecred/example-repo\\\\\\",\\\\\\"type\\\\\\":\\\\\\"AUTHOR\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-repo/issues/2#issuecomment-385576220\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"repositoryName\\\\\\":\\\\\\"sourcecred/example-repo\\\\\\",\\\\\\"type\\\\\\":\\\\\\"COMMENT\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"repositoryName\\":\\"sourcecred/example-repo\\",\\"type\\":\\"AUTHORS\\"}": Object {
+    "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/decentralion\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"AUTHOR\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-repo/issues/2#issuecomment-385576220\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"COMMENT\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"AUTHORS\\"}": Object {
       "dst": Object {
         "id": "https://github.com/decentralion",
         "pluginName": "sourcecred/github-beta",
-        "repositoryName": "sourcecred/example-repo",
         "type": "AUTHOR",
       },
       "payload": Object {},
       "src": Object {
         "id": "https://github.com/sourcecred/example-repo/issues/2#issuecomment-385576220",
         "pluginName": "sourcecred/github-beta",
-        "repositoryName": "sourcecred/example-repo",
         "type": "COMMENT",
       },
     },
-    "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/decentralion\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"repositoryName\\\\\\":\\\\\\"sourcecred/example-repo\\\\\\",\\\\\\"type\\\\\\":\\\\\\"AUTHOR\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-repo/issues/2#issuecomment-385576248\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"repositoryName\\\\\\":\\\\\\"sourcecred/example-repo\\\\\\",\\\\\\"type\\\\\\":\\\\\\"COMMENT\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"repositoryName\\":\\"sourcecred/example-repo\\",\\"type\\":\\"AUTHORS\\"}": Object {
+    "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/decentralion\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"AUTHOR\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-repo/issues/2#issuecomment-385576248\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"COMMENT\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"AUTHORS\\"}": Object {
       "dst": Object {
         "id": "https://github.com/decentralion",
         "pluginName": "sourcecred/github-beta",
-        "repositoryName": "sourcecred/example-repo",
         "type": "AUTHOR",
       },
       "payload": Object {},
       "src": Object {
         "id": "https://github.com/sourcecred/example-repo/issues/2#issuecomment-385576248",
         "pluginName": "sourcecred/github-beta",
-        "repositoryName": "sourcecred/example-repo",
         "type": "COMMENT",
       },
     },
-    "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/decentralion\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"repositoryName\\\\\\":\\\\\\"sourcecred/example-repo\\\\\\",\\\\\\"type\\\\\\":\\\\\\"AUTHOR\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-repo/issues/2#issuecomment-385576273\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"repositoryName\\\\\\":\\\\\\"sourcecred/example-repo\\\\\\",\\\\\\"type\\\\\\":\\\\\\"COMMENT\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"repositoryName\\":\\"sourcecred/example-repo\\",\\"type\\":\\"AUTHORS\\"}": Object {
+    "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/decentralion\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"AUTHOR\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-repo/issues/2#issuecomment-385576273\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"COMMENT\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"AUTHORS\\"}": Object {
       "dst": Object {
         "id": "https://github.com/decentralion",
         "pluginName": "sourcecred/github-beta",
-        "repositoryName": "sourcecred/example-repo",
         "type": "AUTHOR",
       },
       "payload": Object {},
       "src": Object {
         "id": "https://github.com/sourcecred/example-repo/issues/2#issuecomment-385576273",
         "pluginName": "sourcecred/github-beta",
-        "repositoryName": "sourcecred/example-repo",
         "type": "COMMENT",
       },
     },
-    "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/decentralion\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"repositoryName\\\\\\":\\\\\\"sourcecred/example-repo\\\\\\",\\\\\\"type\\\\\\":\\\\\\"AUTHOR\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-repo/issues/2#issuecomment-385576920\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"repositoryName\\\\\\":\\\\\\"sourcecred/example-repo\\\\\\",\\\\\\"type\\\\\\":\\\\\\"COMMENT\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"repositoryName\\":\\"sourcecred/example-repo\\",\\"type\\":\\"AUTHORS\\"}": Object {
+    "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/decentralion\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"AUTHOR\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-repo/issues/2#issuecomment-385576920\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"COMMENT\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"AUTHORS\\"}": Object {
       "dst": Object {
         "id": "https://github.com/decentralion",
         "pluginName": "sourcecred/github-beta",
-        "repositoryName": "sourcecred/example-repo",
         "type": "AUTHOR",
       },
       "payload": Object {},
       "src": Object {
         "id": "https://github.com/sourcecred/example-repo/issues/2#issuecomment-385576920",
         "pluginName": "sourcecred/github-beta",
-        "repositoryName": "sourcecred/example-repo",
         "type": "COMMENT",
       },
     },
-    "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/decentralion\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"repositoryName\\\\\\":\\\\\\"sourcecred/example-repo\\\\\\",\\\\\\"type\\\\\\":\\\\\\"AUTHOR\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-repo/issues/2#issuecomment-385576936\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"repositoryName\\\\\\":\\\\\\"sourcecred/example-repo\\\\\\",\\\\\\"type\\\\\\":\\\\\\"COMMENT\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"repositoryName\\":\\"sourcecred/example-repo\\",\\"type\\":\\"AUTHORS\\"}": Object {
+    "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/decentralion\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"AUTHOR\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-repo/issues/2#issuecomment-385576936\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"COMMENT\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"AUTHORS\\"}": Object {
       "dst": Object {
         "id": "https://github.com/decentralion",
         "pluginName": "sourcecred/github-beta",
-        "repositoryName": "sourcecred/example-repo",
         "type": "AUTHOR",
       },
       "payload": Object {},
       "src": Object {
         "id": "https://github.com/sourcecred/example-repo/issues/2#issuecomment-385576936",
         "pluginName": "sourcecred/github-beta",
-        "repositoryName": "sourcecred/example-repo",
         "type": "COMMENT",
       },
     },
-    "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/decentralion\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"repositoryName\\\\\\":\\\\\\"sourcecred/example-repo\\\\\\",\\\\\\"type\\\\\\":\\\\\\"AUTHOR\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-repo/issues/2\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"repositoryName\\\\\\":\\\\\\"sourcecred/example-repo\\\\\\",\\\\\\"type\\\\\\":\\\\\\"ISSUE\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"repositoryName\\":\\"sourcecred/example-repo\\",\\"type\\":\\"AUTHORS\\"}": Object {
+    "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/decentralion\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"AUTHOR\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-repo/issues/2\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"ISSUE\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"AUTHORS\\"}": Object {
       "dst": Object {
         "id": "https://github.com/decentralion",
         "pluginName": "sourcecred/github-beta",
-        "repositoryName": "sourcecred/example-repo",
         "type": "AUTHOR",
       },
       "payload": Object {},
       "src": Object {
         "id": "https://github.com/sourcecred/example-repo/issues/2",
         "pluginName": "sourcecred/github-beta",
-        "repositoryName": "sourcecred/example-repo",
         "type": "ISSUE",
       },
     },
-    "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/decentralion\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"repositoryName\\\\\\":\\\\\\"sourcecred/example-repo\\\\\\",\\\\\\"type\\\\\\":\\\\\\"AUTHOR\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-repo/issues/6#issuecomment-373768442\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"repositoryName\\\\\\":\\\\\\"sourcecred/example-repo\\\\\\",\\\\\\"type\\\\\\":\\\\\\"COMMENT\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"repositoryName\\":\\"sourcecred/example-repo\\",\\"type\\":\\"AUTHORS\\"}": Object {
+    "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/decentralion\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"AUTHOR\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-repo/issues/6#issuecomment-373768442\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"COMMENT\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"AUTHORS\\"}": Object {
       "dst": Object {
         "id": "https://github.com/decentralion",
         "pluginName": "sourcecred/github-beta",
-        "repositoryName": "sourcecred/example-repo",
         "type": "AUTHOR",
       },
       "payload": Object {},
       "src": Object {
         "id": "https://github.com/sourcecred/example-repo/issues/6#issuecomment-373768442",
         "pluginName": "sourcecred/github-beta",
-        "repositoryName": "sourcecred/example-repo",
         "type": "COMMENT",
       },
     },
-    "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/decentralion\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"repositoryName\\\\\\":\\\\\\"sourcecred/example-repo\\\\\\",\\\\\\"type\\\\\\":\\\\\\"AUTHOR\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-repo/issues/6#issuecomment-373768538\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"repositoryName\\\\\\":\\\\\\"sourcecred/example-repo\\\\\\",\\\\\\"type\\\\\\":\\\\\\"COMMENT\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"repositoryName\\":\\"sourcecred/example-repo\\",\\"type\\":\\"AUTHORS\\"}": Object {
+    "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/decentralion\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"AUTHOR\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-repo/issues/6#issuecomment-373768538\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"COMMENT\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"AUTHORS\\"}": Object {
       "dst": Object {
         "id": "https://github.com/decentralion",
         "pluginName": "sourcecred/github-beta",
-        "repositoryName": "sourcecred/example-repo",
         "type": "AUTHOR",
       },
       "payload": Object {},
       "src": Object {
         "id": "https://github.com/sourcecred/example-repo/issues/6#issuecomment-373768538",
         "pluginName": "sourcecred/github-beta",
-        "repositoryName": "sourcecred/example-repo",
         "type": "COMMENT",
       },
     },
-    "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/decentralion\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"repositoryName\\\\\\":\\\\\\"sourcecred/example-repo\\\\\\",\\\\\\"type\\\\\\":\\\\\\"AUTHOR\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-repo/issues/6#issuecomment-385223316\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"repositoryName\\\\\\":\\\\\\"sourcecred/example-repo\\\\\\",\\\\\\"type\\\\\\":\\\\\\"COMMENT\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"repositoryName\\":\\"sourcecred/example-repo\\",\\"type\\":\\"AUTHORS\\"}": Object {
+    "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/decentralion\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"AUTHOR\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-repo/issues/6#issuecomment-385223316\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"COMMENT\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"AUTHORS\\"}": Object {
       "dst": Object {
         "id": "https://github.com/decentralion",
         "pluginName": "sourcecred/github-beta",
-        "repositoryName": "sourcecred/example-repo",
         "type": "AUTHOR",
       },
       "payload": Object {},
       "src": Object {
         "id": "https://github.com/sourcecred/example-repo/issues/6#issuecomment-385223316",
         "pluginName": "sourcecred/github-beta",
-        "repositoryName": "sourcecred/example-repo",
         "type": "COMMENT",
       },
     },
-    "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/decentralion\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"repositoryName\\\\\\":\\\\\\"sourcecred/example-repo\\\\\\",\\\\\\"type\\\\\\":\\\\\\"AUTHOR\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-repo/issues/6\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"repositoryName\\\\\\":\\\\\\"sourcecred/example-repo\\\\\\",\\\\\\"type\\\\\\":\\\\\\"ISSUE\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"repositoryName\\":\\"sourcecred/example-repo\\",\\"type\\":\\"AUTHORS\\"}": Object {
+    "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/decentralion\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"AUTHOR\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-repo/issues/6\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"ISSUE\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"AUTHORS\\"}": Object {
       "dst": Object {
         "id": "https://github.com/decentralion",
         "pluginName": "sourcecred/github-beta",
-        "repositoryName": "sourcecred/example-repo",
         "type": "AUTHOR",
       },
       "payload": Object {},
       "src": Object {
         "id": "https://github.com/sourcecred/example-repo/issues/6",
         "pluginName": "sourcecred/github-beta",
-        "repositoryName": "sourcecred/example-repo",
         "type": "ISSUE",
       },
     },
-    "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-repo/issues/2#issuecomment-373768703\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"repositoryName\\\\\\":\\\\\\"sourcecred/example-repo\\\\\\",\\\\\\"type\\\\\\":\\\\\\"COMMENT\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-repo/issues/6\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"repositoryName\\\\\\":\\\\\\"sourcecred/example-repo\\\\\\",\\\\\\"type\\\\\\":\\\\\\"ISSUE\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"repositoryName\\":\\"sourcecred/example-repo\\",\\"type\\":\\"REFERENCES\\"}": Object {
+    "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-repo/issues/2#issuecomment-373768703\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"COMMENT\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-repo/issues/6\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"ISSUE\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"REFERENCES\\"}": Object {
       "dst": Object {
         "id": "https://github.com/sourcecred/example-repo/issues/6",
         "pluginName": "sourcecred/github-beta",
-        "repositoryName": "sourcecred/example-repo",
         "type": "ISSUE",
       },
       "payload": Object {},
       "src": Object {
         "id": "https://github.com/sourcecred/example-repo/issues/2#issuecomment-373768703",
         "pluginName": "sourcecred/github-beta",
-        "repositoryName": "sourcecred/example-repo",
         "type": "COMMENT",
       },
     },
-    "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-repo/issues/2#issuecomment-373768850\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"repositoryName\\\\\\":\\\\\\"sourcecred/example-repo\\\\\\",\\\\\\"type\\\\\\":\\\\\\"COMMENT\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-repo/issues/6#issuecomment-373768538\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"repositoryName\\\\\\":\\\\\\"sourcecred/example-repo\\\\\\",\\\\\\"type\\\\\\":\\\\\\"COMMENT\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"repositoryName\\":\\"sourcecred/example-repo\\",\\"type\\":\\"REFERENCES\\"}": Object {
+    "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-repo/issues/2#issuecomment-373768850\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"COMMENT\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-repo/issues/6#issuecomment-373768538\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"COMMENT\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"REFERENCES\\"}": Object {
       "dst": Object {
         "id": "https://github.com/sourcecred/example-repo/issues/6#issuecomment-373768538",
         "pluginName": "sourcecred/github-beta",
-        "repositoryName": "sourcecred/example-repo",
         "type": "COMMENT",
       },
       "payload": Object {},
       "src": Object {
         "id": "https://github.com/sourcecred/example-repo/issues/2#issuecomment-373768850",
         "pluginName": "sourcecred/github-beta",
-        "repositoryName": "sourcecred/example-repo",
         "type": "COMMENT",
       },
     },
-    "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-repo/issues/2#issuecomment-385576920\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"repositoryName\\\\\\":\\\\\\"sourcecred/example-repo\\\\\\",\\\\\\"type\\\\\\":\\\\\\"COMMENT\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-repo/issues/1\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"repositoryName\\\\\\":\\\\\\"sourcecred/example-repo\\\\\\",\\\\\\"type\\\\\\":\\\\\\"ISSUE\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"repositoryName\\":\\"sourcecred/example-repo\\",\\"type\\":\\"REFERENCES\\"}": Object {
+    "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-repo/issues/2#issuecomment-385576920\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"COMMENT\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-repo/issues/1\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"ISSUE\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"REFERENCES\\"}": Object {
       "dst": Object {
         "id": "https://github.com/sourcecred/example-repo/issues/1",
         "pluginName": "sourcecred/github-beta",
-        "repositoryName": "sourcecred/example-repo",
         "type": "ISSUE",
       },
       "payload": Object {},
       "src": Object {
         "id": "https://github.com/sourcecred/example-repo/issues/2#issuecomment-385576920",
         "pluginName": "sourcecred/github-beta",
-        "repositoryName": "sourcecred/example-repo",
         "type": "COMMENT",
       },
     },
-    "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-repo/issues/2#issuecomment-385576920\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"repositoryName\\\\\\":\\\\\\"sourcecred/example-repo\\\\\\",\\\\\\"type\\\\\\":\\\\\\"COMMENT\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-repo/issues/2\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"repositoryName\\\\\\":\\\\\\"sourcecred/example-repo\\\\\\",\\\\\\"type\\\\\\":\\\\\\"ISSUE\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"repositoryName\\":\\"sourcecred/example-repo\\",\\"type\\":\\"REFERENCES\\"}": Object {
+    "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-repo/issues/2#issuecomment-385576920\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"COMMENT\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-repo/issues/2\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"ISSUE\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"REFERENCES\\"}": Object {
       "dst": Object {
         "id": "https://github.com/sourcecred/example-repo/issues/2",
         "pluginName": "sourcecred/github-beta",
-        "repositoryName": "sourcecred/example-repo",
         "type": "ISSUE",
       },
       "payload": Object {},
       "src": Object {
         "id": "https://github.com/sourcecred/example-repo/issues/2#issuecomment-385576920",
         "pluginName": "sourcecred/github-beta",
-        "repositoryName": "sourcecred/example-repo",
         "type": "COMMENT",
       },
     },
-    "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-repo/issues/2\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"repositoryName\\\\\\":\\\\\\"sourcecred/example-repo\\\\\\",\\\\\\"type\\\\\\":\\\\\\"ISSUE\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-repo/issues/1\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"repositoryName\\\\\\":\\\\\\"sourcecred/example-repo\\\\\\",\\\\\\"type\\\\\\":\\\\\\"ISSUE\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"repositoryName\\":\\"sourcecred/example-repo\\",\\"type\\":\\"REFERENCES\\"}": Object {
+    "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-repo/issues/2\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"ISSUE\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-repo/issues/1\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"ISSUE\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"REFERENCES\\"}": Object {
       "dst": Object {
         "id": "https://github.com/sourcecred/example-repo/issues/1",
         "pluginName": "sourcecred/github-beta",
-        "repositoryName": "sourcecred/example-repo",
         "type": "ISSUE",
       },
       "payload": Object {},
       "src": Object {
         "id": "https://github.com/sourcecred/example-repo/issues/2",
         "pluginName": "sourcecred/github-beta",
-        "repositoryName": "sourcecred/example-repo",
         "type": "ISSUE",
       },
     },
-    "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-repo/issues/2\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"repositoryName\\\\\\":\\\\\\"sourcecred/example-repo\\\\\\",\\\\\\"type\\\\\\":\\\\\\"ISSUE\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-repo/issues/2#issuecomment-373768703\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"repositoryName\\\\\\":\\\\\\"sourcecred/example-repo\\\\\\",\\\\\\"type\\\\\\":\\\\\\"COMMENT\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"repositoryName\\":\\"sourcecred/example-repo\\",\\"type\\":\\"CONTAINS\\"}": Object {
+    "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-repo/issues/2\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"ISSUE\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-repo/issues/2#issuecomment-373768703\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"COMMENT\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"CONTAINS\\"}": Object {
       "dst": Object {
         "id": "https://github.com/sourcecred/example-repo/issues/2#issuecomment-373768703",
         "pluginName": "sourcecred/github-beta",
-        "repositoryName": "sourcecred/example-repo",
         "type": "COMMENT",
       },
       "payload": Object {},
       "src": Object {
         "id": "https://github.com/sourcecred/example-repo/issues/2",
         "pluginName": "sourcecred/github-beta",
-        "repositoryName": "sourcecred/example-repo",
         "type": "ISSUE",
       },
     },
-    "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-repo/issues/2\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"repositoryName\\\\\\":\\\\\\"sourcecred/example-repo\\\\\\",\\\\\\"type\\\\\\":\\\\\\"ISSUE\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-repo/issues/2#issuecomment-373768850\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"repositoryName\\\\\\":\\\\\\"sourcecred/example-repo\\\\\\",\\\\\\"type\\\\\\":\\\\\\"COMMENT\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"repositoryName\\":\\"sourcecred/example-repo\\",\\"type\\":\\"CONTAINS\\"}": Object {
+    "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-repo/issues/2\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"ISSUE\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-repo/issues/2#issuecomment-373768850\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"COMMENT\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"CONTAINS\\"}": Object {
       "dst": Object {
         "id": "https://github.com/sourcecred/example-repo/issues/2#issuecomment-373768850",
         "pluginName": "sourcecred/github-beta",
-        "repositoryName": "sourcecred/example-repo",
         "type": "COMMENT",
       },
       "payload": Object {},
       "src": Object {
         "id": "https://github.com/sourcecred/example-repo/issues/2",
         "pluginName": "sourcecred/github-beta",
-        "repositoryName": "sourcecred/example-repo",
         "type": "ISSUE",
       },
     },
-    "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-repo/issues/2\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"repositoryName\\\\\\":\\\\\\"sourcecred/example-repo\\\\\\",\\\\\\"type\\\\\\":\\\\\\"ISSUE\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-repo/issues/2#issuecomment-385576185\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"repositoryName\\\\\\":\\\\\\"sourcecred/example-repo\\\\\\",\\\\\\"type\\\\\\":\\\\\\"COMMENT\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"repositoryName\\":\\"sourcecred/example-repo\\",\\"type\\":\\"CONTAINS\\"}": Object {
+    "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-repo/issues/2\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"ISSUE\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-repo/issues/2#issuecomment-385576185\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"COMMENT\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"CONTAINS\\"}": Object {
       "dst": Object {
         "id": "https://github.com/sourcecred/example-repo/issues/2#issuecomment-385576185",
         "pluginName": "sourcecred/github-beta",
-        "repositoryName": "sourcecred/example-repo",
         "type": "COMMENT",
       },
       "payload": Object {},
       "src": Object {
         "id": "https://github.com/sourcecred/example-repo/issues/2",
         "pluginName": "sourcecred/github-beta",
-        "repositoryName": "sourcecred/example-repo",
         "type": "ISSUE",
       },
     },
-    "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-repo/issues/2\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"repositoryName\\\\\\":\\\\\\"sourcecred/example-repo\\\\\\",\\\\\\"type\\\\\\":\\\\\\"ISSUE\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-repo/issues/2#issuecomment-385576220\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"repositoryName\\\\\\":\\\\\\"sourcecred/example-repo\\\\\\",\\\\\\"type\\\\\\":\\\\\\"COMMENT\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"repositoryName\\":\\"sourcecred/example-repo\\",\\"type\\":\\"CONTAINS\\"}": Object {
+    "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-repo/issues/2\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"ISSUE\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-repo/issues/2#issuecomment-385576220\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"COMMENT\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"CONTAINS\\"}": Object {
       "dst": Object {
         "id": "https://github.com/sourcecred/example-repo/issues/2#issuecomment-385576220",
         "pluginName": "sourcecred/github-beta",
-        "repositoryName": "sourcecred/example-repo",
         "type": "COMMENT",
       },
       "payload": Object {},
       "src": Object {
         "id": "https://github.com/sourcecred/example-repo/issues/2",
         "pluginName": "sourcecred/github-beta",
-        "repositoryName": "sourcecred/example-repo",
         "type": "ISSUE",
       },
     },
-    "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-repo/issues/2\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"repositoryName\\\\\\":\\\\\\"sourcecred/example-repo\\\\\\",\\\\\\"type\\\\\\":\\\\\\"ISSUE\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-repo/issues/2#issuecomment-385576248\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"repositoryName\\\\\\":\\\\\\"sourcecred/example-repo\\\\\\",\\\\\\"type\\\\\\":\\\\\\"COMMENT\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"repositoryName\\":\\"sourcecred/example-repo\\",\\"type\\":\\"CONTAINS\\"}": Object {
+    "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-repo/issues/2\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"ISSUE\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-repo/issues/2#issuecomment-385576248\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"COMMENT\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"CONTAINS\\"}": Object {
       "dst": Object {
         "id": "https://github.com/sourcecred/example-repo/issues/2#issuecomment-385576248",
         "pluginName": "sourcecred/github-beta",
-        "repositoryName": "sourcecred/example-repo",
         "type": "COMMENT",
       },
       "payload": Object {},
       "src": Object {
         "id": "https://github.com/sourcecred/example-repo/issues/2",
         "pluginName": "sourcecred/github-beta",
-        "repositoryName": "sourcecred/example-repo",
         "type": "ISSUE",
       },
     },
-    "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-repo/issues/2\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"repositoryName\\\\\\":\\\\\\"sourcecred/example-repo\\\\\\",\\\\\\"type\\\\\\":\\\\\\"ISSUE\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-repo/issues/2#issuecomment-385576273\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"repositoryName\\\\\\":\\\\\\"sourcecred/example-repo\\\\\\",\\\\\\"type\\\\\\":\\\\\\"COMMENT\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"repositoryName\\":\\"sourcecred/example-repo\\",\\"type\\":\\"CONTAINS\\"}": Object {
+    "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-repo/issues/2\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"ISSUE\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-repo/issues/2#issuecomment-385576273\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"COMMENT\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"CONTAINS\\"}": Object {
       "dst": Object {
         "id": "https://github.com/sourcecred/example-repo/issues/2#issuecomment-385576273",
         "pluginName": "sourcecred/github-beta",
-        "repositoryName": "sourcecred/example-repo",
         "type": "COMMENT",
       },
       "payload": Object {},
       "src": Object {
         "id": "https://github.com/sourcecred/example-repo/issues/2",
         "pluginName": "sourcecred/github-beta",
-        "repositoryName": "sourcecred/example-repo",
         "type": "ISSUE",
       },
     },
-    "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-repo/issues/2\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"repositoryName\\\\\\":\\\\\\"sourcecred/example-repo\\\\\\",\\\\\\"type\\\\\\":\\\\\\"ISSUE\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-repo/issues/2#issuecomment-385576920\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"repositoryName\\\\\\":\\\\\\"sourcecred/example-repo\\\\\\",\\\\\\"type\\\\\\":\\\\\\"COMMENT\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"repositoryName\\":\\"sourcecred/example-repo\\",\\"type\\":\\"CONTAINS\\"}": Object {
+    "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-repo/issues/2\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"ISSUE\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-repo/issues/2#issuecomment-385576920\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"COMMENT\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"CONTAINS\\"}": Object {
       "dst": Object {
         "id": "https://github.com/sourcecred/example-repo/issues/2#issuecomment-385576920",
         "pluginName": "sourcecred/github-beta",
-        "repositoryName": "sourcecred/example-repo",
         "type": "COMMENT",
       },
       "payload": Object {},
       "src": Object {
         "id": "https://github.com/sourcecred/example-repo/issues/2",
         "pluginName": "sourcecred/github-beta",
-        "repositoryName": "sourcecred/example-repo",
         "type": "ISSUE",
       },
     },
-    "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-repo/issues/2\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"repositoryName\\\\\\":\\\\\\"sourcecred/example-repo\\\\\\",\\\\\\"type\\\\\\":\\\\\\"ISSUE\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-repo/issues/2#issuecomment-385576936\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"repositoryName\\\\\\":\\\\\\"sourcecred/example-repo\\\\\\",\\\\\\"type\\\\\\":\\\\\\"COMMENT\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"repositoryName\\":\\"sourcecred/example-repo\\",\\"type\\":\\"CONTAINS\\"}": Object {
+    "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-repo/issues/2\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"ISSUE\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-repo/issues/2#issuecomment-385576936\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"COMMENT\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"CONTAINS\\"}": Object {
       "dst": Object {
         "id": "https://github.com/sourcecred/example-repo/issues/2#issuecomment-385576936",
         "pluginName": "sourcecred/github-beta",
-        "repositoryName": "sourcecred/example-repo",
         "type": "COMMENT",
       },
       "payload": Object {},
       "src": Object {
         "id": "https://github.com/sourcecred/example-repo/issues/2",
         "pluginName": "sourcecred/github-beta",
-        "repositoryName": "sourcecred/example-repo",
         "type": "ISSUE",
       },
     },
-    "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-repo/issues/6#issuecomment-385223316\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"repositoryName\\\\\\":\\\\\\"sourcecred/example-repo\\\\\\",\\\\\\"type\\\\\\":\\\\\\"COMMENT\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-repo/issues/2\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"repositoryName\\\\\\":\\\\\\"sourcecred/example-repo\\\\\\",\\\\\\"type\\\\\\":\\\\\\"ISSUE\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"repositoryName\\":\\"sourcecred/example-repo\\",\\"type\\":\\"REFERENCES\\"}": Object {
+    "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-repo/issues/6#issuecomment-385223316\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"COMMENT\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-repo/issues/2\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"ISSUE\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"REFERENCES\\"}": Object {
       "dst": Object {
         "id": "https://github.com/sourcecred/example-repo/issues/2",
         "pluginName": "sourcecred/github-beta",
-        "repositoryName": "sourcecred/example-repo",
         "type": "ISSUE",
       },
       "payload": Object {},
       "src": Object {
         "id": "https://github.com/sourcecred/example-repo/issues/6#issuecomment-385223316",
         "pluginName": "sourcecred/github-beta",
-        "repositoryName": "sourcecred/example-repo",
         "type": "COMMENT",
       },
     },
-    "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-repo/issues/6\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"repositoryName\\\\\\":\\\\\\"sourcecred/example-repo\\\\\\",\\\\\\"type\\\\\\":\\\\\\"ISSUE\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-repo/issues/6#issuecomment-373768442\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"repositoryName\\\\\\":\\\\\\"sourcecred/example-repo\\\\\\",\\\\\\"type\\\\\\":\\\\\\"COMMENT\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"repositoryName\\":\\"sourcecred/example-repo\\",\\"type\\":\\"CONTAINS\\"}": Object {
+    "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-repo/issues/6\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"ISSUE\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-repo/issues/6#issuecomment-373768442\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"COMMENT\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"CONTAINS\\"}": Object {
       "dst": Object {
         "id": "https://github.com/sourcecred/example-repo/issues/6#issuecomment-373768442",
         "pluginName": "sourcecred/github-beta",
-        "repositoryName": "sourcecred/example-repo",
         "type": "COMMENT",
       },
       "payload": Object {},
       "src": Object {
         "id": "https://github.com/sourcecred/example-repo/issues/6",
         "pluginName": "sourcecred/github-beta",
-        "repositoryName": "sourcecred/example-repo",
         "type": "ISSUE",
       },
     },
-    "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-repo/issues/6\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"repositoryName\\\\\\":\\\\\\"sourcecred/example-repo\\\\\\",\\\\\\"type\\\\\\":\\\\\\"ISSUE\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-repo/issues/6#issuecomment-373768538\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"repositoryName\\\\\\":\\\\\\"sourcecred/example-repo\\\\\\",\\\\\\"type\\\\\\":\\\\\\"COMMENT\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"repositoryName\\":\\"sourcecred/example-repo\\",\\"type\\":\\"CONTAINS\\"}": Object {
+    "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-repo/issues/6\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"ISSUE\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-repo/issues/6#issuecomment-373768538\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"COMMENT\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"CONTAINS\\"}": Object {
       "dst": Object {
         "id": "https://github.com/sourcecred/example-repo/issues/6#issuecomment-373768538",
         "pluginName": "sourcecred/github-beta",
-        "repositoryName": "sourcecred/example-repo",
         "type": "COMMENT",
       },
       "payload": Object {},
       "src": Object {
         "id": "https://github.com/sourcecred/example-repo/issues/6",
         "pluginName": "sourcecred/github-beta",
-        "repositoryName": "sourcecred/example-repo",
         "type": "ISSUE",
       },
     },
-    "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-repo/issues/6\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"repositoryName\\\\\\":\\\\\\"sourcecred/example-repo\\\\\\",\\\\\\"type\\\\\\":\\\\\\"ISSUE\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-repo/issues/6#issuecomment-385223316\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"repositoryName\\\\\\":\\\\\\"sourcecred/example-repo\\\\\\",\\\\\\"type\\\\\\":\\\\\\"COMMENT\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"repositoryName\\":\\"sourcecred/example-repo\\",\\"type\\":\\"CONTAINS\\"}": Object {
+    "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-repo/issues/6\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"ISSUE\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-repo/issues/6#issuecomment-385223316\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"COMMENT\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"CONTAINS\\"}": Object {
       "dst": Object {
         "id": "https://github.com/sourcecred/example-repo/issues/6#issuecomment-385223316",
         "pluginName": "sourcecred/github-beta",
-        "repositoryName": "sourcecred/example-repo",
         "type": "COMMENT",
       },
       "payload": Object {},
       "src": Object {
         "id": "https://github.com/sourcecred/example-repo/issues/6",
         "pluginName": "sourcecred/github-beta",
-        "repositoryName": "sourcecred/example-repo",
         "type": "ISSUE",
       },
     },
   },
   "nodes": Object {
-    "{\\"id\\":\\"https://github.com/decentralion\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"repositoryName\\":\\"sourcecred/example-repo\\",\\"type\\":\\"AUTHOR\\"}": Object {
+    "{\\"id\\":\\"https://github.com/decentralion\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"AUTHOR\\"}": Object {
       "payload": Object {
         "login": "decentralion",
         "subtype": "USER",
         "url": "https://github.com/decentralion",
       },
     },
-    "{\\"id\\":\\"https://github.com/sourcecred/example-repo/issues/1\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"repositoryName\\":\\"sourcecred/example-repo\\",\\"type\\":\\"ISSUE\\"}": Object {
+    "{\\"id\\":\\"https://github.com/sourcecred/example-repo/issues/1\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"ISSUE\\"}": Object {
       "payload": Object {
         "body": "This is just an example issue.",
         "number": 1,
@@ -921,7 +821,7 @@ Object {
         "url": "https://github.com/sourcecred/example-repo/issues/1",
       },
     },
-    "{\\"id\\":\\"https://github.com/sourcecred/example-repo/issues/2\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"repositoryName\\":\\"sourcecred/example-repo\\",\\"type\\":\\"ISSUE\\"}": Object {
+    "{\\"id\\":\\"https://github.com/sourcecred/example-repo/issues/2\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"ISSUE\\"}": Object {
       "payload": Object {
         "body": "This issue references another issue, namely #1",
         "number": 2,
@@ -929,44 +829,44 @@ Object {
         "url": "https://github.com/sourcecred/example-repo/issues/2",
       },
     },
-    "{\\"id\\":\\"https://github.com/sourcecred/example-repo/issues/2#issuecomment-373768703\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"repositoryName\\":\\"sourcecred/example-repo\\",\\"type\\":\\"COMMENT\\"}": Object {
+    "{\\"id\\":\\"https://github.com/sourcecred/example-repo/issues/2#issuecomment-373768703\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"COMMENT\\"}": Object {
       "payload": Object {
         "body": "It should also be possible to reference by exact url: https://github.com/sourcecred/example-repo/issues/6",
         "url": "https://github.com/sourcecred/example-repo/issues/2#issuecomment-373768703",
       },
     },
-    "{\\"id\\":\\"https://github.com/sourcecred/example-repo/issues/2#issuecomment-373768850\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"repositoryName\\":\\"sourcecred/example-repo\\",\\"type\\":\\"COMMENT\\"}": Object {
+    "{\\"id\\":\\"https://github.com/sourcecred/example-repo/issues/2#issuecomment-373768850\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"COMMENT\\"}": Object {
       "payload": Object {
         "body": "We might also reference individual comments directly.
 https://github.com/sourcecred/example-repo/issues/6#issuecomment-373768538",
         "url": "https://github.com/sourcecred/example-repo/issues/2#issuecomment-373768850",
       },
     },
-    "{\\"id\\":\\"https://github.com/sourcecred/example-repo/issues/2#issuecomment-385576185\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"repositoryName\\":\\"sourcecred/example-repo\\",\\"type\\":\\"COMMENT\\"}": Object {
+    "{\\"id\\":\\"https://github.com/sourcecred/example-repo/issues/2#issuecomment-385576185\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"COMMENT\\"}": Object {
       "payload": Object {
         "body": "Here's a PR by direct url: https://github.com/sourcecred/example-repo/pull/5",
         "url": "https://github.com/sourcecred/example-repo/issues/2#issuecomment-385576185",
       },
     },
-    "{\\"id\\":\\"https://github.com/sourcecred/example-repo/issues/2#issuecomment-385576220\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"repositoryName\\":\\"sourcecred/example-repo\\",\\"type\\":\\"COMMENT\\"}": Object {
+    "{\\"id\\":\\"https://github.com/sourcecred/example-repo/issues/2#issuecomment-385576220\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"COMMENT\\"}": Object {
       "payload": Object {
         "body": "a PR review by url: https://github.com/sourcecred/example-repo/pull/5#pullrequestreview-100313899",
         "url": "https://github.com/sourcecred/example-repo/issues/2#issuecomment-385576220",
       },
     },
-    "{\\"id\\":\\"https://github.com/sourcecred/example-repo/issues/2#issuecomment-385576248\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"repositoryName\\":\\"sourcecred/example-repo\\",\\"type\\":\\"COMMENT\\"}": Object {
+    "{\\"id\\":\\"https://github.com/sourcecred/example-repo/issues/2#issuecomment-385576248\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"COMMENT\\"}": Object {
       "payload": Object {
         "body": "a PR Review Comment by url: https://github.com/sourcecred/example-repo/pull/5#discussion_r171460198",
         "url": "https://github.com/sourcecred/example-repo/issues/2#issuecomment-385576248",
       },
     },
-    "{\\"id\\":\\"https://github.com/sourcecred/example-repo/issues/2#issuecomment-385576273\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"repositoryName\\":\\"sourcecred/example-repo\\",\\"type\\":\\"COMMENT\\"}": Object {
+    "{\\"id\\":\\"https://github.com/sourcecred/example-repo/issues/2#issuecomment-385576273\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"COMMENT\\"}": Object {
       "payload": Object {
         "body": "a user by url: https://github.com/wchargin",
         "url": "https://github.com/sourcecred/example-repo/issues/2#issuecomment-385576273",
       },
     },
-    "{\\"id\\":\\"https://github.com/sourcecred/example-repo/issues/2#issuecomment-385576920\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"repositoryName\\":\\"sourcecred/example-repo\\",\\"type\\":\\"COMMENT\\"}": Object {
+    "{\\"id\\":\\"https://github.com/sourcecred/example-repo/issues/2#issuecomment-385576920\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"COMMENT\\"}": Object {
       "payload": Object {
         "body": "Here are several references:
 #1 
@@ -979,13 +879,13 @@ https://github.com/sourcecred/example-repo/pull/5#pullrequestreview-100313899
         "url": "https://github.com/sourcecred/example-repo/issues/2#issuecomment-385576920",
       },
     },
-    "{\\"id\\":\\"https://github.com/sourcecred/example-repo/issues/2#issuecomment-385576936\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"repositoryName\\":\\"sourcecred/example-repo\\",\\"type\\":\\"COMMENT\\"}": Object {
+    "{\\"id\\":\\"https://github.com/sourcecred/example-repo/issues/2#issuecomment-385576936\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"COMMENT\\"}": Object {
       "payload": Object {
         "body": "This comment has no references.",
         "url": "https://github.com/sourcecred/example-repo/issues/2#issuecomment-385576936",
       },
     },
-    "{\\"id\\":\\"https://github.com/sourcecred/example-repo/issues/6\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"repositoryName\\":\\"sourcecred/example-repo\\",\\"type\\":\\"ISSUE\\"}": Object {
+    "{\\"id\\":\\"https://github.com/sourcecred/example-repo/issues/6\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"ISSUE\\"}": Object {
       "payload": Object {
         "body": "This issue shall shortly have a few comments.",
         "number": 6,
@@ -993,19 +893,19 @@ https://github.com/sourcecred/example-repo/pull/5#pullrequestreview-100313899
         "url": "https://github.com/sourcecred/example-repo/issues/6",
       },
     },
-    "{\\"id\\":\\"https://github.com/sourcecred/example-repo/issues/6#issuecomment-373768442\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"repositoryName\\":\\"sourcecred/example-repo\\",\\"type\\":\\"COMMENT\\"}": Object {
+    "{\\"id\\":\\"https://github.com/sourcecred/example-repo/issues/6#issuecomment-373768442\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"COMMENT\\"}": Object {
       "payload": Object {
         "body": "A wild COMMENT appeared!",
         "url": "https://github.com/sourcecred/example-repo/issues/6#issuecomment-373768442",
       },
     },
-    "{\\"id\\":\\"https://github.com/sourcecred/example-repo/issues/6#issuecomment-373768538\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"repositoryName\\":\\"sourcecred/example-repo\\",\\"type\\":\\"COMMENT\\"}": Object {
+    "{\\"id\\":\\"https://github.com/sourcecred/example-repo/issues/6#issuecomment-373768538\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"COMMENT\\"}": Object {
       "payload": Object {
         "body": "And the maintainer said, \\"Let there be comments!\\"",
         "url": "https://github.com/sourcecred/example-repo/issues/6#issuecomment-373768538",
       },
     },
-    "{\\"id\\":\\"https://github.com/sourcecred/example-repo/issues/6#issuecomment-385223316\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"repositoryName\\":\\"sourcecred/example-repo\\",\\"type\\":\\"COMMENT\\"}": Object {
+    "{\\"id\\":\\"https://github.com/sourcecred/example-repo/issues/6#issuecomment-385223316\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"COMMENT\\"}": Object {
       "payload": Object {
         "body": "This comment references an #2, which itself references an issue. This comment is thus allows us to test that in-references are not included when requesting a Post's references.",
         "url": "https://github.com/sourcecred/example-repo/issues/6#issuecomment-385223316",
@@ -1018,286 +918,250 @@ https://github.com/sourcecred/example-repo/pull/5#pullrequestreview-100313899
 exports[`GithubParser reference detection handles dangling references gracefully 1`] = `
 Object {
   "edges": Object {
-    "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/decentralion\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"repositoryName\\\\\\":\\\\\\"sourcecred/example-repo\\\\\\",\\\\\\"type\\\\\\":\\\\\\"AUTHOR\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-repo/issues/2#issuecomment-373768703\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"repositoryName\\\\\\":\\\\\\"sourcecred/example-repo\\\\\\",\\\\\\"type\\\\\\":\\\\\\"COMMENT\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"repositoryName\\":\\"sourcecred/example-repo\\",\\"type\\":\\"AUTHORS\\"}": Object {
+    "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/decentralion\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"AUTHOR\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-repo/issues/2#issuecomment-373768703\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"COMMENT\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"AUTHORS\\"}": Object {
       "dst": Object {
         "id": "https://github.com/decentralion",
         "pluginName": "sourcecred/github-beta",
-        "repositoryName": "sourcecred/example-repo",
         "type": "AUTHOR",
       },
       "payload": Object {},
       "src": Object {
         "id": "https://github.com/sourcecred/example-repo/issues/2#issuecomment-373768703",
         "pluginName": "sourcecred/github-beta",
-        "repositoryName": "sourcecred/example-repo",
         "type": "COMMENT",
       },
     },
-    "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/decentralion\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"repositoryName\\\\\\":\\\\\\"sourcecred/example-repo\\\\\\",\\\\\\"type\\\\\\":\\\\\\"AUTHOR\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-repo/issues/2#issuecomment-373768850\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"repositoryName\\\\\\":\\\\\\"sourcecred/example-repo\\\\\\",\\\\\\"type\\\\\\":\\\\\\"COMMENT\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"repositoryName\\":\\"sourcecred/example-repo\\",\\"type\\":\\"AUTHORS\\"}": Object {
+    "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/decentralion\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"AUTHOR\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-repo/issues/2#issuecomment-373768850\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"COMMENT\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"AUTHORS\\"}": Object {
       "dst": Object {
         "id": "https://github.com/decentralion",
         "pluginName": "sourcecred/github-beta",
-        "repositoryName": "sourcecred/example-repo",
         "type": "AUTHOR",
       },
       "payload": Object {},
       "src": Object {
         "id": "https://github.com/sourcecred/example-repo/issues/2#issuecomment-373768850",
         "pluginName": "sourcecred/github-beta",
-        "repositoryName": "sourcecred/example-repo",
         "type": "COMMENT",
       },
     },
-    "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/decentralion\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"repositoryName\\\\\\":\\\\\\"sourcecred/example-repo\\\\\\",\\\\\\"type\\\\\\":\\\\\\"AUTHOR\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-repo/issues/2#issuecomment-385576185\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"repositoryName\\\\\\":\\\\\\"sourcecred/example-repo\\\\\\",\\\\\\"type\\\\\\":\\\\\\"COMMENT\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"repositoryName\\":\\"sourcecred/example-repo\\",\\"type\\":\\"AUTHORS\\"}": Object {
+    "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/decentralion\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"AUTHOR\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-repo/issues/2#issuecomment-385576185\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"COMMENT\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"AUTHORS\\"}": Object {
       "dst": Object {
         "id": "https://github.com/decentralion",
         "pluginName": "sourcecred/github-beta",
-        "repositoryName": "sourcecred/example-repo",
         "type": "AUTHOR",
       },
       "payload": Object {},
       "src": Object {
         "id": "https://github.com/sourcecred/example-repo/issues/2#issuecomment-385576185",
         "pluginName": "sourcecred/github-beta",
-        "repositoryName": "sourcecred/example-repo",
         "type": "COMMENT",
       },
     },
-    "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/decentralion\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"repositoryName\\\\\\":\\\\\\"sourcecred/example-repo\\\\\\",\\\\\\"type\\\\\\":\\\\\\"AUTHOR\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-repo/issues/2#issuecomment-385576220\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"repositoryName\\\\\\":\\\\\\"sourcecred/example-repo\\\\\\",\\\\\\"type\\\\\\":\\\\\\"COMMENT\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"repositoryName\\":\\"sourcecred/example-repo\\",\\"type\\":\\"AUTHORS\\"}": Object {
+    "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/decentralion\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"AUTHOR\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-repo/issues/2#issuecomment-385576220\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"COMMENT\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"AUTHORS\\"}": Object {
       "dst": Object {
         "id": "https://github.com/decentralion",
         "pluginName": "sourcecred/github-beta",
-        "repositoryName": "sourcecred/example-repo",
         "type": "AUTHOR",
       },
       "payload": Object {},
       "src": Object {
         "id": "https://github.com/sourcecred/example-repo/issues/2#issuecomment-385576220",
         "pluginName": "sourcecred/github-beta",
-        "repositoryName": "sourcecred/example-repo",
         "type": "COMMENT",
       },
     },
-    "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/decentralion\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"repositoryName\\\\\\":\\\\\\"sourcecred/example-repo\\\\\\",\\\\\\"type\\\\\\":\\\\\\"AUTHOR\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-repo/issues/2#issuecomment-385576248\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"repositoryName\\\\\\":\\\\\\"sourcecred/example-repo\\\\\\",\\\\\\"type\\\\\\":\\\\\\"COMMENT\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"repositoryName\\":\\"sourcecred/example-repo\\",\\"type\\":\\"AUTHORS\\"}": Object {
+    "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/decentralion\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"AUTHOR\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-repo/issues/2#issuecomment-385576248\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"COMMENT\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"AUTHORS\\"}": Object {
       "dst": Object {
         "id": "https://github.com/decentralion",
         "pluginName": "sourcecred/github-beta",
-        "repositoryName": "sourcecred/example-repo",
         "type": "AUTHOR",
       },
       "payload": Object {},
       "src": Object {
         "id": "https://github.com/sourcecred/example-repo/issues/2#issuecomment-385576248",
         "pluginName": "sourcecred/github-beta",
-        "repositoryName": "sourcecred/example-repo",
         "type": "COMMENT",
       },
     },
-    "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/decentralion\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"repositoryName\\\\\\":\\\\\\"sourcecred/example-repo\\\\\\",\\\\\\"type\\\\\\":\\\\\\"AUTHOR\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-repo/issues/2#issuecomment-385576273\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"repositoryName\\\\\\":\\\\\\"sourcecred/example-repo\\\\\\",\\\\\\"type\\\\\\":\\\\\\"COMMENT\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"repositoryName\\":\\"sourcecred/example-repo\\",\\"type\\":\\"AUTHORS\\"}": Object {
+    "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/decentralion\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"AUTHOR\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-repo/issues/2#issuecomment-385576273\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"COMMENT\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"AUTHORS\\"}": Object {
       "dst": Object {
         "id": "https://github.com/decentralion",
         "pluginName": "sourcecred/github-beta",
-        "repositoryName": "sourcecred/example-repo",
         "type": "AUTHOR",
       },
       "payload": Object {},
       "src": Object {
         "id": "https://github.com/sourcecred/example-repo/issues/2#issuecomment-385576273",
         "pluginName": "sourcecred/github-beta",
-        "repositoryName": "sourcecred/example-repo",
         "type": "COMMENT",
       },
     },
-    "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/decentralion\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"repositoryName\\\\\\":\\\\\\"sourcecred/example-repo\\\\\\",\\\\\\"type\\\\\\":\\\\\\"AUTHOR\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-repo/issues/2#issuecomment-385576920\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"repositoryName\\\\\\":\\\\\\"sourcecred/example-repo\\\\\\",\\\\\\"type\\\\\\":\\\\\\"COMMENT\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"repositoryName\\":\\"sourcecred/example-repo\\",\\"type\\":\\"AUTHORS\\"}": Object {
+    "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/decentralion\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"AUTHOR\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-repo/issues/2#issuecomment-385576920\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"COMMENT\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"AUTHORS\\"}": Object {
       "dst": Object {
         "id": "https://github.com/decentralion",
         "pluginName": "sourcecred/github-beta",
-        "repositoryName": "sourcecred/example-repo",
         "type": "AUTHOR",
       },
       "payload": Object {},
       "src": Object {
         "id": "https://github.com/sourcecred/example-repo/issues/2#issuecomment-385576920",
         "pluginName": "sourcecred/github-beta",
-        "repositoryName": "sourcecred/example-repo",
         "type": "COMMENT",
       },
     },
-    "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/decentralion\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"repositoryName\\\\\\":\\\\\\"sourcecred/example-repo\\\\\\",\\\\\\"type\\\\\\":\\\\\\"AUTHOR\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-repo/issues/2#issuecomment-385576936\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"repositoryName\\\\\\":\\\\\\"sourcecred/example-repo\\\\\\",\\\\\\"type\\\\\\":\\\\\\"COMMENT\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"repositoryName\\":\\"sourcecred/example-repo\\",\\"type\\":\\"AUTHORS\\"}": Object {
+    "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/decentralion\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"AUTHOR\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-repo/issues/2#issuecomment-385576936\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"COMMENT\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"AUTHORS\\"}": Object {
       "dst": Object {
         "id": "https://github.com/decentralion",
         "pluginName": "sourcecred/github-beta",
-        "repositoryName": "sourcecred/example-repo",
         "type": "AUTHOR",
       },
       "payload": Object {},
       "src": Object {
         "id": "https://github.com/sourcecred/example-repo/issues/2#issuecomment-385576936",
         "pluginName": "sourcecred/github-beta",
-        "repositoryName": "sourcecred/example-repo",
         "type": "COMMENT",
       },
     },
-    "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/decentralion\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"repositoryName\\\\\\":\\\\\\"sourcecred/example-repo\\\\\\",\\\\\\"type\\\\\\":\\\\\\"AUTHOR\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-repo/issues/2\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"repositoryName\\\\\\":\\\\\\"sourcecred/example-repo\\\\\\",\\\\\\"type\\\\\\":\\\\\\"ISSUE\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"repositoryName\\":\\"sourcecred/example-repo\\",\\"type\\":\\"AUTHORS\\"}": Object {
+    "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/decentralion\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"AUTHOR\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-repo/issues/2\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"ISSUE\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"AUTHORS\\"}": Object {
       "dst": Object {
         "id": "https://github.com/decentralion",
         "pluginName": "sourcecred/github-beta",
-        "repositoryName": "sourcecred/example-repo",
         "type": "AUTHOR",
       },
       "payload": Object {},
       "src": Object {
         "id": "https://github.com/sourcecred/example-repo/issues/2",
         "pluginName": "sourcecred/github-beta",
-        "repositoryName": "sourcecred/example-repo",
         "type": "ISSUE",
       },
     },
-    "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-repo/issues/2#issuecomment-385576920\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"repositoryName\\\\\\":\\\\\\"sourcecred/example-repo\\\\\\",\\\\\\"type\\\\\\":\\\\\\"COMMENT\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-repo/issues/2\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"repositoryName\\\\\\":\\\\\\"sourcecred/example-repo\\\\\\",\\\\\\"type\\\\\\":\\\\\\"ISSUE\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"repositoryName\\":\\"sourcecred/example-repo\\",\\"type\\":\\"REFERENCES\\"}": Object {
+    "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-repo/issues/2#issuecomment-385576920\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"COMMENT\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-repo/issues/2\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"ISSUE\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"REFERENCES\\"}": Object {
       "dst": Object {
         "id": "https://github.com/sourcecred/example-repo/issues/2",
         "pluginName": "sourcecred/github-beta",
-        "repositoryName": "sourcecred/example-repo",
         "type": "ISSUE",
       },
       "payload": Object {},
       "src": Object {
         "id": "https://github.com/sourcecred/example-repo/issues/2#issuecomment-385576920",
         "pluginName": "sourcecred/github-beta",
-        "repositoryName": "sourcecred/example-repo",
         "type": "COMMENT",
       },
     },
-    "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-repo/issues/2\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"repositoryName\\\\\\":\\\\\\"sourcecred/example-repo\\\\\\",\\\\\\"type\\\\\\":\\\\\\"ISSUE\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-repo/issues/2#issuecomment-373768703\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"repositoryName\\\\\\":\\\\\\"sourcecred/example-repo\\\\\\",\\\\\\"type\\\\\\":\\\\\\"COMMENT\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"repositoryName\\":\\"sourcecred/example-repo\\",\\"type\\":\\"CONTAINS\\"}": Object {
+    "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-repo/issues/2\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"ISSUE\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-repo/issues/2#issuecomment-373768703\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"COMMENT\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"CONTAINS\\"}": Object {
       "dst": Object {
         "id": "https://github.com/sourcecred/example-repo/issues/2#issuecomment-373768703",
         "pluginName": "sourcecred/github-beta",
-        "repositoryName": "sourcecred/example-repo",
         "type": "COMMENT",
       },
       "payload": Object {},
       "src": Object {
         "id": "https://github.com/sourcecred/example-repo/issues/2",
         "pluginName": "sourcecred/github-beta",
-        "repositoryName": "sourcecred/example-repo",
         "type": "ISSUE",
       },
     },
-    "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-repo/issues/2\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"repositoryName\\\\\\":\\\\\\"sourcecred/example-repo\\\\\\",\\\\\\"type\\\\\\":\\\\\\"ISSUE\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-repo/issues/2#issuecomment-373768850\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"repositoryName\\\\\\":\\\\\\"sourcecred/example-repo\\\\\\",\\\\\\"type\\\\\\":\\\\\\"COMMENT\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"repositoryName\\":\\"sourcecred/example-repo\\",\\"type\\":\\"CONTAINS\\"}": Object {
+    "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-repo/issues/2\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"ISSUE\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-repo/issues/2#issuecomment-373768850\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"COMMENT\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"CONTAINS\\"}": Object {
       "dst": Object {
         "id": "https://github.com/sourcecred/example-repo/issues/2#issuecomment-373768850",
         "pluginName": "sourcecred/github-beta",
-        "repositoryName": "sourcecred/example-repo",
         "type": "COMMENT",
       },
       "payload": Object {},
       "src": Object {
         "id": "https://github.com/sourcecred/example-repo/issues/2",
         "pluginName": "sourcecred/github-beta",
-        "repositoryName": "sourcecred/example-repo",
         "type": "ISSUE",
       },
     },
-    "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-repo/issues/2\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"repositoryName\\\\\\":\\\\\\"sourcecred/example-repo\\\\\\",\\\\\\"type\\\\\\":\\\\\\"ISSUE\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-repo/issues/2#issuecomment-385576185\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"repositoryName\\\\\\":\\\\\\"sourcecred/example-repo\\\\\\",\\\\\\"type\\\\\\":\\\\\\"COMMENT\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"repositoryName\\":\\"sourcecred/example-repo\\",\\"type\\":\\"CONTAINS\\"}": Object {
+    "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-repo/issues/2\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"ISSUE\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-repo/issues/2#issuecomment-385576185\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"COMMENT\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"CONTAINS\\"}": Object {
       "dst": Object {
         "id": "https://github.com/sourcecred/example-repo/issues/2#issuecomment-385576185",
         "pluginName": "sourcecred/github-beta",
-        "repositoryName": "sourcecred/example-repo",
         "type": "COMMENT",
       },
       "payload": Object {},
       "src": Object {
         "id": "https://github.com/sourcecred/example-repo/issues/2",
         "pluginName": "sourcecred/github-beta",
-        "repositoryName": "sourcecred/example-repo",
         "type": "ISSUE",
       },
     },
-    "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-repo/issues/2\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"repositoryName\\\\\\":\\\\\\"sourcecred/example-repo\\\\\\",\\\\\\"type\\\\\\":\\\\\\"ISSUE\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-repo/issues/2#issuecomment-385576220\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"repositoryName\\\\\\":\\\\\\"sourcecred/example-repo\\\\\\",\\\\\\"type\\\\\\":\\\\\\"COMMENT\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"repositoryName\\":\\"sourcecred/example-repo\\",\\"type\\":\\"CONTAINS\\"}": Object {
+    "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-repo/issues/2\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"ISSUE\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-repo/issues/2#issuecomment-385576220\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"COMMENT\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"CONTAINS\\"}": Object {
       "dst": Object {
         "id": "https://github.com/sourcecred/example-repo/issues/2#issuecomment-385576220",
         "pluginName": "sourcecred/github-beta",
-        "repositoryName": "sourcecred/example-repo",
         "type": "COMMENT",
       },
       "payload": Object {},
       "src": Object {
         "id": "https://github.com/sourcecred/example-repo/issues/2",
         "pluginName": "sourcecred/github-beta",
-        "repositoryName": "sourcecred/example-repo",
         "type": "ISSUE",
       },
     },
-    "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-repo/issues/2\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"repositoryName\\\\\\":\\\\\\"sourcecred/example-repo\\\\\\",\\\\\\"type\\\\\\":\\\\\\"ISSUE\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-repo/issues/2#issuecomment-385576248\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"repositoryName\\\\\\":\\\\\\"sourcecred/example-repo\\\\\\",\\\\\\"type\\\\\\":\\\\\\"COMMENT\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"repositoryName\\":\\"sourcecred/example-repo\\",\\"type\\":\\"CONTAINS\\"}": Object {
+    "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-repo/issues/2\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"ISSUE\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-repo/issues/2#issuecomment-385576248\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"COMMENT\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"CONTAINS\\"}": Object {
       "dst": Object {
         "id": "https://github.com/sourcecred/example-repo/issues/2#issuecomment-385576248",
         "pluginName": "sourcecred/github-beta",
-        "repositoryName": "sourcecred/example-repo",
         "type": "COMMENT",
       },
       "payload": Object {},
       "src": Object {
         "id": "https://github.com/sourcecred/example-repo/issues/2",
         "pluginName": "sourcecred/github-beta",
-        "repositoryName": "sourcecred/example-repo",
         "type": "ISSUE",
       },
     },
-    "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-repo/issues/2\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"repositoryName\\\\\\":\\\\\\"sourcecred/example-repo\\\\\\",\\\\\\"type\\\\\\":\\\\\\"ISSUE\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-repo/issues/2#issuecomment-385576273\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"repositoryName\\\\\\":\\\\\\"sourcecred/example-repo\\\\\\",\\\\\\"type\\\\\\":\\\\\\"COMMENT\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"repositoryName\\":\\"sourcecred/example-repo\\",\\"type\\":\\"CONTAINS\\"}": Object {
+    "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-repo/issues/2\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"ISSUE\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-repo/issues/2#issuecomment-385576273\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"COMMENT\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"CONTAINS\\"}": Object {
       "dst": Object {
         "id": "https://github.com/sourcecred/example-repo/issues/2#issuecomment-385576273",
         "pluginName": "sourcecred/github-beta",
-        "repositoryName": "sourcecred/example-repo",
         "type": "COMMENT",
       },
       "payload": Object {},
       "src": Object {
         "id": "https://github.com/sourcecred/example-repo/issues/2",
         "pluginName": "sourcecred/github-beta",
-        "repositoryName": "sourcecred/example-repo",
         "type": "ISSUE",
       },
     },
-    "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-repo/issues/2\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"repositoryName\\\\\\":\\\\\\"sourcecred/example-repo\\\\\\",\\\\\\"type\\\\\\":\\\\\\"ISSUE\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-repo/issues/2#issuecomment-385576920\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"repositoryName\\\\\\":\\\\\\"sourcecred/example-repo\\\\\\",\\\\\\"type\\\\\\":\\\\\\"COMMENT\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"repositoryName\\":\\"sourcecred/example-repo\\",\\"type\\":\\"CONTAINS\\"}": Object {
+    "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-repo/issues/2\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"ISSUE\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-repo/issues/2#issuecomment-385576920\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"COMMENT\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"CONTAINS\\"}": Object {
       "dst": Object {
         "id": "https://github.com/sourcecred/example-repo/issues/2#issuecomment-385576920",
         "pluginName": "sourcecred/github-beta",
-        "repositoryName": "sourcecred/example-repo",
         "type": "COMMENT",
       },
       "payload": Object {},
       "src": Object {
         "id": "https://github.com/sourcecred/example-repo/issues/2",
         "pluginName": "sourcecred/github-beta",
-        "repositoryName": "sourcecred/example-repo",
         "type": "ISSUE",
       },
     },
-    "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-repo/issues/2\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"repositoryName\\\\\\":\\\\\\"sourcecred/example-repo\\\\\\",\\\\\\"type\\\\\\":\\\\\\"ISSUE\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-repo/issues/2#issuecomment-385576936\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"repositoryName\\\\\\":\\\\\\"sourcecred/example-repo\\\\\\",\\\\\\"type\\\\\\":\\\\\\"COMMENT\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"repositoryName\\":\\"sourcecred/example-repo\\",\\"type\\":\\"CONTAINS\\"}": Object {
+    "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-repo/issues/2\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"ISSUE\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-repo/issues/2#issuecomment-385576936\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"COMMENT\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"CONTAINS\\"}": Object {
       "dst": Object {
         "id": "https://github.com/sourcecred/example-repo/issues/2#issuecomment-385576936",
         "pluginName": "sourcecred/github-beta",
-        "repositoryName": "sourcecred/example-repo",
         "type": "COMMENT",
       },
       "payload": Object {},
       "src": Object {
         "id": "https://github.com/sourcecred/example-repo/issues/2",
         "pluginName": "sourcecred/github-beta",
-        "repositoryName": "sourcecred/example-repo",
         "type": "ISSUE",
       },
     },
   },
   "nodes": Object {
-    "{\\"id\\":\\"https://github.com/decentralion\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"repositoryName\\":\\"sourcecred/example-repo\\",\\"type\\":\\"AUTHOR\\"}": Object {
+    "{\\"id\\":\\"https://github.com/decentralion\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"AUTHOR\\"}": Object {
       "payload": Object {
         "login": "decentralion",
         "subtype": "USER",
         "url": "https://github.com/decentralion",
       },
     },
-    "{\\"id\\":\\"https://github.com/sourcecred/example-repo/issues/2\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"repositoryName\\":\\"sourcecred/example-repo\\",\\"type\\":\\"ISSUE\\"}": Object {
+    "{\\"id\\":\\"https://github.com/sourcecred/example-repo/issues/2\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"ISSUE\\"}": Object {
       "payload": Object {
         "body": "This issue references another issue, namely #1",
         "number": 2,
@@ -1305,44 +1169,44 @@ Object {
         "url": "https://github.com/sourcecred/example-repo/issues/2",
       },
     },
-    "{\\"id\\":\\"https://github.com/sourcecred/example-repo/issues/2#issuecomment-373768703\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"repositoryName\\":\\"sourcecred/example-repo\\",\\"type\\":\\"COMMENT\\"}": Object {
+    "{\\"id\\":\\"https://github.com/sourcecred/example-repo/issues/2#issuecomment-373768703\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"COMMENT\\"}": Object {
       "payload": Object {
         "body": "It should also be possible to reference by exact url: https://github.com/sourcecred/example-repo/issues/6",
         "url": "https://github.com/sourcecred/example-repo/issues/2#issuecomment-373768703",
       },
     },
-    "{\\"id\\":\\"https://github.com/sourcecred/example-repo/issues/2#issuecomment-373768850\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"repositoryName\\":\\"sourcecred/example-repo\\",\\"type\\":\\"COMMENT\\"}": Object {
+    "{\\"id\\":\\"https://github.com/sourcecred/example-repo/issues/2#issuecomment-373768850\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"COMMENT\\"}": Object {
       "payload": Object {
         "body": "We might also reference individual comments directly.
 https://github.com/sourcecred/example-repo/issues/6#issuecomment-373768538",
         "url": "https://github.com/sourcecred/example-repo/issues/2#issuecomment-373768850",
       },
     },
-    "{\\"id\\":\\"https://github.com/sourcecred/example-repo/issues/2#issuecomment-385576185\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"repositoryName\\":\\"sourcecred/example-repo\\",\\"type\\":\\"COMMENT\\"}": Object {
+    "{\\"id\\":\\"https://github.com/sourcecred/example-repo/issues/2#issuecomment-385576185\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"COMMENT\\"}": Object {
       "payload": Object {
         "body": "Here's a PR by direct url: https://github.com/sourcecred/example-repo/pull/5",
         "url": "https://github.com/sourcecred/example-repo/issues/2#issuecomment-385576185",
       },
     },
-    "{\\"id\\":\\"https://github.com/sourcecred/example-repo/issues/2#issuecomment-385576220\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"repositoryName\\":\\"sourcecred/example-repo\\",\\"type\\":\\"COMMENT\\"}": Object {
+    "{\\"id\\":\\"https://github.com/sourcecred/example-repo/issues/2#issuecomment-385576220\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"COMMENT\\"}": Object {
       "payload": Object {
         "body": "a PR review by url: https://github.com/sourcecred/example-repo/pull/5#pullrequestreview-100313899",
         "url": "https://github.com/sourcecred/example-repo/issues/2#issuecomment-385576220",
       },
     },
-    "{\\"id\\":\\"https://github.com/sourcecred/example-repo/issues/2#issuecomment-385576248\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"repositoryName\\":\\"sourcecred/example-repo\\",\\"type\\":\\"COMMENT\\"}": Object {
+    "{\\"id\\":\\"https://github.com/sourcecred/example-repo/issues/2#issuecomment-385576248\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"COMMENT\\"}": Object {
       "payload": Object {
         "body": "a PR Review Comment by url: https://github.com/sourcecred/example-repo/pull/5#discussion_r171460198",
         "url": "https://github.com/sourcecred/example-repo/issues/2#issuecomment-385576248",
       },
     },
-    "{\\"id\\":\\"https://github.com/sourcecred/example-repo/issues/2#issuecomment-385576273\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"repositoryName\\":\\"sourcecred/example-repo\\",\\"type\\":\\"COMMENT\\"}": Object {
+    "{\\"id\\":\\"https://github.com/sourcecred/example-repo/issues/2#issuecomment-385576273\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"COMMENT\\"}": Object {
       "payload": Object {
         "body": "a user by url: https://github.com/wchargin",
         "url": "https://github.com/sourcecred/example-repo/issues/2#issuecomment-385576273",
       },
     },
-    "{\\"id\\":\\"https://github.com/sourcecred/example-repo/issues/2#issuecomment-385576920\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"repositoryName\\":\\"sourcecred/example-repo\\",\\"type\\":\\"COMMENT\\"}": Object {
+    "{\\"id\\":\\"https://github.com/sourcecred/example-repo/issues/2#issuecomment-385576920\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"COMMENT\\"}": Object {
       "payload": Object {
         "body": "Here are several references:
 #1 
@@ -1355,7 +1219,7 @@ https://github.com/sourcecred/example-repo/pull/5#pullrequestreview-100313899
         "url": "https://github.com/sourcecred/example-repo/issues/2#issuecomment-385576920",
       },
     },
-    "{\\"id\\":\\"https://github.com/sourcecred/example-repo/issues/2#issuecomment-385576936\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"repositoryName\\":\\"sourcecred/example-repo\\",\\"type\\":\\"COMMENT\\"}": Object {
+    "{\\"id\\":\\"https://github.com/sourcecred/example-repo/issues/2#issuecomment-385576936\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"COMMENT\\"}": Object {
       "payload": Object {
         "body": "This comment has no references.",
         "url": "https://github.com/sourcecred/example-repo/issues/2#issuecomment-385576936",
@@ -1368,811 +1232,705 @@ https://github.com/sourcecred/example-repo/pull/5#pullrequestreview-100313899
 exports[`GithubParser whole repo parsing parses the entire example-repo as expected 1`] = `
 Object {
   "edges": Object {
-    "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/decentralion\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"repositoryName\\\\\\":\\\\\\"sourcecred/example-repo\\\\\\",\\\\\\"type\\\\\\":\\\\\\"AUTHOR\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-repo/issues/1\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"repositoryName\\\\\\":\\\\\\"sourcecred/example-repo\\\\\\",\\\\\\"type\\\\\\":\\\\\\"ISSUE\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"repositoryName\\":\\"sourcecred/example-repo\\",\\"type\\":\\"AUTHORS\\"}": Object {
+    "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/decentralion\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"AUTHOR\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-repo/issues/1\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"ISSUE\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"AUTHORS\\"}": Object {
       "dst": Object {
         "id": "https://github.com/decentralion",
         "pluginName": "sourcecred/github-beta",
-        "repositoryName": "sourcecred/example-repo",
         "type": "AUTHOR",
       },
       "payload": Object {},
       "src": Object {
         "id": "https://github.com/sourcecred/example-repo/issues/1",
         "pluginName": "sourcecred/github-beta",
-        "repositoryName": "sourcecred/example-repo",
         "type": "ISSUE",
       },
     },
-    "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/decentralion\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"repositoryName\\\\\\":\\\\\\"sourcecred/example-repo\\\\\\",\\\\\\"type\\\\\\":\\\\\\"AUTHOR\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-repo/issues/2#issuecomment-373768703\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"repositoryName\\\\\\":\\\\\\"sourcecred/example-repo\\\\\\",\\\\\\"type\\\\\\":\\\\\\"COMMENT\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"repositoryName\\":\\"sourcecred/example-repo\\",\\"type\\":\\"AUTHORS\\"}": Object {
+    "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/decentralion\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"AUTHOR\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-repo/issues/2#issuecomment-373768703\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"COMMENT\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"AUTHORS\\"}": Object {
       "dst": Object {
         "id": "https://github.com/decentralion",
         "pluginName": "sourcecred/github-beta",
-        "repositoryName": "sourcecred/example-repo",
         "type": "AUTHOR",
       },
       "payload": Object {},
       "src": Object {
         "id": "https://github.com/sourcecred/example-repo/issues/2#issuecomment-373768703",
         "pluginName": "sourcecred/github-beta",
-        "repositoryName": "sourcecred/example-repo",
         "type": "COMMENT",
       },
     },
-    "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/decentralion\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"repositoryName\\\\\\":\\\\\\"sourcecred/example-repo\\\\\\",\\\\\\"type\\\\\\":\\\\\\"AUTHOR\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-repo/issues/2#issuecomment-373768850\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"repositoryName\\\\\\":\\\\\\"sourcecred/example-repo\\\\\\",\\\\\\"type\\\\\\":\\\\\\"COMMENT\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"repositoryName\\":\\"sourcecred/example-repo\\",\\"type\\":\\"AUTHORS\\"}": Object {
+    "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/decentralion\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"AUTHOR\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-repo/issues/2#issuecomment-373768850\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"COMMENT\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"AUTHORS\\"}": Object {
       "dst": Object {
         "id": "https://github.com/decentralion",
         "pluginName": "sourcecred/github-beta",
-        "repositoryName": "sourcecred/example-repo",
         "type": "AUTHOR",
       },
       "payload": Object {},
       "src": Object {
         "id": "https://github.com/sourcecred/example-repo/issues/2#issuecomment-373768850",
         "pluginName": "sourcecred/github-beta",
-        "repositoryName": "sourcecred/example-repo",
         "type": "COMMENT",
       },
     },
-    "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/decentralion\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"repositoryName\\\\\\":\\\\\\"sourcecred/example-repo\\\\\\",\\\\\\"type\\\\\\":\\\\\\"AUTHOR\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-repo/issues/2#issuecomment-385576185\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"repositoryName\\\\\\":\\\\\\"sourcecred/example-repo\\\\\\",\\\\\\"type\\\\\\":\\\\\\"COMMENT\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"repositoryName\\":\\"sourcecred/example-repo\\",\\"type\\":\\"AUTHORS\\"}": Object {
+    "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/decentralion\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"AUTHOR\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-repo/issues/2#issuecomment-385576185\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"COMMENT\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"AUTHORS\\"}": Object {
       "dst": Object {
         "id": "https://github.com/decentralion",
         "pluginName": "sourcecred/github-beta",
-        "repositoryName": "sourcecred/example-repo",
         "type": "AUTHOR",
       },
       "payload": Object {},
       "src": Object {
         "id": "https://github.com/sourcecred/example-repo/issues/2#issuecomment-385576185",
         "pluginName": "sourcecred/github-beta",
-        "repositoryName": "sourcecred/example-repo",
         "type": "COMMENT",
       },
     },
-    "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/decentralion\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"repositoryName\\\\\\":\\\\\\"sourcecred/example-repo\\\\\\",\\\\\\"type\\\\\\":\\\\\\"AUTHOR\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-repo/issues/2#issuecomment-385576220\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"repositoryName\\\\\\":\\\\\\"sourcecred/example-repo\\\\\\",\\\\\\"type\\\\\\":\\\\\\"COMMENT\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"repositoryName\\":\\"sourcecred/example-repo\\",\\"type\\":\\"AUTHORS\\"}": Object {
+    "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/decentralion\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"AUTHOR\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-repo/issues/2#issuecomment-385576220\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"COMMENT\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"AUTHORS\\"}": Object {
       "dst": Object {
         "id": "https://github.com/decentralion",
         "pluginName": "sourcecred/github-beta",
-        "repositoryName": "sourcecred/example-repo",
         "type": "AUTHOR",
       },
       "payload": Object {},
       "src": Object {
         "id": "https://github.com/sourcecred/example-repo/issues/2#issuecomment-385576220",
         "pluginName": "sourcecred/github-beta",
-        "repositoryName": "sourcecred/example-repo",
         "type": "COMMENT",
       },
     },
-    "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/decentralion\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"repositoryName\\\\\\":\\\\\\"sourcecred/example-repo\\\\\\",\\\\\\"type\\\\\\":\\\\\\"AUTHOR\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-repo/issues/2#issuecomment-385576248\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"repositoryName\\\\\\":\\\\\\"sourcecred/example-repo\\\\\\",\\\\\\"type\\\\\\":\\\\\\"COMMENT\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"repositoryName\\":\\"sourcecred/example-repo\\",\\"type\\":\\"AUTHORS\\"}": Object {
+    "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/decentralion\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"AUTHOR\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-repo/issues/2#issuecomment-385576248\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"COMMENT\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"AUTHORS\\"}": Object {
       "dst": Object {
         "id": "https://github.com/decentralion",
         "pluginName": "sourcecred/github-beta",
-        "repositoryName": "sourcecred/example-repo",
         "type": "AUTHOR",
       },
       "payload": Object {},
       "src": Object {
         "id": "https://github.com/sourcecred/example-repo/issues/2#issuecomment-385576248",
         "pluginName": "sourcecred/github-beta",
-        "repositoryName": "sourcecred/example-repo",
         "type": "COMMENT",
       },
     },
-    "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/decentralion\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"repositoryName\\\\\\":\\\\\\"sourcecred/example-repo\\\\\\",\\\\\\"type\\\\\\":\\\\\\"AUTHOR\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-repo/issues/2#issuecomment-385576273\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"repositoryName\\\\\\":\\\\\\"sourcecred/example-repo\\\\\\",\\\\\\"type\\\\\\":\\\\\\"COMMENT\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"repositoryName\\":\\"sourcecred/example-repo\\",\\"type\\":\\"AUTHORS\\"}": Object {
+    "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/decentralion\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"AUTHOR\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-repo/issues/2#issuecomment-385576273\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"COMMENT\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"AUTHORS\\"}": Object {
       "dst": Object {
         "id": "https://github.com/decentralion",
         "pluginName": "sourcecred/github-beta",
-        "repositoryName": "sourcecred/example-repo",
         "type": "AUTHOR",
       },
       "payload": Object {},
       "src": Object {
         "id": "https://github.com/sourcecred/example-repo/issues/2#issuecomment-385576273",
         "pluginName": "sourcecred/github-beta",
-        "repositoryName": "sourcecred/example-repo",
         "type": "COMMENT",
       },
     },
-    "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/decentralion\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"repositoryName\\\\\\":\\\\\\"sourcecred/example-repo\\\\\\",\\\\\\"type\\\\\\":\\\\\\"AUTHOR\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-repo/issues/2#issuecomment-385576920\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"repositoryName\\\\\\":\\\\\\"sourcecred/example-repo\\\\\\",\\\\\\"type\\\\\\":\\\\\\"COMMENT\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"repositoryName\\":\\"sourcecred/example-repo\\",\\"type\\":\\"AUTHORS\\"}": Object {
+    "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/decentralion\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"AUTHOR\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-repo/issues/2#issuecomment-385576920\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"COMMENT\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"AUTHORS\\"}": Object {
       "dst": Object {
         "id": "https://github.com/decentralion",
         "pluginName": "sourcecred/github-beta",
-        "repositoryName": "sourcecred/example-repo",
         "type": "AUTHOR",
       },
       "payload": Object {},
       "src": Object {
         "id": "https://github.com/sourcecred/example-repo/issues/2#issuecomment-385576920",
         "pluginName": "sourcecred/github-beta",
-        "repositoryName": "sourcecred/example-repo",
         "type": "COMMENT",
       },
     },
-    "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/decentralion\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"repositoryName\\\\\\":\\\\\\"sourcecred/example-repo\\\\\\",\\\\\\"type\\\\\\":\\\\\\"AUTHOR\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-repo/issues/2#issuecomment-385576936\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"repositoryName\\\\\\":\\\\\\"sourcecred/example-repo\\\\\\",\\\\\\"type\\\\\\":\\\\\\"COMMENT\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"repositoryName\\":\\"sourcecred/example-repo\\",\\"type\\":\\"AUTHORS\\"}": Object {
+    "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/decentralion\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"AUTHOR\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-repo/issues/2#issuecomment-385576936\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"COMMENT\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"AUTHORS\\"}": Object {
       "dst": Object {
         "id": "https://github.com/decentralion",
         "pluginName": "sourcecred/github-beta",
-        "repositoryName": "sourcecred/example-repo",
         "type": "AUTHOR",
       },
       "payload": Object {},
       "src": Object {
         "id": "https://github.com/sourcecred/example-repo/issues/2#issuecomment-385576936",
         "pluginName": "sourcecred/github-beta",
-        "repositoryName": "sourcecred/example-repo",
         "type": "COMMENT",
       },
     },
-    "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/decentralion\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"repositoryName\\\\\\":\\\\\\"sourcecred/example-repo\\\\\\",\\\\\\"type\\\\\\":\\\\\\"AUTHOR\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-repo/issues/2\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"repositoryName\\\\\\":\\\\\\"sourcecred/example-repo\\\\\\",\\\\\\"type\\\\\\":\\\\\\"ISSUE\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"repositoryName\\":\\"sourcecred/example-repo\\",\\"type\\":\\"AUTHORS\\"}": Object {
+    "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/decentralion\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"AUTHOR\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-repo/issues/2\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"ISSUE\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"AUTHORS\\"}": Object {
       "dst": Object {
         "id": "https://github.com/decentralion",
         "pluginName": "sourcecred/github-beta",
-        "repositoryName": "sourcecred/example-repo",
         "type": "AUTHOR",
       },
       "payload": Object {},
       "src": Object {
         "id": "https://github.com/sourcecred/example-repo/issues/2",
         "pluginName": "sourcecred/github-beta",
-        "repositoryName": "sourcecred/example-repo",
         "type": "ISSUE",
       },
     },
-    "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/decentralion\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"repositoryName\\\\\\":\\\\\\"sourcecred/example-repo\\\\\\",\\\\\\"type\\\\\\":\\\\\\"AUTHOR\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-repo/issues/4\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"repositoryName\\\\\\":\\\\\\"sourcecred/example-repo\\\\\\",\\\\\\"type\\\\\\":\\\\\\"ISSUE\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"repositoryName\\":\\"sourcecred/example-repo\\",\\"type\\":\\"AUTHORS\\"}": Object {
+    "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/decentralion\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"AUTHOR\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-repo/issues/4\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"ISSUE\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"AUTHORS\\"}": Object {
       "dst": Object {
         "id": "https://github.com/decentralion",
         "pluginName": "sourcecred/github-beta",
-        "repositoryName": "sourcecred/example-repo",
         "type": "AUTHOR",
       },
       "payload": Object {},
       "src": Object {
         "id": "https://github.com/sourcecred/example-repo/issues/4",
         "pluginName": "sourcecred/github-beta",
-        "repositoryName": "sourcecred/example-repo",
         "type": "ISSUE",
       },
     },
-    "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/decentralion\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"repositoryName\\\\\\":\\\\\\"sourcecred/example-repo\\\\\\",\\\\\\"type\\\\\\":\\\\\\"AUTHOR\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-repo/issues/6#issuecomment-373768442\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"repositoryName\\\\\\":\\\\\\"sourcecred/example-repo\\\\\\",\\\\\\"type\\\\\\":\\\\\\"COMMENT\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"repositoryName\\":\\"sourcecred/example-repo\\",\\"type\\":\\"AUTHORS\\"}": Object {
+    "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/decentralion\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"AUTHOR\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-repo/issues/6#issuecomment-373768442\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"COMMENT\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"AUTHORS\\"}": Object {
       "dst": Object {
         "id": "https://github.com/decentralion",
         "pluginName": "sourcecred/github-beta",
-        "repositoryName": "sourcecred/example-repo",
         "type": "AUTHOR",
       },
       "payload": Object {},
       "src": Object {
         "id": "https://github.com/sourcecred/example-repo/issues/6#issuecomment-373768442",
         "pluginName": "sourcecred/github-beta",
-        "repositoryName": "sourcecred/example-repo",
         "type": "COMMENT",
       },
     },
-    "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/decentralion\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"repositoryName\\\\\\":\\\\\\"sourcecred/example-repo\\\\\\",\\\\\\"type\\\\\\":\\\\\\"AUTHOR\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-repo/issues/6#issuecomment-373768538\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"repositoryName\\\\\\":\\\\\\"sourcecred/example-repo\\\\\\",\\\\\\"type\\\\\\":\\\\\\"COMMENT\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"repositoryName\\":\\"sourcecred/example-repo\\",\\"type\\":\\"AUTHORS\\"}": Object {
+    "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/decentralion\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"AUTHOR\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-repo/issues/6#issuecomment-373768538\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"COMMENT\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"AUTHORS\\"}": Object {
       "dst": Object {
         "id": "https://github.com/decentralion",
         "pluginName": "sourcecred/github-beta",
-        "repositoryName": "sourcecred/example-repo",
         "type": "AUTHOR",
       },
       "payload": Object {},
       "src": Object {
         "id": "https://github.com/sourcecred/example-repo/issues/6#issuecomment-373768538",
         "pluginName": "sourcecred/github-beta",
-        "repositoryName": "sourcecred/example-repo",
         "type": "COMMENT",
       },
     },
-    "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/decentralion\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"repositoryName\\\\\\":\\\\\\"sourcecred/example-repo\\\\\\",\\\\\\"type\\\\\\":\\\\\\"AUTHOR\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-repo/issues/6#issuecomment-385223316\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"repositoryName\\\\\\":\\\\\\"sourcecred/example-repo\\\\\\",\\\\\\"type\\\\\\":\\\\\\"COMMENT\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"repositoryName\\":\\"sourcecred/example-repo\\",\\"type\\":\\"AUTHORS\\"}": Object {
+    "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/decentralion\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"AUTHOR\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-repo/issues/6#issuecomment-385223316\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"COMMENT\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"AUTHORS\\"}": Object {
       "dst": Object {
         "id": "https://github.com/decentralion",
         "pluginName": "sourcecred/github-beta",
-        "repositoryName": "sourcecred/example-repo",
         "type": "AUTHOR",
       },
       "payload": Object {},
       "src": Object {
         "id": "https://github.com/sourcecred/example-repo/issues/6#issuecomment-385223316",
         "pluginName": "sourcecred/github-beta",
-        "repositoryName": "sourcecred/example-repo",
         "type": "COMMENT",
       },
     },
-    "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/decentralion\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"repositoryName\\\\\\":\\\\\\"sourcecred/example-repo\\\\\\",\\\\\\"type\\\\\\":\\\\\\"AUTHOR\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-repo/issues/6\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"repositoryName\\\\\\":\\\\\\"sourcecred/example-repo\\\\\\",\\\\\\"type\\\\\\":\\\\\\"ISSUE\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"repositoryName\\":\\"sourcecred/example-repo\\",\\"type\\":\\"AUTHORS\\"}": Object {
+    "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/decentralion\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"AUTHOR\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-repo/issues/6\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"ISSUE\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"AUTHORS\\"}": Object {
       "dst": Object {
         "id": "https://github.com/decentralion",
         "pluginName": "sourcecred/github-beta",
-        "repositoryName": "sourcecred/example-repo",
         "type": "AUTHOR",
       },
       "payload": Object {},
       "src": Object {
         "id": "https://github.com/sourcecred/example-repo/issues/6",
         "pluginName": "sourcecred/github-beta",
-        "repositoryName": "sourcecred/example-repo",
         "type": "ISSUE",
       },
     },
-    "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/decentralion\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"repositoryName\\\\\\":\\\\\\"sourcecred/example-repo\\\\\\",\\\\\\"type\\\\\\":\\\\\\"AUTHOR\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-repo/issues/7\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"repositoryName\\\\\\":\\\\\\"sourcecred/example-repo\\\\\\",\\\\\\"type\\\\\\":\\\\\\"ISSUE\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"repositoryName\\":\\"sourcecred/example-repo\\",\\"type\\":\\"AUTHORS\\"}": Object {
+    "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/decentralion\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"AUTHOR\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-repo/issues/7\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"ISSUE\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"AUTHORS\\"}": Object {
       "dst": Object {
         "id": "https://github.com/decentralion",
         "pluginName": "sourcecred/github-beta",
-        "repositoryName": "sourcecred/example-repo",
         "type": "AUTHOR",
       },
       "payload": Object {},
       "src": Object {
         "id": "https://github.com/sourcecred/example-repo/issues/7",
         "pluginName": "sourcecred/github-beta",
-        "repositoryName": "sourcecred/example-repo",
         "type": "ISSUE",
       },
     },
-    "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/decentralion\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"repositoryName\\\\\\":\\\\\\"sourcecred/example-repo\\\\\\",\\\\\\"type\\\\\\":\\\\\\"AUTHOR\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-repo/issues/8\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"repositoryName\\\\\\":\\\\\\"sourcecred/example-repo\\\\\\",\\\\\\"type\\\\\\":\\\\\\"ISSUE\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"repositoryName\\":\\"sourcecred/example-repo\\",\\"type\\":\\"AUTHORS\\"}": Object {
+    "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/decentralion\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"AUTHOR\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-repo/issues/8\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"ISSUE\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"AUTHORS\\"}": Object {
       "dst": Object {
         "id": "https://github.com/decentralion",
         "pluginName": "sourcecred/github-beta",
-        "repositoryName": "sourcecred/example-repo",
         "type": "AUTHOR",
       },
       "payload": Object {},
       "src": Object {
         "id": "https://github.com/sourcecred/example-repo/issues/8",
         "pluginName": "sourcecred/github-beta",
-        "repositoryName": "sourcecred/example-repo",
         "type": "ISSUE",
       },
     },
-    "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/decentralion\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"repositoryName\\\\\\":\\\\\\"sourcecred/example-repo\\\\\\",\\\\\\"type\\\\\\":\\\\\\"AUTHOR\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-repo/pull/3#issuecomment-369162222\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"repositoryName\\\\\\":\\\\\\"sourcecred/example-repo\\\\\\",\\\\\\"type\\\\\\":\\\\\\"COMMENT\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"repositoryName\\":\\"sourcecred/example-repo\\",\\"type\\":\\"AUTHORS\\"}": Object {
+    "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/decentralion\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"AUTHOR\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-repo/pull/3#issuecomment-369162222\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"COMMENT\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"AUTHORS\\"}": Object {
       "dst": Object {
         "id": "https://github.com/decentralion",
         "pluginName": "sourcecred/github-beta",
-        "repositoryName": "sourcecred/example-repo",
         "type": "AUTHOR",
       },
       "payload": Object {},
       "src": Object {
         "id": "https://github.com/sourcecred/example-repo/pull/3#issuecomment-369162222",
         "pluginName": "sourcecred/github-beta",
-        "repositoryName": "sourcecred/example-repo",
         "type": "COMMENT",
       },
     },
-    "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/decentralion\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"repositoryName\\\\\\":\\\\\\"sourcecred/example-repo\\\\\\",\\\\\\"type\\\\\\":\\\\\\"AUTHOR\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-repo/pull/3\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"repositoryName\\\\\\":\\\\\\"sourcecred/example-repo\\\\\\",\\\\\\"type\\\\\\":\\\\\\"PULL_REQUEST\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"repositoryName\\":\\"sourcecred/example-repo\\",\\"type\\":\\"AUTHORS\\"}": Object {
+    "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/decentralion\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"AUTHOR\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-repo/pull/3\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"PULL_REQUEST\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"AUTHORS\\"}": Object {
       "dst": Object {
         "id": "https://github.com/decentralion",
         "pluginName": "sourcecred/github-beta",
-        "repositoryName": "sourcecred/example-repo",
         "type": "AUTHOR",
       },
       "payload": Object {},
       "src": Object {
         "id": "https://github.com/sourcecred/example-repo/pull/3",
         "pluginName": "sourcecred/github-beta",
-        "repositoryName": "sourcecred/example-repo",
         "type": "PULL_REQUEST",
       },
     },
-    "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/decentralion\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"repositoryName\\\\\\":\\\\\\"sourcecred/example-repo\\\\\\",\\\\\\"type\\\\\\":\\\\\\"AUTHOR\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-repo/pull/5\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"repositoryName\\\\\\":\\\\\\"sourcecred/example-repo\\\\\\",\\\\\\"type\\\\\\":\\\\\\"PULL_REQUEST\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"repositoryName\\":\\"sourcecred/example-repo\\",\\"type\\":\\"AUTHORS\\"}": Object {
+    "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/decentralion\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"AUTHOR\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-repo/pull/5\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"PULL_REQUEST\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"AUTHORS\\"}": Object {
       "dst": Object {
         "id": "https://github.com/decentralion",
         "pluginName": "sourcecred/github-beta",
-        "repositoryName": "sourcecred/example-repo",
         "type": "AUTHOR",
       },
       "payload": Object {},
       "src": Object {
         "id": "https://github.com/sourcecred/example-repo/pull/5",
         "pluginName": "sourcecred/github-beta",
-        "repositoryName": "sourcecred/example-repo",
         "type": "PULL_REQUEST",
       },
     },
-    "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-repo/issues/2#issuecomment-373768703\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"repositoryName\\\\\\":\\\\\\"sourcecred/example-repo\\\\\\",\\\\\\"type\\\\\\":\\\\\\"COMMENT\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-repo/issues/6\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"repositoryName\\\\\\":\\\\\\"sourcecred/example-repo\\\\\\",\\\\\\"type\\\\\\":\\\\\\"ISSUE\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"repositoryName\\":\\"sourcecred/example-repo\\",\\"type\\":\\"REFERENCES\\"}": Object {
+    "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-repo/issues/2#issuecomment-373768703\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"COMMENT\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-repo/issues/6\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"ISSUE\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"REFERENCES\\"}": Object {
       "dst": Object {
         "id": "https://github.com/sourcecred/example-repo/issues/6",
         "pluginName": "sourcecred/github-beta",
-        "repositoryName": "sourcecred/example-repo",
         "type": "ISSUE",
       },
       "payload": Object {},
       "src": Object {
         "id": "https://github.com/sourcecred/example-repo/issues/2#issuecomment-373768703",
         "pluginName": "sourcecred/github-beta",
-        "repositoryName": "sourcecred/example-repo",
         "type": "COMMENT",
       },
     },
-    "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-repo/issues/2#issuecomment-373768850\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"repositoryName\\\\\\":\\\\\\"sourcecred/example-repo\\\\\\",\\\\\\"type\\\\\\":\\\\\\"COMMENT\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-repo/issues/6#issuecomment-373768538\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"repositoryName\\\\\\":\\\\\\"sourcecred/example-repo\\\\\\",\\\\\\"type\\\\\\":\\\\\\"COMMENT\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"repositoryName\\":\\"sourcecred/example-repo\\",\\"type\\":\\"REFERENCES\\"}": Object {
+    "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-repo/issues/2#issuecomment-373768850\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"COMMENT\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-repo/issues/6#issuecomment-373768538\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"COMMENT\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"REFERENCES\\"}": Object {
       "dst": Object {
         "id": "https://github.com/sourcecred/example-repo/issues/6#issuecomment-373768538",
         "pluginName": "sourcecred/github-beta",
-        "repositoryName": "sourcecred/example-repo",
         "type": "COMMENT",
       },
       "payload": Object {},
       "src": Object {
         "id": "https://github.com/sourcecred/example-repo/issues/2#issuecomment-373768850",
         "pluginName": "sourcecred/github-beta",
-        "repositoryName": "sourcecred/example-repo",
         "type": "COMMENT",
       },
     },
-    "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-repo/issues/2#issuecomment-385576185\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"repositoryName\\\\\\":\\\\\\"sourcecred/example-repo\\\\\\",\\\\\\"type\\\\\\":\\\\\\"COMMENT\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-repo/pull/5\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"repositoryName\\\\\\":\\\\\\"sourcecred/example-repo\\\\\\",\\\\\\"type\\\\\\":\\\\\\"PULL_REQUEST\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"repositoryName\\":\\"sourcecred/example-repo\\",\\"type\\":\\"REFERENCES\\"}": Object {
+    "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-repo/issues/2#issuecomment-385576185\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"COMMENT\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-repo/pull/5\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"PULL_REQUEST\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"REFERENCES\\"}": Object {
       "dst": Object {
         "id": "https://github.com/sourcecred/example-repo/pull/5",
         "pluginName": "sourcecred/github-beta",
-        "repositoryName": "sourcecred/example-repo",
         "type": "PULL_REQUEST",
       },
       "payload": Object {},
       "src": Object {
         "id": "https://github.com/sourcecred/example-repo/issues/2#issuecomment-385576185",
         "pluginName": "sourcecred/github-beta",
-        "repositoryName": "sourcecred/example-repo",
         "type": "COMMENT",
       },
     },
-    "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-repo/issues/2#issuecomment-385576220\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"repositoryName\\\\\\":\\\\\\"sourcecred/example-repo\\\\\\",\\\\\\"type\\\\\\":\\\\\\"COMMENT\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-repo/pull/5#pullrequestreview-100313899\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"repositoryName\\\\\\":\\\\\\"sourcecred/example-repo\\\\\\",\\\\\\"type\\\\\\":\\\\\\"PULL_REQUEST_REVIEW\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"repositoryName\\":\\"sourcecred/example-repo\\",\\"type\\":\\"REFERENCES\\"}": Object {
+    "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-repo/issues/2#issuecomment-385576220\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"COMMENT\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-repo/pull/5#pullrequestreview-100313899\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"PULL_REQUEST_REVIEW\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"REFERENCES\\"}": Object {
       "dst": Object {
         "id": "https://github.com/sourcecred/example-repo/pull/5#pullrequestreview-100313899",
         "pluginName": "sourcecred/github-beta",
-        "repositoryName": "sourcecred/example-repo",
         "type": "PULL_REQUEST_REVIEW",
       },
       "payload": Object {},
       "src": Object {
         "id": "https://github.com/sourcecred/example-repo/issues/2#issuecomment-385576220",
         "pluginName": "sourcecred/github-beta",
-        "repositoryName": "sourcecred/example-repo",
         "type": "COMMENT",
       },
     },
-    "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-repo/issues/2#issuecomment-385576248\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"repositoryName\\\\\\":\\\\\\"sourcecred/example-repo\\\\\\",\\\\\\"type\\\\\\":\\\\\\"COMMENT\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-repo/pull/5#discussion_r171460198\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"repositoryName\\\\\\":\\\\\\"sourcecred/example-repo\\\\\\",\\\\\\"type\\\\\\":\\\\\\"PULL_REQUEST_REVIEW_COMMENT\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"repositoryName\\":\\"sourcecred/example-repo\\",\\"type\\":\\"REFERENCES\\"}": Object {
+    "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-repo/issues/2#issuecomment-385576248\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"COMMENT\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-repo/pull/5#discussion_r171460198\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"PULL_REQUEST_REVIEW_COMMENT\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"REFERENCES\\"}": Object {
       "dst": Object {
         "id": "https://github.com/sourcecred/example-repo/pull/5#discussion_r171460198",
         "pluginName": "sourcecred/github-beta",
-        "repositoryName": "sourcecred/example-repo",
         "type": "PULL_REQUEST_REVIEW_COMMENT",
       },
       "payload": Object {},
       "src": Object {
         "id": "https://github.com/sourcecred/example-repo/issues/2#issuecomment-385576248",
         "pluginName": "sourcecred/github-beta",
-        "repositoryName": "sourcecred/example-repo",
         "type": "COMMENT",
       },
     },
-    "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-repo/issues/2#issuecomment-385576273\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"repositoryName\\\\\\":\\\\\\"sourcecred/example-repo\\\\\\",\\\\\\"type\\\\\\":\\\\\\"COMMENT\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/wchargin\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"repositoryName\\\\\\":\\\\\\"sourcecred/example-repo\\\\\\",\\\\\\"type\\\\\\":\\\\\\"AUTHOR\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"repositoryName\\":\\"sourcecred/example-repo\\",\\"type\\":\\"REFERENCES\\"}": Object {
+    "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-repo/issues/2#issuecomment-385576273\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"COMMENT\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/wchargin\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"AUTHOR\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"REFERENCES\\"}": Object {
       "dst": Object {
         "id": "https://github.com/wchargin",
         "pluginName": "sourcecred/github-beta",
-        "repositoryName": "sourcecred/example-repo",
         "type": "AUTHOR",
       },
       "payload": Object {},
       "src": Object {
         "id": "https://github.com/sourcecred/example-repo/issues/2#issuecomment-385576273",
         "pluginName": "sourcecred/github-beta",
-        "repositoryName": "sourcecred/example-repo",
         "type": "COMMENT",
       },
     },
-    "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-repo/issues/2#issuecomment-385576920\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"repositoryName\\\\\\":\\\\\\"sourcecred/example-repo\\\\\\",\\\\\\"type\\\\\\":\\\\\\"COMMENT\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-repo/issues/1\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"repositoryName\\\\\\":\\\\\\"sourcecred/example-repo\\\\\\",\\\\\\"type\\\\\\":\\\\\\"ISSUE\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"repositoryName\\":\\"sourcecred/example-repo\\",\\"type\\":\\"REFERENCES\\"}": Object {
+    "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-repo/issues/2#issuecomment-385576920\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"COMMENT\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-repo/issues/1\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"ISSUE\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"REFERENCES\\"}": Object {
       "dst": Object {
         "id": "https://github.com/sourcecred/example-repo/issues/1",
         "pluginName": "sourcecred/github-beta",
-        "repositoryName": "sourcecred/example-repo",
         "type": "ISSUE",
       },
       "payload": Object {},
       "src": Object {
         "id": "https://github.com/sourcecred/example-repo/issues/2#issuecomment-385576920",
         "pluginName": "sourcecred/github-beta",
-        "repositoryName": "sourcecred/example-repo",
         "type": "COMMENT",
       },
     },
-    "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-repo/issues/2#issuecomment-385576920\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"repositoryName\\\\\\":\\\\\\"sourcecred/example-repo\\\\\\",\\\\\\"type\\\\\\":\\\\\\"COMMENT\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-repo/issues/2\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"repositoryName\\\\\\":\\\\\\"sourcecred/example-repo\\\\\\",\\\\\\"type\\\\\\":\\\\\\"ISSUE\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"repositoryName\\":\\"sourcecred/example-repo\\",\\"type\\":\\"REFERENCES\\"}": Object {
+    "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-repo/issues/2#issuecomment-385576920\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"COMMENT\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-repo/issues/2\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"ISSUE\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"REFERENCES\\"}": Object {
       "dst": Object {
         "id": "https://github.com/sourcecred/example-repo/issues/2",
         "pluginName": "sourcecred/github-beta",
-        "repositoryName": "sourcecred/example-repo",
         "type": "ISSUE",
       },
       "payload": Object {},
       "src": Object {
         "id": "https://github.com/sourcecred/example-repo/issues/2#issuecomment-385576920",
         "pluginName": "sourcecred/github-beta",
-        "repositoryName": "sourcecred/example-repo",
         "type": "COMMENT",
       },
     },
-    "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-repo/issues/2#issuecomment-385576920\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"repositoryName\\\\\\":\\\\\\"sourcecred/example-repo\\\\\\",\\\\\\"type\\\\\\":\\\\\\"COMMENT\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-repo/pull/3\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"repositoryName\\\\\\":\\\\\\"sourcecred/example-repo\\\\\\",\\\\\\"type\\\\\\":\\\\\\"PULL_REQUEST\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"repositoryName\\":\\"sourcecred/example-repo\\",\\"type\\":\\"REFERENCES\\"}": Object {
+    "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-repo/issues/2#issuecomment-385576920\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"COMMENT\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-repo/pull/3\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"PULL_REQUEST\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"REFERENCES\\"}": Object {
       "dst": Object {
         "id": "https://github.com/sourcecred/example-repo/pull/3",
         "pluginName": "sourcecred/github-beta",
-        "repositoryName": "sourcecred/example-repo",
         "type": "PULL_REQUEST",
       },
       "payload": Object {},
       "src": Object {
         "id": "https://github.com/sourcecred/example-repo/issues/2#issuecomment-385576920",
         "pluginName": "sourcecred/github-beta",
-        "repositoryName": "sourcecred/example-repo",
         "type": "COMMENT",
       },
     },
-    "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-repo/issues/2#issuecomment-385576920\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"repositoryName\\\\\\":\\\\\\"sourcecred/example-repo\\\\\\",\\\\\\"type\\\\\\":\\\\\\"COMMENT\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-repo/pull/5#discussion_r171460198\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"repositoryName\\\\\\":\\\\\\"sourcecred/example-repo\\\\\\",\\\\\\"type\\\\\\":\\\\\\"PULL_REQUEST_REVIEW_COMMENT\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"repositoryName\\":\\"sourcecred/example-repo\\",\\"type\\":\\"REFERENCES\\"}": Object {
+    "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-repo/issues/2#issuecomment-385576920\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"COMMENT\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-repo/pull/5#discussion_r171460198\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"PULL_REQUEST_REVIEW_COMMENT\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"REFERENCES\\"}": Object {
       "dst": Object {
         "id": "https://github.com/sourcecred/example-repo/pull/5#discussion_r171460198",
         "pluginName": "sourcecred/github-beta",
-        "repositoryName": "sourcecred/example-repo",
         "type": "PULL_REQUEST_REVIEW_COMMENT",
       },
       "payload": Object {},
       "src": Object {
         "id": "https://github.com/sourcecred/example-repo/issues/2#issuecomment-385576920",
         "pluginName": "sourcecred/github-beta",
-        "repositoryName": "sourcecred/example-repo",
         "type": "COMMENT",
       },
     },
-    "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-repo/issues/2#issuecomment-385576920\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"repositoryName\\\\\\":\\\\\\"sourcecred/example-repo\\\\\\",\\\\\\"type\\\\\\":\\\\\\"COMMENT\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-repo/pull/5#pullrequestreview-100313899\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"repositoryName\\\\\\":\\\\\\"sourcecred/example-repo\\\\\\",\\\\\\"type\\\\\\":\\\\\\"PULL_REQUEST_REVIEW\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"repositoryName\\":\\"sourcecred/example-repo\\",\\"type\\":\\"REFERENCES\\"}": Object {
+    "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-repo/issues/2#issuecomment-385576920\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"COMMENT\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-repo/pull/5#pullrequestreview-100313899\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"PULL_REQUEST_REVIEW\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"REFERENCES\\"}": Object {
       "dst": Object {
         "id": "https://github.com/sourcecred/example-repo/pull/5#pullrequestreview-100313899",
         "pluginName": "sourcecred/github-beta",
-        "repositoryName": "sourcecred/example-repo",
         "type": "PULL_REQUEST_REVIEW",
       },
       "payload": Object {},
       "src": Object {
         "id": "https://github.com/sourcecred/example-repo/issues/2#issuecomment-385576920",
         "pluginName": "sourcecred/github-beta",
-        "repositoryName": "sourcecred/example-repo",
         "type": "COMMENT",
       },
     },
-    "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-repo/issues/2\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"repositoryName\\\\\\":\\\\\\"sourcecred/example-repo\\\\\\",\\\\\\"type\\\\\\":\\\\\\"ISSUE\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-repo/issues/1\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"repositoryName\\\\\\":\\\\\\"sourcecred/example-repo\\\\\\",\\\\\\"type\\\\\\":\\\\\\"ISSUE\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"repositoryName\\":\\"sourcecred/example-repo\\",\\"type\\":\\"REFERENCES\\"}": Object {
+    "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-repo/issues/2\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"ISSUE\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-repo/issues/1\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"ISSUE\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"REFERENCES\\"}": Object {
       "dst": Object {
         "id": "https://github.com/sourcecred/example-repo/issues/1",
         "pluginName": "sourcecred/github-beta",
-        "repositoryName": "sourcecred/example-repo",
         "type": "ISSUE",
       },
       "payload": Object {},
       "src": Object {
         "id": "https://github.com/sourcecred/example-repo/issues/2",
         "pluginName": "sourcecred/github-beta",
-        "repositoryName": "sourcecred/example-repo",
         "type": "ISSUE",
       },
     },
-    "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-repo/issues/2\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"repositoryName\\\\\\":\\\\\\"sourcecred/example-repo\\\\\\",\\\\\\"type\\\\\\":\\\\\\"ISSUE\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-repo/issues/2#issuecomment-373768703\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"repositoryName\\\\\\":\\\\\\"sourcecred/example-repo\\\\\\",\\\\\\"type\\\\\\":\\\\\\"COMMENT\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"repositoryName\\":\\"sourcecred/example-repo\\",\\"type\\":\\"CONTAINS\\"}": Object {
+    "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-repo/issues/2\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"ISSUE\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-repo/issues/2#issuecomment-373768703\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"COMMENT\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"CONTAINS\\"}": Object {
       "dst": Object {
         "id": "https://github.com/sourcecred/example-repo/issues/2#issuecomment-373768703",
         "pluginName": "sourcecred/github-beta",
-        "repositoryName": "sourcecred/example-repo",
         "type": "COMMENT",
       },
       "payload": Object {},
       "src": Object {
         "id": "https://github.com/sourcecred/example-repo/issues/2",
         "pluginName": "sourcecred/github-beta",
-        "repositoryName": "sourcecred/example-repo",
         "type": "ISSUE",
       },
     },
-    "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-repo/issues/2\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"repositoryName\\\\\\":\\\\\\"sourcecred/example-repo\\\\\\",\\\\\\"type\\\\\\":\\\\\\"ISSUE\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-repo/issues/2#issuecomment-373768850\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"repositoryName\\\\\\":\\\\\\"sourcecred/example-repo\\\\\\",\\\\\\"type\\\\\\":\\\\\\"COMMENT\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"repositoryName\\":\\"sourcecred/example-repo\\",\\"type\\":\\"CONTAINS\\"}": Object {
+    "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-repo/issues/2\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"ISSUE\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-repo/issues/2#issuecomment-373768850\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"COMMENT\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"CONTAINS\\"}": Object {
       "dst": Object {
         "id": "https://github.com/sourcecred/example-repo/issues/2#issuecomment-373768850",
         "pluginName": "sourcecred/github-beta",
-        "repositoryName": "sourcecred/example-repo",
         "type": "COMMENT",
       },
       "payload": Object {},
       "src": Object {
         "id": "https://github.com/sourcecred/example-repo/issues/2",
         "pluginName": "sourcecred/github-beta",
-        "repositoryName": "sourcecred/example-repo",
         "type": "ISSUE",
       },
     },
-    "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-repo/issues/2\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"repositoryName\\\\\\":\\\\\\"sourcecred/example-repo\\\\\\",\\\\\\"type\\\\\\":\\\\\\"ISSUE\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-repo/issues/2#issuecomment-385576185\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"repositoryName\\\\\\":\\\\\\"sourcecred/example-repo\\\\\\",\\\\\\"type\\\\\\":\\\\\\"COMMENT\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"repositoryName\\":\\"sourcecred/example-repo\\",\\"type\\":\\"CONTAINS\\"}": Object {
+    "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-repo/issues/2\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"ISSUE\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-repo/issues/2#issuecomment-385576185\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"COMMENT\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"CONTAINS\\"}": Object {
       "dst": Object {
         "id": "https://github.com/sourcecred/example-repo/issues/2#issuecomment-385576185",
         "pluginName": "sourcecred/github-beta",
-        "repositoryName": "sourcecred/example-repo",
         "type": "COMMENT",
       },
       "payload": Object {},
       "src": Object {
         "id": "https://github.com/sourcecred/example-repo/issues/2",
         "pluginName": "sourcecred/github-beta",
-        "repositoryName": "sourcecred/example-repo",
         "type": "ISSUE",
       },
     },
-    "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-repo/issues/2\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"repositoryName\\\\\\":\\\\\\"sourcecred/example-repo\\\\\\",\\\\\\"type\\\\\\":\\\\\\"ISSUE\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-repo/issues/2#issuecomment-385576220\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"repositoryName\\\\\\":\\\\\\"sourcecred/example-repo\\\\\\",\\\\\\"type\\\\\\":\\\\\\"COMMENT\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"repositoryName\\":\\"sourcecred/example-repo\\",\\"type\\":\\"CONTAINS\\"}": Object {
+    "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-repo/issues/2\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"ISSUE\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-repo/issues/2#issuecomment-385576220\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"COMMENT\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"CONTAINS\\"}": Object {
       "dst": Object {
         "id": "https://github.com/sourcecred/example-repo/issues/2#issuecomment-385576220",
         "pluginName": "sourcecred/github-beta",
-        "repositoryName": "sourcecred/example-repo",
         "type": "COMMENT",
       },
       "payload": Object {},
       "src": Object {
         "id": "https://github.com/sourcecred/example-repo/issues/2",
         "pluginName": "sourcecred/github-beta",
-        "repositoryName": "sourcecred/example-repo",
         "type": "ISSUE",
       },
     },
-    "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-repo/issues/2\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"repositoryName\\\\\\":\\\\\\"sourcecred/example-repo\\\\\\",\\\\\\"type\\\\\\":\\\\\\"ISSUE\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-repo/issues/2#issuecomment-385576248\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"repositoryName\\\\\\":\\\\\\"sourcecred/example-repo\\\\\\",\\\\\\"type\\\\\\":\\\\\\"COMMENT\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"repositoryName\\":\\"sourcecred/example-repo\\",\\"type\\":\\"CONTAINS\\"}": Object {
+    "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-repo/issues/2\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"ISSUE\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-repo/issues/2#issuecomment-385576248\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"COMMENT\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"CONTAINS\\"}": Object {
       "dst": Object {
         "id": "https://github.com/sourcecred/example-repo/issues/2#issuecomment-385576248",
         "pluginName": "sourcecred/github-beta",
-        "repositoryName": "sourcecred/example-repo",
         "type": "COMMENT",
       },
       "payload": Object {},
       "src": Object {
         "id": "https://github.com/sourcecred/example-repo/issues/2",
         "pluginName": "sourcecred/github-beta",
-        "repositoryName": "sourcecred/example-repo",
         "type": "ISSUE",
       },
     },
-    "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-repo/issues/2\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"repositoryName\\\\\\":\\\\\\"sourcecred/example-repo\\\\\\",\\\\\\"type\\\\\\":\\\\\\"ISSUE\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-repo/issues/2#issuecomment-385576273\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"repositoryName\\\\\\":\\\\\\"sourcecred/example-repo\\\\\\",\\\\\\"type\\\\\\":\\\\\\"COMMENT\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"repositoryName\\":\\"sourcecred/example-repo\\",\\"type\\":\\"CONTAINS\\"}": Object {
+    "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-repo/issues/2\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"ISSUE\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-repo/issues/2#issuecomment-385576273\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"COMMENT\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"CONTAINS\\"}": Object {
       "dst": Object {
         "id": "https://github.com/sourcecred/example-repo/issues/2#issuecomment-385576273",
         "pluginName": "sourcecred/github-beta",
-        "repositoryName": "sourcecred/example-repo",
         "type": "COMMENT",
       },
       "payload": Object {},
       "src": Object {
         "id": "https://github.com/sourcecred/example-repo/issues/2",
         "pluginName": "sourcecred/github-beta",
-        "repositoryName": "sourcecred/example-repo",
         "type": "ISSUE",
       },
     },
-    "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-repo/issues/2\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"repositoryName\\\\\\":\\\\\\"sourcecred/example-repo\\\\\\",\\\\\\"type\\\\\\":\\\\\\"ISSUE\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-repo/issues/2#issuecomment-385576920\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"repositoryName\\\\\\":\\\\\\"sourcecred/example-repo\\\\\\",\\\\\\"type\\\\\\":\\\\\\"COMMENT\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"repositoryName\\":\\"sourcecred/example-repo\\",\\"type\\":\\"CONTAINS\\"}": Object {
+    "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-repo/issues/2\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"ISSUE\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-repo/issues/2#issuecomment-385576920\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"COMMENT\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"CONTAINS\\"}": Object {
       "dst": Object {
         "id": "https://github.com/sourcecred/example-repo/issues/2#issuecomment-385576920",
         "pluginName": "sourcecred/github-beta",
-        "repositoryName": "sourcecred/example-repo",
         "type": "COMMENT",
       },
       "payload": Object {},
       "src": Object {
         "id": "https://github.com/sourcecred/example-repo/issues/2",
         "pluginName": "sourcecred/github-beta",
-        "repositoryName": "sourcecred/example-repo",
         "type": "ISSUE",
       },
     },
-    "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-repo/issues/2\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"repositoryName\\\\\\":\\\\\\"sourcecred/example-repo\\\\\\",\\\\\\"type\\\\\\":\\\\\\"ISSUE\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-repo/issues/2#issuecomment-385576936\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"repositoryName\\\\\\":\\\\\\"sourcecred/example-repo\\\\\\",\\\\\\"type\\\\\\":\\\\\\"COMMENT\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"repositoryName\\":\\"sourcecred/example-repo\\",\\"type\\":\\"CONTAINS\\"}": Object {
+    "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-repo/issues/2\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"ISSUE\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-repo/issues/2#issuecomment-385576936\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"COMMENT\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"CONTAINS\\"}": Object {
       "dst": Object {
         "id": "https://github.com/sourcecred/example-repo/issues/2#issuecomment-385576936",
         "pluginName": "sourcecred/github-beta",
-        "repositoryName": "sourcecred/example-repo",
         "type": "COMMENT",
       },
       "payload": Object {},
       "src": Object {
         "id": "https://github.com/sourcecred/example-repo/issues/2",
         "pluginName": "sourcecred/github-beta",
-        "repositoryName": "sourcecred/example-repo",
         "type": "ISSUE",
       },
     },
-    "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-repo/issues/6#issuecomment-385223316\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"repositoryName\\\\\\":\\\\\\"sourcecred/example-repo\\\\\\",\\\\\\"type\\\\\\":\\\\\\"COMMENT\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-repo/issues/2\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"repositoryName\\\\\\":\\\\\\"sourcecred/example-repo\\\\\\",\\\\\\"type\\\\\\":\\\\\\"ISSUE\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"repositoryName\\":\\"sourcecred/example-repo\\",\\"type\\":\\"REFERENCES\\"}": Object {
+    "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-repo/issues/6#issuecomment-385223316\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"COMMENT\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-repo/issues/2\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"ISSUE\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"REFERENCES\\"}": Object {
       "dst": Object {
         "id": "https://github.com/sourcecred/example-repo/issues/2",
         "pluginName": "sourcecred/github-beta",
-        "repositoryName": "sourcecred/example-repo",
         "type": "ISSUE",
       },
       "payload": Object {},
       "src": Object {
         "id": "https://github.com/sourcecred/example-repo/issues/6#issuecomment-385223316",
         "pluginName": "sourcecred/github-beta",
-        "repositoryName": "sourcecred/example-repo",
         "type": "COMMENT",
       },
     },
-    "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-repo/issues/6\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"repositoryName\\\\\\":\\\\\\"sourcecred/example-repo\\\\\\",\\\\\\"type\\\\\\":\\\\\\"ISSUE\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-repo/issues/6#issuecomment-373768442\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"repositoryName\\\\\\":\\\\\\"sourcecred/example-repo\\\\\\",\\\\\\"type\\\\\\":\\\\\\"COMMENT\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"repositoryName\\":\\"sourcecred/example-repo\\",\\"type\\":\\"CONTAINS\\"}": Object {
+    "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-repo/issues/6\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"ISSUE\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-repo/issues/6#issuecomment-373768442\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"COMMENT\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"CONTAINS\\"}": Object {
       "dst": Object {
         "id": "https://github.com/sourcecred/example-repo/issues/6#issuecomment-373768442",
         "pluginName": "sourcecred/github-beta",
-        "repositoryName": "sourcecred/example-repo",
         "type": "COMMENT",
       },
       "payload": Object {},
       "src": Object {
         "id": "https://github.com/sourcecred/example-repo/issues/6",
         "pluginName": "sourcecred/github-beta",
-        "repositoryName": "sourcecred/example-repo",
         "type": "ISSUE",
       },
     },
-    "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-repo/issues/6\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"repositoryName\\\\\\":\\\\\\"sourcecred/example-repo\\\\\\",\\\\\\"type\\\\\\":\\\\\\"ISSUE\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-repo/issues/6#issuecomment-373768538\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"repositoryName\\\\\\":\\\\\\"sourcecred/example-repo\\\\\\",\\\\\\"type\\\\\\":\\\\\\"COMMENT\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"repositoryName\\":\\"sourcecred/example-repo\\",\\"type\\":\\"CONTAINS\\"}": Object {
+    "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-repo/issues/6\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"ISSUE\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-repo/issues/6#issuecomment-373768538\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"COMMENT\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"CONTAINS\\"}": Object {
       "dst": Object {
         "id": "https://github.com/sourcecred/example-repo/issues/6#issuecomment-373768538",
         "pluginName": "sourcecred/github-beta",
-        "repositoryName": "sourcecred/example-repo",
         "type": "COMMENT",
       },
       "payload": Object {},
       "src": Object {
         "id": "https://github.com/sourcecred/example-repo/issues/6",
         "pluginName": "sourcecred/github-beta",
-        "repositoryName": "sourcecred/example-repo",
         "type": "ISSUE",
       },
     },
-    "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-repo/issues/6\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"repositoryName\\\\\\":\\\\\\"sourcecred/example-repo\\\\\\",\\\\\\"type\\\\\\":\\\\\\"ISSUE\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-repo/issues/6#issuecomment-385223316\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"repositoryName\\\\\\":\\\\\\"sourcecred/example-repo\\\\\\",\\\\\\"type\\\\\\":\\\\\\"COMMENT\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"repositoryName\\":\\"sourcecred/example-repo\\",\\"type\\":\\"CONTAINS\\"}": Object {
+    "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-repo/issues/6\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"ISSUE\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-repo/issues/6#issuecomment-385223316\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"COMMENT\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"CONTAINS\\"}": Object {
       "dst": Object {
         "id": "https://github.com/sourcecred/example-repo/issues/6#issuecomment-385223316",
         "pluginName": "sourcecred/github-beta",
-        "repositoryName": "sourcecred/example-repo",
         "type": "COMMENT",
       },
       "payload": Object {},
       "src": Object {
         "id": "https://github.com/sourcecred/example-repo/issues/6",
         "pluginName": "sourcecred/github-beta",
-        "repositoryName": "sourcecred/example-repo",
         "type": "ISSUE",
       },
     },
-    "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-repo/pull/3#issuecomment-369162222\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"repositoryName\\\\\\":\\\\\\"sourcecred/example-repo\\\\\\",\\\\\\"type\\\\\\":\\\\\\"COMMENT\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-repo/issues/2\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"repositoryName\\\\\\":\\\\\\"sourcecred/example-repo\\\\\\",\\\\\\"type\\\\\\":\\\\\\"ISSUE\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"repositoryName\\":\\"sourcecred/example-repo\\",\\"type\\":\\"REFERENCES\\"}": Object {
+    "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-repo/pull/3#issuecomment-369162222\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"COMMENT\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-repo/issues/2\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"ISSUE\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"REFERENCES\\"}": Object {
       "dst": Object {
         "id": "https://github.com/sourcecred/example-repo/issues/2",
         "pluginName": "sourcecred/github-beta",
-        "repositoryName": "sourcecred/example-repo",
         "type": "ISSUE",
       },
       "payload": Object {},
       "src": Object {
         "id": "https://github.com/sourcecred/example-repo/pull/3#issuecomment-369162222",
         "pluginName": "sourcecred/github-beta",
-        "repositoryName": "sourcecred/example-repo",
         "type": "COMMENT",
       },
     },
-    "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-repo/pull/3\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"repositoryName\\\\\\":\\\\\\"sourcecred/example-repo\\\\\\",\\\\\\"type\\\\\\":\\\\\\"PULL_REQUEST\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-repo/pull/3#issuecomment-369162222\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"repositoryName\\\\\\":\\\\\\"sourcecred/example-repo\\\\\\",\\\\\\"type\\\\\\":\\\\\\"COMMENT\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"repositoryName\\":\\"sourcecred/example-repo\\",\\"type\\":\\"CONTAINS\\"}": Object {
+    "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-repo/pull/3\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"PULL_REQUEST\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-repo/pull/3#issuecomment-369162222\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"COMMENT\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"CONTAINS\\"}": Object {
       "dst": Object {
         "id": "https://github.com/sourcecred/example-repo/pull/3#issuecomment-369162222",
         "pluginName": "sourcecred/github-beta",
-        "repositoryName": "sourcecred/example-repo",
         "type": "COMMENT",
       },
       "payload": Object {},
       "src": Object {
         "id": "https://github.com/sourcecred/example-repo/pull/3",
         "pluginName": "sourcecred/github-beta",
-        "repositoryName": "sourcecred/example-repo",
         "type": "PULL_REQUEST",
       },
     },
-    "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-repo/pull/5#pullrequestreview-100313899\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"repositoryName\\\\\\":\\\\\\"sourcecred/example-repo\\\\\\",\\\\\\"type\\\\\\":\\\\\\"PULL_REQUEST_REVIEW\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-repo/pull/5#discussion_r171460198\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"repositoryName\\\\\\":\\\\\\"sourcecred/example-repo\\\\\\",\\\\\\"type\\\\\\":\\\\\\"PULL_REQUEST_REVIEW_COMMENT\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"repositoryName\\":\\"sourcecred/example-repo\\",\\"type\\":\\"CONTAINS\\"}": Object {
+    "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-repo/pull/5#pullrequestreview-100313899\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"PULL_REQUEST_REVIEW\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-repo/pull/5#discussion_r171460198\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"PULL_REQUEST_REVIEW_COMMENT\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"CONTAINS\\"}": Object {
       "dst": Object {
         "id": "https://github.com/sourcecred/example-repo/pull/5#discussion_r171460198",
         "pluginName": "sourcecred/github-beta",
-        "repositoryName": "sourcecred/example-repo",
         "type": "PULL_REQUEST_REVIEW_COMMENT",
       },
       "payload": Object {},
       "src": Object {
         "id": "https://github.com/sourcecred/example-repo/pull/5#pullrequestreview-100313899",
         "pluginName": "sourcecred/github-beta",
-        "repositoryName": "sourcecred/example-repo",
         "type": "PULL_REQUEST_REVIEW",
       },
     },
-    "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-repo/pull/5\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"repositoryName\\\\\\":\\\\\\"sourcecred/example-repo\\\\\\",\\\\\\"type\\\\\\":\\\\\\"PULL_REQUEST\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-repo/pull/5#pullrequestreview-100313899\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"repositoryName\\\\\\":\\\\\\"sourcecred/example-repo\\\\\\",\\\\\\"type\\\\\\":\\\\\\"PULL_REQUEST_REVIEW\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"repositoryName\\":\\"sourcecred/example-repo\\",\\"type\\":\\"CONTAINS\\"}": Object {
+    "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-repo/pull/5\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"PULL_REQUEST\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-repo/pull/5#pullrequestreview-100313899\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"PULL_REQUEST_REVIEW\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"CONTAINS\\"}": Object {
       "dst": Object {
         "id": "https://github.com/sourcecred/example-repo/pull/5#pullrequestreview-100313899",
         "pluginName": "sourcecred/github-beta",
-        "repositoryName": "sourcecred/example-repo",
         "type": "PULL_REQUEST_REVIEW",
       },
       "payload": Object {},
       "src": Object {
         "id": "https://github.com/sourcecred/example-repo/pull/5",
         "pluginName": "sourcecred/github-beta",
-        "repositoryName": "sourcecred/example-repo",
         "type": "PULL_REQUEST",
       },
     },
-    "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-repo/pull/5\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"repositoryName\\\\\\":\\\\\\"sourcecred/example-repo\\\\\\",\\\\\\"type\\\\\\":\\\\\\"PULL_REQUEST\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-repo/pull/5#pullrequestreview-100314038\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"repositoryName\\\\\\":\\\\\\"sourcecred/example-repo\\\\\\",\\\\\\"type\\\\\\":\\\\\\"PULL_REQUEST_REVIEW\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"repositoryName\\":\\"sourcecred/example-repo\\",\\"type\\":\\"CONTAINS\\"}": Object {
+    "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-repo/pull/5\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"PULL_REQUEST\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-repo/pull/5#pullrequestreview-100314038\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"PULL_REQUEST_REVIEW\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"CONTAINS\\"}": Object {
       "dst": Object {
         "id": "https://github.com/sourcecred/example-repo/pull/5#pullrequestreview-100314038",
         "pluginName": "sourcecred/github-beta",
-        "repositoryName": "sourcecred/example-repo",
         "type": "PULL_REQUEST_REVIEW",
       },
       "payload": Object {},
       "src": Object {
         "id": "https://github.com/sourcecred/example-repo/pull/5",
         "pluginName": "sourcecred/github-beta",
-        "repositoryName": "sourcecred/example-repo",
         "type": "PULL_REQUEST",
       },
     },
-    "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-repo/pull/5\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"repositoryName\\\\\\":\\\\\\"sourcecred/example-repo\\\\\\",\\\\\\"type\\\\\\":\\\\\\"PULL_REQUEST\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/wchargin\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"repositoryName\\\\\\":\\\\\\"sourcecred/example-repo\\\\\\",\\\\\\"type\\\\\\":\\\\\\"AUTHOR\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"repositoryName\\":\\"sourcecred/example-repo\\",\\"type\\":\\"REFERENCES\\"}": Object {
+    "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-repo/pull/5\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"PULL_REQUEST\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/wchargin\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"AUTHOR\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"REFERENCES\\"}": Object {
       "dst": Object {
         "id": "https://github.com/wchargin",
         "pluginName": "sourcecred/github-beta",
-        "repositoryName": "sourcecred/example-repo",
         "type": "AUTHOR",
       },
       "payload": Object {},
       "src": Object {
         "id": "https://github.com/sourcecred/example-repo/pull/5",
         "pluginName": "sourcecred/github-beta",
-        "repositoryName": "sourcecred/example-repo",
         "type": "PULL_REQUEST",
       },
     },
-    "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/wchargin\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"repositoryName\\\\\\":\\\\\\"sourcecred/example-repo\\\\\\",\\\\\\"type\\\\\\":\\\\\\"AUTHOR\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-repo/pull/5#discussion_r171460198\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"repositoryName\\\\\\":\\\\\\"sourcecred/example-repo\\\\\\",\\\\\\"type\\\\\\":\\\\\\"PULL_REQUEST_REVIEW_COMMENT\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"repositoryName\\":\\"sourcecred/example-repo\\",\\"type\\":\\"AUTHORS\\"}": Object {
+    "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/wchargin\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"AUTHOR\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-repo/pull/5#discussion_r171460198\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"PULL_REQUEST_REVIEW_COMMENT\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"AUTHORS\\"}": Object {
       "dst": Object {
         "id": "https://github.com/wchargin",
         "pluginName": "sourcecred/github-beta",
-        "repositoryName": "sourcecred/example-repo",
         "type": "AUTHOR",
       },
       "payload": Object {},
       "src": Object {
         "id": "https://github.com/sourcecred/example-repo/pull/5#discussion_r171460198",
         "pluginName": "sourcecred/github-beta",
-        "repositoryName": "sourcecred/example-repo",
         "type": "PULL_REQUEST_REVIEW_COMMENT",
       },
     },
-    "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/wchargin\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"repositoryName\\\\\\":\\\\\\"sourcecred/example-repo\\\\\\",\\\\\\"type\\\\\\":\\\\\\"AUTHOR\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-repo/pull/5#pullrequestreview-100313899\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"repositoryName\\\\\\":\\\\\\"sourcecred/example-repo\\\\\\",\\\\\\"type\\\\\\":\\\\\\"PULL_REQUEST_REVIEW\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"repositoryName\\":\\"sourcecred/example-repo\\",\\"type\\":\\"AUTHORS\\"}": Object {
+    "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/wchargin\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"AUTHOR\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-repo/pull/5#pullrequestreview-100313899\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"PULL_REQUEST_REVIEW\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"AUTHORS\\"}": Object {
       "dst": Object {
         "id": "https://github.com/wchargin",
         "pluginName": "sourcecred/github-beta",
-        "repositoryName": "sourcecred/example-repo",
         "type": "AUTHOR",
       },
       "payload": Object {},
       "src": Object {
         "id": "https://github.com/sourcecred/example-repo/pull/5#pullrequestreview-100313899",
         "pluginName": "sourcecred/github-beta",
-        "repositoryName": "sourcecred/example-repo",
         "type": "PULL_REQUEST_REVIEW",
       },
     },
-    "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/wchargin\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"repositoryName\\\\\\":\\\\\\"sourcecred/example-repo\\\\\\",\\\\\\"type\\\\\\":\\\\\\"AUTHOR\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-repo/pull/5#pullrequestreview-100314038\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"repositoryName\\\\\\":\\\\\\"sourcecred/example-repo\\\\\\",\\\\\\"type\\\\\\":\\\\\\"PULL_REQUEST_REVIEW\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"repositoryName\\":\\"sourcecred/example-repo\\",\\"type\\":\\"AUTHORS\\"}": Object {
+    "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/wchargin\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"AUTHOR\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-repo/pull/5#pullrequestreview-100314038\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"PULL_REQUEST_REVIEW\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"AUTHORS\\"}": Object {
       "dst": Object {
         "id": "https://github.com/wchargin",
         "pluginName": "sourcecred/github-beta",
-        "repositoryName": "sourcecred/example-repo",
         "type": "AUTHOR",
       },
       "payload": Object {},
       "src": Object {
         "id": "https://github.com/sourcecred/example-repo/pull/5#pullrequestreview-100314038",
         "pluginName": "sourcecred/github-beta",
-        "repositoryName": "sourcecred/example-repo",
         "type": "PULL_REQUEST_REVIEW",
       },
     },
   },
   "nodes": Object {
-    "{\\"id\\":\\"https://github.com/decentralion\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"repositoryName\\":\\"sourcecred/example-repo\\",\\"type\\":\\"AUTHOR\\"}": Object {
+    "{\\"id\\":\\"https://github.com/decentralion\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"AUTHOR\\"}": Object {
       "payload": Object {
         "login": "decentralion",
         "subtype": "USER",
         "url": "https://github.com/decentralion",
       },
     },
-    "{\\"id\\":\\"https://github.com/sourcecred/example-repo/issues/1\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"repositoryName\\":\\"sourcecred/example-repo\\",\\"type\\":\\"ISSUE\\"}": Object {
+    "{\\"id\\":\\"https://github.com/sourcecred/example-repo/issues/1\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"ISSUE\\"}": Object {
       "payload": Object {
         "body": "This is just an example issue.",
         "number": 1,
@@ -2180,7 +1938,7 @@ Object {
         "url": "https://github.com/sourcecred/example-repo/issues/1",
       },
     },
-    "{\\"id\\":\\"https://github.com/sourcecred/example-repo/issues/2\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"repositoryName\\":\\"sourcecred/example-repo\\",\\"type\\":\\"ISSUE\\"}": Object {
+    "{\\"id\\":\\"https://github.com/sourcecred/example-repo/issues/2\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"ISSUE\\"}": Object {
       "payload": Object {
         "body": "This issue references another issue, namely #1",
         "number": 2,
@@ -2188,44 +1946,44 @@ Object {
         "url": "https://github.com/sourcecred/example-repo/issues/2",
       },
     },
-    "{\\"id\\":\\"https://github.com/sourcecred/example-repo/issues/2#issuecomment-373768703\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"repositoryName\\":\\"sourcecred/example-repo\\",\\"type\\":\\"COMMENT\\"}": Object {
+    "{\\"id\\":\\"https://github.com/sourcecred/example-repo/issues/2#issuecomment-373768703\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"COMMENT\\"}": Object {
       "payload": Object {
         "body": "It should also be possible to reference by exact url: https://github.com/sourcecred/example-repo/issues/6",
         "url": "https://github.com/sourcecred/example-repo/issues/2#issuecomment-373768703",
       },
     },
-    "{\\"id\\":\\"https://github.com/sourcecred/example-repo/issues/2#issuecomment-373768850\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"repositoryName\\":\\"sourcecred/example-repo\\",\\"type\\":\\"COMMENT\\"}": Object {
+    "{\\"id\\":\\"https://github.com/sourcecred/example-repo/issues/2#issuecomment-373768850\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"COMMENT\\"}": Object {
       "payload": Object {
         "body": "We might also reference individual comments directly.
 https://github.com/sourcecred/example-repo/issues/6#issuecomment-373768538",
         "url": "https://github.com/sourcecred/example-repo/issues/2#issuecomment-373768850",
       },
     },
-    "{\\"id\\":\\"https://github.com/sourcecred/example-repo/issues/2#issuecomment-385576185\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"repositoryName\\":\\"sourcecred/example-repo\\",\\"type\\":\\"COMMENT\\"}": Object {
+    "{\\"id\\":\\"https://github.com/sourcecred/example-repo/issues/2#issuecomment-385576185\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"COMMENT\\"}": Object {
       "payload": Object {
         "body": "Here's a PR by direct url: https://github.com/sourcecred/example-repo/pull/5",
         "url": "https://github.com/sourcecred/example-repo/issues/2#issuecomment-385576185",
       },
     },
-    "{\\"id\\":\\"https://github.com/sourcecred/example-repo/issues/2#issuecomment-385576220\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"repositoryName\\":\\"sourcecred/example-repo\\",\\"type\\":\\"COMMENT\\"}": Object {
+    "{\\"id\\":\\"https://github.com/sourcecred/example-repo/issues/2#issuecomment-385576220\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"COMMENT\\"}": Object {
       "payload": Object {
         "body": "a PR review by url: https://github.com/sourcecred/example-repo/pull/5#pullrequestreview-100313899",
         "url": "https://github.com/sourcecred/example-repo/issues/2#issuecomment-385576220",
       },
     },
-    "{\\"id\\":\\"https://github.com/sourcecred/example-repo/issues/2#issuecomment-385576248\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"repositoryName\\":\\"sourcecred/example-repo\\",\\"type\\":\\"COMMENT\\"}": Object {
+    "{\\"id\\":\\"https://github.com/sourcecred/example-repo/issues/2#issuecomment-385576248\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"COMMENT\\"}": Object {
       "payload": Object {
         "body": "a PR Review Comment by url: https://github.com/sourcecred/example-repo/pull/5#discussion_r171460198",
         "url": "https://github.com/sourcecred/example-repo/issues/2#issuecomment-385576248",
       },
     },
-    "{\\"id\\":\\"https://github.com/sourcecred/example-repo/issues/2#issuecomment-385576273\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"repositoryName\\":\\"sourcecred/example-repo\\",\\"type\\":\\"COMMENT\\"}": Object {
+    "{\\"id\\":\\"https://github.com/sourcecred/example-repo/issues/2#issuecomment-385576273\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"COMMENT\\"}": Object {
       "payload": Object {
         "body": "a user by url: https://github.com/wchargin",
         "url": "https://github.com/sourcecred/example-repo/issues/2#issuecomment-385576273",
       },
     },
-    "{\\"id\\":\\"https://github.com/sourcecred/example-repo/issues/2#issuecomment-385576920\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"repositoryName\\":\\"sourcecred/example-repo\\",\\"type\\":\\"COMMENT\\"}": Object {
+    "{\\"id\\":\\"https://github.com/sourcecred/example-repo/issues/2#issuecomment-385576920\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"COMMENT\\"}": Object {
       "payload": Object {
         "body": "Here are several references:
 #1 
@@ -2238,13 +1996,13 @@ https://github.com/sourcecred/example-repo/pull/5#pullrequestreview-100313899
         "url": "https://github.com/sourcecred/example-repo/issues/2#issuecomment-385576920",
       },
     },
-    "{\\"id\\":\\"https://github.com/sourcecred/example-repo/issues/2#issuecomment-385576936\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"repositoryName\\":\\"sourcecred/example-repo\\",\\"type\\":\\"COMMENT\\"}": Object {
+    "{\\"id\\":\\"https://github.com/sourcecred/example-repo/issues/2#issuecomment-385576936\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"COMMENT\\"}": Object {
       "payload": Object {
         "body": "This comment has no references.",
         "url": "https://github.com/sourcecred/example-repo/issues/2#issuecomment-385576936",
       },
     },
-    "{\\"id\\":\\"https://github.com/sourcecred/example-repo/issues/4\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"repositoryName\\":\\"sourcecred/example-repo\\",\\"type\\":\\"ISSUE\\"}": Object {
+    "{\\"id\\":\\"https://github.com/sourcecred/example-repo/issues/4\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"ISSUE\\"}": Object {
       "payload": Object {
         "body": "Alas, its life as an open issue had only just begun.",
         "number": 4,
@@ -2252,7 +2010,7 @@ https://github.com/sourcecred/example-repo/pull/5#pullrequestreview-100313899
         "url": "https://github.com/sourcecred/example-repo/issues/4",
       },
     },
-    "{\\"id\\":\\"https://github.com/sourcecred/example-repo/issues/6\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"repositoryName\\":\\"sourcecred/example-repo\\",\\"type\\":\\"ISSUE\\"}": Object {
+    "{\\"id\\":\\"https://github.com/sourcecred/example-repo/issues/6\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"ISSUE\\"}": Object {
       "payload": Object {
         "body": "This issue shall shortly have a few comments.",
         "number": 6,
@@ -2260,25 +2018,25 @@ https://github.com/sourcecred/example-repo/pull/5#pullrequestreview-100313899
         "url": "https://github.com/sourcecred/example-repo/issues/6",
       },
     },
-    "{\\"id\\":\\"https://github.com/sourcecred/example-repo/issues/6#issuecomment-373768442\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"repositoryName\\":\\"sourcecred/example-repo\\",\\"type\\":\\"COMMENT\\"}": Object {
+    "{\\"id\\":\\"https://github.com/sourcecred/example-repo/issues/6#issuecomment-373768442\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"COMMENT\\"}": Object {
       "payload": Object {
         "body": "A wild COMMENT appeared!",
         "url": "https://github.com/sourcecred/example-repo/issues/6#issuecomment-373768442",
       },
     },
-    "{\\"id\\":\\"https://github.com/sourcecred/example-repo/issues/6#issuecomment-373768538\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"repositoryName\\":\\"sourcecred/example-repo\\",\\"type\\":\\"COMMENT\\"}": Object {
+    "{\\"id\\":\\"https://github.com/sourcecred/example-repo/issues/6#issuecomment-373768538\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"COMMENT\\"}": Object {
       "payload": Object {
         "body": "And the maintainer said, \\"Let there be comments!\\"",
         "url": "https://github.com/sourcecred/example-repo/issues/6#issuecomment-373768538",
       },
     },
-    "{\\"id\\":\\"https://github.com/sourcecred/example-repo/issues/6#issuecomment-385223316\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"repositoryName\\":\\"sourcecred/example-repo\\",\\"type\\":\\"COMMENT\\"}": Object {
+    "{\\"id\\":\\"https://github.com/sourcecred/example-repo/issues/6#issuecomment-385223316\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"COMMENT\\"}": Object {
       "payload": Object {
         "body": "This comment references an #2, which itself references an issue. This comment is thus allows us to test that in-references are not included when requesting a Post's references.",
         "url": "https://github.com/sourcecred/example-repo/issues/6#issuecomment-385223316",
       },
     },
-    "{\\"id\\":\\"https://github.com/sourcecred/example-repo/issues/7\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"repositoryName\\":\\"sourcecred/example-repo\\",\\"type\\":\\"ISSUE\\"}": Object {
+    "{\\"id\\":\\"https://github.com/sourcecred/example-repo/issues/7\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"ISSUE\\"}": Object {
       "payload": Object {
         "body": "Deal with this, naive string display algorithms!!!!!",
         "number": 7,
@@ -2286,7 +2044,7 @@ https://github.com/sourcecred/example-repo/pull/5#pullrequestreview-100313899
         "url": "https://github.com/sourcecred/example-repo/issues/7",
       },
     },
-    "{\\"id\\":\\"https://github.com/sourcecred/example-repo/issues/8\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"repositoryName\\":\\"sourcecred/example-repo\\",\\"type\\":\\"ISSUE\\"}": Object {
+    "{\\"id\\":\\"https://github.com/sourcecred/example-repo/issues/8\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"ISSUE\\"}": Object {
       "payload": Object {
         "body": "Issue with Unicode: ȴሲ𣐳楢👍 :heart: 𐤔𐤁𐤀𐤑𐤍𐤉𐤔𐤌𐤄𐤍𐤍 ❤️
 Issue with Unicode: ȴሲ𣐳楢👍 :heart: 𐤔𐤁𐤀𐤑𐤍𐤉𐤔𐤌𐤄𐤍𐤍 ❤️",
@@ -2295,7 +2053,7 @@ Issue with Unicode: ȴሲ𣐳楢👍 :heart: 𐤔𐤁𐤀𐤑𐤍𐤉𐤔𐤌�
         "url": "https://github.com/sourcecred/example-repo/issues/8",
       },
     },
-    "{\\"id\\":\\"https://github.com/sourcecred/example-repo/pull/3\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"repositoryName\\":\\"sourcecred/example-repo\\",\\"type\\":\\"PULL_REQUEST\\"}": Object {
+    "{\\"id\\":\\"https://github.com/sourcecred/example-repo/pull/3\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"PULL_REQUEST\\"}": Object {
       "payload": Object {
         "body": "Oh look, it's a pull request.",
         "number": 3,
@@ -2303,13 +2061,13 @@ Issue with Unicode: ȴሲ𣐳楢👍 :heart: 𐤔𐤁𐤀𐤑𐤍𐤉𐤔𐤌�
         "url": "https://github.com/sourcecred/example-repo/pull/3",
       },
     },
-    "{\\"id\\":\\"https://github.com/sourcecred/example-repo/pull/3#issuecomment-369162222\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"repositoryName\\":\\"sourcecred/example-repo\\",\\"type\\":\\"COMMENT\\"}": Object {
+    "{\\"id\\":\\"https://github.com/sourcecred/example-repo/pull/3#issuecomment-369162222\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"COMMENT\\"}": Object {
       "payload": Object {
         "body": "It seems apropos to reference something from a pull request comment... eg: #2 ",
         "url": "https://github.com/sourcecred/example-repo/pull/3#issuecomment-369162222",
       },
     },
-    "{\\"id\\":\\"https://github.com/sourcecred/example-repo/pull/5\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"repositoryName\\":\\"sourcecred/example-repo\\",\\"type\\":\\"PULL_REQUEST\\"}": Object {
+    "{\\"id\\":\\"https://github.com/sourcecred/example-repo/pull/5\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"PULL_REQUEST\\"}": Object {
       "payload": Object {
         "body": "@wchargin could you please do the following:
 - add a commit comment
@@ -2321,27 +2079,27 @@ Issue with Unicode: ȴሲ𣐳楢👍 :heart: 𐤔𐤁𐤀𐤑𐤍𐤉𐤔𐤌�
         "url": "https://github.com/sourcecred/example-repo/pull/5",
       },
     },
-    "{\\"id\\":\\"https://github.com/sourcecred/example-repo/pull/5#discussion_r171460198\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"repositoryName\\":\\"sourcecred/example-repo\\",\\"type\\":\\"PULL_REQUEST_REVIEW_COMMENT\\"}": Object {
+    "{\\"id\\":\\"https://github.com/sourcecred/example-repo/pull/5#discussion_r171460198\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"PULL_REQUEST_REVIEW_COMMENT\\"}": Object {
       "payload": Object {
         "body": "seems a bit capricious",
         "url": "https://github.com/sourcecred/example-repo/pull/5#discussion_r171460198",
       },
     },
-    "{\\"id\\":\\"https://github.com/sourcecred/example-repo/pull/5#pullrequestreview-100313899\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"repositoryName\\":\\"sourcecred/example-repo\\",\\"type\\":\\"PULL_REQUEST_REVIEW\\"}": Object {
+    "{\\"id\\":\\"https://github.com/sourcecred/example-repo/pull/5#pullrequestreview-100313899\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"PULL_REQUEST_REVIEW\\"}": Object {
       "payload": Object {
         "body": "hmmm.jpg",
         "state": "CHANGES_REQUESTED",
         "url": "https://github.com/sourcecred/example-repo/pull/5#pullrequestreview-100313899",
       },
     },
-    "{\\"id\\":\\"https://github.com/sourcecred/example-repo/pull/5#pullrequestreview-100314038\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"repositoryName\\":\\"sourcecred/example-repo\\",\\"type\\":\\"PULL_REQUEST_REVIEW\\"}": Object {
+    "{\\"id\\":\\"https://github.com/sourcecred/example-repo/pull/5#pullrequestreview-100314038\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"PULL_REQUEST_REVIEW\\"}": Object {
       "payload": Object {
         "body": "I'm sold",
         "state": "APPROVED",
         "url": "https://github.com/sourcecred/example-repo/pull/5#pullrequestreview-100314038",
       },
     },
-    "{\\"id\\":\\"https://github.com/wchargin\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"repositoryName\\":\\"sourcecred/example-repo\\",\\"type\\":\\"AUTHOR\\"}": Object {
+    "{\\"id\\":\\"https://github.com/wchargin\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"AUTHOR\\"}": Object {
       "payload": Object {
         "login": "wchargin",
         "subtype": "USER",

--- a/src/plugins/github/api.js
+++ b/src/plugins/github/api.js
@@ -48,11 +48,9 @@ function assertEntityType(e: Entity, t: NodeType) {
 }
 
 export class Repository {
-  repositoryName: string;
   graph: Graph<NodePayload, EdgePayload>;
 
-  constructor(repositoryName: string, graph: Graph<NodePayload, EdgePayload>) {
-    this.repositoryName = repositoryName;
+  constructor(graph: Graph<NodePayload, EdgePayload>) {
     this.graph = graph;
   }
 

--- a/src/plugins/github/api.test.js
+++ b/src/plugins/github/api.test.js
@@ -12,8 +12,8 @@ import {
   PULL_REQUEST_REVIEW_COMMENT_NODE_TYPE,
 } from "./types";
 describe("GitHub porcelain API", () => {
-  const graph = parse("sourcecred/example-repo", exampleRepoData);
-  const repo = new Repository("sourcecred/example-repo", graph);
+  const graph = parse(exampleRepoData);
+  const repo = new Repository(graph);
   function issueOrPRByNumber(n: number): Issue | PullRequest {
     const result = repo.issueOrPRByNumber(n);
     if (result == null) {

--- a/src/plugins/github/parser.js
+++ b/src/plugins/github/parser.js
@@ -34,28 +34,24 @@ import {Graph, edgeID} from "../../core/graph";
 import {findReferences} from "./findReferences";
 
 export function parse(
-  repositoryName: string,
   repositoryJSON: RepositoryJSON
 ): Graph<NodePayload, EdgePayload> {
-  const parser = new GithubParser(repositoryName);
+  const parser = new GithubParser();
   parser.addData(repositoryJSON);
   parser.addReferenceEdges();
   return parser.graph;
 }
 
 class GithubParser {
-  repositoryName: string;
   graph: Graph<NodePayload, EdgePayload>;
 
-  constructor(repositoryName: string) {
-    this.repositoryName = repositoryName;
+  constructor() {
     this.graph = new Graph();
   }
 
   makeNodeAddress(type: NodeType, url: string): Address {
     return {
       pluginName: PLUGIN_NAME,
-      repositoryName: this.repositoryName,
       type,
       id: url,
     };
@@ -64,7 +60,6 @@ class GithubParser {
   makeEdgeAddress(type: EdgeType, src: Address, dst: Address): Address {
     return {
       pluginName: PLUGIN_NAME,
-      repositoryName: this.repositoryName,
       type,
       id: edgeID(src, dst),
     };

--- a/src/plugins/github/parser.test.js
+++ b/src/plugins/github/parser.test.js
@@ -26,7 +26,7 @@ describe("GithubParser", () => {
   }
 
   describe("whole repo parsing", () => {
-    const graph = parse("sourcecred/example-repo", exampleRepoData);
+    const graph = parse(exampleRepoData);
 
     it("parses the entire example-repo as expected", () => {
       expect(graph).toMatchSnapshot();
@@ -114,7 +114,7 @@ describe("GithubParser", () => {
         },
       },
     };
-    return parse("sourcecred/example-repo", exampleData);
+    return parse(exampleData);
   }
 
   describe("issue parsing", () => {


### PR DESCRIPTION
See [#190] for context.

The change is almost entirely straightforward; the only "interesting"
decision I made was to move the repo owner and repo name into the string
id for the Artifact Plugin addresses, as the id would otherwise not be
unique.

[#190]: https://github.com/sourcecred/sourcecred/issues/190#issuecomment-386362870