### PR TITLE
Split `GithubResponseJSON` and `RepositoryJSON`

### DIFF
--- a/src/plugins/github/fetchGithubRepo.js
+++ b/src/plugins/github/fetchGithubRepo.js
@@ -8,7 +8,7 @@ import fetch from "isomorphic-fetch";
 
 import {stringify, inlineLayout} from "../../graphql/queries";
 import {createQuery, createVariables, postQueryExhaustive} from "./graphql";
-import type {RepositoryJSON} from "./graphql";
+import type {GithubResponseJSON} from "./graphql";
 
 /**
  * Scrape data from a GitHub repo using the GitHub API.
@@ -29,7 +29,7 @@ export default function fetchGithubRepo(
   repoOwner: string,
   repoName: string,
   token: string
-): Promise<RepositoryJSON> {
+): Promise<GithubResponseJSON> {
   repoOwner = String(repoOwner);
   repoName = String(repoName);
   token = String(token);
@@ -52,7 +52,7 @@ export default function fetchGithubRepo(
   return postQueryExhaustive(
     (somePayload) => postQuery(somePayload, token),
     payload
-  ).then((x: RepositoryJSON) => {
+  ).then((x: GithubResponseJSON) => {
     ensureNoMorePages(x);
     return x;
   });

--- a/src/plugins/github/graphql.js
+++ b/src/plugins/github/graphql.js
@@ -101,12 +101,14 @@ export type ConnectionJSON<+T> = {|
   |},
 |};
 
+export type GithubResponseJSON = {|
+  +repository: RepositoryJSON,
+|};
+
 export type RepositoryJSON = {|
-  +repository: {
-    +id: string,
-    +issues: ConnectionJSON<IssueJSON>,
-    +pullRequests: ConnectionJSON<PullRequestJSON>,
-  },
+  +id: string,
+  +issues: ConnectionJSON<IssueJSON>,
+  +pullRequests: ConnectionJSON<PullRequestJSON>,
 |};
 
 /**

--- a/src/plugins/github/parser.js
+++ b/src/plugins/github/parser.js
@@ -21,6 +21,7 @@ import type {
 
 import {MERGED_AS_EDGE_TYPE} from "./types";
 import type {
+  GithubResponseJSON,
   RepositoryJSON,
   PullRequestReviewJSON,
   PullRequestJSON,
@@ -36,10 +37,10 @@ import {findReferences} from "./findReferences";
 import {commitAddress} from "../git/address";
 
 export function parse(
-  repositoryJSON: RepositoryJSON
+  githubResponseJSON: GithubResponseJSON
 ): Graph<NodePayload, EdgePayload> {
   const parser = new GithubParser();
-  parser.addData(repositoryJSON);
+  parser.addData(githubResponseJSON);
   parser.addReferenceEdges();
   return parser.graph;
 }
@@ -320,10 +321,12 @@ class GithubParser {
     return danglingReferences;
   }
 
-  addData(dataJson: RepositoryJSON) {
-    dataJson.repository.issues.nodes.forEach((i) => this.addIssue(i));
-    dataJson.repository.pullRequests.nodes.forEach((pr) =>
-      this.addPullRequest(pr)
-    );
+  addRepository(repositoryJSON: RepositoryJSON) {
+    repositoryJSON.issues.nodes.forEach((i) => this.addIssue(i));
+    repositoryJSON.pullRequests.nodes.forEach((pr) => this.addPullRequest(pr));
+  }
+
+  addData(dataJson: GithubResponseJSON) {
+    this.addRepository(dataJson.repository);
   }
 }

--- a/src/plugins/github/parser.test.js
+++ b/src/plugins/github/parser.test.js
@@ -3,7 +3,7 @@
 import {AUTHORS_EDGE_TYPE, CONTAINS_EDGE_TYPE} from "./types";
 import type {NodePayload, EdgePayload} from "./types";
 import {parse} from "./parser";
-import type {RepositoryJSON, PullRequestJSON, IssueJSON} from "./graphql";
+import type {GithubResponseJSON, PullRequestJSON, IssueJSON} from "./graphql";
 import {Graph} from "../../core/graph";
 import exampleRepoData from "./demoData/example-github.json";
 
@@ -95,7 +95,7 @@ describe("GithubParser", () => {
   }: ExampleInput): Graph<NodePayload, EdgePayload> {
     const issues = issueNums.map(getIssue);
     const pullRequests = prNums.map(getPR);
-    const exampleData: RepositoryJSON = {
+    const exampleData: GithubResponseJSON = {
       repository: {
         id: exampleRepoData.repository.id,
         issues: {


### PR DESCRIPTION
Currently, we generate a `RepositoryJSON` object via querying GitHub.
That `RepositoryJSON` object has a `repository` field... which is weird,
and suggests we got the names slightly wrong.

This commit renames the top-level response to `GithubResponseJSON`, and
factors the `repository` field out as `RepositoryJSON`. Correspondingly,
the `addData` and `addRepository` methods on the parser are now
distinct.

This is a precursor for #171.

Test plan: This is a simple refactor; the fact that yarn travis passes
should be sufficient.