### PR TITLE
CLI commands error on unhandled promise rejection

### DIFF
--- a/src/cli/commands/combine.js
+++ b/src/cli/commands/combine.js
@@ -7,6 +7,13 @@ import {promisify} from "util";
 
 import {Graph} from "../../core/graph";
 
+// Makes the script crash on unhandled rejections instead of silently
+// ignoring them. In the future, promise rejections that are not handled will
+// terminate the Node.js process with a non-zero exit code.
+process.on("unhandledRejection", (err) => {
+  throw err;
+});
+
 export default class CombineCommand extends Command {
   static description = "combine multiple contribution graphs into one big graph";
 

--- a/src/cli/commands/graph.js
+++ b/src/cli/commands/graph.js
@@ -9,6 +9,13 @@ import {pluginNames} from "../common";
 
 const execDependencyGraph = require("../../tools/execDependencyGraph").default;
 
+// Makes the script crash on unhandled rejections instead of silently
+// ignoring them. In the future, promise rejections that are not handled will
+// terminate the Node.js process with a non-zero exit code.
+process.on("unhandledRejection", (err) => {
+  throw err;
+});
+
 export default class GraphCommand extends Command {
   static description = `\
 create the contribution graph for a repository

--- a/src/cli/commands/pluginGraph.js
+++ b/src/cli/commands/pluginGraph.js
@@ -9,6 +9,13 @@ import createGitGraph from "../../plugins/git/cloneGitGraph";
 import createGithubGraph from "../../plugins/github/fetchGithubGraph";
 import {pluginNames} from "../common";
 
+// Makes the script crash on unhandled rejections instead of silently
+// ignoring them. In the future, promise rejections that are not handled will
+// terminate the Node.js process with a non-zero exit code.
+process.on("unhandledRejection", (err) => {
+  throw err;
+});
+
 export default class PluginGraphCommand extends Command {
   static description = "create the contribution graph for a single plugin";
 


### PR DESCRIPTION
Previously, if a CLI command had an unhandled promise rejection, this
would result in a spurious success and zero exit value.

This commit causes all of our CLI commands to instead fail if they have
an unhandled promise rejection.

Test plan: Previously, `sourcecred graph src-d go-git` would claim to
succeed, although it actually fails due to an unrelated bug. After this
change is applied, it correctly fails to retrieve the GitHub graph (and
hte combine step is never run).