### PR TITLE
Extract a common SOURCECRED_DIRECTORY flag

### DIFF
--- a/src/cli/common.js
+++ b/src/cli/common.js
@@ -1,5 +1,6 @@
 // @flow
 
+import {flags} from "@oclif/command";
 import os from "os";
 import path from "path";
 
@@ -8,6 +9,15 @@ export function pluginNames() {
   return ["git", "github"];
 }
 
-export function defaultStorageDirectory() {
+function defaultStorageDirectory() {
   return path.join(os.tmpdir(), "sourcecred");
+}
+
+export function sourcecredDirectoryFlag() {
+  return flags.string({
+    char: "d",
+    description: "directory for storing graphs and other SourceCred data",
+    env: "SOURCECRED_DIRECTORY",
+    default: () => defaultStorageDirectory(),
+  });
 }


### PR DESCRIPTION
Summary:
This solves two problems:

 1. The “output directory” argument to `sourcecred graph` is also the
    input directory to other commands, like `sourcecred analyze`
    (hypothetically). In such cases, it would be nice for the flag to
    have the same name, but clearly `--output-directory` does not always
    make sense.

 2. In addition to storing graphs, we’ll need to store other kinds of
    data: settings, intermediate data for plugins to cache results, etc.
    We should store these under a single umbrella.

With both of these problems in mind, it makes sense to create a
`SOURCECRED_DIRECTORY` flag under which we store all relevant data.

Test Plan:
Run:
```shell
$ yarn backend
$ node bin/sourcecred.js help graph
$ node bin/sourcecred.js graph sourcecred example-github
$ node bin/sourcecred.js graph sourcecred example-github -d /tmp/sorcecrod
$ SOURCECRED_DIRECTORY=/tmp/srccrd node bin/sourcecred.js graph sourcecred example-github
$ for dir in /tmp/{sourcecred,sorcecrod,srccrd}; do find "${dir}"; done
```

wchargin-branch: graph-directory