### PR TITLE
GH Porcelain: Move `authors` top-level Porcelain

### DIFF
--- a/src/plugins/github/porcelain.js
+++ b/src/plugins/github/porcelain.js
@@ -133,6 +133,12 @@ export class Porcelain {
     }
     return repo[0];
   }
+
+  authors(): Author[] {
+    return this.graph
+      .nodes({type: AUTHOR_NODE_TYPE})
+      .map((n) => new Author(this.graph, n.address));
+  }
 }
 
 class GithubEntity<T: NodePayload> {
@@ -199,12 +205,6 @@ export class Repository extends GithubEntity<RepositoryNodePayload> {
     return this.graph
       .nodes({type: PULL_REQUEST_NODE_TYPE})
       .map((n) => new PullRequest(this.graph, n.address));
-  }
-
-  authors(): Author[] {
-    return this.graph
-      .nodes({type: AUTHOR_NODE_TYPE})
-      .map((n) => new Author(this.graph, n.address));
   }
 }
 

--- a/src/plugins/github/porcelain.test.js
+++ b/src/plugins/github/porcelain.test.js
@@ -150,7 +150,7 @@ describe("GitHub porcelain", () => {
     });
 
     it("Authors", () => {
-      const authors = repo.authors();
+      const authors = porcelain.authors();
       // So we don't need to manually update the test if a new person posts
       expect(authors.length).toMatchSnapshot();
 


### PR DESCRIPTION
Currently, the `authors` method is attached at the Repository level.
This is incorrect; it actually finds all the authors in the graph, not
all the authors of that repository. This commit moves the method to the
correct class.

Test plan: This function is only used in test code. The tests still
pass.