### PR TITLE
Create "REPOSITORY" nodes in GitHub plugin graph

### DIFF
--- a/src/plugins/artifact/editor/adapters/__snapshots__/githubPluginAdapter.test.js.snap
+++ b/src/plugins/artifact/editor/adapters/__snapshots__/githubPluginAdapter.test.js.snap
@@ -18,6 +18,21 @@ Array [
     "type": "AUTHOR",
   },
   Object {
+    "id": "https://github.com/sourcecred/example-github",
+    "payload": Object {
+      "name": "example-github",
+      "owner": "sourcecred",
+      "url": "https://github.com/sourcecred/example-github",
+    },
+    "rendered": <div>
+      type: 
+      REPOSITORY
+       (details to be implemented)
+</div>,
+    "title": "sourcecred/example-github",
+    "type": "REPOSITORY",
+  },
+  Object {
     "id": "https://github.com/sourcecred/example-github/issues/1",
     "payload": Object {
       "body": "This is just an example issue.",

--- a/src/plugins/artifact/editor/adapters/githubPluginAdapter.js
+++ b/src/plugins/artifact/editor/adapters/githubPluginAdapter.js
@@ -7,6 +7,7 @@ import type {Node} from "../../../../core/graph";
 import type {
   NodePayload,
   NodeType,
+  RepositoryNodePayload,
   IssueNodePayload,
   PullRequestNodePayload,
   CommentNodePayload,
@@ -46,6 +47,9 @@ const adapter: PluginAdapter<NodePayload> = {
           return adapter.extractTitle(graph, graph.node(neighbor));
         });
     }
+    function extractRepositoryTitle(node: Node<RepositoryNodePayload>) {
+      return `${node.payload.owner}/${node.payload.name}`;
+    }
     function extractIssueOrPrTitle(
       node: Node<IssueNodePayload | PullRequestNodePayload>
     ) {
@@ -80,6 +84,8 @@ const adapter: PluginAdapter<NodePayload> = {
     const anyNode: Node<any> = node;
     const type: NodeType = (node.address.type: any);
     switch (type) {
+      case "REPOSITORY":
+        return extractRepositoryTitle(anyNode);
       case "ISSUE":
       case "PULL_REQUEST":
         return extractIssueOrPrTitle(anyNode);

--- a/src/plugins/github/__snapshots__/parser.test.js.snap
+++ b/src/plugins/github/__snapshots__/parser.test.js.snap
@@ -25,6 +25,13 @@ Object {
         "url": "https://github.com/decentralion",
       },
     },
+    "{\\"id\\":\\"https://github.com/sourcecred/example-github\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"REPOSITORY\\"}": Object {
+      "payload": Object {
+        "name": "example-github",
+        "owner": "sourcecred",
+        "url": "https://github.com/sourcecred/example-github",
+      },
+    },
     "{\\"id\\":\\"https://github.com/sourcecred/example-github/issues/1\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"ISSUE\\"}": Object {
       "payload": Object {
         "body": "This is just an example issue.",
@@ -138,6 +145,13 @@ Object {
         "login": "decentralion",
         "subtype": "USER",
         "url": "https://github.com/decentralion",
+      },
+    },
+    "{\\"id\\":\\"https://github.com/sourcecred/example-github\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"REPOSITORY\\"}": Object {
+      "payload": Object {
+        "name": "example-github",
+        "owner": "sourcecred",
+        "url": "https://github.com/sourcecred/example-github",
       },
     },
     "{\\"id\\":\\"https://github.com/sourcecred/example-github/issues/6\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"ISSUE\\"}": Object {
@@ -301,6 +315,13 @@ Object {
         "url": "https://github.com/decentralion",
       },
     },
