### PR TITLE
GH Porcelain: add `Repository.from`

### DIFF
--- a/src/plugins/github/porcelain.js
+++ b/src/plugins/github/porcelain.js
@@ -162,6 +162,10 @@ class GithubEntity<T: NodePayload> {
 }
 
 export class Repository extends GithubEntity<RepositoryNodePayload> {
+  static from(e: Entity): Repository {
+    assertEntityType(e, REPOSITORY_NODE_TYPE);
+    return (e: any);
+  }
   // TODO: Now that the Repository is a node in the graph, re-write methods
   // that find issues and PRs to find neighbors of the repository rather than
   // any matching nodes in the graph. Then, behavior will be correct in the

--- a/src/plugins/github/porcelain.test.js
+++ b/src/plugins/github/porcelain.test.js
@@ -6,6 +6,7 @@ import exampleRepoData from "./demoData/example-github.json";
 import {
   asEntity,
   Porcelain,
+  Repository,
   Issue,
   PullRequest,
   Comment,
@@ -169,6 +170,7 @@ describe("GitHub porcelain", () => {
 
   describe("has type coercion that", () => {
     it("allows refining types when correct", () => {
+      const _unused_repo: Repository = Repository.from(repo);
       const _unused_issue: Issue = Issue.from(issueOrPRByNumber(1));
       const _unused_pr: PullRequest = PullRequest.from(issueOrPRByNumber(3));
       const _unused_author: Author = Author.from(
@@ -179,6 +181,9 @@ describe("GitHub porcelain", () => {
       );
     });
     it("throws an error on bad type refinement", () => {
+      expect(() => Repository.from(issueOrPRByNumber(1))).toThrowError(
+        "to have type REPOSITORY"
+      );
       expect(() => PullRequest.from(issueOrPRByNumber(1))).toThrowError(
         "to have type PULL_REQUEST"
       );


### PR DESCRIPTION
I think the absence of this method when I added the `Repository` class
was a bug.

Test plan: There are new unit tests.