### PR TITLE
Reorganize GitHub porcelain tests

### DIFF
--- a/src/plugins/github/__snapshots__/porcelain.test.js.snap
+++ b/src/plugins/github/__snapshots__/porcelain.test.js.snap
@@ -1,66 +1,175 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`GitHub porcelain has wrappers for Authors 1`] = `2`;
-
-exports[`GitHub porcelain has wrappers for Authors 2`] = `
+exports[`GitHub porcelain all wrappers provide a type() method 1`] = `
 Object {
-  "address": Object {
-    "id": "https://github.com/decentralion",
-    "pluginName": "sourcecred/github-beta",
-    "type": "AUTHOR",
-  },
-  "payload": Object {
-    "login": "decentralion",
-    "subtype": "USER",
-    "url": "https://github.com/decentralion",
-  },
+  "https://github.com/decentralion": "AUTHOR",
+  "https://github.com/sourcecred/example-github/issues/2": "ISSUE",
+  "https://github.com/sourcecred/example-github/issues/2#issuecomment-373768703": "COMMENT",
+  "https://github.com/sourcecred/example-github/pull/5": "PULL_REQUEST",
+  "https://github.com/sourcecred/example-github/pull/5#discussion_r171460198": "PULL_REQUEST_REVIEW_COMMENT",
+  "https://github.com/sourcecred/example-github/pull/5#pullrequestreview-100313899": "PULL_REQUEST_REVIEW",
 }
 `;
 
-exports[`GitHub porcelain has wrappers for Comments 1`] = `3`;
-
-exports[`GitHub porcelain has wrappers for Comments 2`] = `
+exports[`GitHub porcelain all wrappers provide a url() method 1`] = `
 Object {
-  "address": Object {
-    "id": "https://github.com/sourcecred/example-github/issues/6#issuecomment-373768442",
-    "pluginName": "sourcecred/github-beta",
-    "type": "COMMENT",
-  },
-  "payload": Object {
-    "body": "A wild COMMENT appeared!",
-    "url": "https://github.com/sourcecred/example-github/issues/6#issuecomment-373768442",
-  },
+  "https://github.com/decentralion": "https://github.com/decentralion",
+  "https://github.com/sourcecred/example-github/issues/2": "https://github.com/sourcecred/example-github/issues/2",
+  "https://github.com/sourcecred/example-github/issues/2#issuecomment-373768703": "https://github.com/sourcecred/example-github/issues/2#issuecomment-373768703",
+  "https://github.com/sourcecred/example-github/pull/5": "https://github.com/sourcecred/example-github/pull/5",
+  "https://github.com/sourcecred/example-github/pull/5#discussion_r171460198": "https://github.com/sourcecred/example-github/pull/5#discussion_r171460198",
+  "https://github.com/sourcecred/example-github/pull/5#pullrequestreview-100313899": "https://github.com/sourcecred/example-github/pull/5#pullrequestreview-100313899",
 }
 `;
 
