### PR TITLE
Add `sourcecred.js` CLI scaffolding using yargs

### DIFF
--- a/config/paths.js
+++ b/config/paths.js
@@ -68,5 +68,6 @@ module.exports = {
     loadAndPrintGitRepository: resolveApp(
       "src/plugins/git/bin/loadAndPrintRepository.js"
     ),
+    sourcecred: resolveApp("src/tools/sourcecred.js"),
   },
 };

--- a/package.json
+++ b/package.json
@@ -51,7 +51,8 @@
     "webpack": "3.8.1",
     "webpack-dev-server": "2.9.4",
     "webpack-manifest-plugin": "1.3.2",
-    "whatwg-fetch": "2.0.3"
+    "whatwg-fetch": "2.0.3",
+    "yargs": "^11.0.0"
   },
   "scripts": {
     "precommit": "npm run lint-staged",

--- a/src/tools/sourcecred.js
+++ b/src/tools/sourcecred.js
@@ -1,0 +1,134 @@
+//@flow
+
+/*
+ * CLI for loading SourceCred graphs. Main entry point for SourceCred users.
+ *
+ * For usage, run node bin/sourcecred.js --help
+ */
+
+import yargs from "yargs/yargs";
+import os from "os";
+import path from "path";
+
+function pluginGraph(
+  repoOwner: string,
+  repoName: string,
+  plugin: string,
+  githubToken?: string
+) {
+  console.log(
+    `
+    pluginGraph
+    repoOwner: ${repoOwner}
+    repoName: ${repoName}
+    plugin: ${plugin}
+    githubToken?: ${githubToken || "null"}
+    `
+  );
+}
+
+function graph(
+  repoOwner: string,
+  repoName: string,
+  outputDir: string,
+  githubToken: string
+) {
+  console.log(
+    `graph
+    repoOwner: ${repoOwner}
+    repoName: ${repoName}
+    outputDir: ${outputDir}
+    githubToken: ${githubToken}`
+  );
+}
+
+function combine(files: string[]) {
+  console.log(`combine files: ${files.join(",")}`);
+}
+
+function main() {
+  function defaultBuilder(yargs) {
+    return yargs.strict();
+  }
+
+  function repoPositional(yargs) {
+    return yargs
+      .positional("repoOwner", {
+        describe: "the owner of the repository",
+      })
+      .positional("repoName", {describe: "the name of the repository"});
+  }
+
+  function githubToken(yargs, options) {
+    const required = options != null && options.required;
+    yargs = yargs.option("github-token", {
+      demandOption: required,
+      describe:
+        "a GitHub API token, as generated at https://github.com/settings/tokens/new",
+    });
+    return yargs;
+  }
+
+  function outputDir(yargs) {
+    yargs.option("output-dir", {
+      describe: "directory to place SourceCred graphs into",
+      default: path.join(os.tmpdir(), "sourcecred"),
+    });
+    return yargs;
+  }
+
+  const parser = yargs()
+    .command(
+      "graph <repoOwner> <repoName>",
+      "fetch, combine, and save SourceCred contribution graphs across all standard plugins",
+      (yargs) => {
+        yargs = defaultBuilder(yargs);
+        yargs = repoPositional(yargs);
+        yargs = githubToken(yargs, {required: true});
+        outputDir(yargs);
+      },
+      (argv) => {
+        let {repoOwner, repoName, githubToken, outputDir} = argv;
+        graph(repoOwner, repoName, outputDir, githubToken);
+      }
+    )
+    .command(
+      "plugin-graph <repoOwner> <repoName>",
+      "print the contribution graph for a particular plugin",
+      (yargs) => {
+        yargs = defaultBuilder(yargs);
+        yargs = repoPositional(yargs);
+        yargs = yargs.option("plugin", {
+          type: "string",
+          choices: ["git", "github"],
+          describe: "which plugin to load a graph for",
+          demandOption: true,
+        });
+        githubToken(yargs);
+      },
+      (argv) => {
+        let {repoOwner, repoName, githubToken, plugin} = argv;
+        if (typeof plugin !== "string") {
+          throw new Error("plugin-graph requires a single string plugin name");
+        }
+        pluginGraph(repoOwner, repoName, plugin, githubToken);
+      }
+    )
+    .command(
+      "combine",
+      "combine multiple SourceCred graphs and print the resulting graph",
+      (yargs) =>
+        defaultBuilder(yargs).option("outputFile", {
+          type: "string",
+          describe: "File to write output to; prints to stdout if unset",
+        }),
+      (argv) => {
+        let files = argv._.slice(1);
+        combine(files);
+      }
+    )
+    .strict();
+  parser.parse(process.argv.slice(2));
+}
+
+main();

--- a/yarn.lock
+++ b/yarn.lock
@@ -1420,6 +1420,14 @@ cliui@^3.2.0:
     strip-ansi "^3.0.1"
     wrap-ansi "^2.0.0"
 
+cliui@^4.0.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/cliui/-/cliui-4.1.0.tgz#348422dbe82d800b3022eef4f6ac10bf2e4d1b49"
+  dependencies:
+    string-width "^2.1.1"
+    strip-ansi "^4.0.0"
+    wrap-ansi "^2.0.0"
+
 clone@^1.0.2:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/clone/-/clone-1.0.3.tgz#298d7e2231660f40c003c2ed3140decf3f53085f"
@@ -7126,6 +7134,29 @@ yargs-parser@^7.0.0:
   resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-7.0.0.tgz#8d0ac42f16ea55debd332caf4c4038b3e3f5dfd9"
   dependencies:
     camelcase "^4.1.0"
+
+yargs-parser@^9.0.2:
+  version "9.0.2"
+  resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-9.0.2.tgz#9ccf6a43460fe4ed40a9bb68f48d43b8a68cc077"
+  dependencies:
+    camelcase "^4.1.0"
+
+yargs@^11.0.0:
+  version "11.0.0"
+  resolved "https://registry.yarnpkg.com/yargs/-/yargs-11.0.0.tgz#c052931006c5eee74610e5fc0354bedfd08a201b"
+  dependencies:
+    cliui "^4.0.0"
+    decamelize "^1.1.1"
+    find-up "^2.1.0"
+    get-caller-file "^1.0.1"
+    os-locale "^2.0.0"
+    require-directory "^2.1.1"
+    require-main-filename "^1.0.1"
+    set-blocking "^2.0.0"
+    string-width "^2.0.0"
+    which-module "^2.0.0"
+    y18n "^3.2.1"
+    yargs-parser "^9.0.2"
 
 yargs@^6.6.0:
   version "6.6.0"


### PR DESCRIPTION
Adds a scaffold CLI for SourceCred, with the following commands:

`sourcecred.js graph <repoOwner> <repoName> --github-token=1234`
`sourcecred.js combine file1 file2....`
`sourcecred.js plugin-graph <repoOwner> <repoName> --plugin=git`

Test plan: Compiled the binary and then ran a variety of example
commands, like:

```
$ yarn backend;

$ node bin/sourcecred.js graph sourcecred sourcecred
# errors due to missing argument: github-token

$ node bin/sourcecred.js graph sourcecred sourcecred github-token=123
# works

$ node bin/sourcecred.js graph sourcecred sourcecred github-token=123 \
 --outputDir ~/.sourcecred

# works

$ node bin/sourcecred.js plugin-graph sourcecred sourcecred \
--plugin=github
# works

$ node bin/sourcecred.js plugin-graph sc sc
# doesn't work, missing plugin

and so forth
```