### PR TITLE
Fix flow errors in paths.js

### DIFF
--- a/config/paths.js
+++ b/config/paths.js
@@ -1,7 +1,6 @@
-// @no-flow
+// @flow
 const path = require("path");
 const fs = require("fs");
-const url = require("url");
 
 // Make sure any symlinks in the project folder are resolved:
 // https://github.com/facebookincubator/create-react-app/issues/637
@@ -10,10 +9,10 @@ const resolveApp = (relativePath) => path.resolve(appDirectory, relativePath);
 
 const envPublicUrl = process.env.PUBLIC_URL;
 
-function ensureSlash(path, needsSlash) {
+function ensureSlash(path /*: string */, needsSlash /*: bool */) {
   const hasSlash = path.endsWith("/");
   if (hasSlash && !needsSlash) {
-    return path.substr(path, path.length - 1);
+    return path.substr(0, path.length - 1);
   } else if (!hasSlash && needsSlash) {
     return `${path}/`;
   } else {
@@ -21,20 +20,16 @@ function ensureSlash(path, needsSlash) {
   }
 }
 
-const getPublicUrl = (appPackageJson) =>
-  envPublicUrl || require(appPackageJson).homepage;
+const getPublicUrl = () => envPublicUrl || "/";
 
-// We use `PUBLIC_URL` environment variable or "homepage" field to infer
-// "public path" at which the app is served.
+// We use `PUBLIC_URL` environment variable field to infer "public path" at
+// which the app is served. Defaults to "/"
 // Webpack needs to know it to put the right <script> hrefs into HTML even in
 // single-page apps that may serve index.html for nested URLs like /todos/42.
 // We can't use a relative path in HTML because we don't want to load something
 // like /todos/42/static/js/bundle.7289d.js. We have to know the root.
-function getServedPath(appPackageJson) {
-  const publicUrl = getPublicUrl(appPackageJson);
-  const servedUrl =
-    envPublicUrl || (publicUrl ? url.parse(publicUrl).pathname : "/");
-  return ensureSlash(servedUrl, true);
+function getServedPath() {
+  return ensureSlash(getPublicUrl(), true);
 }
 
 // config after eject: we're in ./config/
@@ -49,8 +44,8 @@ module.exports = {
   yarnLockFile: resolveApp("yarn.lock"),
   testsSetup: resolveApp("src/setupTests.js"),
   appNodeModules: resolveApp("node_modules"),
-  publicUrl: getPublicUrl(resolveApp("package.json")),
-  servedPath: getServedPath(resolveApp("package.json")),
+  publicUrl: getPublicUrl(),
+  servedPath: getServedPath(),
 
   backendBuild: resolveApp("bin"),
   // This object should have one key-value pair per entry point. For


### PR DESCRIPTION
- Fix accidental string-to-NaN coercion in ensureSlash
- Don't dynamically require package.json; to determine public url, just
use the environment variable or "/"

Test plan: `yarn start` and travis still work