### PR TITLE
Change plugin graph label from "PASS" to "DONE"

### DIFF
--- a/src/cli/commands/graph.js
+++ b/src/cli/commands/graph.js
@@ -68,7 +68,7 @@ function graph(
   console.log("Storing graphs into: " + scopedDirectory);
   mkdirp.sync(scopedDirectory);
   const tasks = makeTasks(scopedDirectory, {repoOwner, repoName, token});
-  execDependencyGraph(tasks).then(({success}) => {
+  execDependencyGraph(tasks, {taskPassLabel: "DONE"}).then(({success}) => {
     process.exitCode = success ? 0 : 1;
   });
 }


### PR DESCRIPTION
Test Plan:
Run `node bin/sourcecred.js graph sourcecred example-github` and note
the new output:
```
Storing graphs into: /tmp/sourcecred/sourcecred/example-github

Starting tasks
  GO   create-git
  GO   create-github
 DONE  create-git
 DONE  create-github
  GO   combine
 DONE  combine

Full results
 DONE  create-git
 DONE  create-github
 DONE  combine

Overview
Final result:  SUCCESS
```

wchargin-branch: plugin-graph-label