### PR TITLE
Add CLI for printing a fresh Git graph

### DIFF
--- a/config/paths.js
+++ b/config/paths.js
@@ -61,6 +61,9 @@ module.exports = {
       "src/plugins/github/bin/fetchAndPrintGithubRepo.js"
     ),
     createExampleRepo: resolveApp("src/plugins/git/bin/createExampleRepo.js"),
+    cloneAndPrintGitGraph: resolveApp(
+      "src/plugins/git/bin/cloneAndPrintGitGraph.js"
+    ),
     loadAndPrintGitRepository: resolveApp(
       "src/plugins/git/bin/loadAndPrintRepository.js"
     ),

--- a/src/plugins/git/bin/cloneAndPrintGitGraph.js
+++ b/src/plugins/git/bin/cloneAndPrintGitGraph.js
@@ -1,0 +1,36 @@
+// @flow
+
+/*
+ * Command-line utility to load Git data using the API in
+ * ../cloneGitGraph, and print it to stdout. Useful for testing or
+ * saving some data to disk.
+ *
+ * Usage:
+ *
+ *   node bin/cloneAndPrintGitGraph.js REPO_OWNER REPO_NAME
+ *
+ */
+
+import cloneGitGraph from "../cloneGitGraph";
+import stringify from "json-stable-stringify";
+
+function parseArgs() {
+  const argv = process.argv.slice(2);
+  const fail = () => {
+    const invocation = process.argv.slice(0, 2).join(" ");
+    throw new Error(`Usage: ${invocation} REPO_OWNER REPO_NAME`);
+  };
+  if (argv.length !== 2) {
+    fail();
+  }
+  const [repoOwner, repoName] = argv;
+  return {repoOwner, repoName};
+}
+
+function main() {
+  const {repoOwner, repoName} = parseArgs();
+  const graph = cloneGitGraph(repoOwner, repoName);
+  console.log(stringify(graph, {space: 4}));
+}
+
+main();

--- a/src/plugins/git/cloneAndLoadRepository.js
+++ b/src/plugins/git/cloneAndLoadRepository.js
@@ -1,0 +1,29 @@
+// @flow
+
+import tmp from "tmp";
+import {localGit} from "./gitUtils";
+import type {Repository} from "./types";
+import {loadRepository} from "./loadRepository";
+
+/**
+ * Load Git Repository data from a fresh clone of a GitHub repo.
+ *
+ * @param {String} repoOwner
+ *   the GitHub username of the owner of the repository to be cloned
+ * @param {String} repoName
+ *   the name of the repository to be cloned
+ * @return {Repository}
+ *   the parsed Repository from the cloned repo
+ */
+export default function cloneAndLoadRepository(
+  repoOwner: string,
+  repoName: string
+): Repository {
+  const cloneUrl = `https://github.com/${repoOwner}/${repoName}.git`;
+  const tmpdir = tmp.dirSync({unsafeCleanup: true});
+  const git = localGit(tmpdir.name);
+  git(["clone", cloneUrl, ".", "--quiet"]);
+  const result = loadRepository(tmpdir.name, "HEAD");
+  tmpdir.removeCallback();
+  return result;
+}

--- a/src/plugins/git/cloneGitGraph.js
+++ b/src/plugins/git/cloneGitGraph.js
@@ -1,0 +1,24 @@
+// @flow
+
+import cloneAndLoadRepository from "./cloneAndLoadRepository";
+import {createGraph} from "./createGraph";
+import type {NodePayload, EdgePayload} from "./types";
+import type {Graph} from "../../core/graph";
+
+/**
+ * Load Git contribution graph from a fresh clone of a GitHub repo.
+ *
+ * @param {String} repoOwner
+ *   the GitHub username of the owner of the repository to be cloned
+ * @param {String} repoName
+ *   the name of the repository to be cloned
+ * @return {Graph<NodePayload, EdgePayload>}
+ *   the Git contribution graph
+ */
+export default function fetchGitGraph(
+  repoOwner: string,
+  repoName: string
+): Graph<NodePayload, EdgePayload> {
+  const repo = cloneAndLoadRepository(repoOwner, repoName);
+  return createGraph(repo);
+}


### PR DESCRIPTION
`cloneAndPrintGitGraph` clones a git repository, and generates a Git
object graph for that repository.

This can be run as follows:
```
yarn backend;
node bin/cloneAndPrintGitGraph sourcecred example-git
```

This commit also adds two utility modules:
* `cloneAndLoadRepository` , which clones a Git repository to a tmpdir,
parses the `Repository` data out, and then cleans up.
* `cloneGitGraph`, which calls `cloneAndLoadRepository` and `createGraph`

Test plan: These don't fit well into our CI, because they require
network access to clone repositories from GitHub. I verified that the
functions work via the demo script above.