### PR TITLE
Add `src/tools/bin/printCombinedGraph.js`

### DIFF
--- a/config/paths.js
+++ b/config/paths.js
@@ -64,6 +64,7 @@ module.exports = {
     cloneAndPrintGitGraph: resolveApp(
       "src/plugins/git/bin/cloneAndPrintGitGraph.js"
     ),
+    printCombinedGraph: resolveApp("src/tools/bin/printCombinedGraph.js"),
     loadAndPrintGitRepository: resolveApp(
       "src/plugins/git/bin/loadAndPrintRepository.js"
     ),

--- a/src/tools/bin/printCombinedGraph.js
+++ b/src/tools/bin/printCombinedGraph.js
@@ -1,0 +1,42 @@
+/*
+ * Command-line utility to fetch data for multiple plugins and print a combined
+ * graph. Currently imports data from the Git and GitHub plugins.
+ *
+ * Usage:
+ *
+ *   node bin/printCombinedGraph.js REPO_OWNER REPO_NAME TOKEN
+ *
+ * where TOKEN is a GitHub authentication token, as generated from
+ * https://github.com/settings/tokens/new.
+ */
+
+import stringify from "json-stable-stringify";
+import {loadCombinedGraph} from "../loadCombinedGraph";
+
+function parseArgs() {
+  const argv = process.argv.slice(2);
+  const fail = () => {
+    const invocation = process.argv.slice(0, 2).join(" ");
+    throw new Error(`Usage: ${invocation} REPO_OWNER REPO_NAME TOKEN`);
+  };
+  if (argv.length !== 3) {
+    fail();
+  }
+  const [repoOwner, repoName, token] = argv;
+  return {repoOwner, repoName, token};
+}
+
+function main() {
+  const {repoOwner, repoName, token} = parseArgs();
+  loadCombinedGraph(repoOwner, repoName, token)
+    .then((data) => {
+      console.log(stringify(data, {space: 4}));
+    })
+    .catch((errors) => {
+      console.error("Errors processing the result:");
+      console.error(errors);
+      process.exit(1);
+    });
+}
+
+main();

--- a/src/tools/loadCombinedGraph.js
+++ b/src/tools/loadCombinedGraph.js
@@ -1,0 +1,35 @@
+// @flow
+
+import cloneGitGraph from "../plugins/git/cloneGitGraph";
+import fetchGithubGraph from "../plugins/github/fetchGithubGraph";
+import type {
+  NodePayload as GithubNodePayload,
+  EdgePayload as GithubEdgePayload,
+} from "../plugins/github/types";
+import type {
+  NodePayload as GitNodePayload,
+  EdgePayload as GitEdgePayload,
+} from "../plugins/git/types";
+import {Graph} from "../core/graph";
+
+export type NodePayload = GitNodePayload | GithubNodePayload;
+export type EdgePayload = GitEdgePayload | GithubEdgePayload;
+/**
+ * Load a cross-plugin contribution graph for the given GitHub repo
+ *
+ * @param {String} repoOwner
+ *   the GitHub username of the owner of the repository to be cloned
+ * @param {String} repoName
+ *   the name of the repository to be cloned
+ * @return {Promise<Graph<NodePayload, EdgePayload>>}
+ *   a Promise containing the combined contribution graph
+ */
+export function loadCombinedGraph(
+  repoOwner: string,
+  repoName: string,
+  token: string
+): Promise<Graph<NodePayload, EdgePayload>> {
+  const githubGraphPromise = fetchGithubGraph(repoOwner, repoName, token);
+  const gitGraph = cloneGitGraph(repoOwner, repoName);
+  return githubGraphPromise.then((x) => Graph.mergeConservative(gitGraph, x));
+}


### PR DESCRIPTION
`printCombinedGraph` loads and prints a cross-plugin combined
contribution graph for a given GitHub repository.

It is a simple executable wrapper around `src/tools/loadCombinedGraph`.

Example usage:
`node bin/printCombinedGraph.js sourcecred example-git $GITHUB_TOKEN`