### PR TITLE
Expose `commitAddress` from the Git plugin

### DIFF
--- a/src/plugins/git/address.js
+++ b/src/plugins/git/address.js
@@ -1,0 +1,17 @@
+// @flow
+
+import type {Address} from "../../core/address";
+import type {EdgeType, NodeType} from "./types";
+import {COMMIT_NODE_TYPE, GIT_PLUGIN_NAME} from "./types";
+
+export function _makeAddress(type: NodeType | EdgeType, id: string): Address {
+  return {
+    pluginName: GIT_PLUGIN_NAME,
+    type,
+    id,
+  };
+}
+
+export function commitAddress(hash: string): Address {
+  return _makeAddress(COMMIT_NODE_TYPE, hash);
+}


### PR DESCRIPTION
For the GitHub plugin to create edges pointing to commits from the Git
plugin, it needs a way to create the appropriate address given the
commit's hash. This commit exposes that functionality by moving
`makeAddress` out of the "createGraph" module and into a new "address"
module, and using it to implement `commitAddress`.

Test plan: The code is so trivial that I don't think it merits testing.