### PR TITLE
Make `ensure-flow.sh` more precise and accurate

### DIFF
--- a/scripts/ensure-flow.sh
+++ b/scripts/ensure-flow.sh
@@ -1,7 +1,7 @@
-#!/bin/bash
+#!/bin/sh
 set -eu
-comm -13 -z \
-  <(git grep -z --name-only -e @flow -e @no-flow | sort -z) \
-  <(find src config scripts -name '*.js' -print0 | sort -z) \
-  | tr '\0' '\n' \
-  | diff -u /dev/null -
+git grep -Fz --files-without-match -e '@flow' -e '@no-flow' -- '*.js' \
+    | grep -zv '^flow-typed/' \
+    | tr '\0' '\n' \
+    | tee /dev/stderr \
+    | diff -q /dev/null - >/dev/null


### PR DESCRIPTION
Summary:
This fixes two problems in the previous version:
  - A new JS file not checked into git, but with a `@flow` directive,
    would cause `ensure-flow` to fail, because one list of files was
    from `git grep` and the other was from `find`.
  - Only the hard-coded directories `src config scripts` were searched.

Now, we search all JS files checked into Git, except for some hard-coded
exceptions, namely `flow-typed`.

Test Plan:
  1. Add `foo.js`, not checked into Git. Note that `ensure-flow` passes.
  2. Add `@flow` to `foo.js`, and note that `ensure-flow` still passes.
  3. Remove `@flow` from `.eslintrc.js`, and note that `ensure-flow`
     fails and nicely prints the filename. (Note: this file is at the
     repository root.)
  4. Create a file `echo stuff >$'naughty\nfilename.js'`, and note that
     `ensure-flow` has the correct behavior in both positive and
     negative cases.

wchargin-branch: ensure-flow-improvements