### PR TITLE
Connect PRs and commits via MERGED_AS edges

### DIFF
--- a/src/plugins/github/__snapshots__/api.test.js.snap
+++ b/src/plugins/github/__snapshots__/api.test.js.snap
@@ -49,7 +49,7 @@ Object {
 }
 `;
 
-exports[`GitHub porcelain API has wrappers for PullRequests 1`] = `
+exports[`GitHub porcelain API has wrappers for PullRequests Merged 1`] = `
 Object {
   "address": Object {
     "id": "https://github.com/sourcecred/example-github/pull/3",

--- a/src/plugins/github/__snapshots__/parser.test.js.snap
+++ b/src/plugins/github/__snapshots__/parser.test.js.snap
@@ -199,6 +199,21 @@ Object {
         "type": "PULL_REQUEST_REVIEW",
       },
     },
+    "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/pull/5\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"PULL_REQUEST\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"6d5b3aa31ebb68a06ceb46bbd6cf49b6ccd6f5e6\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/git-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"COMMIT\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"MERGED_AS\\"}": Object {
+      "dst": Object {
+        "id": "6d5b3aa31ebb68a06ceb46bbd6cf49b6ccd6f5e6",
+        "pluginName": "sourcecred/git-beta",
+        "type": "COMMIT",
+      },
+      "payload": Object {
+        "hash": "6d5b3aa31ebb68a06ceb46bbd6cf49b6ccd6f5e6",
+      },
+      "src": Object {
+        "id": "https://github.com/sourcecred/example-github/pull/5",
+        "pluginName": "sourcecred/github-beta",
+        "type": "PULL_REQUEST",
+      },
+    },
     "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/pull/5\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"PULL_REQUEST\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/pull/5#pullrequestreview-100313899\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"PULL_REQUEST_REVIEW\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"CONTAINS\\"}": Object {
       "dst": Object {
         "id": "https://github.com/sourcecred/example-github/pull/5#pullrequestreview-100313899",
@@ -352,6 +367,21 @@ Object {
         "type": "AUTHOR",
       },
       "payload": Object {},
+      "src": Object {
+        "id": "https://github.com/sourcecred/example-github/pull/3",
+        "pluginName": "sourcecred/github-beta",
+        "type": "PULL_REQUEST",
+      },
+    },
+    "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/pull/3\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"PULL_REQUEST\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"0a223346b4e6dec0127b1e6aa892c4ee0424b66a\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/git-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"COMMIT\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"MERGED_AS\\"}": Object {
+      "dst": Object {
+        "id": "0a223346b4e6dec0127b1e6aa892c4ee0424b66a",
+        "pluginName": "sourcecred/git-beta",
+        "type": "COMMIT",
+      },
+      "payload": Object {
+        "hash": "0a223346b4e6dec0127b1e6aa892c4ee0424b66a",
+      },
       "src": Object {
         "id": "https://github.com/sourcecred/example-github/pull/3",
         "pluginName": "sourcecred/github-beta",
@@ -1830,6 +1860,21 @@ Object {
         "type": "COMMENT",
       },
     },
+    "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/pull/3\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"PULL_REQUEST\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"0a223346b4e6dec0127b1e6aa892c4ee0424b66a\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/git-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"COMMIT\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"MERGED_AS\\"}": Object {
+      "dst": Object {
+        "id": "0a223346b4e6dec0127b1e6aa892c4ee0424b66a",
+        "pluginName": "sourcecred/git-beta",
+        "type": "COMMIT",
+      },
+      "payload": Object {
+        "hash": "0a223346b4e6dec0127b1e6aa892c4ee0424b66a",
+      },
+      "src": Object {
+        "id": "https://github.com/sourcecred/example-github/pull/3",
+        "pluginName": "sourcecred/github-beta",
+        "type": "PULL_REQUEST",
+      },
+    },
     "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/pull/3\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"PULL_REQUEST\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/pull/3#issuecomment-369162222\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"COMMENT\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"CONTAINS\\"}": Object {
       "dst": Object {
         "id": "https://github.com/sourcecred/example-github/pull/3#issuecomment-369162222",
@@ -1854,6 +1899,21 @@ Object {
         "id": "https://github.com/sourcecred/example-github/pull/5#pullrequestreview-100313899",
         "pluginName": "sourcecred/github-beta",
         "type": "PULL_REQUEST_REVIEW",
+      },
+    },
+    "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/pull/5\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"PULL_REQUEST\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"6d5b3aa31ebb68a06ceb46bbd6cf49b6ccd6f5e6\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/git-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"COMMIT\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"MERGED_AS\\"}": Object {
+      "dst": Object {
+        "id": "6d5b3aa31ebb68a06ceb46bbd6cf49b6ccd6f5e6",
+        "pluginName": "sourcecred/git-beta",
+        "type": "COMMIT",
+      },
+      "payload": Object {
+        "hash": "6d5b3aa31ebb68a06ceb46bbd6cf49b6ccd6f5e6",
+      },
+      "src": Object {
+        "id": "https://github.com/sourcecred/example-github/pull/5",
+        "pluginName": "sourcecred/github-beta",
+        "type": "PULL_REQUEST",
       },
     },
     "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/pull/5\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"PULL_REQUEST\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/pull/5#pullrequestreview-100313899\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"PULL_REQUEST_REVIEW\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"CONTAINS\\"}": Object {

--- a/src/plugins/github/api.test.js
+++ b/src/plugins/github/api.test.js
@@ -35,18 +35,26 @@ describe("GitHub porcelain API", () => {
       expect(issue.address()).toEqual(issue.node().address);
       expect(issue.authors().map((x) => x.login())).toEqual(["decentralion"]);
     });
-
-    it("PullRequests", () => {
-      const pullRequest = issueOrPRByNumber(3);
-      expect(pullRequest.body()).toBe("Oh look, it's a pull request.");
-      expect(pullRequest.title()).toBe("Add README, merge via PR.");
-      expect(pullRequest.url()).toBe(
-        "https://github.com/sourcecred/example-github/pull/3"
-      );
-      expect(pullRequest.number()).toBe(3);
-      expect(pullRequest.type()).toBe(PULL_REQUEST_NODE_TYPE);
-      expect(pullRequest.node()).toMatchSnapshot();
-      expect(pullRequest.address()).toEqual(pullRequest.node().address);
+    describe("PullRequests", () => {
+      it("Merged", () => {
+        const pullRequest = PullRequest.from(issueOrPRByNumber(3));
+        expect(pullRequest.body()).toBe("Oh look, it's a pull request.");
+        expect(pullRequest.title()).toBe("Add README, merge via PR.");
+        expect(pullRequest.url()).toBe(
+          "https://github.com/sourcecred/example-github/pull/3"
+        );
+        expect(pullRequest.number()).toBe(3);
+        expect(pullRequest.type()).toBe(PULL_REQUEST_NODE_TYPE);
+        expect(pullRequest.node()).toMatchSnapshot();
+        expect(pullRequest.address()).toEqual(pullRequest.node().address);
+        expect(pullRequest.mergeCommitHash()).toEqual(
+          "0a223346b4e6dec0127b1e6aa892c4ee0424b66a"
+        );
+      });
+      it("Unmerged", () => {
+        const pullRequest = PullRequest.from(issueOrPRByNumber(9));
+        expect(pullRequest.mergeCommitHash()).toEqual(null);
+      });
     });
 
     it("Pull Request Reviews", () => {

--- a/src/plugins/github/types.js
+++ b/src/plugins/github/types.js
@@ -98,6 +98,8 @@ export type AuthorsEdgePayload = {};
 export const AUTHORS_EDGE_TYPE: "AUTHORS" = "AUTHORS";
 export type ContainsEdgePayload = {};
 export const CONTAINS_EDGE_TYPE: "CONTAINS" = "CONTAINS";
+export type MergedAsEdgePayload = {|+hash: string|};
+export const MERGED_AS_EDGE_TYPE: "MERGED_AS" = "MERGED_AS";
 export type ReferencesEdgePayload = {};
 export const REFERENCES_EDGE_TYPE: "REFERENCES" = "REFERENCES";
 
@@ -110,6 +112,10 @@ export type EdgeTypes = {|
     payload: ContainsEdgePayload,
     type: typeof CONTAINS_EDGE_TYPE,
   },
+  MERGED_AS: {
+    payload: MergedAsEdgePayload,
+    type: typeof MERGED_AS_EDGE_TYPE,
+  },
   REFERENCES: {
     payload: ReferencesEdgePayload,
     type: typeof REFERENCES_EDGE_TYPE,
@@ -119,6 +125,7 @@ export type EdgeTypes = {|
 export type EdgeType =
   | typeof AUTHORS_EDGE_TYPE
   | typeof CONTAINS_EDGE_TYPE
+  | typeof MERGED_AS_EDGE_TYPE
   | typeof REFERENCES_EDGE_TYPE;
 
 export type EdgePayload =


### PR DESCRIPTION
This adds MERGED_AS edges which link from a PullRequest to a Commit. It
adds a corresponding `mergedCommitHash` method on the porcelain PR that
returns the hash of the merged commit (if available).

I would have preferred to return a porcelain wrapper over the commit,
but since we don't have a porcelain Git api, it seemed preferrable to
return the hash as a string. Returning a Node would both break
consistency in the porcelain api, and be problematic as the node does
not necessarily exist in the api. To ensure that the hash is available
without parsing Addresses, I used the edge payload. :)

Test plan:
Inspect the snapshot changes in the graph (they are fairly readable) and
the api testing in api.test.js.