### PR TITLE
Deleted users no longer break GitHub parser

### DIFF
--- a/src/plugins/github/graphql.js
+++ b/src/plugins/github/graphql.js
@@ -631,6 +631,11 @@ function mergeDirect<T>(destination: T, source: any): T {
   }
 }
 
+// If a user deletes their account, then the author is null
+// (the UI will show that the message was written by @ghost).
+// Therefore, NullableAuthorJSON is preferred to AuthorJSON
+// for most actual usage.
+export type NullableAuthorJSON = AuthorJSON | null;
 export type AuthorJSON = {|
   +__typename: "User" | "Bot" | "Organization",
   +id: string,
@@ -667,7 +672,7 @@ export type IssueJSON = {|
   +title: string,
   +body: string,
   +number: number,
-  +author: AuthorJSON,
+  +author: NullableAuthorJSON,
   +comments: ConnectionJSON<CommentJSON>,
 |};
 
@@ -695,7 +700,7 @@ export type PullRequestJSON = {|
   +title: string,
   +body: string,
   +number: number,
-  +author: AuthorJSON,
+  +author: NullableAuthorJSON,
   +comments: ConnectionJSON<CommentJSON>,
   +reviews: ConnectionJSON<PullRequestReviewJSON>,
   // If present, oid is the commit SHA of the merged commit.
@@ -727,7 +732,7 @@ export type CommentJSON = {|
   +id: string,
   +url: string,
   +body: string,
-  +author: AuthorJSON,
+  +author: NullableAuthorJSON,
 |};
 function commentsFragment(): FragmentDefinition {
   const b = build;
@@ -754,7 +759,7 @@ export type PullRequestReviewJSON = {|
   +id: string,
   +url: string,
   +body: string,
-  +author: AuthorJSON,
+  +author: NullableAuthorJSON,
   +state: PullRequestReviewState,
   +comments: ConnectionJSON<PullRequestReviewCommentJSON>,
 |};
@@ -779,7 +784,7 @@ export type PullRequestReviewCommentJSON = {|
   +id: string,
   +url: string,
   +body: string,
-  +author: AuthorJSON,
+  +author: NullableAuthorJSON,
 |};
 function reviewCommentsFragment(): FragmentDefinition {
   const b = build;

--- a/src/plugins/github/parser.js
+++ b/src/plugins/github/parser.js
@@ -27,7 +27,7 @@ import type {
   PullRequestJSON,
   IssueJSON,
   CommentJSON,
-  AuthorJSON,
+  NullableAuthorJSON,
 } from "./graphql";
 
 import type {Address} from "../../core/address";
@@ -76,8 +76,11 @@ class GithubParser {
       | PullRequestReviewCommentNodePayload
       | PullRequestReviewNodePayload
     >,
-    authorJson: AuthorJSON
+    authorJson: NullableAuthorJSON
   ) {
+    if (authorJson == null) {
+      return;
+    }
     let authorType: AuthorSubtype;
     switch (authorJson.__typename) {
       case "User":


### PR DESCRIPTION
When a GitHub user delete their account, all of their comments remain,
but with a `null` author. Previously, our code did not account for this
possibility. Now it does (by simply not adding an AUTHORSHIP edge).
Conveniently, our porcelain API already represents authors as a list, so
this doesn't require any change in porcelain API usage.

Test plan:
I did not add any unit tests, simply because
creating-and-deleting a GitHub user to make a repro seemed like a bit of
a pain. However, it is very unlikely that this bug will re-occur,
because the nullability of AuthorJSON is now enforced at the type level
inside graphql.js.

Also, running `node bin/sourcecred.js src-d go-git` now succeeds instead
of failing.