### PR TITLE
Start a production server from `sourcecred start`

### DIFF
--- a/src/app/apiApp.js
+++ b/src/app/apiApp.js
@@ -2,8 +2,14 @@
 
 import express from "express";
 
-export default function apiApp(sourcecredDirectory: string) {
+export default function apiApp(
+  sourcecredDirectory: string,
+  staticFiles?: string
+) {
   const app = express();
   app.use("/api/v1/data", express.static(sourcecredDirectory));
+  if (staticFiles != null) {
+    app.use(express.static(staticFiles));
+  }
   return app;
 }


### PR DESCRIPTION
Summary:
This commit changes `yarn start` to run a production version of the API
server, which serves static files from a pre-built directory and also
handles API requests.

Test Plan:
```shell
$ yarn build
$ yarn backend
$ node ./bin/sourcecred.js start -d /tmp/srccrd &
$ mkdir -p /tmp/srccrd
$ echo hello >/tmp/srccrd/world
$ curl -s localhost:4000/ | file -
/dev/stdin: HTML document, ASCII text, with very long lines, with no line terminators
$ curl -s localhost:4000/api/v1/data/world
hello
```

wchargin-branch: cli-start-prod-server