### PR TITLE
Upgrade Flow to v0.72.0

### DIFF
--- a/config/babel.js
+++ b/config/babel.js
@@ -90,10 +90,11 @@ if (env === "test") {
       // JSX, Flow
       require.resolve("babel-preset-react"),
     ],
-    plugins: plugins.concat([
+    plugins: [
+      ...plugins,
       // Compiles import() to a deferred require()
       require.resolve("babel-plugin-dynamic-import-node"),
-    ]),
+    ],
   };
 } else {
   module.exports = {
@@ -119,26 +120,25 @@ if (env === "test") {
       // JSX, Flow
       require.resolve("babel-preset-react"),
     ],
-    plugins: plugins.concat(
-      backend
+    plugins: [
+      ...plugins,
+      ...(backend
         ? [
             // Must come before `babel-plugin-transform-regenerator`.
             require.resolve("babel-plugin-transform-es2015-for-of"),
           ]
-        : [],
+        : []),
+      // function* () { yield 42; yield 43; }
       [
-        // function* () { yield 42; yield 43; }
-        [
-          require.resolve("babel-plugin-transform-regenerator"),
-          {
-            // Async functions are converted to generators by babel-preset-env
-            async: false,
-          },
-        ],
-        // Adds syntax support for import()
-        require.resolve("babel-plugin-syntax-dynamic-import"),
-      ]
-    ),
+        require.resolve("babel-plugin-transform-regenerator"),
+        {
+          // Async functions are converted to generators by babel-preset-env
+          async: false,
+        },
+      ],
+      // Adds syntax support for import()
+      require.resolve("babel-plugin-syntax-dynamic-import"),
+    ],
   };
 
   if (env === "production") {

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "express": "^4.16.3",
     "extract-text-webpack-plugin": "3.0.2",
     "file-loader": "1.1.5",
-    "flow-bin": "^0.65.0",
+    "flow-bin": "^0.72.0",
     "fs-extra": "3.0.1",
     "html-webpack-plugin": "2.29.0",
     "husky": "^0.14.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2901,9 +2901,9 @@ flatten@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/flatten/-/flatten-1.0.2.tgz#dae46a9d78fbe25292258cc1e780a41d95c03782"
 
-flow-bin@^0.65.0:
-  version "0.65.0"
-  resolved "https://registry.yarnpkg.com/flow-bin/-/flow-bin-0.65.0.tgz#64ffeca27211c786e2d68508c65686ba1b8a2169"
+flow-bin@^0.72.0:
+  version "0.72.0"
+  resolved "https://registry.yarnpkg.com/flow-bin/-/flow-bin-0.72.0.tgz#12051180fb2db7ccb728fefe67c77e955e92a44d"
 
 for-in@^1.0.1:
   version "1.0.2"


### PR DESCRIPTION
Summary:
A few changes were made to code that is correct (as far as I can tell),
but for which Flow can no longer infer a type parameter. The change is a
bit more annoying than it otherwise would be, because this particular
file is run directly via node and so must use Flow’s comment syntax for
type annotations, but Prettier breaks such comments in the cases that we
need. We work around this by rewriting the original code to avoid the
need for comments.

Test Plan:
In addition to standard CI, run `yarn build` and then run a server from
`build/`, to see that the production build produces a working bundle.
(That the app loads and renders is sufficient.)

wchargin-branch: upgrade-flow-v0.72.0