### PR TITLE
Ensure that flow is used in all js files

### DIFF
--- a/config/env.js
+++ b/config/env.js
@@ -1,3 +1,4 @@
+// @no-flow
 const fs = require("fs");
 const path = require("path");
 const paths = require("./paths");

--- a/config/jest/cssTransform.js
+++ b/config/jest/cssTransform.js
@@ -1,3 +1,4 @@
+// @no-flow
 // This is a custom Jest transformer turning style imports into empty objects.
 // http://facebook.github.io/jest/docs/en/webpack.html
 

--- a/config/jest/fileTransform.js
+++ b/config/jest/fileTransform.js
@@ -1,3 +1,4 @@
+// @no-flow
 const path = require("path");
 
 // This is a custom Jest transformer turning file imports into filenames.

--- a/config/paths.js
+++ b/config/paths.js
@@ -1,3 +1,4 @@
+// @no-flow
 const path = require("path");
 const fs = require("fs");
 const url = require("url");

--- a/config/polyfills.js
+++ b/config/polyfills.js
@@ -1,3 +1,4 @@
+// @no-flow
 if (typeof Promise === "undefined") {
   // Rejection tracking prevents a common issue where React gets into an
   // inconsistent state due to an error, but it gets swallowed by a Promise,

--- a/config/travis.js
+++ b/config/travis.js
@@ -18,6 +18,11 @@ function main() {
 function makeTasks(mode /*: "BASIC" | "FULL" */) {
   const basicTasks = [
     {
+      id: "ensure-flow-typing",
+      cmd: ["./scripts/ensure-flow.sh"],
+      deps: [],
+    },
+    {
       id: "check-pretty",
       cmd: ["npm", "run", "--silent", "check-pretty"],
       deps: [],

--- a/config/webpack.config.backend.js
+++ b/config/webpack.config.backend.js
@@ -1,3 +1,4 @@
+// @no-flow
 const webpack = require("webpack");
 const eslintFormatter = require("react-dev-utils/eslintFormatter");
 const ModuleScopePlugin = require("react-dev-utils/ModuleScopePlugin");

--- a/config/webpack.config.dev.js
+++ b/config/webpack.config.dev.js
@@ -1,3 +1,4 @@
+// @no-flow
 const autoprefixer = require("autoprefixer");
 const path = require("path");
 const webpack = require("webpack");

--- a/config/webpack.config.prod.js
+++ b/config/webpack.config.prod.js
@@ -1,3 +1,4 @@
+// @no-flow
 const autoprefixer = require("autoprefixer");
 const path = require("path");
 const webpack = require("webpack");

--- a/config/webpackDevServer.config.js
+++ b/config/webpackDevServer.config.js
@@ -1,3 +1,4 @@
+// @no-flow
 const errorOverlayMiddleware = require("react-dev-utils/errorOverlayMiddleware");
 const noopServiceWorkerMiddleware = require("react-dev-utils/noopServiceWorkerMiddleware");
 const ignoredFiles = require("react-dev-utils/ignoredFiles");

--- a/scripts/backend.js
+++ b/scripts/backend.js
@@ -1,3 +1,4 @@
+// @no-flow
 "use strict";
 
 // Do this as the first thing so that any code reading it knows the right env.

--- a/scripts/build.js
+++ b/scripts/build.js
@@ -1,3 +1,4 @@
+// @no-flow
 "use strict";
 
 // Do this as the first thing so that any code reading it knows the right env.

--- a/scripts/ensure-flow.sh
+++ b/scripts/ensure-flow.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+set -eu
+comm -13 -z \
+  <(git grep -z --name-only -e @flow -e @no-flow | sort -z) \
+  <(find src config scripts -name '*.js' -print0 | sort -z) \
+  | tr '\0' '\n' \
+  | diff -u /dev/null -

--- a/scripts/start.js
+++ b/scripts/start.js
@@ -1,3 +1,4 @@
+// @no-flow
 "use strict";
 
 // Do this as the first thing so that any code reading it knows the right env.

--- a/scripts/test.js
+++ b/scripts/test.js
@@ -1,3 +1,4 @@
+// @no-flow
 "use strict";
 
 // Do this as the first thing so that any code reading it knows the right env.

--- a/src/cli/sourcecred.js
+++ b/src/cli/sourcecred.js
@@ -1,3 +1,4 @@
+// @no-flow
 require("@oclif/command")
   .run()
   .catch(require("@oclif/errors/handle"));

--- a/src/plugins/artifact/editor/App.test.js
+++ b/src/plugins/artifact/editor/App.test.js
@@ -1,3 +1,4 @@
+// @no-flow
 import React from "react";
 import ReactDOM from "react-dom";
 import App from "./App";

--- a/src/plugins/artifact/editor/index.js
+++ b/src/plugins/artifact/editor/index.js
@@ -1,3 +1,4 @@
+// @no-flow
 import React from "react";
 import ReactDOM from "react-dom";
 import "./index.css";

--- a/src/plugins/artifact/editor/registerServiceWorker.js
+++ b/src/plugins/artifact/editor/registerServiceWorker.js
@@ -1,3 +1,4 @@
+// @no-flow
 // In production, we register a service worker to serve assets from local cache.
 
 // This lets the app load faster on subsequent visits in production, and gives

--- a/src/plugins/github/bin/fetchAndPrintGithubRepo.js
+++ b/src/plugins/github/bin/fetchAndPrintGithubRepo.js
@@ -1,3 +1,4 @@
+// @no-flow
 /*
  * Command-line utility to fetch GitHub data using the API in
  * ../fetchGithubRepo, and print it to stdout. Useful for testing or


### PR DESCRIPTION
This script ensures that `@flow` or `@no-flow` is present in
every js file. Every existing js file that would fail this check has
been given `@no-flow`, we should work to remove all of these in the
future.

Test plan:
I verified that `yarn travis` fails before fixing the other js files,
and passes afterwards.