### PR TITLE
Update GitHub to use NodeReference & NodePorcelain

### DIFF
--- a/src/app/credExplorer/pagerankTable.js
+++ b/src/app/credExplorer/pagerankTable.js
@@ -6,6 +6,7 @@ import stringify from "json-stable-stringify";
 import {Graph} from "../../core/graph";
 import type {Address} from "../../core/address";
 import {AddressMap} from "../../core/address";
+import {NodeReference} from "../../core/porcelain";
 import {PLUGIN_NAME as GITHUB_PLUGIN_NAME} from "../../plugins/github/pluginName";
 import {GIT_PLUGIN_NAME} from "../../plugins/git/types";
 import {nodeDescription as githubNodeDescription} from "../../plugins/github/render";
@@ -24,16 +25,16 @@ type State = {
   |},
 };
 
-function nodeDescription(graph, address) {
-  switch (address.pluginName) {
+function nodeDescription(ref) {
+  switch (ref.address().pluginName) {
     case GITHUB_PLUGIN_NAME: {
-      return githubNodeDescription(graph, address);
+      return githubNodeDescription(ref);
     }
     case GIT_PLUGIN_NAME: {
-      return gitNodeDescription(graph, address);
+      return gitNodeDescription(ref.graph(), ref.address());
     }
     default: {
-      return stringify(address);
+      return stringify(ref.address());
     }
   }
 }
@@ -184,7 +185,7 @@ class RecursiveTable extends React.Component<RTProps, RTState> {
           >
             {expanded ? "\u2212" : "+"}
           </button>
-          {nodeDescription(graph, address)}
+          {nodeDescription(new NodeReference(graph, address))}
         </td>
         <td>{(score * 100).toPrecision(3)}</td>
         <td>{Math.log(score).toPrecision(3)}</td>

--- a/src/plugins/github/render.js
+++ b/src/plugins/github/render.js
@@ -4,64 +4,82 @@
  * Methods for rendering and displaying GitHub nodes.
  */
 import stringify from "json-stable-stringify";
-import {Graph} from "../../core/graph";
-import type {Address} from "../../core/address";
+import type {NodeReference} from "../../core/porcelain";
+import type {NodePayload} from "./types";
 import {
-  asEntity,
-  Issue,
-  PullRequest,
-  Comment,
-  PullRequestReview,
-  PullRequestReviewComment,
-  Author,
-  Repository,
+  GithubReference,
+  AuthorReference,
+  AuthorPorcelain,
+  CommentReference,
+  IssueReference,
+  IssuePorcelain,
+  PullRequestReference,
+  PullRequestPorcelain,
+  PullRequestReviewReference,
+  PullRequestReviewCommentReference,
+  RepositoryPorcelain,
 } from "./porcelain";
 
 /* Give a short description for the GitHub node at given address.
  * Useful for e.g. displaying a title.
  */
-export function nodeDescription(graph: Graph<any, any>, addr: Address) {
-  const entity = asEntity(graph, addr);
-  const type = entity.type();
+export function nodeDescription(ref: NodeReference<NodePayload>) {
+  const porcelain = ref.get();
+  if (porcelain == null) {
+    return `[unknown ${ref.type()}]`;
+  }
+  const type = new GithubReference(ref).type();
   switch (type) {
     case "REPOSITORY": {
-      const repo = Repository.from(entity);
+      const repo = new RepositoryPorcelain(porcelain);
       return `${repo.owner()}/${repo.name()}`;
     }
     case "ISSUE": {
-      const issue = Issue.from(entity);
+      const issue = new IssuePorcelain(porcelain);
       return `#${issue.number()}: ${issue.title()}`;
     }
     case "PULL_REQUEST": {
-      const pr = PullRequest.from(entity);
+      const pr = new PullRequestPorcelain(porcelain);
       return `#${pr.number()}: ${pr.title()}`;
     }
     case "COMMENT": {
-      const comment = Comment.from(entity);
-      const author = comment.authors()[0];
-      return `comment by @${author.login()} on #${comment.parent().number()}`;
+      const comment = new CommentReference(ref);
+      const issue = comment.parent();
+      return `comment by @${authors(comment)} on #${num(issue)}`;
     }
     case "PULL_REQUEST_REVIEW": {
-      const review = PullRequestReview.from(entity);
-      const author = review.authors()[0];
-      return `review by @${author.login()} on #${review.parent().number()}`;
+      const review = new PullRequestReviewReference(ref);
+      const pr = review.parent();
+      return `review by @${authors(review)} on #${num(pr)}`;
     }
     case "PULL_REQUEST_REVIEW_COMMENT": {
-      const comment = PullRequestReviewComment.from(entity);
-      const author = comment.authors()[0];
+      const comment = new PullRequestReviewCommentReference(ref);
       const pr = comment.parent().parent();
-      return `review comment by @${author.login()} on #${pr.number()}`;
+      return `review comment by @${authors(comment)} on #${num(pr)}`;
     }
     case "AUTHOR": {
-      const author = Author.from(entity);
-      return `@${author.login()}`;
+      return `@${new AuthorPorcelain(porcelain).login()}`;
     }
     default: {
       // eslint-disable-next-line no-unused-expressions
       (type: empty);
       throw new Error(
-        `Tried to write description for invalid type ${stringify(addr)}`
+        `Tried to write description for invalid type ${stringify(
+          ref.address()
+        )}`
       );
     }
   }
+}
+
+function num(x: IssueReference | PullRequestReference) {
+  const np = x.get();
+  return np == null ? "[unknown]" : np.number();
+}
+
+function authors(authorable: {+authors: () => AuthorReference[]}) {
+  // TODO: modify to accomodate multi-authorship
+  const authorRefs = authorable.authors();
+  const firstAuthor = authorRefs[0].get();
+  return firstAuthor != null ? firstAuthor.login() : "[unknown]";
 }


### PR DESCRIPTION
See #286 for context. 
There are a few miscellaneous changes in
src/app/credExplorer to change clients to use the new API.

Test plan:
New unit test were added, and existing behavior is preserved. Most of
the functionality of the GitHub porcelain was already well tested.

Paired with @wchargin