### PR TITLE
Turn on flow for scripts/{backend,build,test}.js

### DIFF
--- a/config/babel.js
+++ b/config/babel.js
@@ -49,7 +49,7 @@ const plugins = [
 // https://github.com/facebookincubator/create-react-app/issues/720
 // It’s also nice that we can enforce `NODE_ENV` being specified.
 var env = process.env.BABEL_ENV || process.env.NODE_ENV;
-var backend = !!process.env.SOURCECRED_BACKEND;
+var backend = process.env.SOURCECRED_BACKEND === "true";
 if (env !== "development" && env !== "test" && env !== "production") {
   throw new Error(
     "Using `babel-preset-react-app` requires that you specify `NODE_ENV` or " +

--- a/scripts/backend.js
+++ b/scripts/backend.js
@@ -1,10 +1,10 @@
-// @no-flow
+// @flow
 "use strict";
 
 // Do this as the first thing so that any code reading it knows the right env.
 process.env.NODE_ENV = process.env.NODE_ENV || "development";
 process.env.BABEL_ENV = process.env.NODE_ENV;
-process.env.SOURCECRED_BACKEND = true;
+process.env.SOURCECRED_BACKEND = "true";
 
 // Makes the script crash on unhandled rejections instead of silently
 // ignoring them. In the future, promise rejections that are not handled will

--- a/scripts/build.js
+++ b/scripts/build.js
@@ -1,4 +1,4 @@
-// @no-flow
+// @flow
 "use strict";
 
 // Do this as the first thing so that any code reading it knows the right env.
@@ -23,7 +23,6 @@ const config = require("../config/webpack.config.prod");
 const paths = require("../config/paths");
 const checkRequiredFiles = require("react-dev-utils/checkRequiredFiles");
 const formatWebpackMessages = require("react-dev-utils/formatWebpackMessages");
-const printHostingInstructions = require("react-dev-utils/printHostingInstructions");
 const FileSizeReporter = require("react-dev-utils/FileSizeReporter");
 const printBuildError = require("react-dev-utils/printBuildError");
 
@@ -81,18 +80,6 @@ measureFileSizesBeforeBuild(paths.appBuild)
         WARN_AFTER_CHUNK_GZIP_SIZE
       );
       console.log();
-
-      const appPackage = require(paths.appPackageJson);
-      const publicUrl = paths.publicUrl;
-      const publicPath = config.output.publicPath;
-      const buildFolder = path.relative(process.cwd(), paths.appBuild);
-      printHostingInstructions(
-        appPackage,
-        publicUrl,
-        publicPath,
-        buildFolder,
-        useYarn
-      );
     },
     (err) => {
       console.log(chalk.red("Failed to compile.\n"));

--- a/scripts/test.js
+++ b/scripts/test.js
@@ -1,4 +1,4 @@
-// @no-flow
+// @flow
 "use strict";
 
 // Do this as the first thing so that any code reading it knows the right env.


### PR DESCRIPTION
- scripts/backend.js: We incorrectly set an environment variable to
a boolean, when in fact it must be a string. Fixed it to set a string
value "true", and updated usage in config/babel.js
- scripts/test.js: No changes
- scripts/build.js: Removed a call to printHostingInstructions, so that
we don't need to require the package.json.

Test plan:
`yarn travis --full` passes, and the SourceCred cli still works.