### PR TITLE
Separate GitHub `issueByNumber`/`prByNumber`

### DIFF
--- a/src/plugins/github/porcelain.js
+++ b/src/plugins/github/porcelain.js
@@ -173,19 +173,30 @@ export class Repository extends GithubEntity<RepositoryNodePayload> {
     return (e: any);
   }
 
-  issueOrPRByNumber(number: number): ?(Issue | PullRequest) {
-    let result: Issue | PullRequest;
-    this.graph
-      .neighborhood(this.nodeAddress, {
-        edgeType: CONTAINS_EDGE_TYPE,
-      })
-      .forEach(({neighbor}) => {
-        const payload = this.graph.node(neighbor).payload;
-        if (payload.number === number) {
-          result = (asEntity(this.graph, neighbor): any);
-        }
-      });
-    return result;
+  issueByNumber(number: number): ?Issue {
+    for (const {neighbor} of this.graph.neighborhood(this.nodeAddress, {
+      edgeType: CONTAINS_EDGE_TYPE,
+      direction: "OUT",
+      nodeType: ISSUE_NODE_TYPE,
+    })) {
+      const node = this.graph.node(neighbor);
+      if (node.payload.number === number) {
+        return new Issue(this.graph, neighbor);
+      }
+    }
+  }
+
+  pullRequestByNumber(number: number): ?PullRequest {
+    for (const {neighbor} of this.graph.neighborhood(this.nodeAddress, {
+      edgeType: CONTAINS_EDGE_TYPE,
+      direction: "OUT",
+      nodeType: PULL_REQUEST_NODE_TYPE,
+    })) {
+      const node = this.graph.node(neighbor);
+      if (node.payload.number === number) {
+        return new PullRequest(this.graph, neighbor);
+      }
+    }
   }
 
   owner(): string {


### PR DESCRIPTION
Summary:
Instead of having one function that returns a union, we present two
functions, each of which returns a more specific type.

Paired with @decentralion.

Test Plan:
Existing unit tests pass, with sufficient modifications.

wchargin-branch: separate-issueByNumber-prByNumber