### PR TITLE
Exclude node modules from backend build

### DIFF
--- a/config/webpack.config.backend.js
+++ b/config/webpack.config.backend.js
@@ -2,6 +2,7 @@ const webpack = require("webpack");
 const eslintFormatter = require("react-dev-utils/eslintFormatter");
 const ModuleScopePlugin = require("react-dev-utils/ModuleScopePlugin");
 const paths = require("./paths");
+const nodeExternals = require("webpack-node-externals");
 
 // This is the backend configuration. It builds applications that target
 // Node and will not run in a browser.
@@ -11,6 +12,7 @@ module.exports = {
   // Target Node instead of the browser.
   target: "node",
   entry: paths.backendEntryPoints,
+  externals: [nodeExternals()],
   output: {
     path: paths.backendBuild,
     // Generated JS file names (with nested folders).
@@ -65,7 +67,6 @@ module.exports = {
         ],
       },
     ],
-    exprContextCritical: false,
   },
   plugins: [
     new webpack.DefinePlugin({

--- a/package.json
+++ b/package.json
@@ -119,6 +119,7 @@
     "enzyme-adapter-react-16": "^1.1.1",
     "enzyme-to-json": "^3.3.3",
     "mkdirp": "^0.5.1",
-    "tmp": "^0.0.33"
+    "tmp": "^0.0.33",
+    "webpack-node-externals": "^1.7.2"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -6941,6 +6941,10 @@ webpack-manifest-plugin@1.3.2:
     fs-extra "^0.30.0"
     lodash ">=3.5 <5"
 
+webpack-node-externals@^1.7.2:
+  version "1.7.2"
+  resolved "https://registry.yarnpkg.com/webpack-node-externals/-/webpack-node-externals-1.7.2.tgz#6e1ee79ac67c070402ba700ef033a9b8d52ac4e3"
+
 webpack-sources@^1.0.1:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/webpack-sources/-/webpack-sources-1.1.0.tgz#a101ebae59d6507354d71d8013950a3a8b7a5a54"


### PR DESCRIPTION
Setup following directions from [webpack-node-externals]

[webpack-node-externals]: https://www.npmjs.com/package/webpack-node-externals

This fixes the build problem in https://github.com/sourcecred/sourcecred/pull/210

Test plan: `yarn backend` still succeeds, and the binary scripts still
work. The resultant binaries are much smaller, as seen below (note build
time is the same).

before:
```
❯ yarn backend 
yarn run v1.5.1
$ node scripts/backend.js
Building backend applications...
Compiled successfully.

File sizes after gzip:

  231.37 KB  bin/printCombinedGraph.js
  199.5 KB   bin/fetchAndPrintGithubRepo.js
  46.41 KB   bin/cloneAndPrintGitGraph.js
  21.48 KB   bin/createExampleRepo.js
  17.71 KB   bin/loadAndPrintGitRepository.js

Build completed; results in 'bin'.
Done in 4.46s.
```
after:
```
❯ yarn backend 
yarn run v1.5.1
$ node scripts/backend.js
Building backend applications...
Compiled successfully.

File sizes after gzip:

  27.78 KB  bin/printCombinedGraph.js
  12.73 KB  bin/cloneAndPrintGitGraph.js
  12.41 KB  bin/fetchAndPrintGithubRepo.js
  6.03 KB   bin/loadAndPrintGitRepository.js
  5.52 KB   bin/createExampleRepo.js

Build completed; results in 'bin'.
Done in 4.28s.
```