+    "{\\"id\\":\\"https://github.com/sourcecred/example-github\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"REPOSITORY\\"}": Object {
+      "payload": Object {
+        "name": "example-github",
+        "owner": "sourcecred",
+        "url": "https://github.com/sourcecred/example-github",
+      },
+    },
     "{\\"id\\":\\"https://github.com/sourcecred/example-github/pull/5\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"PULL_REQUEST\\"}": Object {
       "payload": Object {
         "body": "@wchargin could you please do the following:
@@ -408,6 +429,13 @@ Object {
         "login": "decentralion",
         "subtype": "USER",
         "url": "https://github.com/decentralion",
+      },
+    },
+    "{\\"id\\":\\"https://github.com/sourcecred/example-github\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"REPOSITORY\\"}": Object {
+      "payload": Object {
+        "name": "example-github",
+        "owner": "sourcecred",
+        "url": "https://github.com/sourcecred/example-github",
       },
     },
     "{\\"id\\":\\"https://github.com/sourcecred/example-github/pull/3\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"PULL_REQUEST\\"}": Object {
@@ -843,6 +871,13 @@ Object {
         "url": "https://github.com/decentralion",
       },
     },
+    "{\\"id\\":\\"https://github.com/sourcecred/example-github\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"REPOSITORY\\"}": Object {
+      "payload": Object {
+        "name": "example-github",
+        "owner": "sourcecred",
+        "url": "https://github.com/sourcecred/example-github",
+      },
+    },
     "{\\"id\\":\\"https://github.com/sourcecred/example-github/issues/1\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"ISSUE\\"}": Object {
       "payload": Object {
         "body": "This is just an example issue.",
@@ -1189,6 +1224,13 @@ Object {
         "login": "decentralion",
         "subtype": "USER",
         "url": "https://github.com/decentralion",
+      },
+    },
+    "{\\"id\\":\\"https://github.com/sourcecred/example-github\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"REPOSITORY\\"}": Object {
+      "payload": Object {
+        "name": "example-github",
+        "owner": "sourcecred",
+        "url": "https://github.com/sourcecred/example-github",
       },
     },
     "{\\"id\\":\\"https://github.com/sourcecred/example-github/issues/2\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"ISSUE\\"}": Object {
@@ -2014,6 +2056,13 @@ Object {
         "login": "decentralion",
         "subtype": "USER",
         "url": "https://github.com/decentralion",
+      },
+    },
+    "{\\"id\\":\\"https://github.com/sourcecred/example-github\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"REPOSITORY\\"}": Object {
+      "payload": Object {
+        "name": "example-github",
+        "owner": "sourcecred",
+        "url": "https://github.com/sourcecred/example-github",
       },
     },
     "{\\"id\\":\\"https://github.com/sourcecred/example-github/issues/1\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"ISSUE\\"}": Object {

