### PR TITLE
Add `nodeDescription` for GitHub nodes

### DIFF
--- a/src/plugins/github/__snapshots__/porcelain.test.js.snap
+++ b/src/plugins/github/__snapshots__/porcelain.test.js.snap
@@ -79,6 +79,17 @@ Object {
 }
 `;
 
+exports[`GitHub porcelain nodes have nice descriptions 1`] = `
+Object {
+  "https://github.com/decentralion": "@decentralion",
+  "https://github.com/sourcecred/example-github/issues/2": "#2: A referencing issue.",
+  "https://github.com/sourcecred/example-github/issues/2#issuecomment-373768703": "comment by @decentralion on #2",
+  "https://github.com/sourcecred/example-github/pull/5": "#5: This pull request will be more contentious. I can feel it...",
+  "https://github.com/sourcecred/example-github/pull/5#discussion_r171460198": "review comment by @wchargin on #5",
+  "https://github.com/sourcecred/example-github/pull/5#pullrequestreview-100313899": "review by @wchargin on #5",
+}
+`;
+
 exports[`GitHub porcelain posts have authors 1`] = `
 Object {
   "https://github.com/sourcecred/example-github/issues/2": Array [

--- a/src/plugins/github/porcelain.test.js
+++ b/src/plugins/github/porcelain.test.js
@@ -24,6 +24,8 @@ import {
   PULL_REQUEST_REVIEW_COMMENT_NODE_TYPE,
 } from "./types";
 
+import {nodeDescription} from "./render";
+
 import {PLUGIN_NAME} from "./pluginName";
 
 describe("GitHub porcelain", () => {
@@ -330,5 +332,15 @@ describe("GitHub porcelain", () => {
       const referenced = Author.from(references[0]);
       expect(referenced.login()).toBe("wchargin");
     });
+  });
+
+  it("nodes have nice descriptions", () => {
+    // This test really should be in its own file, but for expedience I am
+    // putting it here.  TODO: Refactor general purpose testutils out of this
+    // file, and move this test to render.test.js (assuming we don't move the
+    // description method into the porcelain anyway...)
+    expectPropertiesToMatchSnapshot(allWrappers, (e) =>
+      nodeDescription(e.graph, e.address())
+    );
   });
 });

--- a/src/plugins/github/render.js
+++ b/src/plugins/github/render.js
@@ -1,0 +1,67 @@
+// @flow
+
+/*
+ * Methods for rendering and displaying GitHub nodes.
+ */
+import stringify from "json-stable-stringify";
+import {Graph} from "../../core/graph";
+import type {Address} from "../../core/address";
+import {
+  asEntity,
+  Issue,
+  PullRequest,
+  Comment,
+  PullRequestReview,
+  PullRequestReviewComment,
+  Author,
+  Repository,
+} from "./porcelain";
+
+/* Give a short description for the GitHub node at given address.
+ * Useful for e.g. displaying a title.
+ */
+export function nodeDescription(graph: Graph<any, any>, addr: Address) {
+  const entity = asEntity(graph, addr);
+  const type = entity.type();
+  switch (type) {
+    case "REPOSITORY": {
+      const repo = Repository.from(entity);
+      return `${repo.owner()}/${repo.name()}`;
+    }
+    case "ISSUE": {
+      const issue = Issue.from(entity);
+      return `#${issue.number()}: ${issue.title()}`;
+    }
+    case "PULL_REQUEST": {
+      const pr = PullRequest.from(entity);
+      return `#${pr.number()}: ${pr.title()}`;
+    }
+    case "COMMENT": {
+      const comment = Comment.from(entity);
+      const author = comment.authors()[0];
+      return `comment by @${author.login()} on #${comment.parent().number()}`;
+    }
+    case "PULL_REQUEST_REVIEW": {
+      const review = PullRequestReview.from(entity);
+      const author = review.authors()[0];
+      return `review by @${author.login()} on #${review.parent().number()}`;
+    }
+    case "PULL_REQUEST_REVIEW_COMMENT": {
+      const comment = PullRequestReviewComment.from(entity);
+      const author = comment.authors()[0];
+      const pr = comment.parent().parent();
+      return `review comment by @${author.login()} on #${pr.number()}`;
+    }
+    case "AUTHOR": {
+      const author = Author.from(entity);
+      return `@${author.login()}`;
+    }
+    default: {
+      // eslint-disable-next-line no-unused-expressions
+      (type: empty);
+      throw new Error(
+        `Tried to write description for invalid type ${stringify(addr)}`
+      );
+    }
+  }
+}


### PR DESCRIPTION
`nodeDescription` gives a short, readable description of the content at
a given node.

Test plan: View the included snapshot test.