### PR TITLE
Use `SparseMarkovChain` in `basicPagerank`

### DIFF
--- a/src/app/credExplorer/__snapshots__/basicPagerank.test.js.snap
+++ b/src/app/credExplorer/__snapshots__/basicPagerank.test.js.snap
@@ -2,7 +2,7 @@
 
 exports[`graphToMarkovChain is correct for a trivial one-node chain 1`] = `
 Object {
-  "inNeighbors": Array [
+  "chain": Array [
     Object {
       "neighbor": Uint32Array [
         0,

--- a/src/app/credExplorer/basicPagerank.test.js
+++ b/src/app/credExplorer/basicPagerank.test.js
@@ -1,7 +1,7 @@
 // @flow
 
 import {Graph} from "../../core/graph";
-import {graphToTypedArrayMarkovChain} from "./basicPagerank";
+import {graphToOrderedSparseMarkovChain} from "./basicPagerank";
 
 describe("graphToMarkovChain", () => {
   it("is correct for a trivial one-node chain", () => {
@@ -14,6 +14,6 @@ describe("graphToMarkovChain", () => {
       },
       payload: "yes",
     });
-    expect(graphToTypedArrayMarkovChain(g)).toMatchSnapshot();
+    expect(graphToOrderedSparseMarkovChain(g)).toMatchSnapshot();
   });
 });


### PR DESCRIPTION
Summary:
This commit slightly reorganizes the internals of `basicPagerank` to use
the `SparseMarkovChain` type from the `markovChain` module.

Test Plan:
Behavior of `yarn start` is unchanged.

wchargin-branch: use-sparsemarkovchain