### PR TITLE
Pull merge commit SHAs from GitHub

### DIFF
--- a/src/plugins/github/demoData/example-github.json
+++ b/src/plugins/github/demoData/example-github.json
@@ -286,6 +286,9 @@
                         }
                     },
                     "id": "MDExOlB1bGxSZXF1ZXN0MTcxODg3NzQx",
+                    "mergeCommit": {
+                        "oid": "0a223346b4e6dec0127b1e6aa892c4ee0424b66a"
+                    },
                     "number": 3,
                     "reviews": {
                         "nodes": [
@@ -315,6 +318,9 @@
                         }
                     },
                     "id": "MDExOlB1bGxSZXF1ZXN0MTcxODg4NTIy",
+                    "mergeCommit": {
+                        "oid": "6d5b3aa31ebb68a06ceb46bbd6cf49b6ccd6f5e6"
+                    },
                     "number": 5,
                     "reviews": {
                         "nodes": [
@@ -395,6 +401,7 @@
                         }
                     },
                     "id": "MDExOlB1bGxSZXF1ZXN0MTg1ODA2MTU3",
+                    "mergeCommit": null,
                     "number": 9,
                     "reviews": {
                         "nodes": [

--- a/src/plugins/github/graphql.js
+++ b/src/plugins/github/graphql.js
@@ -690,6 +690,8 @@ export type PullRequestJSON = {|
   +author: AuthorJSON,
   +comments: ConnectionJSON<CommentJSON>,
   +reviews: ConnectionJSON<PullRequestReviewJSON>,
+  // If present, oid is the commit SHA of the merged commit.
+  +mergeCommit: ?{|+oid: string|},
 |};
 function pullRequestsFragment(): FragmentDefinition {
   const b = build;
@@ -701,6 +703,7 @@ function pullRequestsFragment(): FragmentDefinition {
       b.field("title"),
       b.field("body"),
       b.field("number"),
+      b.field("mergeCommit", {}, [b.field("oid")]),
       makeAuthor(),
       b.field("comments", {first: b.literal(PAGE_SIZE_COMMENTS)}, [
         b.fragmentSpread("comments"),


### PR DESCRIPTION
This commit adds a few fields to the PullRequest query fragment so that
we now retrieve merge commit shas. In cases where there is no merge
commit (ie the PR did not merge), the field is null. Observe that this
is the case for our example unmerged pull request.

Test plan: Inspect the changes to the demo data, and verify that they
are appropriate.