--- a/src/plugins/github/api.test.js
+++ b/src/plugins/github/api.test.js
@@ -13,7 +13,9 @@ import {
 } from "./types";
 describe("GitHub porcelain API", () => {
   const graph = parse(exampleRepoData);
-  const repo = new Repository(graph);
+  // TODO: Create a higher level API that contains all the repositories
+  const repoNode = graph.nodes({type: "REPOSITORY"})[0];
+  const repo = new Repository(graph, repoNode.address);
   function issueOrPRByNumber(n: number): Issue | PullRequest {
     const result = repo.issueOrPRByNumber(n);
     if (result == null) {
@@ -22,6 +24,11 @@ describe("GitHub porcelain API", () => {
     return result;
   }
   describe("has wrappers for", () => {
+    it("Repositories", () => {
+      expect(repo.url()).toBe("https://github.com/sourcecred/example-github");
+      expect(repo.owner()).toBe("sourcecred");
+      expect(repo.name()).toBe("example-github");
+    });
     it("Issues", () => {
       const issue = issueOrPRByNumber(1);
       expect(issue.title()).toBe("An example issue.");

--- a/src/plugins/github/parser.js
+++ b/src/plugins/github/parser.js
@@ -9,6 +9,7 @@ import type {
   NodePayload,
   EdgePayload,
   PullRequestReviewNodePayload,
+  RepositoryNodePayload,
   AuthorNodePayload,
   AuthorsEdgePayload,
   PullRequestReviewCommentNodePayload,
@@ -273,6 +274,8 @@ class GithubParser {
       const anyNode: Node<any> = node;
       const type: NodeType = (node.address.type: any);
       switch (type) {
+        case "REPOSITORY":
+          break;
         case "ISSUE":
         case "PULL_REQUEST":
           const thisPayload: IssueNodePayload | PullRequestNodePayload =
@@ -322,6 +325,16 @@ class GithubParser {
   }
 
   addRepository(repositoryJSON: RepositoryJSON) {
+    const repositoryPayload: RepositoryNodePayload = {
+      url: repositoryJSON.url,
+      name: repositoryJSON.name,
+      owner: repositoryJSON.owner.login,
+    };
+    const repositoryNode: Node<RepositoryNodePayload> = {
+      address: this.makeNodeAddress("REPOSITORY", repositoryJSON.url),
+      payload: repositoryPayload,
+    };
+    this.graph.addNode(repositoryNode);
     repositoryJSON.issues.nodes.forEach((i) => this.addIssue(i));
     repositoryJSON.pullRequests.nodes.forEach((pr) => this.addPullRequest(pr));
   }

--- a/src/plugins/github/types.js
+++ b/src/plugins/github/types.js
@@ -1,6 +1,13 @@
 // @flow
 
 /** Node Types */
+export const REPOSITORY_NODE_TYPE: "REPOSITORY" = "REPOSITORY";
+export type RepositoryNodePayload = {|
+  +name: string,
+  +owner: string,
+  +url: string,
+|};
+
 export const ISSUE_NODE_TYPE: "ISSUE" = "ISSUE";
 export type IssueNodePayload = {|
   +url: string,
@@ -60,6 +67,10 @@ export type AuthorNodePayload = {|
 // useful at the value layer as $ElementType<NodeTypes, "ISSUE">, for
 // instance.
 export type NodeTypes = {|
+  REPOSITORY: {
+    payload: RepositoryNodePayload,
+    type: typeof REPOSITORY_NODE_TYPE,
+  },
   ISSUE: {payload: IssueNodePayload, type: typeof ISSUE_NODE_TYPE},
   PULL_REQUEST: {
     payload: PullRequestNodePayload,
@@ -78,6 +89,7 @@ export type NodeTypes = {|
 |};
 
 export type NodeType =
+  | typeof REPOSITORY_NODE_TYPE
   | typeof ISSUE_NODE_TYPE
   | typeof PULL_REQUEST_NODE_TYPE
   | typeof COMMENT_NODE_TYPE
@@ -86,6 +98,7 @@ export type NodeType =
   | typeof AUTHOR_NODE_TYPE;
 
 export type NodePayload =
+  | RepositoryNodePayload
   | IssueNodePayload
   | PullRequestNodePayload
   | CommentNodePayload


### PR DESCRIPTION
This commit creates a new node type in the GitHub graph: the REPOSITORY
node. The REPOSITORY node has the following payload properties:
- url (string)
- name (string)
- owner (string)

Things this commit does:
- Add new node type and payload type (RepositoryNodePayload)
- Update parser to instantiate the new node type
- Update api.js to have Repository wrap the new node type (thus
Repository is a GitHub entity)
- Update snapshots
- Update users of GitHub node types to ensure they are exhaustive

Things that will come in a followon commit:
- Add CONTAINS edges from the repository to all its PRs and Issues
- Update the Repository porcelain to use those edges, rather than
scanning the graph for every possible Issue/PR (eventually those might
belong to other Repositories)
- Create a GitHubGraph abstraction in the porcelain, which makes it easy
to find all of the Repositories in a graph

Note that retrieving the repository owner technically involved fetching
the whole owner representation (as a GitHub user). I could have chosen
to add that user to the graph, with a "OWNS" edge pointing to the
repository. For simplicity's sake, I've declined to do that, and instead
just parse the owner's name directly.

Test plan:
Added tests to verify that the Repository porcelain entity has the right
properties. Combined with the snapshot tests, that should be sufficient.

This mostly completes #171