### PR TITLE
Query GitHub for repository information

### DIFF
--- a/src/plugins/github/demoData/example-github.json
+++ b/src/plugins/github/demoData/example-github.json
@@ -256,6 +256,13 @@
                 "hasNextPage": false
             }
         },
+        "name": "example-github",
+        "owner": {
+            "__typename": "Organization",
+            "id": "MDEyOk9yZ2FuaXphdGlvbjM1NzExNjY3",
+            "login": "sourcecred",
+            "url": "https://github.com/sourcecred"
+        },
         "pullRequests": {
             "nodes": [
                 {
@@ -419,6 +426,7 @@
                 "endCursor": "Y3Vyc29yOnYyOpHOCxMtTQ==",
                 "hasNextPage": false
             }
-        }
+        },
+        "url": "https://github.com/sourcecred/example-github"
     }
 }

--- a/src/plugins/github/graphql.js
+++ b/src/plugins/github/graphql.js
@@ -109,6 +109,9 @@ export type RepositoryJSON = {|
   +id: string,
   +issues: ConnectionJSON<IssueJSON>,
   +pullRequests: ConnectionJSON<PullRequestJSON>,
+  +url: string,
+  +name: string,
+  +owner: AuthorJSON,
 |};
 
 /**
@@ -126,6 +129,9 @@ export function createQuery(): Body {
           "repository",
           {owner: b.variable("repoOwner"), name: b.variable("repoName")},
           [
+            b.field("url"),
+            b.field("name"),
+            b.field("owner", {}, [b.fragmentSpread("whoami")]),
             b.field("id"),
             b.field("issues", {first: b.literal(PAGE_SIZE_ISSUES)}, [
               b.fragmentSpread("issues"),

--- a/src/plugins/github/parser.test.js
+++ b/src/plugins/github/parser.test.js
@@ -97,7 +97,7 @@ describe("GithubParser", () => {
     const pullRequests = prNums.map(getPR);
     const exampleData: GithubResponseJSON = {
       repository: {
-        id: exampleRepoData.repository.id,
+        ...exampleRepoData.repository,
         issues: {
           nodes: issues,
           pageInfo: {


### PR DESCRIPTION
This commit pulls new information from GitHub about the url, name, and
owner of a GitHub repository. Part of #171.

Test plan: example-github-repo.json has been updated. `yarn travis
--full` passes. This should be sufficient.