### PR TITLE
Enable unambiguous absolute path imports for node

### DIFF
--- a/.flowconfig
+++ b/.flowconfig
@@ -8,5 +8,6 @@ flow-typed
 [lints]
 
 [options]
+module.name_mapper='^@/' -> '<PROJECT_ROOT>/src/'
 
 [strict]

--- a/config/webpack.config.backend.js
+++ b/config/webpack.config.backend.js
@@ -2,6 +2,7 @@
 const webpack = require("webpack");
 const eslintFormatter = require("react-dev-utils/eslintFormatter");
 const ModuleScopePlugin = require("react-dev-utils/ModuleScopePlugin");
+const path = require("path");
 const paths = require("./paths");
 const nodeExternals = require("webpack-node-externals");
 
@@ -25,6 +26,9 @@ module.exports = {
   },
   resolve: {
     extensions: [".js", ".json"],
+    alias: {
+      "@": path.join(__dirname, "..", "src"),
+    },
     plugins: [
       // Prevents users from importing files from outside of src/ (or node_modules/).
       // This often causes confusion because we only process files within src/ with babel.

--- a/config/webpack.config.dev.js
+++ b/config/webpack.config.dev.js
@@ -83,6 +83,7 @@ module.exports = {
     // for React Native Web.
     extensions: [".web.js", ".mjs", ".js", ".json", ".web.jsx", ".jsx"],
     alias: {
+      "@": path.join(__dirname, "..", "src"),
       // Support React Native Web
       // https://www.smashingmagazine.com/2016/08/a-glimpse-into-the-future-with-react-native-for-web/
       "react-native": "react-native-web",

--- a/config/webpack.config.prod.js
+++ b/config/webpack.config.prod.js
@@ -89,6 +89,7 @@ module.exports = {
     // for React Native Web.
     extensions: [".web.js", ".mjs", ".js", ".json", ".web.jsx", ".jsx"],
     alias: {
+      "@": path.join(__dirname, "..", "src"),
       // Support React Native Web
       // https://www.smashingmagazine.com/2016/08/a-glimpse-into-the-future-with-react-native-for-web/
       "react-native": "react-native-web",

--- a/package.json
+++ b/package.json
@@ -99,7 +99,9 @@
     "transformIgnorePatterns": [
       "[/\\\\]node_modules[/\\\\].+\\.(js|jsx|mjs)$"
     ],
+    "moduleDirectories": ["node_modules", "src"],
     "moduleNameMapper": {
+      "^@/(.*)$": "<rootDir>/src/$1",
       "^react-native$": "react-native-web"
     },
     "moduleFileExtensions": [

--- a/src/app/App.js
+++ b/src/app/App.js
@@ -3,7 +3,7 @@
 import React from "react";
 import {BrowserRouter as Router, Route, NavLink} from "react-router-dom";
 
-import ArtifactEditor from "../plugins/artifact/editor/App";
+import ArtifactEditor from "@/plugins/artifact/editor/App";
 import CredExplorer from "./credExplorer/App";
 
 export default class App extends React.Component<{}> {

--- a/src/app/credExplorer/App.js
+++ b/src/app/credExplorer/App.js
@@ -3,7 +3,7 @@
 import React from "react";
 import {StyleSheet, css} from "aphrodite/no-important";
 
-import {Graph} from "../../core/graph";
+import {Graph} from "@/core/graph";
 import basicPagerank from "./basicPagerank";
 import LocalStore from "./LocalStore";
 import type {PagerankResult} from "./basicPagerank";

--- a/src/app/credExplorer/basicPagerank.js
+++ b/src/app/credExplorer/basicPagerank.js
@@ -1,15 +1,15 @@
 // @flow
 
-import type {Address} from "../../core/address";
-import type {Edge} from "../../core/graph";
-import {AddressMap} from "../../core/address";
-import {Graph} from "../../core/graph";
+import type {Address} from "@/core/address";
+import type {Edge} from "@/core/graph";
+import {AddressMap} from "@/core/address";
+import {Graph} from "@/core/graph";
 
 import type {
   Distribution,
   SparseMarkovChain,
-} from "../../core/attribution/markovChain";
-import {findStationaryDistribution} from "../../core/attribution/markovChain";
+} from "@/core/attribution/markovChain";
+import {findStationaryDistribution} from "@/core/attribution/markovChain";
 
 export type PagerankResult = AddressMap<{|
   +address: Address,

--- a/src/app/credExplorer/basicPagerank.test.js
+++ b/src/app/credExplorer/basicPagerank.test.js
@@ -1,6 +1,6 @@
 // @flow
 
-import {Graph} from "../../core/graph";
+import {Graph} from "@/core/graph";
 import {graphToOrderedSparseMarkovChain} from "./basicPagerank";
 
 describe("graphToMarkovChain", () => {

--- a/src/app/credExplorer/pagerankTable.js
+++ b/src/app/credExplorer/pagerankTable.js
@@ -3,13 +3,13 @@
 import React from "react";
 import stringify from "json-stable-stringify";
 
-import {Graph} from "../../core/graph";
-import type {Address} from "../../core/address";
-import {AddressMap} from "../../core/address";
-import {PLUGIN_NAME as GITHUB_PLUGIN_NAME} from "../../plugins/github/pluginName";
-import {GIT_PLUGIN_NAME} from "../../plugins/git/types";
-import {nodeDescription as githubNodeDescription} from "../../plugins/github/render";
-import {nodeDescription as gitNodeDescription} from "../../plugins/git/render";
+import {Graph} from "@/core/graph";
+import type {Address} from "@/core/address";
+import {AddressMap} from "@/core/address";
+import {PLUGIN_NAME as GITHUB_PLUGIN_NAME} from "@/plugins/github/pluginName";
+import {GIT_PLUGIN_NAME} from "@/plugins/git/types";
+import {nodeDescription as githubNodeDescription} from "@/plugins/github/render";
+import {nodeDescription as gitNodeDescription} from "@/plugins/git/render";
 import type {PagerankResult} from "./basicPagerank";
 
 type Props = {

--- a/src/cli/commands/combine.js
+++ b/src/cli/commands/combine.js
@@ -5,7 +5,7 @@ import fs from "fs";
 import stringify from "json-stable-stringify";
 import {promisify} from "util";
 
-import {Graph} from "../../core/graph";
+import {Graph} from "@/core/graph";
 
 // Makes the script crash on unhandled rejections instead of silently
 // ignoring them. In the future, promise rejections that are not handled will

--- a/src/cli/commands/pluginGraph.js
+++ b/src/cli/commands/pluginGraph.js
@@ -3,10 +3,10 @@
 import {Command, flags} from "@oclif/command";
 import stringify from "json-stable-stringify";
 
-import type {Graph} from "../../core/graph";
+import type {Graph} from "@/core/graph";
 import type {PluginName} from "../common";
-import createGitGraph from "../../plugins/git/cloneGitGraph";
-import createGithubGraph from "../../plugins/github/fetchGithubGraph";
+import createGitGraph from "@/plugins/git/cloneGitGraph";
+import createGithubGraph from "@/plugins/github/fetchGithubGraph";
 import {pluginNames} from "../common";
 
 // Makes the script crash on unhandled rejections instead of silently

--- a/src/cli/commands/start.js
+++ b/src/cli/commands/start.js
@@ -5,7 +5,7 @@ import chalk from "chalk";
 import fs from "fs";
 import {choosePort} from "react-dev-utils/WebpackDevServerUtils";
 
-import apiApp from "../../app/apiApp";
+import apiApp from "@/app/apiApp";
 import {sourcecredDirectoryFlag} from "../common";
 
 // Makes the script crash on unhandled rejections instead of silently

--- a/src/plugins/artifact/artifactPlugin.js
+++ b/src/plugins/artifact/artifactPlugin.js
@@ -1,7 +1,7 @@
 // @flow
 
-import type {Address} from "../../core/address";
-import type {Graph} from "../../core/graph";
+import type {Address} from "@/core/address";
+import type {Graph} from "@/core/graph";
 
 export const ARTIFACT_PLUGIN_NAME = "sourcecred/artifact-beta";
 

--- a/src/plugins/artifact/artifactPlugin.test.js
+++ b/src/plugins/artifact/artifactPlugin.test.js
@@ -1,6 +1,6 @@
 // @flow
 
-import {Graph} from "../../core/graph";
+import {Graph} from "@/core/graph";
 import {artifactAddress} from "./artifactPlugin";
 
 describe("artifactPlugin", () => {

--- a/src/plugins/artifact/editor/App.js
+++ b/src/plugins/artifact/editor/App.js
@@ -5,11 +5,11 @@ import {StyleSheet, css} from "aphrodite/no-important";
 
 import "./pluginAdapter";
 
-import type {Graph, Node} from "../../../core/graph";
+import type {Graph, Node} from "@/core/graph";
 import type {
   NodePayload as GithubNodePayload,
   EdgePayload as GithubEdgePayload,
-} from "../../github/types";
+} from "@/plugins/github/types";
 import type {
   NodePayload as ArtifactNodePayload,
   EdgePayload as ArtifactEdgePayload,

--- a/src/plugins/artifact/editor/ArtifactGraphEditor.js
+++ b/src/plugins/artifact/editor/ArtifactGraphEditor.js
@@ -2,10 +2,10 @@
 
 import React from "react";
 
-import type {Node} from "../../../core/graph";
+import type {Node} from "@/core/graph";
 import type {Settings} from "./SettingsConfig";
 import type {NodePayload, EdgePayload} from "../artifactPlugin";
-import {Graph} from "../../../core/graph";
+import {Graph} from "@/core/graph";
 import {artifactAddress} from "../artifactPlugin";
 
 type Props = {

--- a/src/plugins/artifact/editor/ArtifactGraphEditor.test.js
+++ b/src/plugins/artifact/editor/ArtifactGraphEditor.test.js
@@ -3,7 +3,7 @@
 import React from "react";
 import {shallow} from "enzyme";
 
-import {Graph} from "../../../core/graph";
+import {Graph} from "@/core/graph";
 import {ArtifactGraphEditor} from "./ArtifactGraphEditor";
 import {artifactAddress} from "../artifactPlugin";
 

--- a/src/plugins/artifact/editor/ContributionList.js
+++ b/src/plugins/artifact/editor/ContributionList.js
@@ -2,9 +2,9 @@
 
 import React from "react";
 
-import type {Node} from "../../../core/graph";
+import type {Node} from "@/core/graph";
 import {AdapterSet} from "./adapterSet";
-import {Graph} from "../../../core/graph";
+import {Graph} from "@/core/graph";
 
 type Props = {
   graph: ?Graph<any, any>,

--- a/src/plugins/artifact/editor/ContributionList.test.js
+++ b/src/plugins/artifact/editor/ContributionList.test.js
@@ -5,12 +5,12 @@ import React from "react";
 import {shallow} from "enzyme";
 import enzymeToJSON from "enzyme-to-json";
 
-import type {Address} from "../../../core/address";
-import type {Node} from "../../../core/graph";
+import type {Address} from "@/core/address";
+import type {Node} from "@/core/graph";
 import type {PluginAdapter} from "./pluginAdapter";
 import {AdapterSet} from "./adapterSet";
 import {ContributionList} from "./ContributionList";
-import {Graph} from "../../../core/graph";
+import {Graph} from "@/core/graph";
 
 require("../../../app/testUtil").configureAphrodite();
 require("../../../app/testUtil").configureEnzyme();

--- a/src/plugins/artifact/editor/GithubGraphFetcher.js
+++ b/src/plugins/artifact/editor/GithubGraphFetcher.js
@@ -2,14 +2,14 @@
 
 import React from "react";
 
-import type {Graph} from "../../../core/graph";
+import type {Graph} from "@/core/graph";
 import type {Settings} from "./SettingsConfig";
-import fetchGithubRepo from "../../github/fetchGithubRepo";
+import fetchGithubRepo from "@/plugins/github/fetchGithubRepo";
 import type {
   NodePayload as GithubNodePayload,
   EdgePayload as GithubEdgePayload,
-} from "../../github/types";
-import {parse} from "../../github/parser";
+} from "@/plugins/github/types";
+import {parse} from "@/plugins/github/parser";
 
 type Props = {
   settings: Settings,

--- a/src/plugins/artifact/editor/LocalStore.js
+++ b/src/plugins/artifact/editor/LocalStore.js
@@ -1,5 +1,5 @@
 // @flow
 
-import LocalStore from "../../../app/LocalStore";
+import LocalStore from "@/app/LocalStore";
 
 export default new LocalStore({version: "1", keyPrefix: "artifact-editor"});

--- a/src/plugins/artifact/editor/adapterSet.js
+++ b/src/plugins/artifact/editor/adapterSet.js
@@ -1,6 +1,6 @@
 // @flow
 
-import type {Node} from "../../../core/graph";
+import type {Node} from "@/core/graph";
 import type {PluginAdapter} from "./pluginAdapter";
 
 export class AdapterSet {

--- a/src/plugins/artifact/editor/adapters/githubPluginAdapter.js
+++ b/src/plugins/artifact/editor/adapters/githubPluginAdapter.js
@@ -2,8 +2,8 @@
 
 import React from "react";
 
-import {Graph} from "../../../../core/graph";
-import type {Node} from "../../../../core/graph";
+import {Graph} from "@/core/graph";
+import type {Node} from "@/core/graph";
 import type {
   NodePayload,
   NodeType,
@@ -14,10 +14,10 @@ import type {
   PullRequestReviewCommentNodePayload,
   PullRequestReviewNodePayload,
   AuthorNodePayload,
-} from "../../../github/types";
+} from "@/plugins/github/types";
 import type {PluginAdapter} from "../pluginAdapter";
-import {PLUGIN_NAME} from "../../../github/pluginName";
-import {CONTAINS_EDGE_TYPE} from "../../../github/types";
+import {PLUGIN_NAME} from "@/plugins/github/pluginName";
+import {CONTAINS_EDGE_TYPE} from "@/plugins/github/types";
 
 const adapter: PluginAdapter<NodePayload> = {
   pluginName: PLUGIN_NAME,

--- a/src/plugins/artifact/editor/adapters/githubPluginAdapter.test.js
+++ b/src/plugins/artifact/editor/adapters/githubPluginAdapter.test.js
@@ -5,8 +5,8 @@ import {shallow} from "enzyme";
 import enzymeToJSON from "enzyme-to-json";
 import stringify from "json-stable-stringify";
 
-import {parse} from "../../../github/parser";
-import exampleRepoData from "../../../github/demoData/example-github.json";
+import {parse} from "@/plugins/github/parser";
+import exampleRepoData from "@/plugins/github/demoData/example-github.json";
 import adapter from "./githubPluginAdapter";
 
 require("../../../../app/testUtil").configureEnzyme();

--- a/src/plugins/artifact/editor/pluginAdapter.js
+++ b/src/plugins/artifact/editor/pluginAdapter.js
@@ -1,6 +1,6 @@
 // @flow
 
-import type {Graph, Node} from "../../../core/graph";
+import type {Graph, Node} from "@/core/graph";
 import type {ComponentType} from "react";
 
 export interface PluginAdapter<-NodePayload> {

--- a/src/plugins/git/address.js
+++ b/src/plugins/git/address.js
@@ -1,6 +1,6 @@
 // @flow
 
-import type {Address} from "../../core/address";
+import type {Address} from "@/core/address";
 import type {EdgeType, NodeType} from "./types";
 import {COMMIT_NODE_TYPE, GIT_PLUGIN_NAME} from "./types";
 

--- a/src/plugins/git/cloneGitGraph.js
+++ b/src/plugins/git/cloneGitGraph.js
@@ -3,7 +3,7 @@
 import cloneAndLoadRepository from "./cloneAndLoadRepository";
 import {createGraph} from "./createGraph";
 import type {NodePayload, EdgePayload} from "./types";
-import type {Graph} from "../../core/graph";
+import type {Graph} from "@/core/graph";
 
 /**
  * Load Git contribution graph from a fresh clone of a GitHub repo.

--- a/src/plugins/git/createGraph.js
+++ b/src/plugins/git/createGraph.js
@@ -1,6 +1,6 @@
 // @flow
 
-import type {Edge, Node} from "../../core/graph";
+import type {Edge, Node} from "@/core/graph";
 import type {
   BecomesEdgePayload,
   BlobNodePayload,
@@ -16,7 +16,7 @@ import type {
   TreeEntryNodePayload,
   TreeNodePayload,
 } from "./types";
-import {Graph, edgeID} from "../../core/graph";
+import {Graph, edgeID} from "@/core/graph";
 import {
   BECOMES_EDGE_TYPE,
   BLOB_NODE_TYPE,

--- a/src/plugins/git/createGraph.test.js
+++ b/src/plugins/git/createGraph.test.js
@@ -2,8 +2,8 @@
 
 import cloneDeep from "lodash.clonedeep";
 
-import type {Address} from "../../core/address";
-import type {Edge} from "../../core/graph";
+import type {Address} from "@/core/address";
+import type {Edge} from "@/core/graph";
 import type {BecomesEdge} from "./createGraph";
 import type {BecomesEdgePayload, Hash, Tree} from "./types";
 import {_makeAddress} from "./address";

--- a/src/plugins/git/render.js
+++ b/src/plugins/git/render.js
@@ -1,7 +1,7 @@
 // @flow
 
-import type {Address} from "../../core/address";
-import type {Graph} from "../../core/graph";
+import type {Address} from "@/core/address";
+import type {Graph} from "@/core/graph";
 import type {NodeType, SubmoduleCommitPayload} from "./types";
 
 /**

--- a/src/plugins/git/render.test.js
+++ b/src/plugins/git/render.test.js
@@ -7,8 +7,8 @@ import type {
   TreeEntryNodePayload,
   SubmoduleCommitPayload,
 } from "./types";
-import type {Node} from "../../core/graph";
-import {Graph} from "../../core/graph";
+import type {Node} from "@/core/graph";
+import {Graph} from "@/core/graph";
 import {_makeAddress, commitAddress} from "./address";
 import {nodeDescription} from "./render";
 import {submoduleCommitId, treeEntryId} from "./types";

--- a/src/plugins/github/fetchGithubGraph.js
+++ b/src/plugins/github/fetchGithubGraph.js
@@ -5,7 +5,7 @@
  */
 
 import type {NodePayload, EdgePayload} from "./types";
-import type {Graph} from "../../core/graph";
+import type {Graph} from "@/core/graph";
 import fetchGithubRepo from "./fetchGithubRepo";
 import {parse} from "./parser";
 

--- a/src/plugins/github/fetchGithubRepo.js
+++ b/src/plugins/github/fetchGithubRepo.js
@@ -6,7 +6,7 @@
 
 import fetch from "isomorphic-fetch";
 
-import {stringify, inlineLayout} from "../../graphql/queries";
+import {stringify, inlineLayout} from "@/graphql/queries";
 import {createQuery, createVariables, postQueryExhaustive} from "./graphql";
 import type {GithubResponseJSON} from "./graphql";
 

--- a/src/plugins/github/graphql.js
+++ b/src/plugins/github/graphql.js
@@ -5,8 +5,8 @@ import type {
   FragmentDefinition,
   Selection,
   QueryDefinition,
-} from "../../graphql/queries";
-import {build} from "../../graphql/queries";
+} from "@/graphql/queries";
+import {build} from "@/graphql/queries";
 
 /**
  * This module defines the GraphQL query that we use to access the

--- a/src/plugins/github/graphql.test.js
+++ b/src/plugins/github/graphql.test.js
@@ -1,7 +1,7 @@
 // @flow
 
 import type {Continuation} from "./graphql";
-import {build} from "../../graphql/queries";
+import {build} from "@/graphql/queries";
 import {
   PAGE_LIMIT,
   createQuery,

--- a/src/plugins/github/parser.js
+++ b/src/plugins/github/parser.js
@@ -2,7 +2,7 @@
 
 import stringify from "json-stable-stringify";
 
-import type {Node, Edge} from "../../core/graph";
+import type {Node, Edge} from "@/core/graph";
 import type {
   NodeType,
   EdgeType,
@@ -31,11 +31,11 @@ import type {
   NullableAuthorJSON,
 } from "./graphql";
 
-import type {Address} from "../../core/address";
+import type {Address} from "@/core/address";
 import {PLUGIN_NAME} from "./pluginName";
-import {Graph, edgeID} from "../../core/graph";
+import {Graph, edgeID} from "@/core/graph";
 import {findReferences} from "./findReferences";
-import {commitAddress} from "../git/address";
+import {commitAddress} from "@/plugins/git/address";
 
 export function parse(
   githubResponseJSON: GithubResponseJSON

--- a/src/plugins/github/parser.test.js
+++ b/src/plugins/github/parser.test.js
@@ -4,7 +4,7 @@ import {AUTHORS_EDGE_TYPE, CONTAINS_EDGE_TYPE} from "./types";
 import type {NodePayload, EdgePayload} from "./types";
 import {parse} from "./parser";
 import type {GithubResponseJSON, PullRequestJSON, IssueJSON} from "./graphql";
-import {Graph} from "../../core/graph";
+import {Graph} from "@/core/graph";
 import exampleRepoData from "./demoData/example-github.json";
 
 describe("GithubParser", () => {

--- a/src/plugins/github/porcelain.js
+++ b/src/plugins/github/porcelain.js
@@ -15,9 +15,9 @@
  */
 import stringify from "json-stable-stringify";
 
-import {Graph} from "../../core/graph";
-import type {Node} from "../../core/graph";
-import type {Address} from "../../core/address";
+import {Graph} from "@/core/graph";
+import type {Node} from "@/core/graph";
+import type {Address} from "@/core/address";
 import type {
   AuthorNodePayload,
   AuthorSubtype,
@@ -50,7 +50,7 @@ import {
 
 import {PLUGIN_NAME} from "./pluginName";
 
-import {COMMIT_NODE_TYPE} from "../git/types";
+import {COMMIT_NODE_TYPE} from "@/plugins/git/types";
 
 export type Entity =
   | Repository

--- a/src/plugins/github/porcelain.test.js
+++ b/src/plugins/github/porcelain.test.js
@@ -1,6 +1,6 @@
 // @flow
 
-import type {Address} from "../../core/address";
+import type {Address} from "@/core/address";
 import {parse} from "./parser";
 import exampleRepoData from "./demoData/example-github.json";
 import type {Entity} from "./porcelain";

--- a/src/plugins/github/render.js
+++ b/src/plugins/github/render.js
@@ -4,8 +4,8 @@
  * Methods for rendering and displaying GitHub nodes.
  */
 import stringify from "json-stable-stringify";
-import {Graph} from "../../core/graph";
-import type {Address} from "../../core/address";
+import {Graph} from "@/core/graph";
+import type {Address} from "@/core/address";
 import {
   asEntity,
   Issue,

--- a/src/tools/loadCombinedGraph.js
+++ b/src/tools/loadCombinedGraph.js
@@ -1,16 +1,16 @@
 // @flow
 
-import cloneGitGraph from "../plugins/git/cloneGitGraph";
-import fetchGithubGraph from "../plugins/github/fetchGithubGraph";
+import cloneGitGraph from "@/plugins/git/cloneGitGraph";
+import fetchGithubGraph from "@/plugins/github/fetchGithubGraph";
 import type {
   NodePayload as GithubNodePayload,
   EdgePayload as GithubEdgePayload,
-} from "../plugins/github/types";
+} from "@/plugins/github/types";
 import type {
   NodePayload as GitNodePayload,
   EdgePayload as GitEdgePayload,
-} from "../plugins/git/types";
-import {Graph} from "../core/graph";
+} from "@/plugins/git/types";
+import {Graph} from "@/core/graph";
 
 export type NodePayload = GitNodePayload | GithubNodePayload;
 export type EdgePayload = GitEdgePayload | GithubEdgePayload;


### PR DESCRIPTION
This commit configures webpack, jest, and flow so that we can use the @
symbol in module imports as a reference to the project's `src/`
directory.

For example, instead of:
`import {Stuff} from "../../../core/graph"`
You can now write:
`import {Stuff} from "@/core/graph"`

The files `.flowconfig`, `config/webpack.config/{backend,dev,prod}.js`
and `package.json` were manually changed to enable module name aliasing.
All other changes in the commit were generated automatically by running
the following two commands:

```
find src -name '*.js' | xargs sed -ri 's%(from ")(../)+(plugins/)?(git|github|artifact)/%\1@/plugins/\4/%g'
find src -name '*.js' | xargs sed -ri 's%(from ")(../)+(core|graphql|tools|app)?/%\1@/\3/%g'
```

This fixes #256.

To see an alternative that is slightly more concise (no `"@/"` at the
beginning of imports) but has the disadvantage of creating potential
name collisions with node modules, see #282.

Test plan:
* `yarn travis --full` passes.
* `yarn start` produces a working dev server.
* `yarn build && yarn backend && node bin/sourcecred.js start` produces
a working web application.