### PR TITLE
Run commands/graph with more heap available

### DIFF
--- a/src/cli/common.js
+++ b/src/cli/common.js
@@ -21,3 +21,11 @@ export function sourcecredDirectoryFlag() {
     default: () => defaultStorageDirectory(),
   });
 }
+
+export function nodeMaxOldSpaceSizeFlag() {
+  return flags.integer({
+    description: "--max_old_space_size flag to node; increases available heap",
+    default: 8192,
+    env: "SOURCECRED_NODE_MAX_OLD_SPACE",
+  });
+}


### PR DESCRIPTION
`sourcecred graph` tends to die due to lack of heap during the Git
plugin. Node defaults to ~1.76GB of heap available, which is just not
that much. This commit uses the `--max_old_space_size` argument to
`node` to increase the limit. We use a default value of `8192`, and it's
configurable by the user via a flag.

This command is only available natively in `sourcecred graph`, because
that command turns on other node processes. For commands that run in
their original process, you would need to set the value yourself.