### PR TITLE
Change `execDependencyGraph` export format

### DIFF
--- a/config/travis.js
+++ b/config/travis.js
@@ -1,6 +1,6 @@
 // @flow
 
-const execDependencyGraph = require("../src/tools/execDependencyGraph");
+const execDependencyGraph = require("../src/tools/execDependencyGraph").default;
 
 main();
 

--- a/src/tools/execDependencyGraph.js
+++ b/src/tools/execDependencyGraph.js
@@ -28,7 +28,7 @@ type OverallResult = {|
 |};
 */
 
-module.exports = async function execDepgraph(
+exports.default = async function execDependencyGraph(
   tasks /*: $ReadOnlyArray<Task> */
 ) /*: Promise<OverallResult> */ {
   const tasksById /*: {[TaskId]: Task} */ = {};


### PR DESCRIPTION
Summary:
To be honest, I have no idea what exactly this does or why it’s
necessary, but if we don’t do this then it is not possible to `import`
the exported member from a Webpack-bundled script. I’ve seen this
pattern before; one day I’ll actually figure out what it does. :-)

Test Plan:
Note that `yarn travis` (success) and `yarn travis --full` (failure; no
GitHub token) both have the expected behaviors.

wchargin-branch: execdependencygraph-export