-exports[`GitHub porcelain has wrappers for Issues 1`] = `
+exports[`GitHub porcelain issues and pull requests have comments 1`] = `
 Object {
-  "address": Object {
-    "id": "https://github.com/sourcecred/example-github/issues/1",
-    "pluginName": "sourcecred/github-beta",
-    "type": "ISSUE",
-  },
-  "payload": Object {
-    "body": "This is just an example issue.",
-    "number": 1,
-    "title": "An example issue.",
-    "url": "https://github.com/sourcecred/example-github/issues/1",
-  },
+  "https://github.com/sourcecred/example-github/issues/1": Array [],
+  "https://github.com/sourcecred/example-github/issues/2": Array [
+    "https://github.com/sourcecred/example-github/issues/2#issuecomment-373768703",
+    "https://github.com/sourcecred/example-github/issues/2#issuecomment-373768850",
+    "https://github.com/sourcecred/example-github/issues/2#issuecomment-385576185",
+    "https://github.com/sourcecred/example-github/issues/2#issuecomment-385576220",
+    "https://github.com/sourcecred/example-github/issues/2#issuecomment-385576248",
+    "https://github.com/sourcecred/example-github/issues/2#issuecomment-385576273",
+    "https://github.com/sourcecred/example-github/issues/2#issuecomment-385576920",
+    "https://github.com/sourcecred/example-github/issues/2#issuecomment-385576936",
+  ],
+  "https://github.com/sourcecred/example-github/issues/4": Array [],
+  "https://github.com/sourcecred/example-github/issues/6": Array [
+    "https://github.com/sourcecred/example-github/issues/6#issuecomment-373768442",
+    "https://github.com/sourcecred/example-github/issues/6#issuecomment-373768538",
+    "https://github.com/sourcecred/example-github/issues/6#issuecomment-385223316",
+  ],
+  "https://github.com/sourcecred/example-github/issues/7": Array [],
+  "https://github.com/sourcecred/example-github/issues/8": Array [],
+  "https://github.com/sourcecred/example-github/pull/3": Array [
+    "https://github.com/sourcecred/example-github/pull/3#issuecomment-369162222",
+  ],
+  "https://github.com/sourcecred/example-github/pull/5": Array [],
+  "https://github.com/sourcecred/example-github/pull/9": Array [],
 }
 `;
 
-exports[`GitHub porcelain has wrappers for PullRequests Merged 1`] = `
+exports[`GitHub porcelain issues and pull requests have numbers 1`] = `
 Object {
-  "address": Object {
-    "id": "https://github.com/sourcecred/example-github/pull/3",
-    "pluginName": "sourcecred/github-beta",
-    "type": "PULL_REQUEST",
-  },
-  "payload": Object {
-    "body": "Oh look, it's a pull request.",
-    "number": 3,
-    "title": "Add README, merge via PR.",
-    "url": "https://github.com/sourcecred/example-github/pull/3",
-  },
+  "https://github.com/sourcecred/example-github/issues/1": 1,
+  "https://github.com/sourcecred/example-github/issues/2": 2,
+  "https://github.com/sourcecred/example-github/issues/4": 4,
+  "https://github.com/sourcecred/example-github/issues/6": 6,
+  "https://github.com/sourcecred/example-github/issues/7": 7,
+  "https://github.com/sourcecred/example-github/issues/8": 8,
+  "https://github.com/sourcecred/example-github/pull/3": 3,
+  "https://github.com/sourcecred/example-github/pull/5": 5,
+  "https://github.com/sourcecred/example-github/pull/9": 9,
+}
+`;
+
+exports[`GitHub porcelain issues and pull requests have titles 1`] = `
+Object {
+  "https://github.com/sourcecred/example-github/issues/1": "An example issue.",
+  "https://github.com/sourcecred/example-github/issues/2": "A referencing issue.",
+  "https://github.com/sourcecred/example-github/issues/4": "A closed pull request",
+  "https://github.com/sourcecred/example-github/issues/6": "An issue with comments",
+  "https://github.com/sourcecred/example-github/issues/7": "An issue with an extremely long title, which even has a VerySuperFragicalisticialiManyCharacterUberLongTriplePlusGood word in it, and should really be truncated intelligently or something",
+  "https://github.com/sourcecred/example-github/issues/8": "Issue with Unicode: ȴሲ𣐳楢👍 :heart: 𐤔𐤁𐤀𐤑𐤍𐤉𐤔𐤌𐤄𐤍𐤍 ❤️",
+  "https://github.com/sourcecred/example-github/pull/3": "Add README, merge via PR.",
+  "https://github.com/sourcecred/example-github/pull/5": "This pull request will be more contentious. I can feel it...",
+  "https://github.com/sourcecred/example-github/pull/9": "An unmerged pull request",
+}
+`;
+
+exports[`GitHub porcelain posts have authors 1`] = `
+Object {
+  "https://github.com/sourcecred/example-github/issues/2": Array [
+    "decentralion",
+  ],
+  "https://github.com/sourcecred/example-github/issues/2#issuecomment-373768703": Array [
+    "decentralion",
+  ],
+  "https://github.com/sourcecred/example-github/pull/5": Array [
+    "decentralion",
+  ],
+  "https://github.com/sourcecred/example-github/pull/5#discussion_r171460198": Array [
+    "wchargin",
+  ],
+  "https://github.com/sourcecred/example-github/pull/5#pullrequestreview-100313899": Array [
+    "wchargin",
+  ],
+}
+`;
+
+exports[`GitHub porcelain posts have bodies 1`] = `
+Object {
+  "https://github.com/sourcecred/example-github/issues/2": "This issue references another issue, namely #1",
+  "https://github.com/sourcecred/example-github/issues/2#issuecomment-373768703": "It should also be possible to reference by exact url: https://github.com/sourcecred/example-github/issues/6",
+  "https://github.com/sourcecred/example-github/pull/5": "@wchargin could you please do the following:
+- add a commit comment
+- add a review comment requesting some trivial change
+- i'll change it
+- then approve the pr",
+  "https://github.com/sourcecred/example-github/pull/5#discussion_r171460198": "seems a bit capricious",
+  "https://github.com/sourcecred/example-github/pull/5#pullrequestreview-100313899": "hmmm.jpg",
+}
+`;
+
+exports[`GitHub porcelain posts have parents 1`] = `
+Object {
+  "https://github.com/sourcecred/example-github/issues/2": "https://github.com/sourcecred/example-github",
+  "https://github.com/sourcecred/example-github/issues/2#issuecomment-373768703": "https://github.com/sourcecred/example-github/issues/2",
+  "https://github.com/sourcecred/example-github/pull/5": "https://github.com/sourcecred/example-github",
+  "https://github.com/sourcecred/example-github/pull/5#discussion_r171460198": "https://github.com/sourcecred/example-github/pull/5#pullrequestreview-100313899",
+  "https://github.com/sourcecred/example-github/pull/5#pullrequestreview-100313899": "https://github.com/sourcecred/example-github/pull/5",
+}
+`;
+
+exports[`GitHub porcelain posts have references 1`] = `
+Object {
+  "https://github.com/sourcecred/example-github/issues/2": Array [
+    "https://github.com/sourcecred/example-github/issues/1",
+  ],
+  "https://github.com/sourcecred/example-github/issues/2#issuecomment-373768703": Array [
+    "https://github.com/sourcecred/example-github/issues/6",
+  ],
+  "https://github.com/sourcecred/example-github/pull/5": Array [
+    "https://github.com/wchargin",
+  ],
+  "https://github.com/sourcecred/example-github/pull/5#discussion_r171460198": Array [],
+  "https://github.com/sourcecred/example-github/pull/5#pullrequestreview-100313899": Array [],
+}
+`;
+
+exports[`GitHub porcelain pull request reviews have review comments 1`] = `
+Object {
+  "https://github.com/sourcecred/example-github/pull/5#pullrequestreview-100313899": Array [
+    "https://github.com/sourcecred/example-github/pull/5#discussion_r171460198",
+  ],
+  "https://github.com/sourcecred/example-github/pull/5#pullrequestreview-100314038": Array [],
+}
+`;
+
+exports[`GitHub porcelain pull request reviews have states 1`] = `
+Object {
+  "https://github.com/sourcecred/example-github/pull/5#pullrequestreview-100313899": "CHANGES_REQUESTED",
+  "https://github.com/sourcecred/example-github/pull/5#pullrequestreview-100314038": "APPROVED",
+}
+`;
+
+exports[`GitHub porcelain pull requests have mergeCommitHashes 1`] = `
+Object {
+  "https://github.com/sourcecred/example-github/pull/3": "0a223346b4e6dec0127b1e6aa892c4ee0424b66a",
+  "https://github.com/sourcecred/example-github/pull/5": "6d5b3aa31ebb68a06ceb46bbd6cf49b6ccd6f5e6",
+  "https://github.com/sourcecred/example-github/pull/9": null,
+}
+`;
+
+exports[`GitHub porcelain pull requests have reviews 1`] = `
+Object {
+  "https://github.com/sourcecred/example-github/pull/3": Array [],
+  "https://github.com/sourcecred/example-github/pull/5": Array [
+    "https://github.com/sourcecred/example-github/pull/5#pullrequestreview-100313899",
+    "https://github.com/sourcecred/example-github/pull/5#pullrequestreview-100314038",
+  ],
+  "https://github.com/sourcecred/example-github/pull/9": Array [],
 }
 `;


### PR DESCRIPTION
This re-organizes the GitHub porcelain tests to be:
- organized by each method signature, rather than having blocks that
test many different methods on each wrapper
- make extensive use of snapshot tests for convenience

Test plan: Inspect the new unit tests, and the corresponding snapshots.
It should be relatively easy to do this because you can copy+paste the
urls to verify the properties.