### PR TITLE
Add `@flow` to `.eslintrc.js`

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,3 +1,4 @@
+// @flow
 module.exports = {
   extends: "react-app",
   rules: {


### PR DESCRIPTION
Summary:
Even though it’s not really a source file, and it lives at the
repository root, it might as well have typing to make sure that we don’t
do anything really dumb.

Test Plan:
`yarn flow` still passes.

wchargin-branch: flow-eslintrc