### PR TITLE
Find BECOMES edges for a high-level repository

### DIFF
--- a/src/plugins/git/__snapshots__/createGraph.test.js.snap
+++ b/src/plugins/git/__snapshots__/createGraph.test.js.snap
@@ -1393,6 +1393,63 @@ Object {
 }
 `;
 
+exports[`findBecomesEdges works on the example repository 1`] = `
+Array [
+  Object {
+    "becomesEdge": Object {
+      "from": Object {
+        "name": "src",
+        "tree": "819fc546cea489476ce8dc90785e9ba7753d0a8f",
+      },
+      "path": Array [
+        "src",
+      ],
+      "to": Object {
+        "name": "src",
+        "tree": "bbf3b8b3d26a4f884b5c022d46851f593d329192",
+      },
+    },
+    "childCommit": "69c5aad50eec8f2a0a07c988c3b283a6490eb45b",
+    "parentCommit": "e8b7a8f19701cd5a25e4a097d513ead60e5f8bcc",
+  },
+  Object {
+    "becomesEdge": Object {
+      "from": Object {
+        "name": "quantum_gravity.py",
+        "tree": "7b79d579b62994faba3b69fdf8aa442586c32681",
+      },
+      "path": Array [
+        "src",
+        "quantum_gravity.py",
+      ],
+      "to": Object {
+        "name": "quantum_gravity.py",
+        "tree": "78fc9c83023386854c6bfdc5761c0e58f68e226f",
+      },
+    },
+    "childCommit": "69c5aad50eec8f2a0a07c988c3b283a6490eb45b",
+    "parentCommit": "e8b7a8f19701cd5a25e4a097d513ead60e5f8bcc",
+  },
+  Object {
+    "becomesEdge": Object {
+      "from": Object {
+        "name": "pygravitydefier",
+        "tree": "569e1d383759903134df75230d63c0090196d4cb",
+      },
+      "path": Array [
+        "pygravitydefier",
+      ],
+      "to": Object {
+        "name": "pygravitydefier",
+        "tree": "819fc546cea489476ce8dc90785e9ba7753d0a8f",
+      },
+    },
+    "childCommit": "e8b7a8f19701cd5a25e4a097d513ead60e5f8bcc",
+    "parentCommit": "d160cca97611e9dfed642522ad44408d0292e8ea",
+  },
+]
+`;
+
 exports[`findBecomesEdgesForCommits works on the example repository 1`] = `
 Array [
   Object {

--- a/src/plugins/git/createGraph.js
+++ b/src/plugins/git/createGraph.js
@@ -249,6 +249,26 @@ export function* findBecomesEdgesForCommits(
   }
 }
 
+export function* findBecomesEdges(
+  repository: Repository
+): Iterator<{|
+  +childCommit: Hash,
+  +parentCommit: Hash,
+  +becomesEdge: BecomesEdge,
+|}> {
+  for (const childCommit of Object.keys(repository.commits)) {
+    for (const parentCommit of repository.commits[childCommit].parentHashes) {
+      for (const becomesEdge of findBecomesEdgesForCommits(
+        repository,
+        childCommit,
+        parentCommit
+      )) {
+        yield {childCommit, parentCommit, becomesEdge};
+      }
+    }
+  }
+}
+
 export function createGraph(
   repository: Repository
 ): Graph<NodePayload, EdgePayload> {

--- a/src/plugins/git/createGraph.test.js
+++ b/src/plugins/git/createGraph.test.js
@@ -4,7 +4,11 @@ import cloneDeep from "lodash.clonedeep";
 
 import type {BecomesEdge} from "./createGraph";
 import type {Hash, Tree} from "./types";
-import {createGraph, findBecomesEdgesForCommits} from "./createGraph";
+import {
+  createGraph,
+  findBecomesEdges,
+  findBecomesEdgesForCommits,
+} from "./createGraph";
 import {
   BLOB_NODE_TYPE,
   COMMIT_NODE_TYPE,
@@ -459,5 +463,12 @@ describe("findBecomesEdgesForCommits", () => {
     expect(expected).toEqual(
       expect.arrayContaining((result.slice(): $ReadOnlyArray<mixed>).slice())
     );
+  });
+});
+
+describe("findBecomesEdges", () => {
+  it("works on the example repository", () => {
+    const data = makeData();
+    expect(Array.from(findBecomesEdges(data))).toMatchSnapshot();
   });
 });


### PR DESCRIPTION
Test Plan:
For the snapshot: verify that two of the BECOMES edges are the same as
those tested in `findBecomesEdgesForCommits` and that they have the
right commit hashes; then, verify that the remaining edge is correct.

wchargin-branch: high-level-becomes-repository