### PR TITLE
markovChain should scale to >200k nodes

### DIFF
--- a/src/core/attribution/markovChain.js
+++ b/src/core/attribution/markovChain.js
@@ -106,9 +106,14 @@ export function findStationaryDistribution(
   };
   let r0 = uniformDistribution(chain.length);
   function computeDelta(pi0, pi1) {
+    let maxDelta = -Infinity;
     // Here, we assume that `pi0.nodeOrder` and `pi1.nodeOrder` are the
     // same (i.e., there has been no permutation).
-    return Math.max(...pi0.map((x, i) => Math.abs(x - pi1[i])));
+    pi0.forEach((x, i) => {
+      const delta = Math.abs(x - pi1[i]);
+      maxDelta = Math.max(delta, maxDelta);
+    });
+    return maxDelta;
   }
   let iteration = 0;
   while (true) {


### PR DESCRIPTION
`markovChain.findStationaryDistribution` is currently written such that
it blows the function call stack size if it is called with ~100k nodes.

This commit effects a small refactor so that the delta is computed in a
loop over elements in the distribution, rather than creating a massive
function arguments list. This results in the correct behavior.

Test plan:
We discussed offline and decided not to test it. Reasons:

- We could factor out `computeDelta` and test that function in
isolation, but I think this provides very, very little value. The class
of regression it protects against is almost precisely the case where
someone reverts this commit.

- We could test the entire `findStationaryDistribution` function, which
is more valuable, but requires a large, slow test case (~1 sec)

- This is a bug that is unlikely to re-occur or to slip by unnoticed if
it does. It's also unlikely to surface in future refactoring.