### PR TITLE
Use versioning for `Graph` and `AddressMap`

### DIFF
--- a/src/core/__snapshots__/address.test.js.snap
+++ b/src/core/__snapshots__/address.test.js.snap
@@ -1,16 +1,22 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`address AddressMap stringifies to JSON 1`] = `
-Object {
-  "{\\"id\\":\\"mansion\\",\\"pluginName\\":\\"houseville\\",\\"type\\":\\"HOME\\"}": Object {
-    "baths": 5,
-    "beds": 10,
+Array [
+  Object {
+    "type": "sourcecred/sourcecred/AddressMap",
+    "version": "0.1.0",
   },
-  "{\\"id\\":\\"mattressStore\\",\\"pluginName\\":\\"houseville\\",\\"type\\":\\"BUSINESS\\"}": Object {
-    "baths": 1,
-    "beds": 99,
+  Object {
+    "{\\"id\\":\\"mansion\\",\\"pluginName\\":\\"houseville\\",\\"type\\":\\"HOME\\"}": Object {
+      "baths": 5,
+      "beds": 10,
+    },
+    "{\\"id\\":\\"mattressStore\\",\\"pluginName\\":\\"houseville\\",\\"type\\":\\"BUSINESS\\"}": Object {
+      "baths": 1,
+      "beds": 99,
+    },
   },
-}
+]
 `;
 
 exports[`address toString and fromString serialization looks good in snapshot review 1`] = `

--- a/src/core/__snapshots__/graph.test.js.snap
+++ b/src/core/__snapshots__/graph.test.js.snap
@@ -1,138 +1,156 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`graph #Graph JSON functions should serialize a simple graph 1`] = `
-Object {
-  "edges": Object {
-    "{\\"id\\":\\"crab-self-assessment\\",\\"pluginName\\":\\"hill_cooking_pot\\",\\"type\\":\\"SILLY\\"}": Object {
-      "dst": Object {
-        "id": "razorclaw_crab#2",
-        "pluginName": "hill_cooking_pot",
-        "type": "FOOD",
-      },
-      "payload": Object {
-        "evaluation": "not effective at avoiding hero",
-      },
-      "src": Object {
-        "id": "razorclaw_crab#2",
-        "pluginName": "hill_cooking_pot",
-        "type": "FOOD",
-      },
-    },
-    "{\\"id\\":\\"hero_of_time#0@again_cooks@seafood_fruit_mix#3\\",\\"pluginName\\":\\"hill_cooking_pot\\",\\"type\\":\\"ACTION\\"}": Object {
-      "dst": Object {
-        "id": "hero_of_time#0",
-        "pluginName": "hill_cooking_pot",
-        "type": "PC",
-      },
-      "payload": Object {
-        "crit": true,
-        "saveScummed": true,
-      },
-      "src": Object {
-        "id": "seafood_fruit_mix#3",
-        "pluginName": "hill_cooking_pot",
-        "type": "FOOD",
-      },
-    },
-    "{\\"id\\":\\"hero_of_time#0@cooks@seafood_fruit_mix#3\\",\\"pluginName\\":\\"hill_cooking_pot\\",\\"type\\":\\"ACTION\\"}": Object {
-      "dst": Object {
-        "id": "hero_of_time#0",
-        "pluginName": "hill_cooking_pot",
-        "type": "PC",
-      },
-      "payload": Object {
-        "crit": false,
-      },
-      "src": Object {
-        "id": "seafood_fruit_mix#3",
-        "pluginName": "hill_cooking_pot",
-        "type": "FOOD",
-      },
-    },
-    "{\\"id\\":\\"hero_of_time#0@eats@seafood_fruit_mix#3\\",\\"pluginName\\":\\"hill_cooking_pot\\",\\"type\\":\\"ACTION\\"}": Object {
-      "dst": Object {
-        "id": "seafood_fruit_mix#3",
-        "pluginName": "hill_cooking_pot",
-        "type": "FOOD",
-      },
-      "payload": Object {},
-      "src": Object {
-        "id": "hero_of_time#0",
-        "pluginName": "hill_cooking_pot",
-        "type": "PC",
-      },
-    },
-    "{\\"id\\":\\"hero_of_time#0@grabs@razorclaw_crab#2\\",\\"pluginName\\":\\"hill_cooking_pot\\",\\"type\\":\\"ACTION\\"}": Object {
-      "dst": Object {
-        "id": "hero_of_time#0",
-        "pluginName": "hill_cooking_pot",
-        "type": "PC",
-      },
-      "payload": Object {},
-      "src": Object {
-        "id": "razorclaw_crab#2",
-        "pluginName": "hill_cooking_pot",
-        "type": "FOOD",
-      },
-    },
-    "{\\"id\\":\\"hero_of_time#0@picks@mighty_bananas#1\\",\\"pluginName\\":\\"hill_cooking_pot\\",\\"type\\":\\"ACTION\\"}": Object {
-      "dst": Object {
-        "id": "hero_of_time#0",
-        "pluginName": "hill_cooking_pot",
-        "type": "PC",
-      },
-      "payload": Object {},
-      "src": Object {
-        "id": "mighty_bananas#1",
-        "pluginName": "hill_cooking_pot",
-        "type": "FOOD",
-      },
-    },
-    "{\\"id\\":\\"mighty_bananas#1@included_in@seafood_fruit_mix#3\\",\\"pluginName\\":\\"hill_cooking_pot\\",\\"type\\":\\"INGREDIENT\\"}": Object {
-      "dst": Object {
-        "id": "mighty_bananas#1",
-        "pluginName": "hill_cooking_pot",
-        "type": "FOOD",
-      },
-      "payload": Object {},
-      "src": Object {
-        "id": "seafood_fruit_mix#3",
-        "pluginName": "hill_cooking_pot",
-        "type": "FOOD",
-      },
-    },
-    "{\\"id\\":\\"razorclaw_crab#2@included_in@seafood_fruit_mix#3\\",\\"pluginName\\":\\"hill_cooking_pot\\",\\"type\\":\\"INGREDIENT\\"}": Object {
-      "dst": Object {
-        "id": "razorclaw_crab#2",
-        "pluginName": "hill_cooking_pot",
-        "type": "FOOD",
-      },
-      "payload": Object {},
-      "src": Object {
-        "id": "seafood_fruit_mix#3",
-        "pluginName": "hill_cooking_pot",
-        "type": "FOOD",
-      },
-    },
+Array [
+  Object {
+    "type": "sourcecred/sourcecred/Graph",
+    "version": "0.1.0",
   },
-  "nodes": Object {
-    "{\\"id\\":\\"hero_of_time#0\\",\\"pluginName\\":\\"hill_cooking_pot\\",\\"type\\":\\"PC\\"}": Object {
-      "payload": Object {},
-    },
-    "{\\"id\\":\\"mighty_bananas#1\\",\\"pluginName\\":\\"hill_cooking_pot\\",\\"type\\":\\"FOOD\\"}": Object {
-      "payload": Object {},
-    },
-    "{\\"id\\":\\"razorclaw_crab#2\\",\\"pluginName\\":\\"hill_cooking_pot\\",\\"type\\":\\"FOOD\\"}": Object {
-      "payload": Object {},
-    },
-    "{\\"id\\":\\"seafood_fruit_mix#3\\",\\"pluginName\\":\\"hill_cooking_pot\\",\\"type\\":\\"FOOD\\"}": Object {
-      "payload": Object {
-        "effect": Array [
-          "attack_power",
-          1,
-        ],
+  Object {
+    "edges": Array [
+      Object {
+        "type": "sourcecred/sourcecred/AddressMap",
+        "version": "0.1.0",
       },
-    },
+      Object {
+        "{\\"id\\":\\"crab-self-assessment\\",\\"pluginName\\":\\"hill_cooking_pot\\",\\"type\\":\\"SILLY\\"}": Object {
+          "dst": Object {
+            "id": "razorclaw_crab#2",
+            "pluginName": "hill_cooking_pot",
+            "type": "FOOD",
+          },
+          "payload": Object {
+            "evaluation": "not effective at avoiding hero",
+          },
+          "src": Object {
+            "id": "razorclaw_crab#2",
+            "pluginName": "hill_cooking_pot",
+            "type": "FOOD",
+          },
+        },
+        "{\\"id\\":\\"hero_of_time#0@again_cooks@seafood_fruit_mix#3\\",\\"pluginName\\":\\"hill_cooking_pot\\",\\"type\\":\\"ACTION\\"}": Object {
+          "dst": Object {
+            "id": "hero_of_time#0",
+            "pluginName": "hill_cooking_pot",
+            "type": "PC",
+          },
+          "payload": Object {
+            "crit": true,
+            "saveScummed": true,
+          },
+          "src": Object {
+            "id": "seafood_fruit_mix#3",
+            "pluginName": "hill_cooking_pot",
+            "type": "FOOD",
+          },
+        },
+        "{\\"id\\":\\"hero_of_time#0@cooks@seafood_fruit_mix#3\\",\\"pluginName\\":\\"hill_cooking_pot\\",\\"type\\":\\"ACTION\\"}": Object {
+          "dst": Object {
+            "id": "hero_of_time#0",
+            "pluginName": "hill_cooking_pot",
+            "type": "PC",
+          },
+          "payload": Object {
+            "crit": false,
+          },
+          "src": Object {
+            "id": "seafood_fruit_mix#3",
+            "pluginName": "hill_cooking_pot",
+            "type": "FOOD",
+          },
+        },
+        "{\\"id\\":\\"hero_of_time#0@eats@seafood_fruit_mix#3\\",\\"pluginName\\":\\"hill_cooking_pot\\",\\"type\\":\\"ACTION\\"}": Object {
+          "dst": Object {
+            "id": "seafood_fruit_mix#3",
+            "pluginName": "hill_cooking_pot",
+            "type": "FOOD",
+          },
+          "payload": Object {},
+          "src": Object {
+            "id": "hero_of_time#0",
+            "pluginName": "hill_cooking_pot",
+            "type": "PC",
+          },
+        },
+        "{\\"id\\":\\"hero_of_time#0@grabs@razorclaw_crab#2\\",\\"pluginName\\":\\"hill_cooking_pot\\",\\"type\\":\\"ACTION\\"}": Object {
+          "dst": Object {
+            "id": "hero_of_time#0",
+            "pluginName": "hill_cooking_pot",
+            "type": "PC",
+          },
+          "payload": Object {},
+          "src": Object {
+            "id": "razorclaw_crab#2",
+            "pluginName": "hill_cooking_pot",
+            "type": "FOOD",
+          },
+        },
+        "{\\"id\\":\\"hero_of_time#0@picks@mighty_bananas#1\\",\\"pluginName\\":\\"hill_cooking_pot\\",\\"type\\":\\"ACTION\\"}": Object {
+          "dst": Object {
+            "id": "hero_of_time#0",
+            "pluginName": "hill_cooking_pot",
+            "type": "PC",
+          },
+          "payload": Object {},
+          "src": Object {
+            "id": "mighty_bananas#1",
+            "pluginName": "hill_cooking_pot",
+            "type": "FOOD",
+          },
+        },
+        "{\\"id\\":\\"mighty_bananas#1@included_in@seafood_fruit_mix#3\\",\\"pluginName\\":\\"hill_cooking_pot\\",\\"type\\":\\"INGREDIENT\\"}": Object {
+          "dst": Object {
+            "id": "mighty_bananas#1",
+            "pluginName": "hill_cooking_pot",
+            "type": "FOOD",
+          },
+          "payload": Object {},
+          "src": Object {
+            "id": "seafood_fruit_mix#3",
+            "pluginName": "hill_cooking_pot",
+            "type": "FOOD",
+          },
+        },
+        "{\\"id\\":\\"razorclaw_crab#2@included_in@seafood_fruit_mix#3\\",\\"pluginName\\":\\"hill_cooking_pot\\",\\"type\\":\\"INGREDIENT\\"}": Object {
+          "dst": Object {
+            "id": "razorclaw_crab#2",
+            "pluginName": "hill_cooking_pot",
+            "type": "FOOD",
+          },
+          "payload": Object {},
+          "src": Object {
+            "id": "seafood_fruit_mix#3",
+            "pluginName": "hill_cooking_pot",
+            "type": "FOOD",
+          },
+        },
+      },
+    ],
+    "nodes": Array [
+      Object {
+        "type": "sourcecred/sourcecred/AddressMap",
+        "version": "0.1.0",
+      },
+      Object {
+        "{\\"id\\":\\"hero_of_time#0\\",\\"pluginName\\":\\"hill_cooking_pot\\",\\"type\\":\\"PC\\"}": Object {
+          "payload": Object {},
+        },
+        "{\\"id\\":\\"mighty_bananas#1\\",\\"pluginName\\":\\"hill_cooking_pot\\",\\"type\\":\\"FOOD\\"}": Object {
+          "payload": Object {},
+        },
+        "{\\"id\\":\\"razorclaw_crab#2\\",\\"pluginName\\":\\"hill_cooking_pot\\",\\"type\\":\\"FOOD\\"}": Object {
+          "payload": Object {},
+        },
+        "{\\"id\\":\\"seafood_fruit_mix#3\\",\\"pluginName\\":\\"hill_cooking_pot\\",\\"type\\":\\"FOOD\\"}": Object {
+          "payload": Object {
+            "effect": Array [
+              "attack_power",
+              1,
+            ],
+          },
+        },
+      },
+    ],
   },
-}
+]
 `;

--- a/src/core/address.test.js
+++ b/src/core/address.test.js
@@ -3,8 +3,15 @@
 import sortBy from "lodash.sortby";
 import stringify from "json-stable-stringify";
 
+import {fromCompat} from "../util/compat";
 import type {Address} from "./address";
-import {AddressMap, fromString, toString} from "./address";
+import {
+  AddressMap,
+  fromString,
+  toString,
+  COMPAT_TYPE,
+  COMPAT_VERSION,
+} from "./address";
 
 describe("address", () => {
   // Some test data using objects that have addresses, like houses.
@@ -70,7 +77,11 @@ describe("address", () => {
     });
 
     it("stringifies elements sans addresses", () => {
-      const json = makeMap().toJSON();
+      const compatJson = makeMap().toJSON();
+      const json = fromCompat(
+        {type: COMPAT_TYPE, version: COMPAT_VERSION},
+        compatJson
+      );
       Object.keys(json).forEach((k) => {
         const value = json[k];
         expect(Object.keys(value).sort()).toEqual(["baths", "beds"]);

--- a/src/plugins/git/__snapshots__/createGraph.test.js.snap
+++ b/src/plugins/git/__snapshots__/createGraph.test.js.snap
@@ -1,1454 +1,1472 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`createGraph processes a simple repository 1`] = `
-Object {
-  "edges": Object {
-    "{\\"id\\":\\"2f7155e359fd0ecb96ffdca66fa45b6ed5792809:README.txt\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"type\\":\\"INCLUDES\\"}": Object {
-      "dst": Object {
-        "id": "2f7155e359fd0ecb96ffdca66fa45b6ed5792809:README.txt",
-        "pluginName": "sourcecred/git-beta",
-        "type": "TREE_ENTRY",
-      },
-      "payload": Object {
-        "name": "README.txt",
-      },
-      "src": Object {
-        "id": "2f7155e359fd0ecb96ffdca66fa45b6ed5792809",
-        "pluginName": "sourcecred/git-beta",
-        "type": "TREE",
-      },
-    },
-    "{\\"id\\":\\"2f7155e359fd0ecb96ffdca66fa45b6ed5792809:science.txt\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"type\\":\\"INCLUDES\\"}": Object {
-      "dst": Object {
-        "id": "2f7155e359fd0ecb96ffdca66fa45b6ed5792809:science.txt",
-        "pluginName": "sourcecred/git-beta",
-        "type": "TREE_ENTRY",
-      },
-      "payload": Object {
-        "name": "science.txt",
-      },
-      "src": Object {
-        "id": "2f7155e359fd0ecb96ffdca66fa45b6ed5792809",
-        "pluginName": "sourcecred/git-beta",
-        "type": "TREE",
-      },
-    },
-    "{\\"id\\":\\"3715ddfb8d4c4fd2a6f6af75488c82f84c92ec2f^1\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"type\\":\\"HAS_PARENT\\"}": Object {
-      "dst": Object {
-        "id": "69c5aad50eec8f2a0a07c988c3b283a6490eb45b",
-        "pluginName": "sourcecred/git-beta",
-        "type": "COMMIT",
-      },
-      "payload": Object {
-        "parentIndex": 1,
-      },
-      "src": Object {
-        "id": "3715ddfb8d4c4fd2a6f6af75488c82f84c92ec2f",
-        "pluginName": "sourcecred/git-beta",
-        "type": "COMMIT",
-      },
-    },
-    "{\\"id\\":\\"3dfb84795e07341b05fad3a0d5a55f8304b2d7d8:.gitmodules\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"type\\":\\"INCLUDES\\"}": Object {
-      "dst": Object {
-        "id": "3dfb84795e07341b05fad3a0d5a55f8304b2d7d8:.gitmodules",
-        "pluginName": "sourcecred/git-beta",
-        "type": "TREE_ENTRY",
-      },
-      "payload": Object {
-        "name": ".gitmodules",
-      },
-      "src": Object {
-        "id": "3dfb84795e07341b05fad3a0d5a55f8304b2d7d8",
-        "pluginName": "sourcecred/git-beta",
-        "type": "TREE",
-      },
-    },
-    "{\\"id\\":\\"3dfb84795e07341b05fad3a0d5a55f8304b2d7d8:README.txt\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"type\\":\\"INCLUDES\\"}": Object {
-      "dst": Object {
-        "id": "3dfb84795e07341b05fad3a0d5a55f8304b2d7d8:README.txt",
-        "pluginName": "sourcecred/git-beta",
-        "type": "TREE_ENTRY",
-      },
-      "payload": Object {
-        "name": "README.txt",
-      },
-      "src": Object {
-        "id": "3dfb84795e07341b05fad3a0d5a55f8304b2d7d8",
-        "pluginName": "sourcecred/git-beta",
-        "type": "TREE",
-      },
-    },
-    "{\\"id\\":\\"3dfb84795e07341b05fad3a0d5a55f8304b2d7d8:pygravitydefier\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"type\\":\\"INCLUDES\\"}": Object {
-      "dst": Object {
-        "id": "3dfb84795e07341b05fad3a0d5a55f8304b2d7d8:pygravitydefier",
-        "pluginName": "sourcecred/git-beta",
-        "type": "TREE_ENTRY",
-      },
-      "payload": Object {
-        "name": "pygravitydefier",
-      },
-      "src": Object {
-        "id": "3dfb84795e07341b05fad3a0d5a55f8304b2d7d8",
-        "pluginName": "sourcecred/git-beta",
-        "type": "TREE",
-      },
-    },
-    "{\\"id\\":\\"3dfb84795e07341b05fad3a0d5a55f8304b2d7d8:science.txt\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"type\\":\\"INCLUDES\\"}": Object {
-      "dst": Object {
-        "id": "3dfb84795e07341b05fad3a0d5a55f8304b2d7d8:science.txt",
-        "pluginName": "sourcecred/git-beta",
-        "type": "TREE_ENTRY",
-      },
-      "payload": Object {
-        "name": "science.txt",
-      },
-      "src": Object {
-        "id": "3dfb84795e07341b05fad3a0d5a55f8304b2d7d8",
-        "pluginName": "sourcecred/git-beta",
-        "type": "TREE",
-      },
-    },
-    "{\\"id\\":\\"569e1d383759903134df75230d63c0090196d4cb:.gitmodules\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"type\\":\\"INCLUDES\\"}": Object {
-      "dst": Object {
-        "id": "569e1d383759903134df75230d63c0090196d4cb:.gitmodules",
-        "pluginName": "sourcecred/git-beta",
-        "type": "TREE_ENTRY",
-      },
-      "payload": Object {
-        "name": ".gitmodules",
-      },
-      "src": Object {
-        "id": "569e1d383759903134df75230d63c0090196d4cb",
-        "pluginName": "sourcecred/git-beta",
-        "type": "TREE",
-      },
-    },
-    "{\\"id\\":\\"569e1d383759903134df75230d63c0090196d4cb:README.txt\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"type\\":\\"INCLUDES\\"}": Object {
-      "dst": Object {
-        "id": "569e1d383759903134df75230d63c0090196d4cb:README.txt",
-        "pluginName": "sourcecred/git-beta",
-        "type": "TREE_ENTRY",
-      },
-      "payload": Object {
-        "name": "README.txt",
-      },
-      "src": Object {
-        "id": "569e1d383759903134df75230d63c0090196d4cb",
-        "pluginName": "sourcecred/git-beta",
-        "type": "TREE",
-      },
-    },
-    "{\\"id\\":\\"569e1d383759903134df75230d63c0090196d4cb:TODOS.txt\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"type\\":\\"INCLUDES\\"}": Object {
-      "dst": Object {
-        "id": "569e1d383759903134df75230d63c0090196d4cb:TODOS.txt",
-        "pluginName": "sourcecred/git-beta",
-        "type": "TREE_ENTRY",
-      },
-      "payload": Object {
-        "name": "TODOS.txt",
-      },
-      "src": Object {
-        "id": "569e1d383759903134df75230d63c0090196d4cb",
-        "pluginName": "sourcecred/git-beta",
-        "type": "TREE",
-      },
-    },
-    "{\\"id\\":\\"569e1d383759903134df75230d63c0090196d4cb:pygravitydefier\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"type\\":\\"INCLUDES\\"}": Object {
-      "dst": Object {
-        "id": "569e1d383759903134df75230d63c0090196d4cb:pygravitydefier",
-        "pluginName": "sourcecred/git-beta",
-        "type": "TREE_ENTRY",
-      },
-      "payload": Object {
-        "name": "pygravitydefier",
-      },
-      "src": Object {
-        "id": "569e1d383759903134df75230d63c0090196d4cb",
-        "pluginName": "sourcecred/git-beta",
-        "type": "TREE",
-      },
-    },
-    "{\\"id\\":\\"569e1d383759903134df75230d63c0090196d4cb:science.txt\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"type\\":\\"INCLUDES\\"}": Object {
-      "dst": Object {
-        "id": "569e1d383759903134df75230d63c0090196d4cb:science.txt",
-        "pluginName": "sourcecred/git-beta",
-        "type": "TREE_ENTRY",
-      },
-      "payload": Object {
-        "name": "science.txt",
-      },
-      "src": Object {
-        "id": "569e1d383759903134df75230d63c0090196d4cb",
-        "pluginName": "sourcecred/git-beta",
-        "type": "TREE",
-      },
-    },
-    "{\\"id\\":\\"569e1d383759903134df75230d63c0090196d4cb:src\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"type\\":\\"INCLUDES\\"}": Object {
-      "dst": Object {
-        "id": "569e1d383759903134df75230d63c0090196d4cb:src",
-        "pluginName": "sourcecred/git-beta",
-        "type": "TREE_ENTRY",
-      },
-      "payload": Object {
-        "name": "src",
-      },
-      "src": Object {
-        "id": "569e1d383759903134df75230d63c0090196d4cb",
-        "pluginName": "sourcecred/git-beta",
-        "type": "TREE",
-      },
-    },
-    "{\\"id\\":\\"69c5aad50eec8f2a0a07c988c3b283a6490eb45b^1\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"type\\":\\"HAS_PARENT\\"}": Object {
-      "dst": Object {
-        "id": "e8b7a8f19701cd5a25e4a097d513ead60e5f8bcc",
-        "pluginName": "sourcecred/git-beta",
-        "type": "COMMIT",
-      },
-      "payload": Object {
-        "parentIndex": 1,
-      },
-      "src": Object {
-        "id": "69c5aad50eec8f2a0a07c988c3b283a6490eb45b",
-        "pluginName": "sourcecred/git-beta",
-        "type": "COMMIT",
-      },
-    },
-    "{\\"id\\":\\"78fc9c83023386854c6bfdc5761c0e58f68e226f:index.py\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"type\\":\\"INCLUDES\\"}": Object {
-      "dst": Object {
-        "id": "78fc9c83023386854c6bfdc5761c0e58f68e226f:index.py",
-        "pluginName": "sourcecred/git-beta",
-        "type": "TREE_ENTRY",
-      },
-      "payload": Object {
-        "name": "index.py",
-      },
-      "src": Object {
-        "id": "78fc9c83023386854c6bfdc5761c0e58f68e226f",
-        "pluginName": "sourcecred/git-beta",
-        "type": "TREE",
-      },
-    },
-    "{\\"id\\":\\"78fc9c83023386854c6bfdc5761c0e58f68e226f:quantum_gravity.py\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"type\\":\\"INCLUDES\\"}": Object {
-      "dst": Object {
-        "id": "78fc9c83023386854c6bfdc5761c0e58f68e226f:quantum_gravity.py",
-        "pluginName": "sourcecred/git-beta",
-        "type": "TREE_ENTRY",
-      },
-      "payload": Object {
-        "name": "quantum_gravity.py",
-      },
-      "src": Object {
-        "id": "78fc9c83023386854c6bfdc5761c0e58f68e226f",
-        "pluginName": "sourcecred/git-beta",
-        "type": "TREE",
-      },
-    },
-    "{\\"id\\":\\"7b79d579b62994faba3b69fdf8aa442586c32681:index.py\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"type\\":\\"INCLUDES\\"}": Object {
-      "dst": Object {
-        "id": "7b79d579b62994faba3b69fdf8aa442586c32681:index.py",
-        "pluginName": "sourcecred/git-beta",
-        "type": "TREE_ENTRY",
-      },
-      "payload": Object {
-        "name": "index.py",
-      },
-      "src": Object {
-        "id": "7b79d579b62994faba3b69fdf8aa442586c32681",
-        "pluginName": "sourcecred/git-beta",
-        "type": "TREE",
-      },
-    },
-    "{\\"id\\":\\"7b79d579b62994faba3b69fdf8aa442586c32681:quantum_gravity.py\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"type\\":\\"INCLUDES\\"}": Object {
-      "dst": Object {
-        "id": "7b79d579b62994faba3b69fdf8aa442586c32681:quantum_gravity.py",
-        "pluginName": "sourcecred/git-beta",
-        "type": "TREE_ENTRY",
-      },
-      "payload": Object {
-        "name": "quantum_gravity.py",
-      },
-      "src": Object {
-        "id": "7b79d579b62994faba3b69fdf8aa442586c32681",
-        "pluginName": "sourcecred/git-beta",
-        "type": "TREE",
-      },
-    },
-    "{\\"id\\":\\"7be3ecfee5314ffa9b2d93fc4377792b2d6d70ed:.gitmodules\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"type\\":\\"INCLUDES\\"}": Object {
-      "dst": Object {
-        "id": "7be3ecfee5314ffa9b2d93fc4377792b2d6d70ed:.gitmodules",
-        "pluginName": "sourcecred/git-beta",
-        "type": "TREE_ENTRY",
-      },
-      "payload": Object {
-        "name": ".gitmodules",
-      },
-      "src": Object {
-        "id": "7be3ecfee5314ffa9b2d93fc4377792b2d6d70ed",
-        "pluginName": "sourcecred/git-beta",
-        "type": "TREE",
-      },
-    },
-    "{\\"id\\":\\"7be3ecfee5314ffa9b2d93fc4377792b2d6d70ed:README.txt\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"type\\":\\"INCLUDES\\"}": Object {
-      "dst": Object {
-        "id": "7be3ecfee5314ffa9b2d93fc4377792b2d6d70ed:README.txt",
-        "pluginName": "sourcecred/git-beta",
-        "type": "TREE_ENTRY",
-      },
-      "payload": Object {
-        "name": "README.txt",
-      },
-      "src": Object {
-        "id": "7be3ecfee5314ffa9b2d93fc4377792b2d6d70ed",
-        "pluginName": "sourcecred/git-beta",
-        "type": "TREE",
-      },
-    },
-    "{\\"id\\":\\"7be3ecfee5314ffa9b2d93fc4377792b2d6d70ed:pygravitydefier\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"type\\":\\"INCLUDES\\"}": Object {
-      "dst": Object {
-        "id": "7be3ecfee5314ffa9b2d93fc4377792b2d6d70ed:pygravitydefier",
-        "pluginName": "sourcecred/git-beta",
-        "type": "TREE_ENTRY",
-      },
-      "payload": Object {
-        "name": "pygravitydefier",
-      },
-      "src": Object {
-        "id": "7be3ecfee5314ffa9b2d93fc4377792b2d6d70ed",
-        "pluginName": "sourcecred/git-beta",
-        "type": "TREE",
-      },
-    },
-    "{\\"id\\":\\"7be3ecfee5314ffa9b2d93fc4377792b2d6d70ed:science.txt\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"type\\":\\"INCLUDES\\"}": Object {
-      "dst": Object {
-        "id": "7be3ecfee5314ffa9b2d93fc4377792b2d6d70ed:science.txt",
-        "pluginName": "sourcecred/git-beta",
-        "type": "TREE_ENTRY",
-      },
-      "payload": Object {
-        "name": "science.txt",
-      },
-      "src": Object {
-        "id": "7be3ecfee5314ffa9b2d93fc4377792b2d6d70ed",
-        "pluginName": "sourcecred/git-beta",
-        "type": "TREE",
-      },
-    },
-    "{\\"id\\":\\"7be3ecfee5314ffa9b2d93fc4377792b2d6d70ed:src\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"type\\":\\"INCLUDES\\"}": Object {
-      "dst": Object {
-        "id": "7be3ecfee5314ffa9b2d93fc4377792b2d6d70ed:src",
-        "pluginName": "sourcecred/git-beta",
-        "type": "TREE_ENTRY",
-      },
-      "payload": Object {
-        "name": "src",
-      },
-      "src": Object {
-        "id": "7be3ecfee5314ffa9b2d93fc4377792b2d6d70ed",
-        "pluginName": "sourcecred/git-beta",
-        "type": "TREE",
-      },
-    },
-    "{\\"id\\":\\"819fc546cea489476ce8dc90785e9ba7753d0a8f:.gitmodules\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"type\\":\\"INCLUDES\\"}": Object {
-      "dst": Object {
-        "id": "819fc546cea489476ce8dc90785e9ba7753d0a8f:.gitmodules",
-        "pluginName": "sourcecred/git-beta",
-        "type": "TREE_ENTRY",
-      },
-      "payload": Object {
-        "name": ".gitmodules",
-      },
-      "src": Object {
-        "id": "819fc546cea489476ce8dc90785e9ba7753d0a8f",
-        "pluginName": "sourcecred/git-beta",
-        "type": "TREE",
-      },
-    },
-    "{\\"id\\":\\"819fc546cea489476ce8dc90785e9ba7753d0a8f:README.txt\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"type\\":\\"INCLUDES\\"}": Object {
-      "dst": Object {
-        "id": "819fc546cea489476ce8dc90785e9ba7753d0a8f:README.txt",
-        "pluginName": "sourcecred/git-beta",
-        "type": "TREE_ENTRY",
-      },
-      "payload": Object {
-        "name": "README.txt",
-      },
-      "src": Object {
-        "id": "819fc546cea489476ce8dc90785e9ba7753d0a8f",
-        "pluginName": "sourcecred/git-beta",
-        "type": "TREE",
-      },
-    },
-    "{\\"id\\":\\"819fc546cea489476ce8dc90785e9ba7753d0a8f:TODOS.txt\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"type\\":\\"INCLUDES\\"}": Object {
-      "dst": Object {
-        "id": "819fc546cea489476ce8dc90785e9ba7753d0a8f:TODOS.txt",
-        "pluginName": "sourcecred/git-beta",
-        "type": "TREE_ENTRY",
-      },
-      "payload": Object {
-        "name": "TODOS.txt",
-      },
-      "src": Object {
-        "id": "819fc546cea489476ce8dc90785e9ba7753d0a8f",
-        "pluginName": "sourcecred/git-beta",
-        "type": "TREE",
-      },
-    },
-    "{\\"id\\":\\"819fc546cea489476ce8dc90785e9ba7753d0a8f:pygravitydefier\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"type\\":\\"INCLUDES\\"}": Object {
-      "dst": Object {
-        "id": "819fc546cea489476ce8dc90785e9ba7753d0a8f:pygravitydefier",
-        "pluginName": "sourcecred/git-beta",
-        "type": "TREE_ENTRY",
-      },
-      "payload": Object {
-        "name": "pygravitydefier",
-      },
-      "src": Object {
-        "id": "819fc546cea489476ce8dc90785e9ba7753d0a8f",
-        "pluginName": "sourcecred/git-beta",
-        "type": "TREE",
-      },
-    },
-    "{\\"id\\":\\"819fc546cea489476ce8dc90785e9ba7753d0a8f:science.txt\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"type\\":\\"INCLUDES\\"}": Object {
-      "dst": Object {
-        "id": "819fc546cea489476ce8dc90785e9ba7753d0a8f:science.txt",
-        "pluginName": "sourcecred/git-beta",
-        "type": "TREE_ENTRY",
-      },
-      "payload": Object {
-        "name": "science.txt",
-      },
-      "src": Object {
-        "id": "819fc546cea489476ce8dc90785e9ba7753d0a8f",
-        "pluginName": "sourcecred/git-beta",
-        "type": "TREE",
-      },
-    },
-    "{\\"id\\":\\"819fc546cea489476ce8dc90785e9ba7753d0a8f:src\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"type\\":\\"INCLUDES\\"}": Object {
-      "dst": Object {
-        "id": "819fc546cea489476ce8dc90785e9ba7753d0a8f:src",
-        "pluginName": "sourcecred/git-beta",
-        "type": "TREE_ENTRY",
-      },
-      "payload": Object {
-        "name": "src",
-      },
-      "src": Object {
-        "id": "819fc546cea489476ce8dc90785e9ba7753d0a8f",
-        "pluginName": "sourcecred/git-beta",
-        "type": "TREE",
-      },
-    },
-    "{\\"id\\":\\"8d287c3bfbf8455ef30187bf5153ffc1b6eef268^1\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"type\\":\\"HAS_PARENT\\"}": Object {
-      "dst": Object {
-        "id": "c08ee3a4edea384d5291ffcbf06724a13ed72325",
-        "pluginName": "sourcecred/git-beta",
-        "type": "COMMIT",
-      },
-      "payload": Object {
-        "parentIndex": 1,
-      },
-      "src": Object {
-        "id": "8d287c3bfbf8455ef30187bf5153ffc1b6eef268",
-        "pluginName": "sourcecred/git-beta",
-        "type": "COMMIT",
-      },
-    },
-    "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"2f7155e359fd0ecb96ffdca66fa45b6ed5792809:README.txt\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/git-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"TREE_ENTRY\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"0fb31858c8e3710be77e1dbb8880acf8a5543d82\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/git-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"BLOB\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"type\\":\\"HAS_CONTENTS\\"}": Object {
-      "dst": Object {
-        "id": "0fb31858c8e3710be77e1dbb8880acf8a5543d82",
-        "pluginName": "sourcecred/git-beta",
-        "type": "BLOB",
-      },
-      "payload": Object {},
-      "src": Object {
-        "id": "2f7155e359fd0ecb96ffdca66fa45b6ed5792809:README.txt",
-        "pluginName": "sourcecred/git-beta",
-        "type": "TREE_ENTRY",
-      },
-    },
-    "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"2f7155e359fd0ecb96ffdca66fa45b6ed5792809:science.txt\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/git-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"TREE_ENTRY\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"f1f2514ca6d7a6a1a0511957021b1995bf9ace1c\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/git-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"BLOB\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"type\\":\\"HAS_CONTENTS\\"}": Object {
-      "dst": Object {
-        "id": "f1f2514ca6d7a6a1a0511957021b1995bf9ace1c",
-        "pluginName": "sourcecred/git-beta",
-        "type": "BLOB",
-      },
-      "payload": Object {},
-      "src": Object {
-        "id": "2f7155e359fd0ecb96ffdca66fa45b6ed5792809:science.txt",
-        "pluginName": "sourcecred/git-beta",
-        "type": "TREE_ENTRY",
-      },
-    },
-    "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"3715ddfb8d4c4fd2a6f6af75488c82f84c92ec2f\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/git-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"COMMIT\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"7be3ecfee5314ffa9b2d93fc4377792b2d6d70ed\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/git-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"TREE\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"type\\":\\"HAS_TREE\\"}": Object {
-      "dst": Object {
-        "id": "7be3ecfee5314ffa9b2d93fc4377792b2d6d70ed",
-        "pluginName": "sourcecred/git-beta",
-        "type": "TREE",
-      },
-      "payload": Object {},
-      "src": Object {
-        "id": "3715ddfb8d4c4fd2a6f6af75488c82f84c92ec2f",
-        "pluginName": "sourcecred/git-beta",
-        "type": "COMMIT",
-      },
-    },
-    "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"3dfb84795e07341b05fad3a0d5a55f8304b2d7d8:.gitmodules\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/git-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"TREE_ENTRY\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"8c6cac301e763aa6d36466e0a775eb804be2c311\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/git-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"BLOB\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"type\\":\\"HAS_CONTENTS\\"}": Object {
-      "dst": Object {
-        "id": "8c6cac301e763aa6d36466e0a775eb804be2c311",
-        "pluginName": "sourcecred/git-beta",
-        "type": "BLOB",
-      },
-      "payload": Object {},
-      "src": Object {
-        "id": "3dfb84795e07341b05fad3a0d5a55f8304b2d7d8:.gitmodules",
-        "pluginName": "sourcecred/git-beta",
-        "type": "TREE_ENTRY",
-      },
-    },
-    "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"3dfb84795e07341b05fad3a0d5a55f8304b2d7d8:README.txt\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/git-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"TREE_ENTRY\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"0fb31858c8e3710be77e1dbb8880acf8a5543d82\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/git-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"BLOB\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"type\\":\\"HAS_CONTENTS\\"}": Object {
-      "dst": Object {
-        "id": "0fb31858c8e3710be77e1dbb8880acf8a5543d82",
-        "pluginName": "sourcecred/git-beta",
-        "type": "BLOB",
-      },
-      "payload": Object {},
-      "src": Object {
-        "id": "3dfb84795e07341b05fad3a0d5a55f8304b2d7d8:README.txt",
-        "pluginName": "sourcecred/git-beta",
-        "type": "TREE_ENTRY",
-      },
-    },
-    "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"3dfb84795e07341b05fad3a0d5a55f8304b2d7d8:pygravitydefier\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/git-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"TREE_ENTRY\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-git-submodule.git@762c062fbdc7ec198cd693e95d55b374a08ff3e3\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/git-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"SUBMODULE_COMMIT\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"type\\":\\"HAS_CONTENTS\\"}": Object {
-      "dst": Object {
-        "id": "https://github.com/sourcecred/example-git-submodule.git@762c062fbdc7ec198cd693e95d55b374a08ff3e3",
-        "pluginName": "sourcecred/git-beta",
-        "type": "SUBMODULE_COMMIT",
-      },
-      "payload": Object {},
-      "src": Object {
-        "id": "3dfb84795e07341b05fad3a0d5a55f8304b2d7d8:pygravitydefier",
-        "pluginName": "sourcecred/git-beta",
-        "type": "TREE_ENTRY",
-      },
-    },
-    "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"3dfb84795e07341b05fad3a0d5a55f8304b2d7d8:science.txt\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/git-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"TREE_ENTRY\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"f1f2514ca6d7a6a1a0511957021b1995bf9ace1c\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/git-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"BLOB\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"type\\":\\"HAS_CONTENTS\\"}": Object {
-      "dst": Object {
-        "id": "f1f2514ca6d7a6a1a0511957021b1995bf9ace1c",
-        "pluginName": "sourcecred/git-beta",
-        "type": "BLOB",
-      },
-      "payload": Object {},
-      "src": Object {
-        "id": "3dfb84795e07341b05fad3a0d5a55f8304b2d7d8:science.txt",
-        "pluginName": "sourcecred/git-beta",
-        "type": "TREE_ENTRY",
-      },
-    },
-    "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"569e1d383759903134df75230d63c0090196d4cb:.gitmodules\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/git-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"TREE_ENTRY\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"8c6cac301e763aa6d36466e0a775eb804be2c311\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/git-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"BLOB\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"type\\":\\"HAS_CONTENTS\\"}": Object {
-      "dst": Object {
-        "id": "8c6cac301e763aa6d36466e0a775eb804be2c311",
-        "pluginName": "sourcecred/git-beta",
-        "type": "BLOB",
-      },
-      "payload": Object {},
-      "src": Object {
-        "id": "569e1d383759903134df75230d63c0090196d4cb:.gitmodules",
-        "pluginName": "sourcecred/git-beta",
-        "type": "TREE_ENTRY",
-      },
-    },
-    "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"569e1d383759903134df75230d63c0090196d4cb:README.txt\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/git-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"TREE_ENTRY\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"0fb31858c8e3710be77e1dbb8880acf8a5543d82\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/git-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"BLOB\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"type\\":\\"HAS_CONTENTS\\"}": Object {
-      "dst": Object {
-        "id": "0fb31858c8e3710be77e1dbb8880acf8a5543d82",
-        "pluginName": "sourcecred/git-beta",
-        "type": "BLOB",
-      },
-      "payload": Object {},
-      "src": Object {
-        "id": "569e1d383759903134df75230d63c0090196d4cb:README.txt",
-        "pluginName": "sourcecred/git-beta",
-        "type": "TREE_ENTRY",
-      },
-    },
-    "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"569e1d383759903134df75230d63c0090196d4cb:TODOS.txt\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/git-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"TREE_ENTRY\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"ddec7477206c30c31b81482e56b877a0b3c2638b\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/git-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"BLOB\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"type\\":\\"HAS_CONTENTS\\"}": Object {
-      "dst": Object {
-        "id": "ddec7477206c30c31b81482e56b877a0b3c2638b",
-        "pluginName": "sourcecred/git-beta",
-        "type": "BLOB",
-      },
-      "payload": Object {},
-      "src": Object {
-        "id": "569e1d383759903134df75230d63c0090196d4cb:TODOS.txt",
-        "pluginName": "sourcecred/git-beta",
-        "type": "TREE_ENTRY",
-      },
-    },
-    "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"569e1d383759903134df75230d63c0090196d4cb:pygravitydefier\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/git-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"TREE_ENTRY\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-git-submodule.git@762c062fbdc7ec198cd693e95d55b374a08ff3e3\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/git-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"SUBMODULE_COMMIT\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"type\\":\\"HAS_CONTENTS\\"}": Object {
-      "dst": Object {
-        "id": "https://github.com/sourcecred/example-git-submodule.git@762c062fbdc7ec198cd693e95d55b374a08ff3e3",
-        "pluginName": "sourcecred/git-beta",
-        "type": "SUBMODULE_COMMIT",
-      },
-      "payload": Object {},
-      "src": Object {
-        "id": "569e1d383759903134df75230d63c0090196d4cb:pygravitydefier",
-        "pluginName": "sourcecred/git-beta",
-        "type": "TREE_ENTRY",
-      },
-    },
-    "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"569e1d383759903134df75230d63c0090196d4cb:science.txt\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/git-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"TREE_ENTRY\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"f1f2514ca6d7a6a1a0511957021b1995bf9ace1c\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/git-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"BLOB\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"type\\":\\"HAS_CONTENTS\\"}": Object {
-      "dst": Object {
-        "id": "f1f2514ca6d7a6a1a0511957021b1995bf9ace1c",
-        "pluginName": "sourcecred/git-beta",
-        "type": "BLOB",
-      },
-      "payload": Object {},
-      "src": Object {
-        "id": "569e1d383759903134df75230d63c0090196d4cb:science.txt",
-        "pluginName": "sourcecred/git-beta",
-        "type": "TREE_ENTRY",
-      },
-    },
-    "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"569e1d383759903134df75230d63c0090196d4cb:src\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/git-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"TREE_ENTRY\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"7b79d579b62994faba3b69fdf8aa442586c32681\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/git-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"TREE\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"type\\":\\"HAS_CONTENTS\\"}": Object {
-      "dst": Object {
-        "id": "7b79d579b62994faba3b69fdf8aa442586c32681",
-        "pluginName": "sourcecred/git-beta",
-        "type": "TREE",
-      },
-      "payload": Object {},
-      "src": Object {
-        "id": "569e1d383759903134df75230d63c0090196d4cb:src",
-        "pluginName": "sourcecred/git-beta",
-        "type": "TREE_ENTRY",
-      },
-    },
-    "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"69c5aad50eec8f2a0a07c988c3b283a6490eb45b\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/git-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"COMMIT\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"bbf3b8b3d26a4f884b5c022d46851f593d329192\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/git-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"TREE\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"type\\":\\"HAS_TREE\\"}": Object {
-      "dst": Object {
-        "id": "bbf3b8b3d26a4f884b5c022d46851f593d329192",
-        "pluginName": "sourcecred/git-beta",
-        "type": "TREE",
-      },
-      "payload": Object {},
-      "src": Object {
-        "id": "69c5aad50eec8f2a0a07c988c3b283a6490eb45b",
-        "pluginName": "sourcecred/git-beta",
-        "type": "COMMIT",
-      },
-    },
-    "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"78fc9c83023386854c6bfdc5761c0e58f68e226f:index.py\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/git-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"TREE_ENTRY\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"674b0b476989384510304846248b3acd16206782\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/git-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"BLOB\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"type\\":\\"HAS_CONTENTS\\"}": Object {
-      "dst": Object {
-        "id": "674b0b476989384510304846248b3acd16206782",
-        "pluginName": "sourcecred/git-beta",
-        "type": "BLOB",
-      },
-      "payload": Object {},
-      "src": Object {
-        "id": "78fc9c83023386854c6bfdc5761c0e58f68e226f:index.py",
-        "pluginName": "sourcecred/git-beta",
-        "type": "TREE_ENTRY",
-      },
-    },
-    "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"78fc9c83023386854c6bfdc5761c0e58f68e226f:quantum_gravity.py\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/git-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"TREE_ENTRY\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"aea4f28abb23abde151b0ead4063227f8bf6c0b0\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/git-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"BLOB\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"type\\":\\"HAS_CONTENTS\\"}": Object {
-      "dst": Object {
-        "id": "aea4f28abb23abde151b0ead4063227f8bf6c0b0",
-        "pluginName": "sourcecred/git-beta",
-        "type": "BLOB",
-      },
-      "payload": Object {},
-      "src": Object {
-        "id": "78fc9c83023386854c6bfdc5761c0e58f68e226f:quantum_gravity.py",
-        "pluginName": "sourcecred/git-beta",
-        "type": "TREE_ENTRY",
-      },
-    },
-    "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"7b79d579b62994faba3b69fdf8aa442586c32681:index.py\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/git-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"TREE_ENTRY\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"674b0b476989384510304846248b3acd16206782\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/git-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"BLOB\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"type\\":\\"HAS_CONTENTS\\"}": Object {
-      "dst": Object {
-        "id": "674b0b476989384510304846248b3acd16206782",
-        "pluginName": "sourcecred/git-beta",
-        "type": "BLOB",
-      },
-      "payload": Object {},
-      "src": Object {
-        "id": "7b79d579b62994faba3b69fdf8aa442586c32681:index.py",
-        "pluginName": "sourcecred/git-beta",
-        "type": "TREE_ENTRY",
-      },
-    },
-    "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"7b79d579b62994faba3b69fdf8aa442586c32681:quantum_gravity.py\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/git-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"TREE_ENTRY\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"887ad856bbc1373da146106c86cb581ad78cdafe\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/git-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"BLOB\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"type\\":\\"HAS_CONTENTS\\"}": Object {
-      "dst": Object {
-        "id": "887ad856bbc1373da146106c86cb581ad78cdafe",
-        "pluginName": "sourcecred/git-beta",
-        "type": "BLOB",
-      },
-      "payload": Object {},
-      "src": Object {
-        "id": "7b79d579b62994faba3b69fdf8aa442586c32681:quantum_gravity.py",
-        "pluginName": "sourcecred/git-beta",
-        "type": "TREE_ENTRY",
-      },
-    },
-    "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"7be3ecfee5314ffa9b2d93fc4377792b2d6d70ed:.gitmodules\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/git-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"TREE_ENTRY\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"8c6cac301e763aa6d36466e0a775eb804be2c311\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/git-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"BLOB\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"type\\":\\"HAS_CONTENTS\\"}": Object {
-      "dst": Object {
-        "id": "8c6cac301e763aa6d36466e0a775eb804be2c311",
-        "pluginName": "sourcecred/git-beta",
-        "type": "BLOB",
-      },
-      "payload": Object {},
-      "src": Object {
-        "id": "7be3ecfee5314ffa9b2d93fc4377792b2d6d70ed:.gitmodules",
-        "pluginName": "sourcecred/git-beta",
-        "type": "TREE_ENTRY",
-      },
-    },
-    "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"7be3ecfee5314ffa9b2d93fc4377792b2d6d70ed:README.txt\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/git-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"TREE_ENTRY\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"0fb31858c8e3710be77e1dbb8880acf8a5543d82\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/git-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"BLOB\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"type\\":\\"HAS_CONTENTS\\"}": Object {
-      "dst": Object {
-        "id": "0fb31858c8e3710be77e1dbb8880acf8a5543d82",
-        "pluginName": "sourcecred/git-beta",
-        "type": "BLOB",
-      },
-      "payload": Object {},
-      "src": Object {
-        "id": "7be3ecfee5314ffa9b2d93fc4377792b2d6d70ed:README.txt",
-        "pluginName": "sourcecred/git-beta",
-        "type": "TREE_ENTRY",
-      },
-    },
-    "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"7be3ecfee5314ffa9b2d93fc4377792b2d6d70ed:pygravitydefier\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/git-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"TREE_ENTRY\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-git-submodule.git@29ef158bc982733e2ba429fcf73e2f7562244188\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/git-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"SUBMODULE_COMMIT\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"type\\":\\"HAS_CONTENTS\\"}": Object {
-      "dst": Object {
-        "id": "https://github.com/sourcecred/example-git-submodule.git@29ef158bc982733e2ba429fcf73e2f7562244188",
-        "pluginName": "sourcecred/git-beta",
-        "type": "SUBMODULE_COMMIT",
-      },
-      "payload": Object {},
-      "src": Object {
-        "id": "7be3ecfee5314ffa9b2d93fc4377792b2d6d70ed:pygravitydefier",
-        "pluginName": "sourcecred/git-beta",
-        "type": "TREE_ENTRY",
-      },
-    },
-    "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"7be3ecfee5314ffa9b2d93fc4377792b2d6d70ed:science.txt\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/git-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"TREE_ENTRY\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"f1f2514ca6d7a6a1a0511957021b1995bf9ace1c\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/git-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"BLOB\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"type\\":\\"HAS_CONTENTS\\"}": Object {
-      "dst": Object {
-        "id": "f1f2514ca6d7a6a1a0511957021b1995bf9ace1c",
-        "pluginName": "sourcecred/git-beta",
-        "type": "BLOB",
-      },
-      "payload": Object {},
-      "src": Object {
-        "id": "7be3ecfee5314ffa9b2d93fc4377792b2d6d70ed:science.txt",
-        "pluginName": "sourcecred/git-beta",
-        "type": "TREE_ENTRY",
-      },
-    },
-    "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"7be3ecfee5314ffa9b2d93fc4377792b2d6d70ed:src\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/git-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"TREE_ENTRY\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"78fc9c83023386854c6bfdc5761c0e58f68e226f\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/git-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"TREE\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"type\\":\\"HAS_CONTENTS\\"}": Object {
-      "dst": Object {
-        "id": "78fc9c83023386854c6bfdc5761c0e58f68e226f",
-        "pluginName": "sourcecred/git-beta",
-        "type": "TREE",
-      },
-      "payload": Object {},
-      "src": Object {
-        "id": "7be3ecfee5314ffa9b2d93fc4377792b2d6d70ed:src",
-        "pluginName": "sourcecred/git-beta",
-        "type": "TREE_ENTRY",
-      },
-    },
-    "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"819fc546cea489476ce8dc90785e9ba7753d0a8f:.gitmodules\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/git-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"TREE_ENTRY\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"8c6cac301e763aa6d36466e0a775eb804be2c311\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/git-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"BLOB\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"type\\":\\"HAS_CONTENTS\\"}": Object {
-      "dst": Object {
-        "id": "8c6cac301e763aa6d36466e0a775eb804be2c311",
-        "pluginName": "sourcecred/git-beta",
-        "type": "BLOB",
-      },
-      "payload": Object {},
-      "src": Object {
-        "id": "819fc546cea489476ce8dc90785e9ba7753d0a8f:.gitmodules",
-        "pluginName": "sourcecred/git-beta",
-        "type": "TREE_ENTRY",
-      },
-    },
-    "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"819fc546cea489476ce8dc90785e9ba7753d0a8f:README.txt\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/git-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"TREE_ENTRY\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"0fb31858c8e3710be77e1dbb8880acf8a5543d82\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/git-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"BLOB\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"type\\":\\"HAS_CONTENTS\\"}": Object {
-      "dst": Object {
-        "id": "0fb31858c8e3710be77e1dbb8880acf8a5543d82",
-        "pluginName": "sourcecred/git-beta",
-        "type": "BLOB",
-      },
-      "payload": Object {},
-      "src": Object {
-        "id": "819fc546cea489476ce8dc90785e9ba7753d0a8f:README.txt",
-        "pluginName": "sourcecred/git-beta",
-        "type": "TREE_ENTRY",
-      },
-    },
-    "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"819fc546cea489476ce8dc90785e9ba7753d0a8f:TODOS.txt\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/git-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"TREE_ENTRY\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"ddec7477206c30c31b81482e56b877a0b3c2638b\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/git-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"BLOB\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"type\\":\\"HAS_CONTENTS\\"}": Object {
-      "dst": Object {
-        "id": "ddec7477206c30c31b81482e56b877a0b3c2638b",
-        "pluginName": "sourcecred/git-beta",
-        "type": "BLOB",
-      },
-      "payload": Object {},
-      "src": Object {
-        "id": "819fc546cea489476ce8dc90785e9ba7753d0a8f:TODOS.txt",
-        "pluginName": "sourcecred/git-beta",
-        "type": "TREE_ENTRY",
-      },
-    },
-    "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"819fc546cea489476ce8dc90785e9ba7753d0a8f:pygravitydefier\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/git-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"TREE_ENTRY\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-git-submodule.git@29ef158bc982733e2ba429fcf73e2f7562244188\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/git-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"SUBMODULE_COMMIT\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"type\\":\\"HAS_CONTENTS\\"}": Object {
-      "dst": Object {
-        "id": "https://github.com/sourcecred/example-git-submodule.git@29ef158bc982733e2ba429fcf73e2f7562244188",
-        "pluginName": "sourcecred/git-beta",
-        "type": "SUBMODULE_COMMIT",
-      },
-      "payload": Object {},
-      "src": Object {
-        "id": "819fc546cea489476ce8dc90785e9ba7753d0a8f:pygravitydefier",
-        "pluginName": "sourcecred/git-beta",
-        "type": "TREE_ENTRY",
-      },
-    },
-    "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"819fc546cea489476ce8dc90785e9ba7753d0a8f:science.txt\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/git-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"TREE_ENTRY\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"f1f2514ca6d7a6a1a0511957021b1995bf9ace1c\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/git-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"BLOB\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"type\\":\\"HAS_CONTENTS\\"}": Object {
-      "dst": Object {
-        "id": "f1f2514ca6d7a6a1a0511957021b1995bf9ace1c",
-        "pluginName": "sourcecred/git-beta",
-        "type": "BLOB",
-      },
-      "payload": Object {},
-      "src": Object {
-        "id": "819fc546cea489476ce8dc90785e9ba7753d0a8f:science.txt",
-        "pluginName": "sourcecred/git-beta",
-        "type": "TREE_ENTRY",
-      },
-    },
-    "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"819fc546cea489476ce8dc90785e9ba7753d0a8f:src\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/git-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"TREE_ENTRY\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"7b79d579b62994faba3b69fdf8aa442586c32681\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/git-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"TREE\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"type\\":\\"HAS_CONTENTS\\"}": Object {
-      "dst": Object {
-        "id": "7b79d579b62994faba3b69fdf8aa442586c32681",
-        "pluginName": "sourcecred/git-beta",
-        "type": "TREE",
-      },
-      "payload": Object {},
-      "src": Object {
-        "id": "819fc546cea489476ce8dc90785e9ba7753d0a8f:src",
-        "pluginName": "sourcecred/git-beta",
-        "type": "TREE_ENTRY",
-      },
-    },
-    "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"8d287c3bfbf8455ef30187bf5153ffc1b6eef268\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/git-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"COMMIT\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"3dfb84795e07341b05fad3a0d5a55f8304b2d7d8\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/git-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"TREE\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"type\\":\\"HAS_TREE\\"}": Object {
-      "dst": Object {
-        "id": "3dfb84795e07341b05fad3a0d5a55f8304b2d7d8",
-        "pluginName": "sourcecred/git-beta",
-        "type": "TREE",
-      },
-      "payload": Object {},
-      "src": Object {
-        "id": "8d287c3bfbf8455ef30187bf5153ffc1b6eef268",
-        "pluginName": "sourcecred/git-beta",
-        "type": "COMMIT",
-      },
-    },
-    "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"bbf3b8b3d26a4f884b5c022d46851f593d329192:.gitmodules\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/git-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"TREE_ENTRY\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"8c6cac301e763aa6d36466e0a775eb804be2c311\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/git-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"BLOB\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"type\\":\\"HAS_CONTENTS\\"}": Object {
-      "dst": Object {
-        "id": "8c6cac301e763aa6d36466e0a775eb804be2c311",
-        "pluginName": "sourcecred/git-beta",
-        "type": "BLOB",
-      },
-      "payload": Object {},
-      "src": Object {
-        "id": "bbf3b8b3d26a4f884b5c022d46851f593d329192:.gitmodules",
-        "pluginName": "sourcecred/git-beta",
-        "type": "TREE_ENTRY",
-      },
-    },
-    "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"bbf3b8b3d26a4f884b5c022d46851f593d329192:README.txt\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/git-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"TREE_ENTRY\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"0fb31858c8e3710be77e1dbb8880acf8a5543d82\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/git-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"BLOB\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"type\\":\\"HAS_CONTENTS\\"}": Object {
-      "dst": Object {
-        "id": "0fb31858c8e3710be77e1dbb8880acf8a5543d82",
-        "pluginName": "sourcecred/git-beta",
-        "type": "BLOB",
-      },
-      "payload": Object {},
-      "src": Object {
-        "id": "bbf3b8b3d26a4f884b5c022d46851f593d329192:README.txt",
-        "pluginName": "sourcecred/git-beta",
-        "type": "TREE_ENTRY",
-      },
-    },
-    "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"bbf3b8b3d26a4f884b5c022d46851f593d329192:TODOS.txt\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/git-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"TREE_ENTRY\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"ddec7477206c30c31b81482e56b877a0b3c2638b\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/git-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"BLOB\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"type\\":\\"HAS_CONTENTS\\"}": Object {
-      "dst": Object {
-        "id": "ddec7477206c30c31b81482e56b877a0b3c2638b",
-        "pluginName": "sourcecred/git-beta",
-        "type": "BLOB",
-      },
-      "payload": Object {},
-      "src": Object {
-        "id": "bbf3b8b3d26a4f884b5c022d46851f593d329192:TODOS.txt",
-        "pluginName": "sourcecred/git-beta",
-        "type": "TREE_ENTRY",
-      },
-    },
-    "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"bbf3b8b3d26a4f884b5c022d46851f593d329192:pygravitydefier\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/git-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"TREE_ENTRY\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-git-submodule.git@29ef158bc982733e2ba429fcf73e2f7562244188\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/git-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"SUBMODULE_COMMIT\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"type\\":\\"HAS_CONTENTS\\"}": Object {
-      "dst": Object {
-        "id": "https://github.com/sourcecred/example-git-submodule.git@29ef158bc982733e2ba429fcf73e2f7562244188",
-        "pluginName": "sourcecred/git-beta",
-        "type": "SUBMODULE_COMMIT",
-      },
-      "payload": Object {},
-      "src": Object {
-        "id": "bbf3b8b3d26a4f884b5c022d46851f593d329192:pygravitydefier",
-        "pluginName": "sourcecred/git-beta",
-        "type": "TREE_ENTRY",
-      },
-    },
-    "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"bbf3b8b3d26a4f884b5c022d46851f593d329192:science.txt\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/git-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"TREE_ENTRY\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"f1f2514ca6d7a6a1a0511957021b1995bf9ace1c\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/git-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"BLOB\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"type\\":\\"HAS_CONTENTS\\"}": Object {
-      "dst": Object {
-        "id": "f1f2514ca6d7a6a1a0511957021b1995bf9ace1c",
-        "pluginName": "sourcecred/git-beta",
-        "type": "BLOB",
-      },
-      "payload": Object {},
-      "src": Object {
-        "id": "bbf3b8b3d26a4f884b5c022d46851f593d329192:science.txt",
-        "pluginName": "sourcecred/git-beta",
-        "type": "TREE_ENTRY",
-      },
-    },
-    "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"bbf3b8b3d26a4f884b5c022d46851f593d329192:src\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/git-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"TREE_ENTRY\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"78fc9c83023386854c6bfdc5761c0e58f68e226f\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/git-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"TREE\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"type\\":\\"HAS_CONTENTS\\"}": Object {
-      "dst": Object {
-        "id": "78fc9c83023386854c6bfdc5761c0e58f68e226f",
-        "pluginName": "sourcecred/git-beta",
-        "type": "TREE",
-      },
-      "payload": Object {},
-      "src": Object {
-        "id": "bbf3b8b3d26a4f884b5c022d46851f593d329192:src",
-        "pluginName": "sourcecred/git-beta",
-        "type": "TREE_ENTRY",
-      },
-    },
-    "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"bdff5d94193170015d6cbb549b7b630649428b1f:README.txt\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/git-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"TREE_ENTRY\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"0fb31858c8e3710be77e1dbb8880acf8a5543d82\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/git-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"BLOB\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"type\\":\\"HAS_CONTENTS\\"}": Object {
-      "dst": Object {
-        "id": "0fb31858c8e3710be77e1dbb8880acf8a5543d82",
-        "pluginName": "sourcecred/git-beta",
-        "type": "BLOB",
-      },
-      "payload": Object {},
-      "src": Object {
-        "id": "bdff5d94193170015d6cbb549b7b630649428b1f:README.txt",
-        "pluginName": "sourcecred/git-beta",
-        "type": "TREE_ENTRY",
-      },
-    },
-    "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"c08ee3a4edea384d5291ffcbf06724a13ed72325\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/git-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"COMMIT\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"2f7155e359fd0ecb96ffdca66fa45b6ed5792809\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/git-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"TREE\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"type\\":\\"HAS_TREE\\"}": Object {
-      "dst": Object {
-        "id": "2f7155e359fd0ecb96ffdca66fa45b6ed5792809",
-        "pluginName": "sourcecred/git-beta",
-        "type": "TREE",
-      },
-      "payload": Object {},
-      "src": Object {
-        "id": "c08ee3a4edea384d5291ffcbf06724a13ed72325",
-        "pluginName": "sourcecred/git-beta",
-        "type": "COMMIT",
-      },
-    },
-    "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"c2b51945e7457546912a8ce158ed9d294558d294\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/git-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"COMMIT\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"bdff5d94193170015d6cbb549b7b630649428b1f\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/git-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"TREE\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"type\\":\\"HAS_TREE\\"}": Object {
-      "dst": Object {
-        "id": "bdff5d94193170015d6cbb549b7b630649428b1f",
-        "pluginName": "sourcecred/git-beta",
-        "type": "TREE",
-      },
-      "payload": Object {},
-      "src": Object {
-        "id": "c2b51945e7457546912a8ce158ed9d294558d294",
-        "pluginName": "sourcecred/git-beta",
-        "type": "COMMIT",
-      },
-    },
-    "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"d160cca97611e9dfed642522ad44408d0292e8ea\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/git-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"COMMIT\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"569e1d383759903134df75230d63c0090196d4cb\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/git-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"TREE\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"type\\":\\"HAS_TREE\\"}": Object {
-      "dst": Object {
-        "id": "569e1d383759903134df75230d63c0090196d4cb",
-        "pluginName": "sourcecred/git-beta",
-        "type": "TREE",
-      },
-      "payload": Object {},
-      "src": Object {
-        "id": "d160cca97611e9dfed642522ad44408d0292e8ea",
-        "pluginName": "sourcecred/git-beta",
-        "type": "COMMIT",
-      },
-    },
-    "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"e8b7a8f19701cd5a25e4a097d513ead60e5f8bcc\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/git-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"COMMIT\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"819fc546cea489476ce8dc90785e9ba7753d0a8f\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/git-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"TREE\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"type\\":\\"HAS_TREE\\"}": Object {
-      "dst": Object {
-        "id": "819fc546cea489476ce8dc90785e9ba7753d0a8f",
-        "pluginName": "sourcecred/git-beta",
-        "type": "TREE",
-      },
-      "payload": Object {},
-      "src": Object {
-        "id": "e8b7a8f19701cd5a25e4a097d513ead60e5f8bcc",
-        "pluginName": "sourcecred/git-beta",
-        "type": "COMMIT",
-      },
-    },
-    "{\\"id\\":\\"bbf3b8b3d26a4f884b5c022d46851f593d329192:.gitmodules\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"type\\":\\"INCLUDES\\"}": Object {
-      "dst": Object {
-        "id": "bbf3b8b3d26a4f884b5c022d46851f593d329192:.gitmodules",
-        "pluginName": "sourcecred/git-beta",
-        "type": "TREE_ENTRY",
-      },
-      "payload": Object {
-        "name": ".gitmodules",
-      },
-      "src": Object {
-        "id": "bbf3b8b3d26a4f884b5c022d46851f593d329192",
-        "pluginName": "sourcecred/git-beta",
-        "type": "TREE",
-      },
-    },
-    "{\\"id\\":\\"bbf3b8b3d26a4f884b5c022d46851f593d329192:README.txt\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"type\\":\\"INCLUDES\\"}": Object {
-      "dst": Object {
-        "id": "bbf3b8b3d26a4f884b5c022d46851f593d329192:README.txt",
-        "pluginName": "sourcecred/git-beta",
-        "type": "TREE_ENTRY",
-      },
-      "payload": Object {
-        "name": "README.txt",
-      },
-      "src": Object {
-        "id": "bbf3b8b3d26a4f884b5c022d46851f593d329192",
-        "pluginName": "sourcecred/git-beta",
-        "type": "TREE",
-      },
-    },
-    "{\\"id\\":\\"bbf3b8b3d26a4f884b5c022d46851f593d329192:TODOS.txt\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"type\\":\\"INCLUDES\\"}": Object {
-      "dst": Object {
-        "id": "bbf3b8b3d26a4f884b5c022d46851f593d329192:TODOS.txt",
-        "pluginName": "sourcecred/git-beta",
-        "type": "TREE_ENTRY",
-      },
-      "payload": Object {
-        "name": "TODOS.txt",
-      },
-      "src": Object {
-        "id": "bbf3b8b3d26a4f884b5c022d46851f593d329192",
-        "pluginName": "sourcecred/git-beta",
-        "type": "TREE",
-      },
-    },
-    "{\\"id\\":\\"bbf3b8b3d26a4f884b5c022d46851f593d329192:pygravitydefier\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"type\\":\\"INCLUDES\\"}": Object {
-      "dst": Object {
-        "id": "bbf3b8b3d26a4f884b5c022d46851f593d329192:pygravitydefier",
-        "pluginName": "sourcecred/git-beta",
-        "type": "TREE_ENTRY",
-      },
-      "payload": Object {
-        "name": "pygravitydefier",
-      },
-      "src": Object {
-        "id": "bbf3b8b3d26a4f884b5c022d46851f593d329192",
-        "pluginName": "sourcecred/git-beta",
-        "type": "TREE",
-      },
-    },
-    "{\\"id\\":\\"bbf3b8b3d26a4f884b5c022d46851f593d329192:science.txt\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"type\\":\\"INCLUDES\\"}": Object {
-      "dst": Object {
-        "id": "bbf3b8b3d26a4f884b5c022d46851f593d329192:science.txt",
-        "pluginName": "sourcecred/git-beta",
-        "type": "TREE_ENTRY",
-      },
-      "payload": Object {
-        "name": "science.txt",
-      },
-      "src": Object {
-        "id": "bbf3b8b3d26a4f884b5c022d46851f593d329192",
-        "pluginName": "sourcecred/git-beta",
-        "type": "TREE",
-      },
-    },
-    "{\\"id\\":\\"bbf3b8b3d26a4f884b5c022d46851f593d329192:src\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"type\\":\\"INCLUDES\\"}": Object {
-      "dst": Object {
-        "id": "bbf3b8b3d26a4f884b5c022d46851f593d329192:src",
-        "pluginName": "sourcecred/git-beta",
-        "type": "TREE_ENTRY",
-      },
-      "payload": Object {
-        "name": "src",
-      },
-      "src": Object {
-        "id": "bbf3b8b3d26a4f884b5c022d46851f593d329192",
-        "pluginName": "sourcecred/git-beta",
-        "type": "TREE",
-      },
-    },
-    "{\\"id\\":\\"bdff5d94193170015d6cbb549b7b630649428b1f:README.txt\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"type\\":\\"INCLUDES\\"}": Object {
-      "dst": Object {
-        "id": "bdff5d94193170015d6cbb549b7b630649428b1f:README.txt",
-        "pluginName": "sourcecred/git-beta",
-        "type": "TREE_ENTRY",
-      },
-      "payload": Object {
-        "name": "README.txt",
-      },
-      "src": Object {
-        "id": "bdff5d94193170015d6cbb549b7b630649428b1f",
-        "pluginName": "sourcecred/git-beta",
-        "type": "TREE",
-      },
-    },
-    "{\\"id\\":\\"c08ee3a4edea384d5291ffcbf06724a13ed72325^1\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"type\\":\\"HAS_PARENT\\"}": Object {
-      "dst": Object {
-        "id": "c2b51945e7457546912a8ce158ed9d294558d294",
-        "pluginName": "sourcecred/git-beta",
-        "type": "COMMIT",
-      },
-      "payload": Object {
-        "parentIndex": 1,
-      },
-      "src": Object {
-        "id": "c08ee3a4edea384d5291ffcbf06724a13ed72325",
-        "pluginName": "sourcecred/git-beta",
-        "type": "COMMIT",
-      },
-    },
-    "{\\"id\\":\\"d160cca97611e9dfed642522ad44408d0292e8ea^1\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"type\\":\\"HAS_PARENT\\"}": Object {
-      "dst": Object {
-        "id": "8d287c3bfbf8455ef30187bf5153ffc1b6eef268",
-        "pluginName": "sourcecred/git-beta",
-        "type": "COMMIT",
-      },
-      "payload": Object {
-        "parentIndex": 1,
-      },
-      "src": Object {
-        "id": "d160cca97611e9dfed642522ad44408d0292e8ea",
-        "pluginName": "sourcecred/git-beta",
-        "type": "COMMIT",
-      },
-    },
-    "{\\"id\\":\\"e8b7a8f19701cd5a25e4a097d513ead60e5f8bcc^1\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"type\\":\\"HAS_PARENT\\"}": Object {
-      "dst": Object {
-        "id": "d160cca97611e9dfed642522ad44408d0292e8ea",
-        "pluginName": "sourcecred/git-beta",
-        "type": "COMMIT",
-      },
-      "payload": Object {
-        "parentIndex": 1,
-      },
-      "src": Object {
-        "id": "e8b7a8f19701cd5a25e4a097d513ead60e5f8bcc",
-        "pluginName": "sourcecred/git-beta",
-        "type": "COMMIT",
-      },
-    },
-    "{\\"id\\":\\"{\\\\\\"childCommit\\\\\\":\\\\\\"69c5aad50eec8f2a0a07c988c3b283a6490eb45b\\\\\\",\\\\\\"parentCommit\\\\\\":\\\\\\"e8b7a8f19701cd5a25e4a097d513ead60e5f8bcc\\\\\\",\\\\\\"path\\\\\\":[\\\\\\"src\\\\\\",\\\\\\"quantum_gravity.py\\\\\\"]}\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"type\\":\\"BECOMES\\"}": Object {
-      "dst": Object {
-        "id": "78fc9c83023386854c6bfdc5761c0e58f68e226f:quantum_gravity.py",
-        "pluginName": "sourcecred/git-beta",
-        "type": "TREE_ENTRY",
-      },
-      "payload": Object {
-        "childCommit": "69c5aad50eec8f2a0a07c988c3b283a6490eb45b",
-        "parentCommit": "e8b7a8f19701cd5a25e4a097d513ead60e5f8bcc",
-        "path": Array [
-          "src",
-          "quantum_gravity.py",
-        ],
-      },
-      "src": Object {
-        "id": "7b79d579b62994faba3b69fdf8aa442586c32681:quantum_gravity.py",
-        "pluginName": "sourcecred/git-beta",
-        "type": "TREE_ENTRY",
-      },
-    },
-    "{\\"id\\":\\"{\\\\\\"childCommit\\\\\\":\\\\\\"69c5aad50eec8f2a0a07c988c3b283a6490eb45b\\\\\\",\\\\\\"parentCommit\\\\\\":\\\\\\"e8b7a8f19701cd5a25e4a097d513ead60e5f8bcc\\\\\\",\\\\\\"path\\\\\\":[\\\\\\"src\\\\\\"]}\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"type\\":\\"BECOMES\\"}": Object {
-      "dst": Object {
-        "id": "bbf3b8b3d26a4f884b5c022d46851f593d329192:src",
-        "pluginName": "sourcecred/git-beta",
-        "type": "TREE_ENTRY",
-      },
-      "payload": Object {
-        "childCommit": "69c5aad50eec8f2a0a07c988c3b283a6490eb45b",
-        "parentCommit": "e8b7a8f19701cd5a25e4a097d513ead60e5f8bcc",
-        "path": Array [
-          "src",
-        ],
-      },
-      "src": Object {
-        "id": "819fc546cea489476ce8dc90785e9ba7753d0a8f:src",
-        "pluginName": "sourcecred/git-beta",
-        "type": "TREE_ENTRY",
-      },
-    },
-    "{\\"id\\":\\"{\\\\\\"childCommit\\\\\\":\\\\\\"e8b7a8f19701cd5a25e4a097d513ead60e5f8bcc\\\\\\",\\\\\\"parentCommit\\\\\\":\\\\\\"d160cca97611e9dfed642522ad44408d0292e8ea\\\\\\",\\\\\\"path\\\\\\":[\\\\\\"pygravitydefier\\\\\\"]}\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"type\\":\\"BECOMES\\"}": Object {
-      "dst": Object {
-        "id": "819fc546cea489476ce8dc90785e9ba7753d0a8f:pygravitydefier",
-        "pluginName": "sourcecred/git-beta",
-        "type": "TREE_ENTRY",
-      },
-      "payload": Object {
-        "childCommit": "e8b7a8f19701cd5a25e4a097d513ead60e5f8bcc",
-        "parentCommit": "d160cca97611e9dfed642522ad44408d0292e8ea",
-        "path": Array [
-          "pygravitydefier",
-        ],
-      },
-      "src": Object {
-        "id": "569e1d383759903134df75230d63c0090196d4cb:pygravitydefier",
-        "pluginName": "sourcecred/git-beta",
-        "type": "TREE_ENTRY",
-      },
-    },
+Array [
+  Object {
+    "type": "sourcecred/sourcecred/Graph",
+    "version": "0.1.0",
   },
-  "nodes": Object {
-    "{\\"id\\":\\"0fb31858c8e3710be77e1dbb8880acf8a5543d82\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"type\\":\\"BLOB\\"}": Object {
-      "payload": Object {},
-    },
-    "{\\"id\\":\\"2f7155e359fd0ecb96ffdca66fa45b6ed5792809\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"type\\":\\"TREE\\"}": Object {
-      "payload": Object {},
-    },
-    "{\\"id\\":\\"2f7155e359fd0ecb96ffdca66fa45b6ed5792809:README.txt\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"type\\":\\"TREE_ENTRY\\"}": Object {
-      "payload": Object {
-        "name": "README.txt",
+  Object {
+    "edges": Array [
+      Object {
+        "type": "sourcecred/sourcecred/AddressMap",
+        "version": "0.1.0",
       },
-    },
-    "{\\"id\\":\\"2f7155e359fd0ecb96ffdca66fa45b6ed5792809:science.txt\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"type\\":\\"TREE_ENTRY\\"}": Object {
-      "payload": Object {
-        "name": "science.txt",
+      Object {
+        "{\\"id\\":\\"2f7155e359fd0ecb96ffdca66fa45b6ed5792809:README.txt\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"type\\":\\"INCLUDES\\"}": Object {
+          "dst": Object {
+            "id": "2f7155e359fd0ecb96ffdca66fa45b6ed5792809:README.txt",
+            "pluginName": "sourcecred/git-beta",
+            "type": "TREE_ENTRY",
+          },
+          "payload": Object {
+            "name": "README.txt",
+          },
+          "src": Object {
+            "id": "2f7155e359fd0ecb96ffdca66fa45b6ed5792809",
+            "pluginName": "sourcecred/git-beta",
+            "type": "TREE",
+          },
+        },
+        "{\\"id\\":\\"2f7155e359fd0ecb96ffdca66fa45b6ed5792809:science.txt\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"type\\":\\"INCLUDES\\"}": Object {
+          "dst": Object {
+            "id": "2f7155e359fd0ecb96ffdca66fa45b6ed5792809:science.txt",
+            "pluginName": "sourcecred/git-beta",
+            "type": "TREE_ENTRY",
+          },
+          "payload": Object {
+            "name": "science.txt",
+          },
+          "src": Object {
+            "id": "2f7155e359fd0ecb96ffdca66fa45b6ed5792809",
+            "pluginName": "sourcecred/git-beta",
+            "type": "TREE",
+          },
+        },
+        "{\\"id\\":\\"3715ddfb8d4c4fd2a6f6af75488c82f84c92ec2f^1\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"type\\":\\"HAS_PARENT\\"}": Object {
+          "dst": Object {
+            "id": "69c5aad50eec8f2a0a07c988c3b283a6490eb45b",
+            "pluginName": "sourcecred/git-beta",
+            "type": "COMMIT",
+          },
+          "payload": Object {
+            "parentIndex": 1,
+          },
+          "src": Object {
+            "id": "3715ddfb8d4c4fd2a6f6af75488c82f84c92ec2f",
+            "pluginName": "sourcecred/git-beta",
+            "type": "COMMIT",
+          },
+        },
+        "{\\"id\\":\\"3dfb84795e07341b05fad3a0d5a55f8304b2d7d8:.gitmodules\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"type\\":\\"INCLUDES\\"}": Object {
+          "dst": Object {
+            "id": "3dfb84795e07341b05fad3a0d5a55f8304b2d7d8:.gitmodules",
+            "pluginName": "sourcecred/git-beta",
+            "type": "TREE_ENTRY",
+          },
+          "payload": Object {
+            "name": ".gitmodules",
+          },
+          "src": Object {
+            "id": "3dfb84795e07341b05fad3a0d5a55f8304b2d7d8",
+            "pluginName": "sourcecred/git-beta",
+            "type": "TREE",
+          },
+        },
+        "{\\"id\\":\\"3dfb84795e07341b05fad3a0d5a55f8304b2d7d8:README.txt\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"type\\":\\"INCLUDES\\"}": Object {
+          "dst": Object {
+            "id": "3dfb84795e07341b05fad3a0d5a55f8304b2d7d8:README.txt",
+            "pluginName": "sourcecred/git-beta",
+            "type": "TREE_ENTRY",
+          },
+          "payload": Object {
+            "name": "README.txt",
+          },
+          "src": Object {
+            "id": "3dfb84795e07341b05fad3a0d5a55f8304b2d7d8",
+            "pluginName": "sourcecred/git-beta",
+            "type": "TREE",
+          },
+        },
+        "{\\"id\\":\\"3dfb84795e07341b05fad3a0d5a55f8304b2d7d8:pygravitydefier\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"type\\":\\"INCLUDES\\"}": Object {
+          "dst": Object {
+            "id": "3dfb84795e07341b05fad3a0d5a55f8304b2d7d8:pygravitydefier",
+            "pluginName": "sourcecred/git-beta",
+            "type": "TREE_ENTRY",
+          },
+          "payload": Object {
+            "name": "pygravitydefier",
+          },
+          "src": Object {
+            "id": "3dfb84795e07341b05fad3a0d5a55f8304b2d7d8",
+            "pluginName": "sourcecred/git-beta",
+            "type": "TREE",
+          },
+        },
+        "{\\"id\\":\\"3dfb84795e07341b05fad3a0d5a55f8304b2d7d8:science.txt\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"type\\":\\"INCLUDES\\"}": Object {
+          "dst": Object {
+            "id": "3dfb84795e07341b05fad3a0d5a55f8304b2d7d8:science.txt",
+            "pluginName": "sourcecred/git-beta",
+            "type": "TREE_ENTRY",
+          },
+          "payload": Object {
+            "name": "science.txt",
+          },
+          "src": Object {
+            "id": "3dfb84795e07341b05fad3a0d5a55f8304b2d7d8",
+            "pluginName": "sourcecred/git-beta",
+            "type": "TREE",
+          },
+        },
+        "{\\"id\\":\\"569e1d383759903134df75230d63c0090196d4cb:.gitmodules\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"type\\":\\"INCLUDES\\"}": Object {
+          "dst": Object {
+            "id": "569e1d383759903134df75230d63c0090196d4cb:.gitmodules",
+            "pluginName": "sourcecred/git-beta",
+            "type": "TREE_ENTRY",
+          },
+          "payload": Object {
+            "name": ".gitmodules",
+          },
+          "src": Object {
+            "id": "569e1d383759903134df75230d63c0090196d4cb",
+            "pluginName": "sourcecred/git-beta",
+            "type": "TREE",
+          },
+        },
+        "{\\"id\\":\\"569e1d383759903134df75230d63c0090196d4cb:README.txt\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"type\\":\\"INCLUDES\\"}": Object {
+          "dst": Object {
+            "id": "569e1d383759903134df75230d63c0090196d4cb:README.txt",
+            "pluginName": "sourcecred/git-beta",
+            "type": "TREE_ENTRY",
+          },
+          "payload": Object {
+            "name": "README.txt",
+          },
+          "src": Object {
+            "id": "569e1d383759903134df75230d63c0090196d4cb",
+            "pluginName": "sourcecred/git-beta",
+            "type": "TREE",
+          },
+        },
+        "{\\"id\\":\\"569e1d383759903134df75230d63c0090196d4cb:TODOS.txt\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"type\\":\\"INCLUDES\\"}": Object {
+          "dst": Object {
+            "id": "569e1d383759903134df75230d63c0090196d4cb:TODOS.txt",
+            "pluginName": "sourcecred/git-beta",
+            "type": "TREE_ENTRY",
+          },
+          "payload": Object {
+            "name": "TODOS.txt",
+          },
+          "src": Object {
+            "id": "569e1d383759903134df75230d63c0090196d4cb",
+            "pluginName": "sourcecred/git-beta",
+            "type": "TREE",
+          },
+        },
+        "{\\"id\\":\\"569e1d383759903134df75230d63c0090196d4cb:pygravitydefier\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"type\\":\\"INCLUDES\\"}": Object {
+          "dst": Object {
+            "id": "569e1d383759903134df75230d63c0090196d4cb:pygravitydefier",
+            "pluginName": "sourcecred/git-beta",
+            "type": "TREE_ENTRY",
+          },
+          "payload": Object {
+            "name": "pygravitydefier",
+          },
+          "src": Object {
+            "id": "569e1d383759903134df75230d63c0090196d4cb",
+            "pluginName": "sourcecred/git-beta",
+            "type": "TREE",
+          },
+        },
+        "{\\"id\\":\\"569e1d383759903134df75230d63c0090196d4cb:science.txt\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"type\\":\\"INCLUDES\\"}": Object {
+          "dst": Object {
+            "id": "569e1d383759903134df75230d63c0090196d4cb:science.txt",
+            "pluginName": "sourcecred/git-beta",
+            "type": "TREE_ENTRY",
+          },
+          "payload": Object {
+            "name": "science.txt",
+          },
+          "src": Object {
+            "id": "569e1d383759903134df75230d63c0090196d4cb",
+            "pluginName": "sourcecred/git-beta",
+            "type": "TREE",
+          },
+        },
+        "{\\"id\\":\\"569e1d383759903134df75230d63c0090196d4cb:src\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"type\\":\\"INCLUDES\\"}": Object {
+          "dst": Object {
+            "id": "569e1d383759903134df75230d63c0090196d4cb:src",
+            "pluginName": "sourcecred/git-beta",
+            "type": "TREE_ENTRY",
+          },
+          "payload": Object {
+            "name": "src",
+          },
+          "src": Object {
+            "id": "569e1d383759903134df75230d63c0090196d4cb",
+            "pluginName": "sourcecred/git-beta",
+            "type": "TREE",
+          },
+        },
+        "{\\"id\\":\\"69c5aad50eec8f2a0a07c988c3b283a6490eb45b^1\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"type\\":\\"HAS_PARENT\\"}": Object {
+          "dst": Object {
+            "id": "e8b7a8f19701cd5a25e4a097d513ead60e5f8bcc",
+            "pluginName": "sourcecred/git-beta",
+            "type": "COMMIT",
+          },
+          "payload": Object {
+            "parentIndex": 1,
+          },
+          "src": Object {
+            "id": "69c5aad50eec8f2a0a07c988c3b283a6490eb45b",
+            "pluginName": "sourcecred/git-beta",
+            "type": "COMMIT",
+          },
+        },
+        "{\\"id\\":\\"78fc9c83023386854c6bfdc5761c0e58f68e226f:index.py\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"type\\":\\"INCLUDES\\"}": Object {
+          "dst": Object {
+            "id": "78fc9c83023386854c6bfdc5761c0e58f68e226f:index.py",
+            "pluginName": "sourcecred/git-beta",
+            "type": "TREE_ENTRY",
+          },
+          "payload": Object {
+            "name": "index.py",
+          },
+          "src": Object {
+            "id": "78fc9c83023386854c6bfdc5761c0e58f68e226f",
+            "pluginName": "sourcecred/git-beta",
+            "type": "TREE",
+          },
+        },
+        "{\\"id\\":\\"78fc9c83023386854c6bfdc5761c0e58f68e226f:quantum_gravity.py\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"type\\":\\"INCLUDES\\"}": Object {
+          "dst": Object {
+            "id": "78fc9c83023386854c6bfdc5761c0e58f68e226f:quantum_gravity.py",
+            "pluginName": "sourcecred/git-beta",
+            "type": "TREE_ENTRY",
+          },
+          "payload": Object {
+            "name": "quantum_gravity.py",
+          },
+          "src": Object {
+            "id": "78fc9c83023386854c6bfdc5761c0e58f68e226f",
+            "pluginName": "sourcecred/git-beta",
+            "type": "TREE",
+          },
+        },
+        "{\\"id\\":\\"7b79d579b62994faba3b69fdf8aa442586c32681:index.py\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"type\\":\\"INCLUDES\\"}": Object {
+          "dst": Object {
+            "id": "7b79d579b62994faba3b69fdf8aa442586c32681:index.py",
+            "pluginName": "sourcecred/git-beta",
+            "type": "TREE_ENTRY",
+          },
+          "payload": Object {
+            "name": "index.py",
+          },
+          "src": Object {
+            "id": "7b79d579b62994faba3b69fdf8aa442586c32681",
+            "pluginName": "sourcecred/git-beta",
+            "type": "TREE",
+          },
+        },
+        "{\\"id\\":\\"7b79d579b62994faba3b69fdf8aa442586c32681:quantum_gravity.py\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"type\\":\\"INCLUDES\\"}": Object {
+          "dst": Object {
+            "id": "7b79d579b62994faba3b69fdf8aa442586c32681:quantum_gravity.py",
+            "pluginName": "sourcecred/git-beta",
+            "type": "TREE_ENTRY",
+          },
+          "payload": Object {
+            "name": "quantum_gravity.py",
+          },
+          "src": Object {
+            "id": "7b79d579b62994faba3b69fdf8aa442586c32681",
+            "pluginName": "sourcecred/git-beta",
+            "type": "TREE",
+          },
+        },
+        "{\\"id\\":\\"7be3ecfee5314ffa9b2d93fc4377792b2d6d70ed:.gitmodules\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"type\\":\\"INCLUDES\\"}": Object {
+          "dst": Object {
+            "id": "7be3ecfee5314ffa9b2d93fc4377792b2d6d70ed:.gitmodules",
+            "pluginName": "sourcecred/git-beta",
+            "type": "TREE_ENTRY",
+          },
+          "payload": Object {
+            "name": ".gitmodules",
+          },
+          "src": Object {
+            "id": "7be3ecfee5314ffa9b2d93fc4377792b2d6d70ed",
+            "pluginName": "sourcecred/git-beta",
+            "type": "TREE",
+          },
+        },
+        "{\\"id\\":\\"7be3ecfee5314ffa9b2d93fc4377792b2d6d70ed:README.txt\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"type\\":\\"INCLUDES\\"}": Object {
+          "dst": Object {
+            "id": "7be3ecfee5314ffa9b2d93fc4377792b2d6d70ed:README.txt",
+            "pluginName": "sourcecred/git-beta",
+            "type": "TREE_ENTRY",
+          },
+          "payload": Object {
+            "name": "README.txt",
+          },
+          "src": Object {
+            "id": "7be3ecfee5314ffa9b2d93fc4377792b2d6d70ed",
+            "pluginName": "sourcecred/git-beta",
+            "type": "TREE",
+          },
+        },
+        "{\\"id\\":\\"7be3ecfee5314ffa9b2d93fc4377792b2d6d70ed:pygravitydefier\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"type\\":\\"INCLUDES\\"}": Object {
+          "dst": Object {
+            "id": "7be3ecfee5314ffa9b2d93fc4377792b2d6d70ed:pygravitydefier",
+            "pluginName": "sourcecred/git-beta",
+            "type": "TREE_ENTRY",
+          },
+          "payload": Object {
+            "name": "pygravitydefier",
+          },
+          "src": Object {
+            "id": "7be3ecfee5314ffa9b2d93fc4377792b2d6d70ed",
+            "pluginName": "sourcecred/git-beta",
+            "type": "TREE",
+          },
+        },
+        "{\\"id\\":\\"7be3ecfee5314ffa9b2d93fc4377792b2d6d70ed:science.txt\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"type\\":\\"INCLUDES\\"}": Object {
+          "dst": Object {
+            "id": "7be3ecfee5314ffa9b2d93fc4377792b2d6d70ed:science.txt",
+            "pluginName": "sourcecred/git-beta",
+            "type": "TREE_ENTRY",
+          },
+          "payload": Object {
+            "name": "science.txt",
+          },
+          "src": Object {
+            "id": "7be3ecfee5314ffa9b2d93fc4377792b2d6d70ed",
+            "pluginName": "sourcecred/git-beta",
+            "type": "TREE",
+          },
+        },
+        "{\\"id\\":\\"7be3ecfee5314ffa9b2d93fc4377792b2d6d70ed:src\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"type\\":\\"INCLUDES\\"}": Object {
+          "dst": Object {
+            "id": "7be3ecfee5314ffa9b2d93fc4377792b2d6d70ed:src",
+            "pluginName": "sourcecred/git-beta",
+            "type": "TREE_ENTRY",
+          },
+          "payload": Object {
+            "name": "src",
+          },
+          "src": Object {
+            "id": "7be3ecfee5314ffa9b2d93fc4377792b2d6d70ed",
+            "pluginName": "sourcecred/git-beta",
+            "type": "TREE",
+          },
+        },
+        "{\\"id\\":\\"819fc546cea489476ce8dc90785e9ba7753d0a8f:.gitmodules\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"type\\":\\"INCLUDES\\"}": Object {
+          "dst": Object {
+            "id": "819fc546cea489476ce8dc90785e9ba7753d0a8f:.gitmodules",
+            "pluginName": "sourcecred/git-beta",
+            "type": "TREE_ENTRY",
+          },
+          "payload": Object {
+            "name": ".gitmodules",
+          },
+          "src": Object {
+            "id": "819fc546cea489476ce8dc90785e9ba7753d0a8f",
+            "pluginName": "sourcecred/git-beta",
+            "type": "TREE",
+          },
+        },
+        "{\\"id\\":\\"819fc546cea489476ce8dc90785e9ba7753d0a8f:README.txt\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"type\\":\\"INCLUDES\\"}": Object {
+          "dst": Object {
+            "id": "819fc546cea489476ce8dc90785e9ba7753d0a8f:README.txt",
+            "pluginName": "sourcecred/git-beta",
+            "type": "TREE_ENTRY",
+          },
+          "payload": Object {
+            "name": "README.txt",
+          },
+          "src": Object {
+            "id": "819fc546cea489476ce8dc90785e9ba7753d0a8f",
+            "pluginName": "sourcecred/git-beta",
+            "type": "TREE",
+          },
+        },
+        "{\\"id\\":\\"819fc546cea489476ce8dc90785e9ba7753d0a8f:TODOS.txt\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"type\\":\\"INCLUDES\\"}": Object {
+          "dst": Object {
+            "id": "819fc546cea489476ce8dc90785e9ba7753d0a8f:TODOS.txt",
+            "pluginName": "sourcecred/git-beta",
+            "type": "TREE_ENTRY",
+          },
+          "payload": Object {
+            "name": "TODOS.txt",
+          },
+          "src": Object {
+            "id": "819fc546cea489476ce8dc90785e9ba7753d0a8f",
+            "pluginName": "sourcecred/git-beta",
+            "type": "TREE",
+          },
+        },
+        "{\\"id\\":\\"819fc546cea489476ce8dc90785e9ba7753d0a8f:pygravitydefier\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"type\\":\\"INCLUDES\\"}": Object {
+          "dst": Object {
+            "id": "819fc546cea489476ce8dc90785e9ba7753d0a8f:pygravitydefier",
+            "pluginName": "sourcecred/git-beta",
+            "type": "TREE_ENTRY",
+          },
+          "payload": Object {
+            "name": "pygravitydefier",
+          },
+          "src": Object {
+            "id": "819fc546cea489476ce8dc90785e9ba7753d0a8f",
+            "pluginName": "sourcecred/git-beta",
+            "type": "TREE",
+          },
+        },
+        "{\\"id\\":\\"819fc546cea489476ce8dc90785e9ba7753d0a8f:science.txt\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"type\\":\\"INCLUDES\\"}": Object {
+          "dst": Object {
+            "id": "819fc546cea489476ce8dc90785e9ba7753d0a8f:science.txt",
+            "pluginName": "sourcecred/git-beta",
+            "type": "TREE_ENTRY",
+          },
+          "payload": Object {
+            "name": "science.txt",
+          },
+          "src": Object {
+            "id": "819fc546cea489476ce8dc90785e9ba7753d0a8f",
+            "pluginName": "sourcecred/git-beta",
+            "type": "TREE",
+          },
+        },
+        "{\\"id\\":\\"819fc546cea489476ce8dc90785e9ba7753d0a8f:src\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"type\\":\\"INCLUDES\\"}": Object {
+          "dst": Object {
+            "id": "819fc546cea489476ce8dc90785e9ba7753d0a8f:src",
+            "pluginName": "sourcecred/git-beta",
+            "type": "TREE_ENTRY",
+          },
+          "payload": Object {
+            "name": "src",
+          },
+          "src": Object {
+            "id": "819fc546cea489476ce8dc90785e9ba7753d0a8f",
+            "pluginName": "sourcecred/git-beta",
+            "type": "TREE",
+          },
+        },
+        "{\\"id\\":\\"8d287c3bfbf8455ef30187bf5153ffc1b6eef268^1\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"type\\":\\"HAS_PARENT\\"}": Object {
+          "dst": Object {
+            "id": "c08ee3a4edea384d5291ffcbf06724a13ed72325",
+            "pluginName": "sourcecred/git-beta",
+            "type": "COMMIT",
+          },
+          "payload": Object {
+            "parentIndex": 1,
+          },
+          "src": Object {
+            "id": "8d287c3bfbf8455ef30187bf5153ffc1b6eef268",
+            "pluginName": "sourcecred/git-beta",
+            "type": "COMMIT",
+          },
+        },
+        "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"2f7155e359fd0ecb96ffdca66fa45b6ed5792809:README.txt\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/git-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"TREE_ENTRY\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"0fb31858c8e3710be77e1dbb8880acf8a5543d82\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/git-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"BLOB\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"type\\":\\"HAS_CONTENTS\\"}": Object {
+          "dst": Object {
+            "id": "0fb31858c8e3710be77e1dbb8880acf8a5543d82",
+            "pluginName": "sourcecred/git-beta",
+            "type": "BLOB",
+          },
+          "payload": Object {},
+          "src": Object {
+            "id": "2f7155e359fd0ecb96ffdca66fa45b6ed5792809:README.txt",
+            "pluginName": "sourcecred/git-beta",
+            "type": "TREE_ENTRY",
+          },
+        },
+        "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"2f7155e359fd0ecb96ffdca66fa45b6ed5792809:science.txt\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/git-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"TREE_ENTRY\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"f1f2514ca6d7a6a1a0511957021b1995bf9ace1c\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/git-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"BLOB\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"type\\":\\"HAS_CONTENTS\\"}": Object {
+          "dst": Object {
+            "id": "f1f2514ca6d7a6a1a0511957021b1995bf9ace1c",
+            "pluginName": "sourcecred/git-beta",
+            "type": "BLOB",
+          },
+          "payload": Object {},
+          "src": Object {
+            "id": "2f7155e359fd0ecb96ffdca66fa45b6ed5792809:science.txt",
+            "pluginName": "sourcecred/git-beta",
+            "type": "TREE_ENTRY",
+          },
+        },
+        "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"3715ddfb8d4c4fd2a6f6af75488c82f84c92ec2f\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/git-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"COMMIT\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"7be3ecfee5314ffa9b2d93fc4377792b2d6d70ed\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/git-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"TREE\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"type\\":\\"HAS_TREE\\"}": Object {
+          "dst": Object {
+            "id": "7be3ecfee5314ffa9b2d93fc4377792b2d6d70ed",
+            "pluginName": "sourcecred/git-beta",
+            "type": "TREE",
+          },
+          "payload": Object {},
+          "src": Object {
+            "id": "3715ddfb8d4c4fd2a6f6af75488c82f84c92ec2f",
+            "pluginName": "sourcecred/git-beta",
+            "type": "COMMIT",
+          },
+        },
+        "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"3dfb84795e07341b05fad3a0d5a55f8304b2d7d8:.gitmodules\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/git-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"TREE_ENTRY\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"8c6cac301e763aa6d36466e0a775eb804be2c311\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/git-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"BLOB\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"type\\":\\"HAS_CONTENTS\\"}": Object {
+          "dst": Object {
+            "id": "8c6cac301e763aa6d36466e0a775eb804be2c311",
+            "pluginName": "sourcecred/git-beta",
+            "type": "BLOB",
+          },
+          "payload": Object {},
+          "src": Object {
+            "id": "3dfb84795e07341b05fad3a0d5a55f8304b2d7d8:.gitmodules",
+            "pluginName": "sourcecred/git-beta",
+            "type": "TREE_ENTRY",
+          },
+        },
+        "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"3dfb84795e07341b05fad3a0d5a55f8304b2d7d8:README.txt\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/git-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"TREE_ENTRY\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"0fb31858c8e3710be77e1dbb8880acf8a5543d82\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/git-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"BLOB\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"type\\":\\"HAS_CONTENTS\\"}": Object {
+          "dst": Object {
+            "id": "0fb31858c8e3710be77e1dbb8880acf8a5543d82",
+            "pluginName": "sourcecred/git-beta",
+            "type": "BLOB",
+          },
+          "payload": Object {},
+          "src": Object {
+            "id": "3dfb84795e07341b05fad3a0d5a55f8304b2d7d8:README.txt",
+            "pluginName": "sourcecred/git-beta",
+            "type": "TREE_ENTRY",
+          },
+        },
+        "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"3dfb84795e07341b05fad3a0d5a55f8304b2d7d8:pygravitydefier\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/git-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"TREE_ENTRY\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-git-submodule.git@762c062fbdc7ec198cd693e95d55b374a08ff3e3\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/git-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"SUBMODULE_COMMIT\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"type\\":\\"HAS_CONTENTS\\"}": Object {
+          "dst": Object {
+            "id": "https://github.com/sourcecred/example-git-submodule.git@762c062fbdc7ec198cd693e95d55b374a08ff3e3",
+            "pluginName": "sourcecred/git-beta",
+            "type": "SUBMODULE_COMMIT",
+          },
+          "payload": Object {},
+          "src": Object {
+            "id": "3dfb84795e07341b05fad3a0d5a55f8304b2d7d8:pygravitydefier",
+            "pluginName": "sourcecred/git-beta",
+            "type": "TREE_ENTRY",
+          },
+        },
+        "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"3dfb84795e07341b05fad3a0d5a55f8304b2d7d8:science.txt\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/git-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"TREE_ENTRY\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"f1f2514ca6d7a6a1a0511957021b1995bf9ace1c\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/git-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"BLOB\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"type\\":\\"HAS_CONTENTS\\"}": Object {
+          "dst": Object {
+            "id": "f1f2514ca6d7a6a1a0511957021b1995bf9ace1c",
+            "pluginName": "sourcecred/git-beta",
+            "type": "BLOB",
+          },
+          "payload": Object {},
+          "src": Object {
+            "id": "3dfb84795e07341b05fad3a0d5a55f8304b2d7d8:science.txt",
+            "pluginName": "sourcecred/git-beta",
+            "type": "TREE_ENTRY",
+          },
+        },
+        "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"569e1d383759903134df75230d63c0090196d4cb:.gitmodules\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/git-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"TREE_ENTRY\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"8c6cac301e763aa6d36466e0a775eb804be2c311\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/git-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"BLOB\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"type\\":\\"HAS_CONTENTS\\"}": Object {
+          "dst": Object {
+            "id": "8c6cac301e763aa6d36466e0a775eb804be2c311",
+            "pluginName": "sourcecred/git-beta",
+            "type": "BLOB",
+          },
+          "payload": Object {},
+          "src": Object {
+            "id": "569e1d383759903134df75230d63c0090196d4cb:.gitmodules",
+            "pluginName": "sourcecred/git-beta",
+            "type": "TREE_ENTRY",
+          },
+        },
+        "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"569e1d383759903134df75230d63c0090196d4cb:README.txt\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/git-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"TREE_ENTRY\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"0fb31858c8e3710be77e1dbb8880acf8a5543d82\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/git-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"BLOB\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"type\\":\\"HAS_CONTENTS\\"}": Object {
+          "dst": Object {
+            "id": "0fb31858c8e3710be77e1dbb8880acf8a5543d82",
+            "pluginName": "sourcecred/git-beta",
+            "type": "BLOB",
+          },
+          "payload": Object {},
+          "src": Object {
+            "id": "569e1d383759903134df75230d63c0090196d4cb:README.txt",
+            "pluginName": "sourcecred/git-beta",
+            "type": "TREE_ENTRY",
+          },
+        },
+        "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"569e1d383759903134df75230d63c0090196d4cb:TODOS.txt\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/git-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"TREE_ENTRY\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"ddec7477206c30c31b81482e56b877a0b3c2638b\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/git-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"BLOB\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"type\\":\\"HAS_CONTENTS\\"}": Object {
+          "dst": Object {
+            "id": "ddec7477206c30c31b81482e56b877a0b3c2638b",
+            "pluginName": "sourcecred/git-beta",
+            "type": "BLOB",
+          },
+          "payload": Object {},
+          "src": Object {
+            "id": "569e1d383759903134df75230d63c0090196d4cb:TODOS.txt",
+            "pluginName": "sourcecred/git-beta",
+            "type": "TREE_ENTRY",
+          },
+        },
+        "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"569e1d383759903134df75230d63c0090196d4cb:pygravitydefier\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/git-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"TREE_ENTRY\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-git-submodule.git@762c062fbdc7ec198cd693e95d55b374a08ff3e3\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/git-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"SUBMODULE_COMMIT\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"type\\":\\"HAS_CONTENTS\\"}": Object {
+          "dst": Object {
+            "id": "https://github.com/sourcecred/example-git-submodule.git@762c062fbdc7ec198cd693e95d55b374a08ff3e3",
+            "pluginName": "sourcecred/git-beta",
+            "type": "SUBMODULE_COMMIT",
+          },
+          "payload": Object {},
+          "src": Object {
+            "id": "569e1d383759903134df75230d63c0090196d4cb:pygravitydefier",
+            "pluginName": "sourcecred/git-beta",
+            "type": "TREE_ENTRY",
+          },
+        },
+        "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"569e1d383759903134df75230d63c0090196d4cb:science.txt\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/git-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"TREE_ENTRY\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"f1f2514ca6d7a6a1a0511957021b1995bf9ace1c\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/git-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"BLOB\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"type\\":\\"HAS_CONTENTS\\"}": Object {
+          "dst": Object {
+            "id": "f1f2514ca6d7a6a1a0511957021b1995bf9ace1c",
+            "pluginName": "sourcecred/git-beta",
+            "type": "BLOB",
+          },
+          "payload": Object {},
+          "src": Object {
+            "id": "569e1d383759903134df75230d63c0090196d4cb:science.txt",
+            "pluginName": "sourcecred/git-beta",
+            "type": "TREE_ENTRY",
+          },
+        },
+        "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"569e1d383759903134df75230d63c0090196d4cb:src\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/git-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"TREE_ENTRY\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"7b79d579b62994faba3b69fdf8aa442586c32681\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/git-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"TREE\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"type\\":\\"HAS_CONTENTS\\"}": Object {
+          "dst": Object {
+            "id": "7b79d579b62994faba3b69fdf8aa442586c32681",
+            "pluginName": "sourcecred/git-beta",
+            "type": "TREE",
+          },
+          "payload": Object {},
+          "src": Object {
+            "id": "569e1d383759903134df75230d63c0090196d4cb:src",
+            "pluginName": "sourcecred/git-beta",
+            "type": "TREE_ENTRY",
+          },
+        },
+        "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"69c5aad50eec8f2a0a07c988c3b283a6490eb45b\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/git-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"COMMIT\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"bbf3b8b3d26a4f884b5c022d46851f593d329192\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/git-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"TREE\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"type\\":\\"HAS_TREE\\"}": Object {
+          "dst": Object {
+            "id": "bbf3b8b3d26a4f884b5c022d46851f593d329192",
+            "pluginName": "sourcecred/git-beta",
+            "type": "TREE",
+          },
+          "payload": Object {},
+          "src": Object {
+            "id": "69c5aad50eec8f2a0a07c988c3b283a6490eb45b",
+            "pluginName": "sourcecred/git-beta",
+            "type": "COMMIT",
+          },
+        },
+        "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"78fc9c83023386854c6bfdc5761c0e58f68e226f:index.py\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/git-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"TREE_ENTRY\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"674b0b476989384510304846248b3acd16206782\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/git-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"BLOB\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"type\\":\\"HAS_CONTENTS\\"}": Object {
+          "dst": Object {
+            "id": "674b0b476989384510304846248b3acd16206782",
+            "pluginName": "sourcecred/git-beta",
+            "type": "BLOB",
+          },
+          "payload": Object {},
+          "src": Object {
+            "id": "78fc9c83023386854c6bfdc5761c0e58f68e226f:index.py",
+            "pluginName": "sourcecred/git-beta",
+            "type": "TREE_ENTRY",
+          },
+        },
+        "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"78fc9c83023386854c6bfdc5761c0e58f68e226f:quantum_gravity.py\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/git-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"TREE_ENTRY\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"aea4f28abb23abde151b0ead4063227f8bf6c0b0\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/git-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"BLOB\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"type\\":\\"HAS_CONTENTS\\"}": Object {
+          "dst": Object {
+            "id": "aea4f28abb23abde151b0ead4063227f8bf6c0b0",
+            "pluginName": "sourcecred/git-beta",
+            "type": "BLOB",
+          },
+          "payload": Object {},
+          "src": Object {
+            "id": "78fc9c83023386854c6bfdc5761c0e58f68e226f:quantum_gravity.py",
+            "pluginName": "sourcecred/git-beta",
+            "type": "TREE_ENTRY",
+          },
+        },
+        "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"7b79d579b62994faba3b69fdf8aa442586c32681:index.py\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/git-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"TREE_ENTRY\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"674b0b476989384510304846248b3acd16206782\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/git-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"BLOB\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"type\\":\\"HAS_CONTENTS\\"}": Object {
+          "dst": Object {
+            "id": "674b0b476989384510304846248b3acd16206782",
+            "pluginName": "sourcecred/git-beta",
+            "type": "BLOB",
+          },
+          "payload": Object {},
+          "src": Object {
+            "id": "7b79d579b62994faba3b69fdf8aa442586c32681:index.py",
+            "pluginName": "sourcecred/git-beta",
+            "type": "TREE_ENTRY",
+          },
+        },
+        "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"7b79d579b62994faba3b69fdf8aa442586c32681:quantum_gravity.py\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/git-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"TREE_ENTRY\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"887ad856bbc1373da146106c86cb581ad78cdafe\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/git-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"BLOB\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"type\\":\\"HAS_CONTENTS\\"}": Object {
+          "dst": Object {
+            "id": "887ad856bbc1373da146106c86cb581ad78cdafe",
+            "pluginName": "sourcecred/git-beta",
+            "type": "BLOB",
+          },
+          "payload": Object {},
+          "src": Object {
+            "id": "7b79d579b62994faba3b69fdf8aa442586c32681:quantum_gravity.py",
+            "pluginName": "sourcecred/git-beta",
+            "type": "TREE_ENTRY",
+          },
+        },
+        "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"7be3ecfee5314ffa9b2d93fc4377792b2d6d70ed:.gitmodules\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/git-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"TREE_ENTRY\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"8c6cac301e763aa6d36466e0a775eb804be2c311\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/git-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"BLOB\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"type\\":\\"HAS_CONTENTS\\"}": Object {
+          "dst": Object {
+            "id": "8c6cac301e763aa6d36466e0a775eb804be2c311",
+            "pluginName": "sourcecred/git-beta",
+            "type": "BLOB",
+          },
+          "payload": Object {},
+          "src": Object {
+            "id": "7be3ecfee5314ffa9b2d93fc4377792b2d6d70ed:.gitmodules",
+            "pluginName": "sourcecred/git-beta",
+            "type": "TREE_ENTRY",
+          },
+        },
+        "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"7be3ecfee5314ffa9b2d93fc4377792b2d6d70ed:README.txt\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/git-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"TREE_ENTRY\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"0fb31858c8e3710be77e1dbb8880acf8a5543d82\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/git-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"BLOB\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"type\\":\\"HAS_CONTENTS\\"}": Object {
+          "dst": Object {
+            "id": "0fb31858c8e3710be77e1dbb8880acf8a5543d82",
+            "pluginName": "sourcecred/git-beta",
+            "type": "BLOB",
+          },
+          "payload": Object {},
+          "src": Object {
+            "id": "7be3ecfee5314ffa9b2d93fc4377792b2d6d70ed:README.txt",
+            "pluginName": "sourcecred/git-beta",
+            "type": "TREE_ENTRY",
+          },
+        },
+        "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"7be3ecfee5314ffa9b2d93fc4377792b2d6d70ed:pygravitydefier\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/git-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"TREE_ENTRY\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-git-submodule.git@29ef158bc982733e2ba429fcf73e2f7562244188\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/git-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"SUBMODULE_COMMIT\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"type\\":\\"HAS_CONTENTS\\"}": Object {
+          "dst": Object {
+            "id": "https://github.com/sourcecred/example-git-submodule.git@29ef158bc982733e2ba429fcf73e2f7562244188",
+            "pluginName": "sourcecred/git-beta",
+            "type": "SUBMODULE_COMMIT",
+          },
+          "payload": Object {},
+          "src": Object {
+            "id": "7be3ecfee5314ffa9b2d93fc4377792b2d6d70ed:pygravitydefier",
+            "pluginName": "sourcecred/git-beta",
+            "type": "TREE_ENTRY",
+          },
+        },
+        "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"7be3ecfee5314ffa9b2d93fc4377792b2d6d70ed:science.txt\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/git-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"TREE_ENTRY\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"f1f2514ca6d7a6a1a0511957021b1995bf9ace1c\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/git-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"BLOB\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"type\\":\\"HAS_CONTENTS\\"}": Object {
+          "dst": Object {
+            "id": "f1f2514ca6d7a6a1a0511957021b1995bf9ace1c",
+            "pluginName": "sourcecred/git-beta",
+            "type": "BLOB",
+          },
+          "payload": Object {},
+          "src": Object {
+            "id": "7be3ecfee5314ffa9b2d93fc4377792b2d6d70ed:science.txt",
+            "pluginName": "sourcecred/git-beta",
+            "type": "TREE_ENTRY",
+          },
+        },
+        "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"7be3ecfee5314ffa9b2d93fc4377792b2d6d70ed:src\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/git-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"TREE_ENTRY\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"78fc9c83023386854c6bfdc5761c0e58f68e226f\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/git-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"TREE\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"type\\":\\"HAS_CONTENTS\\"}": Object {
+          "dst": Object {
+            "id": "78fc9c83023386854c6bfdc5761c0e58f68e226f",
+            "pluginName": "sourcecred/git-beta",
+            "type": "TREE",
+          },
+          "payload": Object {},
+          "src": Object {
+            "id": "7be3ecfee5314ffa9b2d93fc4377792b2d6d70ed:src",
+            "pluginName": "sourcecred/git-beta",
+            "type": "TREE_ENTRY",
+          },
+        },
+        "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"819fc546cea489476ce8dc90785e9ba7753d0a8f:.gitmodules\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/git-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"TREE_ENTRY\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"8c6cac301e763aa6d36466e0a775eb804be2c311\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/git-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"BLOB\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"type\\":\\"HAS_CONTENTS\\"}": Object {
+          "dst": Object {
+            "id": "8c6cac301e763aa6d36466e0a775eb804be2c311",
+            "pluginName": "sourcecred/git-beta",
+            "type": "BLOB",
+          },
+          "payload": Object {},
+          "src": Object {
+            "id": "819fc546cea489476ce8dc90785e9ba7753d0a8f:.gitmodules",
+            "pluginName": "sourcecred/git-beta",
+            "type": "TREE_ENTRY",
+          },
+        },
+        "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"819fc546cea489476ce8dc90785e9ba7753d0a8f:README.txt\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/git-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"TREE_ENTRY\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"0fb31858c8e3710be77e1dbb8880acf8a5543d82\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/git-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"BLOB\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"type\\":\\"HAS_CONTENTS\\"}": Object {
+          "dst": Object {
+            "id": "0fb31858c8e3710be77e1dbb8880acf8a5543d82",
+            "pluginName": "sourcecred/git-beta",
+            "type": "BLOB",
+          },
+          "payload": Object {},
+          "src": Object {
+            "id": "819fc546cea489476ce8dc90785e9ba7753d0a8f:README.txt",
+            "pluginName": "sourcecred/git-beta",
+            "type": "TREE_ENTRY",
+          },
+        },
+        "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"819fc546cea489476ce8dc90785e9ba7753d0a8f:TODOS.txt\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/git-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"TREE_ENTRY\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"ddec7477206c30c31b81482e56b877a0b3c2638b\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/git-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"BLOB\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"type\\":\\"HAS_CONTENTS\\"}": Object {
+          "dst": Object {
+            "id": "ddec7477206c30c31b81482e56b877a0b3c2638b",
+            "pluginName": "sourcecred/git-beta",
+            "type": "BLOB",
+          },
+          "payload": Object {},
+          "src": Object {
+            "id": "819fc546cea489476ce8dc90785e9ba7753d0a8f:TODOS.txt",
+            "pluginName": "sourcecred/git-beta",
+            "type": "TREE_ENTRY",
+          },
+        },
+        "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"819fc546cea489476ce8dc90785e9ba7753d0a8f:pygravitydefier\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/git-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"TREE_ENTRY\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-git-submodule.git@29ef158bc982733e2ba429fcf73e2f7562244188\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/git-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"SUBMODULE_COMMIT\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"type\\":\\"HAS_CONTENTS\\"}": Object {
+          "dst": Object {
+            "id": "https://github.com/sourcecred/example-git-submodule.git@29ef158bc982733e2ba429fcf73e2f7562244188",
+            "pluginName": "sourcecred/git-beta",
+            "type": "SUBMODULE_COMMIT",
+          },
+          "payload": Object {},
+          "src": Object {
+            "id": "819fc546cea489476ce8dc90785e9ba7753d0a8f:pygravitydefier",
+            "pluginName": "sourcecred/git-beta",
+            "type": "TREE_ENTRY",
+          },
+        },
+        "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"819fc546cea489476ce8dc90785e9ba7753d0a8f:science.txt\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/git-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"TREE_ENTRY\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"f1f2514ca6d7a6a1a0511957021b1995bf9ace1c\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/git-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"BLOB\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"type\\":\\"HAS_CONTENTS\\"}": Object {
+          "dst": Object {
+            "id": "f1f2514ca6d7a6a1a0511957021b1995bf9ace1c",
+            "pluginName": "sourcecred/git-beta",
+            "type": "BLOB",
+          },
+          "payload": Object {},
+          "src": Object {
+            "id": "819fc546cea489476ce8dc90785e9ba7753d0a8f:science.txt",
+            "pluginName": "sourcecred/git-beta",
+            "type": "TREE_ENTRY",
+          },
+        },
+        "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"819fc546cea489476ce8dc90785e9ba7753d0a8f:src\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/git-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"TREE_ENTRY\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"7b79d579b62994faba3b69fdf8aa442586c32681\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/git-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"TREE\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"type\\":\\"HAS_CONTENTS\\"}": Object {
+          "dst": Object {
+            "id": "7b79d579b62994faba3b69fdf8aa442586c32681",
+            "pluginName": "sourcecred/git-beta",
+            "type": "TREE",
+          },
+          "payload": Object {},
+          "src": Object {
+            "id": "819fc546cea489476ce8dc90785e9ba7753d0a8f:src",
+            "pluginName": "sourcecred/git-beta",
+            "type": "TREE_ENTRY",
+          },
+        },
+        "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"8d287c3bfbf8455ef30187bf5153ffc1b6eef268\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/git-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"COMMIT\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"3dfb84795e07341b05fad3a0d5a55f8304b2d7d8\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/git-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"TREE\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"type\\":\\"HAS_TREE\\"}": Object {
+          "dst": Object {
+            "id": "3dfb84795e07341b05fad3a0d5a55f8304b2d7d8",
+            "pluginName": "sourcecred/git-beta",
+            "type": "TREE",
+          },
+          "payload": Object {},
+          "src": Object {
+            "id": "8d287c3bfbf8455ef30187bf5153ffc1b6eef268",
+            "pluginName": "sourcecred/git-beta",
+            "type": "COMMIT",
+          },
+        },
+        "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"bbf3b8b3d26a4f884b5c022d46851f593d329192:.gitmodules\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/git-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"TREE_ENTRY\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"8c6cac301e763aa6d36466e0a775eb804be2c311\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/git-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"BLOB\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"type\\":\\"HAS_CONTENTS\\"}": Object {
+          "dst": Object {
+            "id": "8c6cac301e763aa6d36466e0a775eb804be2c311",
+            "pluginName": "sourcecred/git-beta",
+            "type": "BLOB",
+          },
+          "payload": Object {},
+          "src": Object {
+            "id": "bbf3b8b3d26a4f884b5c022d46851f593d329192:.gitmodules",
+            "pluginName": "sourcecred/git-beta",
+            "type": "TREE_ENTRY",
+          },
+        },
+        "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"bbf3b8b3d26a4f884b5c022d46851f593d329192:README.txt\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/git-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"TREE_ENTRY\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"0fb31858c8e3710be77e1dbb8880acf8a5543d82\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/git-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"BLOB\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"type\\":\\"HAS_CONTENTS\\"}": Object {
+          "dst": Object {
+            "id": "0fb31858c8e3710be77e1dbb8880acf8a5543d82",
+            "pluginName": "sourcecred/git-beta",
+            "type": "BLOB",
+          },
+          "payload": Object {},
+          "src": Object {
+            "id": "bbf3b8b3d26a4f884b5c022d46851f593d329192:README.txt",
+            "pluginName": "sourcecred/git-beta",
+            "type": "TREE_ENTRY",
+          },
+        },
+        "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"bbf3b8b3d26a4f884b5c022d46851f593d329192:TODOS.txt\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/git-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"TREE_ENTRY\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"ddec7477206c30c31b81482e56b877a0b3c2638b\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/git-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"BLOB\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"type\\":\\"HAS_CONTENTS\\"}": Object {
+          "dst": Object {
+            "id": "ddec7477206c30c31b81482e56b877a0b3c2638b",
+            "pluginName": "sourcecred/git-beta",
+            "type": "BLOB",
+          },
+          "payload": Object {},
+          "src": Object {
+            "id": "bbf3b8b3d26a4f884b5c022d46851f593d329192:TODOS.txt",
+            "pluginName": "sourcecred/git-beta",
+            "type": "TREE_ENTRY",
+          },
+        },
+        "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"bbf3b8b3d26a4f884b5c022d46851f593d329192:pygravitydefier\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/git-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"TREE_ENTRY\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-git-submodule.git@29ef158bc982733e2ba429fcf73e2f7562244188\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/git-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"SUBMODULE_COMMIT\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"type\\":\\"HAS_CONTENTS\\"}": Object {
+          "dst": Object {
+            "id": "https://github.com/sourcecred/example-git-submodule.git@29ef158bc982733e2ba429fcf73e2f7562244188",
+            "pluginName": "sourcecred/git-beta",
+            "type": "SUBMODULE_COMMIT",
+          },
+          "payload": Object {},
+          "src": Object {
+            "id": "bbf3b8b3d26a4f884b5c022d46851f593d329192:pygravitydefier",
+            "pluginName": "sourcecred/git-beta",
+            "type": "TREE_ENTRY",
+          },
+        },
+        "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"bbf3b8b3d26a4f884b5c022d46851f593d329192:science.txt\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/git-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"TREE_ENTRY\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"f1f2514ca6d7a6a1a0511957021b1995bf9ace1c\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/git-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"BLOB\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"type\\":\\"HAS_CONTENTS\\"}": Object {
+          "dst": Object {
+            "id": "f1f2514ca6d7a6a1a0511957021b1995bf9ace1c",
+            "pluginName": "sourcecred/git-beta",
+            "type": "BLOB",
+          },
+          "payload": Object {},
+          "src": Object {
+            "id": "bbf3b8b3d26a4f884b5c022d46851f593d329192:science.txt",
+            "pluginName": "sourcecred/git-beta",
+            "type": "TREE_ENTRY",
+          },
+        },
+        "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"bbf3b8b3d26a4f884b5c022d46851f593d329192:src\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/git-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"TREE_ENTRY\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"78fc9c83023386854c6bfdc5761c0e58f68e226f\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/git-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"TREE\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"type\\":\\"HAS_CONTENTS\\"}": Object {
+          "dst": Object {
+            "id": "78fc9c83023386854c6bfdc5761c0e58f68e226f",
+            "pluginName": "sourcecred/git-beta",
+            "type": "TREE",
+          },
+          "payload": Object {},
+          "src": Object {
+            "id": "bbf3b8b3d26a4f884b5c022d46851f593d329192:src",
+            "pluginName": "sourcecred/git-beta",
+            "type": "TREE_ENTRY",
+          },
+        },
+        "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"bdff5d94193170015d6cbb549b7b630649428b1f:README.txt\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/git-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"TREE_ENTRY\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"0fb31858c8e3710be77e1dbb8880acf8a5543d82\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/git-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"BLOB\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"type\\":\\"HAS_CONTENTS\\"}": Object {
+          "dst": Object {
+            "id": "0fb31858c8e3710be77e1dbb8880acf8a5543d82",
+            "pluginName": "sourcecred/git-beta",
+            "type": "BLOB",
+          },
+          "payload": Object {},
+          "src": Object {
+            "id": "bdff5d94193170015d6cbb549b7b630649428b1f:README.txt",
+            "pluginName": "sourcecred/git-beta",
+            "type": "TREE_ENTRY",
+          },
+        },
+        "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"c08ee3a4edea384d5291ffcbf06724a13ed72325\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/git-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"COMMIT\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"2f7155e359fd0ecb96ffdca66fa45b6ed5792809\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/git-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"TREE\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"type\\":\\"HAS_TREE\\"}": Object {
+          "dst": Object {
+            "id": "2f7155e359fd0ecb96ffdca66fa45b6ed5792809",
+            "pluginName": "sourcecred/git-beta",
+            "type": "TREE",
+          },
+          "payload": Object {},
+          "src": Object {
+            "id": "c08ee3a4edea384d5291ffcbf06724a13ed72325",
+            "pluginName": "sourcecred/git-beta",
+            "type": "COMMIT",
+          },
+        },
+        "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"c2b51945e7457546912a8ce158ed9d294558d294\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/git-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"COMMIT\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"bdff5d94193170015d6cbb549b7b630649428b1f\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/git-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"TREE\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"type\\":\\"HAS_TREE\\"}": Object {
+          "dst": Object {
+            "id": "bdff5d94193170015d6cbb549b7b630649428b1f",
+            "pluginName": "sourcecred/git-beta",
+            "type": "TREE",
+          },
+          "payload": Object {},
+          "src": Object {
+            "id": "c2b51945e7457546912a8ce158ed9d294558d294",
+            "pluginName": "sourcecred/git-beta",
+            "type": "COMMIT",
+          },
+        },
+        "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"d160cca97611e9dfed642522ad44408d0292e8ea\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/git-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"COMMIT\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"569e1d383759903134df75230d63c0090196d4cb\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/git-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"TREE\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"type\\":\\"HAS_TREE\\"}": Object {
+          "dst": Object {
+            "id": "569e1d383759903134df75230d63c0090196d4cb",
+            "pluginName": "sourcecred/git-beta",
+            "type": "TREE",
+          },
+          "payload": Object {},
+          "src": Object {
+            "id": "d160cca97611e9dfed642522ad44408d0292e8ea",
+            "pluginName": "sourcecred/git-beta",
+            "type": "COMMIT",
+          },
+        },
+        "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"e8b7a8f19701cd5a25e4a097d513ead60e5f8bcc\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/git-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"COMMIT\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"819fc546cea489476ce8dc90785e9ba7753d0a8f\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/git-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"TREE\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"type\\":\\"HAS_TREE\\"}": Object {
+          "dst": Object {
+            "id": "819fc546cea489476ce8dc90785e9ba7753d0a8f",
+            "pluginName": "sourcecred/git-beta",
+            "type": "TREE",
+          },
+          "payload": Object {},
+          "src": Object {
+            "id": "e8b7a8f19701cd5a25e4a097d513ead60e5f8bcc",
+            "pluginName": "sourcecred/git-beta",
+            "type": "COMMIT",
+          },
+        },
+        "{\\"id\\":\\"bbf3b8b3d26a4f884b5c022d46851f593d329192:.gitmodules\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"type\\":\\"INCLUDES\\"}": Object {
+          "dst": Object {
+            "id": "bbf3b8b3d26a4f884b5c022d46851f593d329192:.gitmodules",
+            "pluginName": "sourcecred/git-beta",
+            "type": "TREE_ENTRY",
+          },
+          "payload": Object {
+            "name": ".gitmodules",
+          },
+          "src": Object {
+            "id": "bbf3b8b3d26a4f884b5c022d46851f593d329192",
+            "pluginName": "sourcecred/git-beta",
+            "type": "TREE",
+          },
+        },
+        "{\\"id\\":\\"bbf3b8b3d26a4f884b5c022d46851f593d329192:README.txt\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"type\\":\\"INCLUDES\\"}": Object {
+          "dst": Object {
+            "id": "bbf3b8b3d26a4f884b5c022d46851f593d329192:README.txt",
+            "pluginName": "sourcecred/git-beta",
+            "type": "TREE_ENTRY",
+          },
+          "payload": Object {
+            "name": "README.txt",
+          },
+          "src": Object {
+            "id": "bbf3b8b3d26a4f884b5c022d46851f593d329192",
+            "pluginName": "sourcecred/git-beta",
+            "type": "TREE",
+          },
+        },
+        "{\\"id\\":\\"bbf3b8b3d26a4f884b5c022d46851f593d329192:TODOS.txt\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"type\\":\\"INCLUDES\\"}": Object {
+          "dst": Object {
+            "id": "bbf3b8b3d26a4f884b5c022d46851f593d329192:TODOS.txt",
+            "pluginName": "sourcecred/git-beta",
+            "type": "TREE_ENTRY",
+          },
+          "payload": Object {
+            "name": "TODOS.txt",
+          },
+          "src": Object {
+            "id": "bbf3b8b3d26a4f884b5c022d46851f593d329192",
+            "pluginName": "sourcecred/git-beta",
+            "type": "TREE",
+          },
+        },
+        "{\\"id\\":\\"bbf3b8b3d26a4f884b5c022d46851f593d329192:pygravitydefier\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"type\\":\\"INCLUDES\\"}": Object {
+          "dst": Object {
+            "id": "bbf3b8b3d26a4f884b5c022d46851f593d329192:pygravitydefier",
+            "pluginName": "sourcecred/git-beta",
+            "type": "TREE_ENTRY",
+          },
+          "payload": Object {
+            "name": "pygravitydefier",
+          },
+          "src": Object {
+            "id": "bbf3b8b3d26a4f884b5c022d46851f593d329192",
+            "pluginName": "sourcecred/git-beta",
+            "type": "TREE",
+          },
+        },
+        "{\\"id\\":\\"bbf3b8b3d26a4f884b5c022d46851f593d329192:science.txt\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"type\\":\\"INCLUDES\\"}": Object {
+          "dst": Object {
+            "id": "bbf3b8b3d26a4f884b5c022d46851f593d329192:science.txt",
+            "pluginName": "sourcecred/git-beta",
+            "type": "TREE_ENTRY",
+          },
+          "payload": Object {
+            "name": "science.txt",
+          },
+          "src": Object {
+            "id": "bbf3b8b3d26a4f884b5c022d46851f593d329192",
+            "pluginName": "sourcecred/git-beta",
+            "type": "TREE",
+          },
+        },
+        "{\\"id\\":\\"bbf3b8b3d26a4f884b5c022d46851f593d329192:src\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"type\\":\\"INCLUDES\\"}": Object {
+          "dst": Object {
+            "id": "bbf3b8b3d26a4f884b5c022d46851f593d329192:src",
+            "pluginName": "sourcecred/git-beta",
+            "type": "TREE_ENTRY",
+          },
+          "payload": Object {
+            "name": "src",
+          },
+          "src": Object {
+            "id": "bbf3b8b3d26a4f884b5c022d46851f593d329192",
+            "pluginName": "sourcecred/git-beta",
+            "type": "TREE",
+          },
+        },
+        "{\\"id\\":\\"bdff5d94193170015d6cbb549b7b630649428b1f:README.txt\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"type\\":\\"INCLUDES\\"}": Object {
+          "dst": Object {
+            "id": "bdff5d94193170015d6cbb549b7b630649428b1f:README.txt",
+            "pluginName": "sourcecred/git-beta",
+            "type": "TREE_ENTRY",
+          },
+          "payload": Object {
+            "name": "README.txt",
+          },
+          "src": Object {
+            "id": "bdff5d94193170015d6cbb549b7b630649428b1f",
+            "pluginName": "sourcecred/git-beta",
+            "type": "TREE",
+          },
+        },
+        "{\\"id\\":\\"c08ee3a4edea384d5291ffcbf06724a13ed72325^1\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"type\\":\\"HAS_PARENT\\"}": Object {
+          "dst": Object {
+            "id": "c2b51945e7457546912a8ce158ed9d294558d294",
+            "pluginName": "sourcecred/git-beta",
+            "type": "COMMIT",
+          },
+          "payload": Object {
+            "parentIndex": 1,
+          },
+          "src": Object {
+            "id": "c08ee3a4edea384d5291ffcbf06724a13ed72325",
+            "pluginName": "sourcecred/git-beta",
+            "type": "COMMIT",
+          },
+        },
+        "{\\"id\\":\\"d160cca97611e9dfed642522ad44408d0292e8ea^1\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"type\\":\\"HAS_PARENT\\"}": Object {
+          "dst": Object {
+            "id": "8d287c3bfbf8455ef30187bf5153ffc1b6eef268",
+            "pluginName": "sourcecred/git-beta",
+            "type": "COMMIT",
+          },
+          "payload": Object {
+            "parentIndex": 1,
+          },
+          "src": Object {
+            "id": "d160cca97611e9dfed642522ad44408d0292e8ea",
+            "pluginName": "sourcecred/git-beta",
+            "type": "COMMIT",
+          },
+        },
+        "{\\"id\\":\\"e8b7a8f19701cd5a25e4a097d513ead60e5f8bcc^1\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"type\\":\\"HAS_PARENT\\"}": Object {
+          "dst": Object {
+            "id": "d160cca97611e9dfed642522ad44408d0292e8ea",
+            "pluginName": "sourcecred/git-beta",
+            "type": "COMMIT",
+          },
+          "payload": Object {
+            "parentIndex": 1,
+          },
+          "src": Object {
+            "id": "e8b7a8f19701cd5a25e4a097d513ead60e5f8bcc",
+            "pluginName": "sourcecred/git-beta",
+            "type": "COMMIT",
+          },
+        },
+        "{\\"id\\":\\"{\\\\\\"childCommit\\\\\\":\\\\\\"69c5aad50eec8f2a0a07c988c3b283a6490eb45b\\\\\\",\\\\\\"parentCommit\\\\\\":\\\\\\"e8b7a8f19701cd5a25e4a097d513ead60e5f8bcc\\\\\\",\\\\\\"path\\\\\\":[\\\\\\"src\\\\\\",\\\\\\"quantum_gravity.py\\\\\\"]}\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"type\\":\\"BECOMES\\"}": Object {
+          "dst": Object {
+            "id": "78fc9c83023386854c6bfdc5761c0e58f68e226f:quantum_gravity.py",
+            "pluginName": "sourcecred/git-beta",
+            "type": "TREE_ENTRY",
+          },
+          "payload": Object {
+            "childCommit": "69c5aad50eec8f2a0a07c988c3b283a6490eb45b",
+            "parentCommit": "e8b7a8f19701cd5a25e4a097d513ead60e5f8bcc",
+            "path": Array [
+              "src",
+              "quantum_gravity.py",
+            ],
+          },
+          "src": Object {
+            "id": "7b79d579b62994faba3b69fdf8aa442586c32681:quantum_gravity.py",
+            "pluginName": "sourcecred/git-beta",
+            "type": "TREE_ENTRY",
+          },
+        },
+        "{\\"id\\":\\"{\\\\\\"childCommit\\\\\\":\\\\\\"69c5aad50eec8f2a0a07c988c3b283a6490eb45b\\\\\\",\\\\\\"parentCommit\\\\\\":\\\\\\"e8b7a8f19701cd5a25e4a097d513ead60e5f8bcc\\\\\\",\\\\\\"path\\\\\\":[\\\\\\"src\\\\\\"]}\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"type\\":\\"BECOMES\\"}": Object {
+          "dst": Object {
+            "id": "bbf3b8b3d26a4f884b5c022d46851f593d329192:src",
+            "pluginName": "sourcecred/git-beta",
+            "type": "TREE_ENTRY",
+          },
+          "payload": Object {
+            "childCommit": "69c5aad50eec8f2a0a07c988c3b283a6490eb45b",
+            "parentCommit": "e8b7a8f19701cd5a25e4a097d513ead60e5f8bcc",
+            "path": Array [
+              "src",
+            ],
+          },
+          "src": Object {
+            "id": "819fc546cea489476ce8dc90785e9ba7753d0a8f:src",
+            "pluginName": "sourcecred/git-beta",
+            "type": "TREE_ENTRY",
+          },
+        },
+        "{\\"id\\":\\"{\\\\\\"childCommit\\\\\\":\\\\\\"e8b7a8f19701cd5a25e4a097d513ead60e5f8bcc\\\\\\",\\\\\\"parentCommit\\\\\\":\\\\\\"d160cca97611e9dfed642522ad44408d0292e8ea\\\\\\",\\\\\\"path\\\\\\":[\\\\\\"pygravitydefier\\\\\\"]}\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"type\\":\\"BECOMES\\"}": Object {
+          "dst": Object {
+            "id": "819fc546cea489476ce8dc90785e9ba7753d0a8f:pygravitydefier",
+            "pluginName": "sourcecred/git-beta",
+            "type": "TREE_ENTRY",
+          },
+          "payload": Object {
+            "childCommit": "e8b7a8f19701cd5a25e4a097d513ead60e5f8bcc",
+            "parentCommit": "d160cca97611e9dfed642522ad44408d0292e8ea",
+            "path": Array [
+              "pygravitydefier",
+            ],
+          },
+          "src": Object {
+            "id": "569e1d383759903134df75230d63c0090196d4cb:pygravitydefier",
+            "pluginName": "sourcecred/git-beta",
+            "type": "TREE_ENTRY",
+          },
+        },
       },
-    },
-    "{\\"id\\":\\"3715ddfb8d4c4fd2a6f6af75488c82f84c92ec2f\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"type\\":\\"COMMIT\\"}": Object {
-      "payload": Object {},
-    },
-    "{\\"id\\":\\"3dfb84795e07341b05fad3a0d5a55f8304b2d7d8\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"type\\":\\"TREE\\"}": Object {
-      "payload": Object {},
-    },
-    "{\\"id\\":\\"3dfb84795e07341b05fad3a0d5a55f8304b2d7d8:.gitmodules\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"type\\":\\"TREE_ENTRY\\"}": Object {
-      "payload": Object {
-        "name": ".gitmodules",
+    ],
+    "nodes": Array [
+      Object {
+        "type": "sourcecred/sourcecred/AddressMap",
+        "version": "0.1.0",
       },
-    },
-    "{\\"id\\":\\"3dfb84795e07341b05fad3a0d5a55f8304b2d7d8:README.txt\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"type\\":\\"TREE_ENTRY\\"}": Object {
-      "payload": Object {
-        "name": "README.txt",
+      Object {
+        "{\\"id\\":\\"0fb31858c8e3710be77e1dbb8880acf8a5543d82\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"type\\":\\"BLOB\\"}": Object {
+          "payload": Object {},
+        },
+        "{\\"id\\":\\"2f7155e359fd0ecb96ffdca66fa45b6ed5792809\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"type\\":\\"TREE\\"}": Object {
+          "payload": Object {},
+        },
+        "{\\"id\\":\\"2f7155e359fd0ecb96ffdca66fa45b6ed5792809:README.txt\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"type\\":\\"TREE_ENTRY\\"}": Object {
+          "payload": Object {
+            "name": "README.txt",
+          },
+        },
+        "{\\"id\\":\\"2f7155e359fd0ecb96ffdca66fa45b6ed5792809:science.txt\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"type\\":\\"TREE_ENTRY\\"}": Object {
+          "payload": Object {
+            "name": "science.txt",
+          },
+        },
+        "{\\"id\\":\\"3715ddfb8d4c4fd2a6f6af75488c82f84c92ec2f\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"type\\":\\"COMMIT\\"}": Object {
+          "payload": Object {},
+        },
+        "{\\"id\\":\\"3dfb84795e07341b05fad3a0d5a55f8304b2d7d8\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"type\\":\\"TREE\\"}": Object {
+          "payload": Object {},
+        },
+        "{\\"id\\":\\"3dfb84795e07341b05fad3a0d5a55f8304b2d7d8:.gitmodules\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"type\\":\\"TREE_ENTRY\\"}": Object {
+          "payload": Object {
+            "name": ".gitmodules",
+          },
+        },
+        "{\\"id\\":\\"3dfb84795e07341b05fad3a0d5a55f8304b2d7d8:README.txt\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"type\\":\\"TREE_ENTRY\\"}": Object {
+          "payload": Object {
+            "name": "README.txt",
+          },
+        },
+        "{\\"id\\":\\"3dfb84795e07341b05fad3a0d5a55f8304b2d7d8:pygravitydefier\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"type\\":\\"TREE_ENTRY\\"}": Object {
+          "payload": Object {
+            "name": "pygravitydefier",
+          },
+        },
+        "{\\"id\\":\\"3dfb84795e07341b05fad3a0d5a55f8304b2d7d8:science.txt\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"type\\":\\"TREE_ENTRY\\"}": Object {
+          "payload": Object {
+            "name": "science.txt",
+          },
+        },
+        "{\\"id\\":\\"569e1d383759903134df75230d63c0090196d4cb\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"type\\":\\"TREE\\"}": Object {
+          "payload": Object {},
+        },
+        "{\\"id\\":\\"569e1d383759903134df75230d63c0090196d4cb:.gitmodules\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"type\\":\\"TREE_ENTRY\\"}": Object {
+          "payload": Object {
+            "name": ".gitmodules",
+          },
+        },
+        "{\\"id\\":\\"569e1d383759903134df75230d63c0090196d4cb:README.txt\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"type\\":\\"TREE_ENTRY\\"}": Object {
+          "payload": Object {
+            "name": "README.txt",
+          },
+        },
+        "{\\"id\\":\\"569e1d383759903134df75230d63c0090196d4cb:TODOS.txt\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"type\\":\\"TREE_ENTRY\\"}": Object {
+          "payload": Object {
+            "name": "TODOS.txt",
+          },
+        },
+        "{\\"id\\":\\"569e1d383759903134df75230d63c0090196d4cb:pygravitydefier\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"type\\":\\"TREE_ENTRY\\"}": Object {
+          "payload": Object {
+            "name": "pygravitydefier",
+          },
+        },
+        "{\\"id\\":\\"569e1d383759903134df75230d63c0090196d4cb:science.txt\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"type\\":\\"TREE_ENTRY\\"}": Object {
+          "payload": Object {
+            "name": "science.txt",
+          },
+        },
+        "{\\"id\\":\\"569e1d383759903134df75230d63c0090196d4cb:src\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"type\\":\\"TREE_ENTRY\\"}": Object {
+          "payload": Object {
+            "name": "src",
+          },
+        },
+        "{\\"id\\":\\"674b0b476989384510304846248b3acd16206782\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"type\\":\\"BLOB\\"}": Object {
+          "payload": Object {},
+        },
+        "{\\"id\\":\\"69c5aad50eec8f2a0a07c988c3b283a6490eb45b\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"type\\":\\"COMMIT\\"}": Object {
+          "payload": Object {},
+        },
+        "{\\"id\\":\\"78fc9c83023386854c6bfdc5761c0e58f68e226f\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"type\\":\\"TREE\\"}": Object {
+          "payload": Object {},
+        },
+        "{\\"id\\":\\"78fc9c83023386854c6bfdc5761c0e58f68e226f:index.py\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"type\\":\\"TREE_ENTRY\\"}": Object {
+          "payload": Object {
+            "name": "index.py",
+          },
+        },
+        "{\\"id\\":\\"78fc9c83023386854c6bfdc5761c0e58f68e226f:quantum_gravity.py\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"type\\":\\"TREE_ENTRY\\"}": Object {
+          "payload": Object {
+            "name": "quantum_gravity.py",
+          },
+        },
+        "{\\"id\\":\\"7b79d579b62994faba3b69fdf8aa442586c32681\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"type\\":\\"TREE\\"}": Object {
+          "payload": Object {},
+        },
+        "{\\"id\\":\\"7b79d579b62994faba3b69fdf8aa442586c32681:index.py\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"type\\":\\"TREE_ENTRY\\"}": Object {
+          "payload": Object {
+            "name": "index.py",
+          },
+        },
+        "{\\"id\\":\\"7b79d579b62994faba3b69fdf8aa442586c32681:quantum_gravity.py\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"type\\":\\"TREE_ENTRY\\"}": Object {
+          "payload": Object {
+            "name": "quantum_gravity.py",
+          },
+        },
+        "{\\"id\\":\\"7be3ecfee5314ffa9b2d93fc4377792b2d6d70ed\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"type\\":\\"TREE\\"}": Object {
+          "payload": Object {},
+        },
+        "{\\"id\\":\\"7be3ecfee5314ffa9b2d93fc4377792b2d6d70ed:.gitmodules\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"type\\":\\"TREE_ENTRY\\"}": Object {
+          "payload": Object {
+            "name": ".gitmodules",
+          },
+        },
+        "{\\"id\\":\\"7be3ecfee5314ffa9b2d93fc4377792b2d6d70ed:README.txt\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"type\\":\\"TREE_ENTRY\\"}": Object {
+          "payload": Object {
+            "name": "README.txt",
+          },
+        },
+        "{\\"id\\":\\"7be3ecfee5314ffa9b2d93fc4377792b2d6d70ed:pygravitydefier\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"type\\":\\"TREE_ENTRY\\"}": Object {
+          "payload": Object {
+            "name": "pygravitydefier",
+          },
+        },
+        "{\\"id\\":\\"7be3ecfee5314ffa9b2d93fc4377792b2d6d70ed:science.txt\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"type\\":\\"TREE_ENTRY\\"}": Object {
+          "payload": Object {
+            "name": "science.txt",
+          },
+        },
+        "{\\"id\\":\\"7be3ecfee5314ffa9b2d93fc4377792b2d6d70ed:src\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"type\\":\\"TREE_ENTRY\\"}": Object {
+          "payload": Object {
+            "name": "src",
+          },
+        },
+        "{\\"id\\":\\"819fc546cea489476ce8dc90785e9ba7753d0a8f\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"type\\":\\"TREE\\"}": Object {
+          "payload": Object {},
+        },
+        "{\\"id\\":\\"819fc546cea489476ce8dc90785e9ba7753d0a8f:.gitmodules\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"type\\":\\"TREE_ENTRY\\"}": Object {
+          "payload": Object {
+            "name": ".gitmodules",
+          },
+        },
+        "{\\"id\\":\\"819fc546cea489476ce8dc90785e9ba7753d0a8f:README.txt\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"type\\":\\"TREE_ENTRY\\"}": Object {
+          "payload": Object {
+            "name": "README.txt",
+          },
+        },
+        "{\\"id\\":\\"819fc546cea489476ce8dc90785e9ba7753d0a8f:TODOS.txt\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"type\\":\\"TREE_ENTRY\\"}": Object {
+          "payload": Object {
+            "name": "TODOS.txt",
+          },
+        },
+        "{\\"id\\":\\"819fc546cea489476ce8dc90785e9ba7753d0a8f:pygravitydefier\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"type\\":\\"TREE_ENTRY\\"}": Object {
+          "payload": Object {
+            "name": "pygravitydefier",
+          },
+        },
+        "{\\"id\\":\\"819fc546cea489476ce8dc90785e9ba7753d0a8f:science.txt\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"type\\":\\"TREE_ENTRY\\"}": Object {
+          "payload": Object {
+            "name": "science.txt",
+          },
+        },
+        "{\\"id\\":\\"819fc546cea489476ce8dc90785e9ba7753d0a8f:src\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"type\\":\\"TREE_ENTRY\\"}": Object {
+          "payload": Object {
+            "name": "src",
+          },
+        },
+        "{\\"id\\":\\"887ad856bbc1373da146106c86cb581ad78cdafe\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"type\\":\\"BLOB\\"}": Object {
+          "payload": Object {},
+        },
+        "{\\"id\\":\\"8c6cac301e763aa6d36466e0a775eb804be2c311\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"type\\":\\"BLOB\\"}": Object {
+          "payload": Object {},
+        },
+        "{\\"id\\":\\"8d287c3bfbf8455ef30187bf5153ffc1b6eef268\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"type\\":\\"COMMIT\\"}": Object {
+          "payload": Object {},
+        },
+        "{\\"id\\":\\"aea4f28abb23abde151b0ead4063227f8bf6c0b0\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"type\\":\\"BLOB\\"}": Object {
+          "payload": Object {},
+        },
+        "{\\"id\\":\\"bbf3b8b3d26a4f884b5c022d46851f593d329192\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"type\\":\\"TREE\\"}": Object {
+          "payload": Object {},
+        },
+        "{\\"id\\":\\"bbf3b8b3d26a4f884b5c022d46851f593d329192:.gitmodules\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"type\\":\\"TREE_ENTRY\\"}": Object {
+          "payload": Object {
+            "name": ".gitmodules",
+          },
+        },
+        "{\\"id\\":\\"bbf3b8b3d26a4f884b5c022d46851f593d329192:README.txt\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"type\\":\\"TREE_ENTRY\\"}": Object {
+          "payload": Object {
+            "name": "README.txt",
+          },
+        },
+        "{\\"id\\":\\"bbf3b8b3d26a4f884b5c022d46851f593d329192:TODOS.txt\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"type\\":\\"TREE_ENTRY\\"}": Object {
+          "payload": Object {
+            "name": "TODOS.txt",
+          },
+        },
+        "{\\"id\\":\\"bbf3b8b3d26a4f884b5c022d46851f593d329192:pygravitydefier\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"type\\":\\"TREE_ENTRY\\"}": Object {
+          "payload": Object {
+            "name": "pygravitydefier",
+          },
+        },
+        "{\\"id\\":\\"bbf3b8b3d26a4f884b5c022d46851f593d329192:science.txt\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"type\\":\\"TREE_ENTRY\\"}": Object {
+          "payload": Object {
+            "name": "science.txt",
+          },
+        },
+        "{\\"id\\":\\"bbf3b8b3d26a4f884b5c022d46851f593d329192:src\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"type\\":\\"TREE_ENTRY\\"}": Object {
+          "payload": Object {
+            "name": "src",
+          },
+        },
+        "{\\"id\\":\\"bdff5d94193170015d6cbb549b7b630649428b1f\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"type\\":\\"TREE\\"}": Object {
+          "payload": Object {},
+        },
+        "{\\"id\\":\\"bdff5d94193170015d6cbb549b7b630649428b1f:README.txt\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"type\\":\\"TREE_ENTRY\\"}": Object {
+          "payload": Object {
+            "name": "README.txt",
+          },
+        },
+        "{\\"id\\":\\"c08ee3a4edea384d5291ffcbf06724a13ed72325\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"type\\":\\"COMMIT\\"}": Object {
+          "payload": Object {},
+        },
+        "{\\"id\\":\\"c2b51945e7457546912a8ce158ed9d294558d294\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"type\\":\\"COMMIT\\"}": Object {
+          "payload": Object {},
+        },
+        "{\\"id\\":\\"d160cca97611e9dfed642522ad44408d0292e8ea\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"type\\":\\"COMMIT\\"}": Object {
+          "payload": Object {},
+        },
+        "{\\"id\\":\\"ddec7477206c30c31b81482e56b877a0b3c2638b\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"type\\":\\"BLOB\\"}": Object {
+          "payload": Object {},
+        },
+        "{\\"id\\":\\"e8b7a8f19701cd5a25e4a097d513ead60e5f8bcc\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"type\\":\\"COMMIT\\"}": Object {
+          "payload": Object {},
+        },
+        "{\\"id\\":\\"f1f2514ca6d7a6a1a0511957021b1995bf9ace1c\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"type\\":\\"BLOB\\"}": Object {
+          "payload": Object {},
+        },
+        "{\\"id\\":\\"https://github.com/sourcecred/example-git-submodule.git@29ef158bc982733e2ba429fcf73e2f7562244188\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"type\\":\\"SUBMODULE_COMMIT\\"}": Object {
+          "payload": Object {
+            "hash": "29ef158bc982733e2ba429fcf73e2f7562244188",
+            "url": "https://github.com/sourcecred/example-git-submodule.git",
+          },
+        },
+        "{\\"id\\":\\"https://github.com/sourcecred/example-git-submodule.git@762c062fbdc7ec198cd693e95d55b374a08ff3e3\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"type\\":\\"SUBMODULE_COMMIT\\"}": Object {
+          "payload": Object {
+            "hash": "762c062fbdc7ec198cd693e95d55b374a08ff3e3",
+            "url": "https://github.com/sourcecred/example-git-submodule.git",
+          },
+        },
       },
-    },
-    "{\\"id\\":\\"3dfb84795e07341b05fad3a0d5a55f8304b2d7d8:pygravitydefier\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"type\\":\\"TREE_ENTRY\\"}": Object {
-      "payload": Object {
-        "name": "pygravitydefier",
-      },
-    },
-    "{\\"id\\":\\"3dfb84795e07341b05fad3a0d5a55f8304b2d7d8:science.txt\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"type\\":\\"TREE_ENTRY\\"}": Object {
-      "payload": Object {
-        "name": "science.txt",
-      },
-    },
-    "{\\"id\\":\\"569e1d383759903134df75230d63c0090196d4cb\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"type\\":\\"TREE\\"}": Object {
-      "payload": Object {},
-    },
-    "{\\"id\\":\\"569e1d383759903134df75230d63c0090196d4cb:.gitmodules\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"type\\":\\"TREE_ENTRY\\"}": Object {
-      "payload": Object {
-        "name": ".gitmodules",
-      },
-    },
-    "{\\"id\\":\\"569e1d383759903134df75230d63c0090196d4cb:README.txt\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"type\\":\\"TREE_ENTRY\\"}": Object {
-      "payload": Object {
-        "name": "README.txt",
-      },
-    },
-    "{\\"id\\":\\"569e1d383759903134df75230d63c0090196d4cb:TODOS.txt\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"type\\":\\"TREE_ENTRY\\"}": Object {
-      "payload": Object {
-        "name": "TODOS.txt",
-      },
-    },
-    "{\\"id\\":\\"569e1d383759903134df75230d63c0090196d4cb:pygravitydefier\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"type\\":\\"TREE_ENTRY\\"}": Object {
-      "payload": Object {
-        "name": "pygravitydefier",
-      },
-    },
-    "{\\"id\\":\\"569e1d383759903134df75230d63c0090196d4cb:science.txt\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"type\\":\\"TREE_ENTRY\\"}": Object {
-      "payload": Object {
-        "name": "science.txt",
-      },
-    },
-    "{\\"id\\":\\"569e1d383759903134df75230d63c0090196d4cb:src\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"type\\":\\"TREE_ENTRY\\"}": Object {
-      "payload": Object {
-        "name": "src",
-      },
-    },
-    "{\\"id\\":\\"674b0b476989384510304846248b3acd16206782\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"type\\":\\"BLOB\\"}": Object {
-      "payload": Object {},
-    },
-    "{\\"id\\":\\"69c5aad50eec8f2a0a07c988c3b283a6490eb45b\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"type\\":\\"COMMIT\\"}": Object {
-      "payload": Object {},
-    },
-    "{\\"id\\":\\"78fc9c83023386854c6bfdc5761c0e58f68e226f\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"type\\":\\"TREE\\"}": Object {
-      "payload": Object {},
-    },
-    "{\\"id\\":\\"78fc9c83023386854c6bfdc5761c0e58f68e226f:index.py\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"type\\":\\"TREE_ENTRY\\"}": Object {
-      "payload": Object {
-        "name": "index.py",
-      },
-    },
-    "{\\"id\\":\\"78fc9c83023386854c6bfdc5761c0e58f68e226f:quantum_gravity.py\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"type\\":\\"TREE_ENTRY\\"}": Object {
-      "payload": Object {
-        "name": "quantum_gravity.py",
-      },
-    },
-    "{\\"id\\":\\"7b79d579b62994faba3b69fdf8aa442586c32681\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"type\\":\\"TREE\\"}": Object {
-      "payload": Object {},
-    },
-    "{\\"id\\":\\"7b79d579b62994faba3b69fdf8aa442586c32681:index.py\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"type\\":\\"TREE_ENTRY\\"}": Object {
-      "payload": Object {
-        "name": "index.py",
-      },
-    },
-    "{\\"id\\":\\"7b79d579b62994faba3b69fdf8aa442586c32681:quantum_gravity.py\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"type\\":\\"TREE_ENTRY\\"}": Object {
-      "payload": Object {
-        "name": "quantum_gravity.py",
-      },
-    },
-    "{\\"id\\":\\"7be3ecfee5314ffa9b2d93fc4377792b2d6d70ed\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"type\\":\\"TREE\\"}": Object {
-      "payload": Object {},
-    },
-    "{\\"id\\":\\"7be3ecfee5314ffa9b2d93fc4377792b2d6d70ed:.gitmodules\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"type\\":\\"TREE_ENTRY\\"}": Object {
-      "payload": Object {
-        "name": ".gitmodules",
-      },
-    },
-    "{\\"id\\":\\"7be3ecfee5314ffa9b2d93fc4377792b2d6d70ed:README.txt\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"type\\":\\"TREE_ENTRY\\"}": Object {
-      "payload": Object {
-        "name": "README.txt",
-      },
-    },
-    "{\\"id\\":\\"7be3ecfee5314ffa9b2d93fc4377792b2d6d70ed:pygravitydefier\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"type\\":\\"TREE_ENTRY\\"}": Object {
-      "payload": Object {
-        "name": "pygravitydefier",
-      },
-    },
-    "{\\"id\\":\\"7be3ecfee5314ffa9b2d93fc4377792b2d6d70ed:science.txt\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"type\\":\\"TREE_ENTRY\\"}": Object {
-      "payload": Object {
-        "name": "science.txt",
-      },
-    },
-    "{\\"id\\":\\"7be3ecfee5314ffa9b2d93fc4377792b2d6d70ed:src\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"type\\":\\"TREE_ENTRY\\"}": Object {
-      "payload": Object {
-        "name": "src",
-      },
-    },
-    "{\\"id\\":\\"819fc546cea489476ce8dc90785e9ba7753d0a8f\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"type\\":\\"TREE\\"}": Object {
-      "payload": Object {},
-    },
-    "{\\"id\\":\\"819fc546cea489476ce8dc90785e9ba7753d0a8f:.gitmodules\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"type\\":\\"TREE_ENTRY\\"}": Object {
-      "payload": Object {
-        "name": ".gitmodules",
-      },
-    },
-    "{\\"id\\":\\"819fc546cea489476ce8dc90785e9ba7753d0a8f:README.txt\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"type\\":\\"TREE_ENTRY\\"}": Object {
-      "payload": Object {
-        "name": "README.txt",
-      },
-    },
-    "{\\"id\\":\\"819fc546cea489476ce8dc90785e9ba7753d0a8f:TODOS.txt\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"type\\":\\"TREE_ENTRY\\"}": Object {
-      "payload": Object {
-        "name": "TODOS.txt",
-      },
-    },
-    "{\\"id\\":\\"819fc546cea489476ce8dc90785e9ba7753d0a8f:pygravitydefier\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"type\\":\\"TREE_ENTRY\\"}": Object {
-      "payload": Object {
-        "name": "pygravitydefier",
-      },
-    },
-    "{\\"id\\":\\"819fc546cea489476ce8dc90785e9ba7753d0a8f:science.txt\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"type\\":\\"TREE_ENTRY\\"}": Object {
-      "payload": Object {
-        "name": "science.txt",
-      },
-    },
-    "{\\"id\\":\\"819fc546cea489476ce8dc90785e9ba7753d0a8f:src\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"type\\":\\"TREE_ENTRY\\"}": Object {
-      "payload": Object {
-        "name": "src",
-      },
-    },
-    "{\\"id\\":\\"887ad856bbc1373da146106c86cb581ad78cdafe\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"type\\":\\"BLOB\\"}": Object {
-      "payload": Object {},
-    },
-    "{\\"id\\":\\"8c6cac301e763aa6d36466e0a775eb804be2c311\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"type\\":\\"BLOB\\"}": Object {
-      "payload": Object {},
-    },
-    "{\\"id\\":\\"8d287c3bfbf8455ef30187bf5153ffc1b6eef268\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"type\\":\\"COMMIT\\"}": Object {
-      "payload": Object {},
-    },
-    "{\\"id\\":\\"aea4f28abb23abde151b0ead4063227f8bf6c0b0\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"type\\":\\"BLOB\\"}": Object {
-      "payload": Object {},
-    },
-    "{\\"id\\":\\"bbf3b8b3d26a4f884b5c022d46851f593d329192\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"type\\":\\"TREE\\"}": Object {
-      "payload": Object {},
-    },
-    "{\\"id\\":\\"bbf3b8b3d26a4f884b5c022d46851f593d329192:.gitmodules\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"type\\":\\"TREE_ENTRY\\"}": Object {
-      "payload": Object {
-        "name": ".gitmodules",
-      },
-    },
-    "{\\"id\\":\\"bbf3b8b3d26a4f884b5c022d46851f593d329192:README.txt\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"type\\":\\"TREE_ENTRY\\"}": Object {
-      "payload": Object {
-        "name": "README.txt",
-      },
-    },
-    "{\\"id\\":\\"bbf3b8b3d26a4f884b5c022d46851f593d329192:TODOS.txt\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"type\\":\\"TREE_ENTRY\\"}": Object {
-      "payload": Object {
-        "name": "TODOS.txt",
-      },
-    },
-    "{\\"id\\":\\"bbf3b8b3d26a4f884b5c022d46851f593d329192:pygravitydefier\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"type\\":\\"TREE_ENTRY\\"}": Object {
-      "payload": Object {
-        "name": "pygravitydefier",
-      },
-    },
-    "{\\"id\\":\\"bbf3b8b3d26a4f884b5c022d46851f593d329192:science.txt\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"type\\":\\"TREE_ENTRY\\"}": Object {
-      "payload": Object {
-        "name": "science.txt",
-      },
-    },
-    "{\\"id\\":\\"bbf3b8b3d26a4f884b5c022d46851f593d329192:src\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"type\\":\\"TREE_ENTRY\\"}": Object {
-      "payload": Object {
-        "name": "src",
-      },
-    },
-    "{\\"id\\":\\"bdff5d94193170015d6cbb549b7b630649428b1f\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"type\\":\\"TREE\\"}": Object {
-      "payload": Object {},
-    },
-    "{\\"id\\":\\"bdff5d94193170015d6cbb549b7b630649428b1f:README.txt\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"type\\":\\"TREE_ENTRY\\"}": Object {
-      "payload": Object {
-        "name": "README.txt",
-      },
-    },
-    "{\\"id\\":\\"c08ee3a4edea384d5291ffcbf06724a13ed72325\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"type\\":\\"COMMIT\\"}": Object {
-      "payload": Object {},
-    },
-    "{\\"id\\":\\"c2b51945e7457546912a8ce158ed9d294558d294\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"type\\":\\"COMMIT\\"}": Object {
-      "payload": Object {},
-    },
-    "{\\"id\\":\\"d160cca97611e9dfed642522ad44408d0292e8ea\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"type\\":\\"COMMIT\\"}": Object {
-      "payload": Object {},
-    },
-    "{\\"id\\":\\"ddec7477206c30c31b81482e56b877a0b3c2638b\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"type\\":\\"BLOB\\"}": Object {
-      "payload": Object {},
-    },
-    "{\\"id\\":\\"e8b7a8f19701cd5a25e4a097d513ead60e5f8bcc\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"type\\":\\"COMMIT\\"}": Object {
-      "payload": Object {},
-    },
-    "{\\"id\\":\\"f1f2514ca6d7a6a1a0511957021b1995bf9ace1c\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"type\\":\\"BLOB\\"}": Object {
-      "payload": Object {},
-    },
-    "{\\"id\\":\\"https://github.com/sourcecred/example-git-submodule.git@29ef158bc982733e2ba429fcf73e2f7562244188\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"type\\":\\"SUBMODULE_COMMIT\\"}": Object {
-      "payload": Object {
-        "hash": "29ef158bc982733e2ba429fcf73e2f7562244188",
-        "url": "https://github.com/sourcecred/example-git-submodule.git",
-      },
-    },
-    "{\\"id\\":\\"https://github.com/sourcecred/example-git-submodule.git@762c062fbdc7ec198cd693e95d55b374a08ff3e3\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"type\\":\\"SUBMODULE_COMMIT\\"}": Object {
-      "payload": Object {
-        "hash": "762c062fbdc7ec198cd693e95d55b374a08ff3e3",
-        "url": "https://github.com/sourcecred/example-git-submodule.git",
-      },
-    },
+    ],
   },
-}
+]
 `;
 
 exports[`findBecomesEdges works on the example repository 1`] = `

--- a/src/plugins/github/__snapshots__/parser.test.js.snap
+++ b/src/plugins/github/__snapshots__/parser.test.js.snap
@@ -1,1030 +1,1118 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`GithubParser issue parsing parses a simple issue (https://github.com/sourcecred/example-github/issues/1) 1`] = `
-Object {
-  "edges": Object {
-    "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/decentralion\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"AUTHOR\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/issues/1\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"ISSUE\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"AUTHORS\\"}": Object {
-      "dst": Object {
-        "id": "https://github.com/decentralion",
-        "pluginName": "sourcecred/github-beta",
-        "type": "AUTHOR",
-      },
-      "payload": Object {},
-      "src": Object {
-        "id": "https://github.com/sourcecred/example-github/issues/1",
-        "pluginName": "sourcecred/github-beta",
-        "type": "ISSUE",
-      },
-    },
-    "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"REPOSITORY\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/issues/1\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"ISSUE\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"CONTAINS\\"}": Object {
-      "dst": Object {
-        "id": "https://github.com/sourcecred/example-github/issues/1",
-        "pluginName": "sourcecred/github-beta",
-        "type": "ISSUE",
-      },
-      "payload": Object {},
-      "src": Object {
-        "id": "https://github.com/sourcecred/example-github",
-        "pluginName": "sourcecred/github-beta",
-        "type": "REPOSITORY",
-      },
-    },
+Array [
+  Object {
+    "type": "sourcecred/sourcecred/Graph",
+    "version": "0.1.0",
   },
-  "nodes": Object {
-    "{\\"id\\":\\"https://github.com/decentralion\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"AUTHOR\\"}": Object {
-      "payload": Object {
-        "login": "decentralion",
-        "subtype": "USER",
-        "url": "https://github.com/decentralion",
+  Object {
+    "edges": Array [
+      Object {
+        "type": "sourcecred/sourcecred/AddressMap",
+        "version": "0.1.0",
       },
-    },
-    "{\\"id\\":\\"https://github.com/sourcecred/example-github\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"REPOSITORY\\"}": Object {
-      "payload": Object {
-        "name": "example-github",
-        "owner": "sourcecred",
-        "url": "https://github.com/sourcecred/example-github",
+      Object {
+        "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/decentralion\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"AUTHOR\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/issues/1\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"ISSUE\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"AUTHORS\\"}": Object {
+          "dst": Object {
+            "id": "https://github.com/decentralion",
+            "pluginName": "sourcecred/github-beta",
+            "type": "AUTHOR",
+          },
+          "payload": Object {},
+          "src": Object {
+            "id": "https://github.com/sourcecred/example-github/issues/1",
+            "pluginName": "sourcecred/github-beta",
+            "type": "ISSUE",
+          },
+        },
+        "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"REPOSITORY\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/issues/1\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"ISSUE\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"CONTAINS\\"}": Object {
+          "dst": Object {
+            "id": "https://github.com/sourcecred/example-github/issues/1",
+            "pluginName": "sourcecred/github-beta",
+            "type": "ISSUE",
+          },
+          "payload": Object {},
+          "src": Object {
+            "id": "https://github.com/sourcecred/example-github",
+            "pluginName": "sourcecred/github-beta",
+            "type": "REPOSITORY",
+          },
+        },
       },
-    },
-    "{\\"id\\":\\"https://github.com/sourcecred/example-github/issues/1\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"ISSUE\\"}": Object {
-      "payload": Object {
-        "body": "This is just an example issue.",
-        "number": 1,
-        "title": "An example issue.",
-        "url": "https://github.com/sourcecred/example-github/issues/1",
+    ],
+    "nodes": Array [
+      Object {
+        "type": "sourcecred/sourcecred/AddressMap",
+        "version": "0.1.0",
       },
-    },
+      Object {
+        "{\\"id\\":\\"https://github.com/decentralion\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"AUTHOR\\"}": Object {
+          "payload": Object {
+            "login": "decentralion",
+            "subtype": "USER",
+            "url": "https://github.com/decentralion",
+          },
+        },
+        "{\\"id\\":\\"https://github.com/sourcecred/example-github\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"REPOSITORY\\"}": Object {
+          "payload": Object {
+            "name": "example-github",
+            "owner": "sourcecred",
+            "url": "https://github.com/sourcecred/example-github",
+          },
+        },
+        "{\\"id\\":\\"https://github.com/sourcecred/example-github/issues/1\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"ISSUE\\"}": Object {
+          "payload": Object {
+            "body": "This is just an example issue.",
+            "number": 1,
+            "title": "An example issue.",
+            "url": "https://github.com/sourcecred/example-github/issues/1",
+          },
+        },
+      },
+    ],
   },
-}
+]
 `;
 
 exports[`GithubParser issue parsing parses an issue with comments (https://github.com/sourcecred/example-github/issues/6) 1`] = `
-Object {
-  "edges": Object {
-    "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/decentralion\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"AUTHOR\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/issues/6#issuecomment-373768442\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"COMMENT\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"AUTHORS\\"}": Object {
-      "dst": Object {
-        "id": "https://github.com/decentralion",
-        "pluginName": "sourcecred/github-beta",
-        "type": "AUTHOR",
-      },
-      "payload": Object {},
-      "src": Object {
-        "id": "https://github.com/sourcecred/example-github/issues/6#issuecomment-373768442",
-        "pluginName": "sourcecred/github-beta",
-        "type": "COMMENT",
-      },
-    },
-    "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/decentralion\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"AUTHOR\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/issues/6#issuecomment-373768538\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"COMMENT\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"AUTHORS\\"}": Object {
-      "dst": Object {
-        "id": "https://github.com/decentralion",
-        "pluginName": "sourcecred/github-beta",
-        "type": "AUTHOR",
-      },
-      "payload": Object {},
-      "src": Object {
-        "id": "https://github.com/sourcecred/example-github/issues/6#issuecomment-373768538",
-        "pluginName": "sourcecred/github-beta",
-        "type": "COMMENT",
-      },
-    },
-    "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/decentralion\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"AUTHOR\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/issues/6#issuecomment-385223316\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"COMMENT\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"AUTHORS\\"}": Object {
-      "dst": Object {
-        "id": "https://github.com/decentralion",
-        "pluginName": "sourcecred/github-beta",
-        "type": "AUTHOR",
-      },
-      "payload": Object {},
-      "src": Object {
-        "id": "https://github.com/sourcecred/example-github/issues/6#issuecomment-385223316",
-        "pluginName": "sourcecred/github-beta",
-        "type": "COMMENT",
-      },
-    },
-    "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/decentralion\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"AUTHOR\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/issues/6\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"ISSUE\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"AUTHORS\\"}": Object {
-      "dst": Object {
-        "id": "https://github.com/decentralion",
-        "pluginName": "sourcecred/github-beta",
-        "type": "AUTHOR",
-      },
-      "payload": Object {},
-      "src": Object {
-        "id": "https://github.com/sourcecred/example-github/issues/6",
-        "pluginName": "sourcecred/github-beta",
-        "type": "ISSUE",
-      },
-    },
-    "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/issues/6\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"ISSUE\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/issues/6#issuecomment-373768442\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"COMMENT\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"CONTAINS\\"}": Object {
-      "dst": Object {
-        "id": "https://github.com/sourcecred/example-github/issues/6#issuecomment-373768442",
-        "pluginName": "sourcecred/github-beta",
-        "type": "COMMENT",
-      },
-      "payload": Object {},
-      "src": Object {
-        "id": "https://github.com/sourcecred/example-github/issues/6",
-        "pluginName": "sourcecred/github-beta",
-        "type": "ISSUE",
-      },
-    },
-    "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/issues/6\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"ISSUE\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/issues/6#issuecomment-373768538\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"COMMENT\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"CONTAINS\\"}": Object {
-      "dst": Object {
-        "id": "https://github.com/sourcecred/example-github/issues/6#issuecomment-373768538",
-        "pluginName": "sourcecred/github-beta",
-        "type": "COMMENT",
-      },
-      "payload": Object {},
-      "src": Object {
-        "id": "https://github.com/sourcecred/example-github/issues/6",
-        "pluginName": "sourcecred/github-beta",
-        "type": "ISSUE",
-      },
-    },
-    "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/issues/6\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"ISSUE\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/issues/6#issuecomment-385223316\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"COMMENT\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"CONTAINS\\"}": Object {
-      "dst": Object {
-        "id": "https://github.com/sourcecred/example-github/issues/6#issuecomment-385223316",
-        "pluginName": "sourcecred/github-beta",
-        "type": "COMMENT",
-      },
-      "payload": Object {},
-      "src": Object {
-        "id": "https://github.com/sourcecred/example-github/issues/6",
-        "pluginName": "sourcecred/github-beta",
-        "type": "ISSUE",
-      },
-    },
-    "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"REPOSITORY\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/issues/6\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"ISSUE\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"CONTAINS\\"}": Object {
-      "dst": Object {
-        "id": "https://github.com/sourcecred/example-github/issues/6",
-        "pluginName": "sourcecred/github-beta",
-        "type": "ISSUE",
-      },
-      "payload": Object {},
-      "src": Object {
-        "id": "https://github.com/sourcecred/example-github",
-        "pluginName": "sourcecred/github-beta",
-        "type": "REPOSITORY",
-      },
-    },
+Array [
+  Object {
+    "type": "sourcecred/sourcecred/Graph",
+    "version": "0.1.0",
   },
-  "nodes": Object {
-    "{\\"id\\":\\"https://github.com/decentralion\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"AUTHOR\\"}": Object {
-      "payload": Object {
-        "login": "decentralion",
-        "subtype": "USER",
-        "url": "https://github.com/decentralion",
+  Object {
+    "edges": Array [
+      Object {
+        "type": "sourcecred/sourcecred/AddressMap",
+        "version": "0.1.0",
       },
-    },
-    "{\\"id\\":\\"https://github.com/sourcecred/example-github\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"REPOSITORY\\"}": Object {
-      "payload": Object {
-        "name": "example-github",
-        "owner": "sourcecred",
-        "url": "https://github.com/sourcecred/example-github",
+      Object {
+        "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/decentralion\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"AUTHOR\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/issues/6#issuecomment-373768442\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"COMMENT\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"AUTHORS\\"}": Object {
+          "dst": Object {
+            "id": "https://github.com/decentralion",
+            "pluginName": "sourcecred/github-beta",
+            "type": "AUTHOR",
+          },
+          "payload": Object {},
+          "src": Object {
+            "id": "https://github.com/sourcecred/example-github/issues/6#issuecomment-373768442",
+            "pluginName": "sourcecred/github-beta",
+            "type": "COMMENT",
+          },
+        },
+        "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/decentralion\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"AUTHOR\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/issues/6#issuecomment-373768538\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"COMMENT\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"AUTHORS\\"}": Object {
+          "dst": Object {
+            "id": "https://github.com/decentralion",
+            "pluginName": "sourcecred/github-beta",
+            "type": "AUTHOR",
+          },
+          "payload": Object {},
+          "src": Object {
+            "id": "https://github.com/sourcecred/example-github/issues/6#issuecomment-373768538",
+            "pluginName": "sourcecred/github-beta",
+            "type": "COMMENT",
+          },
+        },
+        "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/decentralion\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"AUTHOR\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/issues/6#issuecomment-385223316\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"COMMENT\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"AUTHORS\\"}": Object {
+          "dst": Object {
+            "id": "https://github.com/decentralion",
+            "pluginName": "sourcecred/github-beta",
+            "type": "AUTHOR",
+          },
+          "payload": Object {},
+          "src": Object {
+            "id": "https://github.com/sourcecred/example-github/issues/6#issuecomment-385223316",
+            "pluginName": "sourcecred/github-beta",
+            "type": "COMMENT",
+          },
+        },
+        "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/decentralion\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"AUTHOR\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/issues/6\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"ISSUE\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"AUTHORS\\"}": Object {
+          "dst": Object {
+            "id": "https://github.com/decentralion",
+            "pluginName": "sourcecred/github-beta",
+            "type": "AUTHOR",
+          },
+          "payload": Object {},
+          "src": Object {
+            "id": "https://github.com/sourcecred/example-github/issues/6",
+            "pluginName": "sourcecred/github-beta",
+            "type": "ISSUE",
+          },
+        },
+        "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/issues/6\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"ISSUE\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/issues/6#issuecomment-373768442\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"COMMENT\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"CONTAINS\\"}": Object {
+          "dst": Object {
+            "id": "https://github.com/sourcecred/example-github/issues/6#issuecomment-373768442",
+            "pluginName": "sourcecred/github-beta",
+            "type": "COMMENT",
+          },
+          "payload": Object {},
+          "src": Object {
+            "id": "https://github.com/sourcecred/example-github/issues/6",
+            "pluginName": "sourcecred/github-beta",
+            "type": "ISSUE",
+          },
+        },
+        "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/issues/6\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"ISSUE\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/issues/6#issuecomment-373768538\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"COMMENT\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"CONTAINS\\"}": Object {
+          "dst": Object {
+            "id": "https://github.com/sourcecred/example-github/issues/6#issuecomment-373768538",
+            "pluginName": "sourcecred/github-beta",
+            "type": "COMMENT",
+          },
+          "payload": Object {},
+          "src": Object {
+            "id": "https://github.com/sourcecred/example-github/issues/6",
+            "pluginName": "sourcecred/github-beta",
+            "type": "ISSUE",
+          },
+        },
+        "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/issues/6\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"ISSUE\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/issues/6#issuecomment-385223316\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"COMMENT\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"CONTAINS\\"}": Object {
+          "dst": Object {
+            "id": "https://github.com/sourcecred/example-github/issues/6#issuecomment-385223316",
+            "pluginName": "sourcecred/github-beta",
+            "type": "COMMENT",
+          },
+          "payload": Object {},
+          "src": Object {
+            "id": "https://github.com/sourcecred/example-github/issues/6",
+            "pluginName": "sourcecred/github-beta",
+            "type": "ISSUE",
+          },
+        },
+        "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"REPOSITORY\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/issues/6\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"ISSUE\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"CONTAINS\\"}": Object {
+          "dst": Object {
+            "id": "https://github.com/sourcecred/example-github/issues/6",
+            "pluginName": "sourcecred/github-beta",
+            "type": "ISSUE",
+          },
+          "payload": Object {},
+          "src": Object {
+            "id": "https://github.com/sourcecred/example-github",
+            "pluginName": "sourcecred/github-beta",
+            "type": "REPOSITORY",
+          },
+        },
       },
-    },
-    "{\\"id\\":\\"https://github.com/sourcecred/example-github/issues/6\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"ISSUE\\"}": Object {
-      "payload": Object {
-        "body": "This issue shall shortly have a few comments.",
-        "number": 6,
-        "title": "An issue with comments",
-        "url": "https://github.com/sourcecred/example-github/issues/6",
+    ],
+    "nodes": Array [
+      Object {
+        "type": "sourcecred/sourcecred/AddressMap",
+        "version": "0.1.0",
       },
-    },
-    "{\\"id\\":\\"https://github.com/sourcecred/example-github/issues/6#issuecomment-373768442\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"COMMENT\\"}": Object {
-      "payload": Object {
-        "body": "A wild COMMENT appeared!",
-        "url": "https://github.com/sourcecred/example-github/issues/6#issuecomment-373768442",
+      Object {
+        "{\\"id\\":\\"https://github.com/decentralion\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"AUTHOR\\"}": Object {
+          "payload": Object {
+            "login": "decentralion",
+            "subtype": "USER",
+            "url": "https://github.com/decentralion",
+          },
+        },
+        "{\\"id\\":\\"https://github.com/sourcecred/example-github\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"REPOSITORY\\"}": Object {
+          "payload": Object {
+            "name": "example-github",
+            "owner": "sourcecred",
+            "url": "https://github.com/sourcecred/example-github",
+          },
+        },
+        "{\\"id\\":\\"https://github.com/sourcecred/example-github/issues/6\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"ISSUE\\"}": Object {
+          "payload": Object {
+            "body": "This issue shall shortly have a few comments.",
+            "number": 6,
+            "title": "An issue with comments",
+            "url": "https://github.com/sourcecred/example-github/issues/6",
+          },
+        },
+        "{\\"id\\":\\"https://github.com/sourcecred/example-github/issues/6#issuecomment-373768442\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"COMMENT\\"}": Object {
+          "payload": Object {
+            "body": "A wild COMMENT appeared!",
+            "url": "https://github.com/sourcecred/example-github/issues/6#issuecomment-373768442",
+          },
+        },
+        "{\\"id\\":\\"https://github.com/sourcecred/example-github/issues/6#issuecomment-373768538\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"COMMENT\\"}": Object {
+          "payload": Object {
+            "body": "And the maintainer said, \\"Let there be comments!\\"",
+            "url": "https://github.com/sourcecred/example-github/issues/6#issuecomment-373768538",
+          },
+        },
+        "{\\"id\\":\\"https://github.com/sourcecred/example-github/issues/6#issuecomment-385223316\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"COMMENT\\"}": Object {
+          "payload": Object {
+            "body": "This comment references an #2, which itself references an issue. This comment is thus allows us to test that in-references are not included when requesting a Post's references.",
+            "url": "https://github.com/sourcecred/example-github/issues/6#issuecomment-385223316",
+          },
+        },
       },
-    },
-    "{\\"id\\":\\"https://github.com/sourcecred/example-github/issues/6#issuecomment-373768538\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"COMMENT\\"}": Object {
-      "payload": Object {
-        "body": "And the maintainer said, \\"Let there be comments!\\"",
-        "url": "https://github.com/sourcecred/example-github/issues/6#issuecomment-373768538",
-      },
-    },
-    "{\\"id\\":\\"https://github.com/sourcecred/example-github/issues/6#issuecomment-385223316\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"COMMENT\\"}": Object {
-      "payload": Object {
-        "body": "This comment references an #2, which itself references an issue. This comment is thus allows us to test that in-references are not included when requesting a Post's references.",
-        "url": "https://github.com/sourcecred/example-github/issues/6#issuecomment-385223316",
-      },
-    },
+    ],
   },
-}
+]
 `;
 
 exports[`GithubParser pull request parsing parses a pr with review comments (https://github.com/sourcecred/example-github/pull/3) 1`] = `
-Object {
-  "edges": Object {
-    "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/decentralion\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"AUTHOR\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/pull/5\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"PULL_REQUEST\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"AUTHORS\\"}": Object {
-      "dst": Object {
-        "id": "https://github.com/decentralion",
-        "pluginName": "sourcecred/github-beta",
-        "type": "AUTHOR",
-      },
-      "payload": Object {},
-      "src": Object {
-        "id": "https://github.com/sourcecred/example-github/pull/5",
-        "pluginName": "sourcecred/github-beta",
-        "type": "PULL_REQUEST",
-      },
-    },
-    "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/pull/5#pullrequestreview-100313899\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"PULL_REQUEST_REVIEW\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/pull/5#discussion_r171460198\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"PULL_REQUEST_REVIEW_COMMENT\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"CONTAINS\\"}": Object {
-      "dst": Object {
-        "id": "https://github.com/sourcecred/example-github/pull/5#discussion_r171460198",
-        "pluginName": "sourcecred/github-beta",
-        "type": "PULL_REQUEST_REVIEW_COMMENT",
-      },
-      "payload": Object {},
-      "src": Object {
-        "id": "https://github.com/sourcecred/example-github/pull/5#pullrequestreview-100313899",
-        "pluginName": "sourcecred/github-beta",
-        "type": "PULL_REQUEST_REVIEW",
-      },
-    },
-    "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/pull/5\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"PULL_REQUEST\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"6d5b3aa31ebb68a06ceb46bbd6cf49b6ccd6f5e6\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/git-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"COMMIT\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"MERGED_AS\\"}": Object {
-      "dst": Object {
-        "id": "6d5b3aa31ebb68a06ceb46bbd6cf49b6ccd6f5e6",
-        "pluginName": "sourcecred/git-beta",
-        "type": "COMMIT",
-      },
-      "payload": Object {
-        "hash": "6d5b3aa31ebb68a06ceb46bbd6cf49b6ccd6f5e6",
-      },
-      "src": Object {
-        "id": "https://github.com/sourcecred/example-github/pull/5",
-        "pluginName": "sourcecred/github-beta",
-        "type": "PULL_REQUEST",
-      },
-    },
-    "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/pull/5\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"PULL_REQUEST\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/pull/5#pullrequestreview-100313899\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"PULL_REQUEST_REVIEW\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"CONTAINS\\"}": Object {
-      "dst": Object {
-        "id": "https://github.com/sourcecred/example-github/pull/5#pullrequestreview-100313899",
-        "pluginName": "sourcecred/github-beta",
-        "type": "PULL_REQUEST_REVIEW",
-      },
-      "payload": Object {},
-      "src": Object {
-        "id": "https://github.com/sourcecred/example-github/pull/5",
-        "pluginName": "sourcecred/github-beta",
-        "type": "PULL_REQUEST",
-      },
-    },
-    "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/pull/5\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"PULL_REQUEST\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/pull/5#pullrequestreview-100314038\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"PULL_REQUEST_REVIEW\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"CONTAINS\\"}": Object {
-      "dst": Object {
-        "id": "https://github.com/sourcecred/example-github/pull/5#pullrequestreview-100314038",
-        "pluginName": "sourcecred/github-beta",
-        "type": "PULL_REQUEST_REVIEW",
-      },
-      "payload": Object {},
-      "src": Object {
-        "id": "https://github.com/sourcecred/example-github/pull/5",
-        "pluginName": "sourcecred/github-beta",
-        "type": "PULL_REQUEST",
-      },
-    },
-    "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/pull/5\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"PULL_REQUEST\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/wchargin\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"AUTHOR\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"REFERENCES\\"}": Object {
-      "dst": Object {
-        "id": "https://github.com/wchargin",
-        "pluginName": "sourcecred/github-beta",
-        "type": "AUTHOR",
-      },
-      "payload": Object {},
-      "src": Object {
-        "id": "https://github.com/sourcecred/example-github/pull/5",
-        "pluginName": "sourcecred/github-beta",
-        "type": "PULL_REQUEST",
-      },
-    },
-    "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"REPOSITORY\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/pull/5\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"PULL_REQUEST\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"CONTAINS\\"}": Object {
-      "dst": Object {
-        "id": "https://github.com/sourcecred/example-github/pull/5",
-        "pluginName": "sourcecred/github-beta",
-        "type": "PULL_REQUEST",
-      },
-      "payload": Object {},
-      "src": Object {
-        "id": "https://github.com/sourcecred/example-github",
-        "pluginName": "sourcecred/github-beta",
-        "type": "REPOSITORY",
-      },
-    },
-    "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/wchargin\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"AUTHOR\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/pull/5#discussion_r171460198\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"PULL_REQUEST_REVIEW_COMMENT\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"AUTHORS\\"}": Object {
-      "dst": Object {
-        "id": "https://github.com/wchargin",
-        "pluginName": "sourcecred/github-beta",
-        "type": "AUTHOR",
-      },
-      "payload": Object {},
-      "src": Object {
-        "id": "https://github.com/sourcecred/example-github/pull/5#discussion_r171460198",
-        "pluginName": "sourcecred/github-beta",
-        "type": "PULL_REQUEST_REVIEW_COMMENT",
-      },
-    },
-    "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/wchargin\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"AUTHOR\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/pull/5#pullrequestreview-100313899\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"PULL_REQUEST_REVIEW\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"AUTHORS\\"}": Object {
-      "dst": Object {
-        "id": "https://github.com/wchargin",
-        "pluginName": "sourcecred/github-beta",
-        "type": "AUTHOR",
-      },
-      "payload": Object {},
-      "src": Object {
-        "id": "https://github.com/sourcecred/example-github/pull/5#pullrequestreview-100313899",
-        "pluginName": "sourcecred/github-beta",
-        "type": "PULL_REQUEST_REVIEW",
-      },
-    },
-    "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/wchargin\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"AUTHOR\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/pull/5#pullrequestreview-100314038\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"PULL_REQUEST_REVIEW\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"AUTHORS\\"}": Object {
-      "dst": Object {
-        "id": "https://github.com/wchargin",
-        "pluginName": "sourcecred/github-beta",
-        "type": "AUTHOR",
-      },
-      "payload": Object {},
-      "src": Object {
-        "id": "https://github.com/sourcecred/example-github/pull/5#pullrequestreview-100314038",
-        "pluginName": "sourcecred/github-beta",
-        "type": "PULL_REQUEST_REVIEW",
-      },
-    },
+Array [
+  Object {
+    "type": "sourcecred/sourcecred/Graph",
+    "version": "0.1.0",
   },
-  "nodes": Object {
-    "{\\"id\\":\\"https://github.com/decentralion\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"AUTHOR\\"}": Object {
-      "payload": Object {
-        "login": "decentralion",
-        "subtype": "USER",
-        "url": "https://github.com/decentralion",
+  Object {
+    "edges": Array [
+      Object {
+        "type": "sourcecred/sourcecred/AddressMap",
+        "version": "0.1.0",
       },
-    },
-    "{\\"id\\":\\"https://github.com/sourcecred/example-github\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"REPOSITORY\\"}": Object {
-      "payload": Object {
-        "name": "example-github",
-        "owner": "sourcecred",
-        "url": "https://github.com/sourcecred/example-github",
+      Object {
+        "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/decentralion\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"AUTHOR\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/pull/5\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"PULL_REQUEST\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"AUTHORS\\"}": Object {
+          "dst": Object {
+            "id": "https://github.com/decentralion",
+            "pluginName": "sourcecred/github-beta",
+            "type": "AUTHOR",
+          },
+          "payload": Object {},
+          "src": Object {
+            "id": "https://github.com/sourcecred/example-github/pull/5",
+            "pluginName": "sourcecred/github-beta",
+            "type": "PULL_REQUEST",
+          },
+        },
+        "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/pull/5#pullrequestreview-100313899\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"PULL_REQUEST_REVIEW\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/pull/5#discussion_r171460198\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"PULL_REQUEST_REVIEW_COMMENT\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"CONTAINS\\"}": Object {
+          "dst": Object {
+            "id": "https://github.com/sourcecred/example-github/pull/5#discussion_r171460198",
+            "pluginName": "sourcecred/github-beta",
+            "type": "PULL_REQUEST_REVIEW_COMMENT",
+          },
+          "payload": Object {},
+          "src": Object {
+            "id": "https://github.com/sourcecred/example-github/pull/5#pullrequestreview-100313899",
+            "pluginName": "sourcecred/github-beta",
+            "type": "PULL_REQUEST_REVIEW",
+          },
+        },
+        "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/pull/5\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"PULL_REQUEST\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"6d5b3aa31ebb68a06ceb46bbd6cf49b6ccd6f5e6\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/git-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"COMMIT\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"MERGED_AS\\"}": Object {
+          "dst": Object {
+            "id": "6d5b3aa31ebb68a06ceb46bbd6cf49b6ccd6f5e6",
+            "pluginName": "sourcecred/git-beta",
+            "type": "COMMIT",
+          },
+          "payload": Object {
+            "hash": "6d5b3aa31ebb68a06ceb46bbd6cf49b6ccd6f5e6",
+          },
+          "src": Object {
+            "id": "https://github.com/sourcecred/example-github/pull/5",
+            "pluginName": "sourcecred/github-beta",
+            "type": "PULL_REQUEST",
+          },
+        },
+        "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/pull/5\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"PULL_REQUEST\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/pull/5#pullrequestreview-100313899\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"PULL_REQUEST_REVIEW\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"CONTAINS\\"}": Object {
+          "dst": Object {
+            "id": "https://github.com/sourcecred/example-github/pull/5#pullrequestreview-100313899",
+            "pluginName": "sourcecred/github-beta",
+            "type": "PULL_REQUEST_REVIEW",
+          },
+          "payload": Object {},
+          "src": Object {
+            "id": "https://github.com/sourcecred/example-github/pull/5",
+            "pluginName": "sourcecred/github-beta",
+            "type": "PULL_REQUEST",
+          },
+        },
+        "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/pull/5\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"PULL_REQUEST\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/pull/5#pullrequestreview-100314038\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"PULL_REQUEST_REVIEW\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"CONTAINS\\"}": Object {
+          "dst": Object {
+            "id": "https://github.com/sourcecred/example-github/pull/5#pullrequestreview-100314038",
+            "pluginName": "sourcecred/github-beta",
+            "type": "PULL_REQUEST_REVIEW",
+          },
+          "payload": Object {},
+          "src": Object {
+            "id": "https://github.com/sourcecred/example-github/pull/5",
+            "pluginName": "sourcecred/github-beta",
+            "type": "PULL_REQUEST",
+          },
+        },
+        "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/pull/5\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"PULL_REQUEST\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/wchargin\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"AUTHOR\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"REFERENCES\\"}": Object {
+          "dst": Object {
+            "id": "https://github.com/wchargin",
+            "pluginName": "sourcecred/github-beta",
+            "type": "AUTHOR",
+          },
+          "payload": Object {},
+          "src": Object {
+            "id": "https://github.com/sourcecred/example-github/pull/5",
+            "pluginName": "sourcecred/github-beta",
+            "type": "PULL_REQUEST",
+          },
+        },
+        "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"REPOSITORY\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/pull/5\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"PULL_REQUEST\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"CONTAINS\\"}": Object {
+          "dst": Object {
+            "id": "https://github.com/sourcecred/example-github/pull/5",
+            "pluginName": "sourcecred/github-beta",
+            "type": "PULL_REQUEST",
+          },
+          "payload": Object {},
+          "src": Object {
+            "id": "https://github.com/sourcecred/example-github",
+            "pluginName": "sourcecred/github-beta",
+            "type": "REPOSITORY",
+          },
+        },
+        "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/wchargin\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"AUTHOR\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/pull/5#discussion_r171460198\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"PULL_REQUEST_REVIEW_COMMENT\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"AUTHORS\\"}": Object {
+          "dst": Object {
+            "id": "https://github.com/wchargin",
+            "pluginName": "sourcecred/github-beta",
+            "type": "AUTHOR",
+          },
+          "payload": Object {},
+          "src": Object {
+            "id": "https://github.com/sourcecred/example-github/pull/5#discussion_r171460198",
+            "pluginName": "sourcecred/github-beta",
+            "type": "PULL_REQUEST_REVIEW_COMMENT",
+          },
+        },
+        "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/wchargin\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"AUTHOR\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/pull/5#pullrequestreview-100313899\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"PULL_REQUEST_REVIEW\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"AUTHORS\\"}": Object {
+          "dst": Object {
+            "id": "https://github.com/wchargin",
+            "pluginName": "sourcecred/github-beta",
+            "type": "AUTHOR",
+          },
+          "payload": Object {},
+          "src": Object {
+            "id": "https://github.com/sourcecred/example-github/pull/5#pullrequestreview-100313899",
+            "pluginName": "sourcecred/github-beta",
+            "type": "PULL_REQUEST_REVIEW",
+          },
+        },
+        "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/wchargin\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"AUTHOR\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/pull/5#pullrequestreview-100314038\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"PULL_REQUEST_REVIEW\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"AUTHORS\\"}": Object {
+          "dst": Object {
+            "id": "https://github.com/wchargin",
+            "pluginName": "sourcecred/github-beta",
+            "type": "AUTHOR",
+          },
+          "payload": Object {},
+          "src": Object {
+            "id": "https://github.com/sourcecred/example-github/pull/5#pullrequestreview-100314038",
+            "pluginName": "sourcecred/github-beta",
+            "type": "PULL_REQUEST_REVIEW",
+          },
+        },
       },
-    },
-    "{\\"id\\":\\"https://github.com/sourcecred/example-github/pull/5\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"PULL_REQUEST\\"}": Object {
-      "payload": Object {
-        "body": "@wchargin could you please do the following:
+    ],
+    "nodes": Array [
+      Object {
+        "type": "sourcecred/sourcecred/AddressMap",
+        "version": "0.1.0",
+      },
+      Object {
+        "{\\"id\\":\\"https://github.com/decentralion\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"AUTHOR\\"}": Object {
+          "payload": Object {
+            "login": "decentralion",
+            "subtype": "USER",
+            "url": "https://github.com/decentralion",
+          },
+        },
+        "{\\"id\\":\\"https://github.com/sourcecred/example-github\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"REPOSITORY\\"}": Object {
+          "payload": Object {
+            "name": "example-github",
+            "owner": "sourcecred",
+            "url": "https://github.com/sourcecred/example-github",
+          },
+        },
+        "{\\"id\\":\\"https://github.com/sourcecred/example-github/pull/5\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"PULL_REQUEST\\"}": Object {
+          "payload": Object {
+            "body": "@wchargin could you please do the following:
 - add a commit comment
 - add a review comment requesting some trivial change
 - i'll change it
 - then approve the pr",
-        "number": 5,
-        "title": "This pull request will be more contentious. I can feel it...",
-        "url": "https://github.com/sourcecred/example-github/pull/5",
+            "number": 5,
+            "title": "This pull request will be more contentious. I can feel it...",
+            "url": "https://github.com/sourcecred/example-github/pull/5",
+          },
+        },
+        "{\\"id\\":\\"https://github.com/sourcecred/example-github/pull/5#discussion_r171460198\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"PULL_REQUEST_REVIEW_COMMENT\\"}": Object {
+          "payload": Object {
+            "body": "seems a bit capricious",
+            "url": "https://github.com/sourcecred/example-github/pull/5#discussion_r171460198",
+          },
+        },
+        "{\\"id\\":\\"https://github.com/sourcecred/example-github/pull/5#pullrequestreview-100313899\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"PULL_REQUEST_REVIEW\\"}": Object {
+          "payload": Object {
+            "body": "hmmm.jpg",
+            "state": "CHANGES_REQUESTED",
+            "url": "https://github.com/sourcecred/example-github/pull/5#pullrequestreview-100313899",
+          },
+        },
+        "{\\"id\\":\\"https://github.com/sourcecred/example-github/pull/5#pullrequestreview-100314038\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"PULL_REQUEST_REVIEW\\"}": Object {
+          "payload": Object {
+            "body": "I'm sold",
+            "state": "APPROVED",
+            "url": "https://github.com/sourcecred/example-github/pull/5#pullrequestreview-100314038",
+          },
+        },
+        "{\\"id\\":\\"https://github.com/wchargin\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"AUTHOR\\"}": Object {
+          "payload": Object {
+            "login": "wchargin",
+            "subtype": "USER",
+            "url": "https://github.com/wchargin",
+          },
+        },
       },
-    },
-    "{\\"id\\":\\"https://github.com/sourcecred/example-github/pull/5#discussion_r171460198\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"PULL_REQUEST_REVIEW_COMMENT\\"}": Object {
-      "payload": Object {
-        "body": "seems a bit capricious",
-        "url": "https://github.com/sourcecred/example-github/pull/5#discussion_r171460198",
-      },
-    },
-    "{\\"id\\":\\"https://github.com/sourcecred/example-github/pull/5#pullrequestreview-100313899\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"PULL_REQUEST_REVIEW\\"}": Object {
-      "payload": Object {
-        "body": "hmmm.jpg",
-        "state": "CHANGES_REQUESTED",
-        "url": "https://github.com/sourcecred/example-github/pull/5#pullrequestreview-100313899",
-      },
-    },
-    "{\\"id\\":\\"https://github.com/sourcecred/example-github/pull/5#pullrequestreview-100314038\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"PULL_REQUEST_REVIEW\\"}": Object {
-      "payload": Object {
-        "body": "I'm sold",
-        "state": "APPROVED",
-        "url": "https://github.com/sourcecred/example-github/pull/5#pullrequestreview-100314038",
-      },
-    },
-    "{\\"id\\":\\"https://github.com/wchargin\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"AUTHOR\\"}": Object {
-      "payload": Object {
-        "login": "wchargin",
-        "subtype": "USER",
-        "url": "https://github.com/wchargin",
-      },
-    },
+    ],
   },
-}
+]
 `;
 
 exports[`GithubParser pull request parsing parses a simple pull request (https://github.com/sourcecred/example-github/pull/3) 1`] = `
-Object {
-  "edges": Object {
-    "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/decentralion\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"AUTHOR\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/pull/3#issuecomment-369162222\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"COMMENT\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"AUTHORS\\"}": Object {
-      "dst": Object {
-        "id": "https://github.com/decentralion",
-        "pluginName": "sourcecred/github-beta",
-        "type": "AUTHOR",
-      },
-      "payload": Object {},
-      "src": Object {
-        "id": "https://github.com/sourcecred/example-github/pull/3#issuecomment-369162222",
-        "pluginName": "sourcecred/github-beta",
-        "type": "COMMENT",
-      },
-    },
-    "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/decentralion\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"AUTHOR\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/pull/3\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"PULL_REQUEST\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"AUTHORS\\"}": Object {
-      "dst": Object {
-        "id": "https://github.com/decentralion",
-        "pluginName": "sourcecred/github-beta",
-        "type": "AUTHOR",
-      },
-      "payload": Object {},
-      "src": Object {
-        "id": "https://github.com/sourcecred/example-github/pull/3",
-        "pluginName": "sourcecred/github-beta",
-        "type": "PULL_REQUEST",
-      },
-    },
-    "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/pull/3\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"PULL_REQUEST\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"0a223346b4e6dec0127b1e6aa892c4ee0424b66a\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/git-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"COMMIT\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"MERGED_AS\\"}": Object {
-      "dst": Object {
-        "id": "0a223346b4e6dec0127b1e6aa892c4ee0424b66a",
-        "pluginName": "sourcecred/git-beta",
-        "type": "COMMIT",
-      },
-      "payload": Object {
-        "hash": "0a223346b4e6dec0127b1e6aa892c4ee0424b66a",
-      },
-      "src": Object {
-        "id": "https://github.com/sourcecred/example-github/pull/3",
-        "pluginName": "sourcecred/github-beta",
-        "type": "PULL_REQUEST",
-      },
-    },
-    "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/pull/3\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"PULL_REQUEST\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/pull/3#issuecomment-369162222\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"COMMENT\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"CONTAINS\\"}": Object {
-      "dst": Object {
-        "id": "https://github.com/sourcecred/example-github/pull/3#issuecomment-369162222",
-        "pluginName": "sourcecred/github-beta",
-        "type": "COMMENT",
-      },
-      "payload": Object {},
-      "src": Object {
-        "id": "https://github.com/sourcecred/example-github/pull/3",
-        "pluginName": "sourcecred/github-beta",
-        "type": "PULL_REQUEST",
-      },
-    },
-    "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"REPOSITORY\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/pull/3\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"PULL_REQUEST\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"CONTAINS\\"}": Object {
-      "dst": Object {
-        "id": "https://github.com/sourcecred/example-github/pull/3",
-        "pluginName": "sourcecred/github-beta",
-        "type": "PULL_REQUEST",
-      },
-      "payload": Object {},
-      "src": Object {
-        "id": "https://github.com/sourcecred/example-github",
-        "pluginName": "sourcecred/github-beta",
-        "type": "REPOSITORY",
-      },
-    },
+Array [
+  Object {
+    "type": "sourcecred/sourcecred/Graph",
+    "version": "0.1.0",
   },
-  "nodes": Object {
-    "{\\"id\\":\\"https://github.com/decentralion\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"AUTHOR\\"}": Object {
-      "payload": Object {
-        "login": "decentralion",
-        "subtype": "USER",
-        "url": "https://github.com/decentralion",
+  Object {
+    "edges": Array [
+      Object {
+        "type": "sourcecred/sourcecred/AddressMap",
+        "version": "0.1.0",
       },
-    },
-    "{\\"id\\":\\"https://github.com/sourcecred/example-github\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"REPOSITORY\\"}": Object {
-      "payload": Object {
-        "name": "example-github",
-        "owner": "sourcecred",
-        "url": "https://github.com/sourcecred/example-github",
+      Object {
+        "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/decentralion\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"AUTHOR\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/pull/3#issuecomment-369162222\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"COMMENT\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"AUTHORS\\"}": Object {
+          "dst": Object {
+            "id": "https://github.com/decentralion",
+            "pluginName": "sourcecred/github-beta",
+            "type": "AUTHOR",
+          },
+          "payload": Object {},
+          "src": Object {
+            "id": "https://github.com/sourcecred/example-github/pull/3#issuecomment-369162222",
+            "pluginName": "sourcecred/github-beta",
+            "type": "COMMENT",
+          },
+        },
+        "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/decentralion\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"AUTHOR\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/pull/3\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"PULL_REQUEST\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"AUTHORS\\"}": Object {
+          "dst": Object {
+            "id": "https://github.com/decentralion",
+            "pluginName": "sourcecred/github-beta",
+            "type": "AUTHOR",
+          },
+          "payload": Object {},
+          "src": Object {
+            "id": "https://github.com/sourcecred/example-github/pull/3",
+            "pluginName": "sourcecred/github-beta",
+            "type": "PULL_REQUEST",
+          },
+        },
+        "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/pull/3\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"PULL_REQUEST\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"0a223346b4e6dec0127b1e6aa892c4ee0424b66a\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/git-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"COMMIT\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"MERGED_AS\\"}": Object {
+          "dst": Object {
+            "id": "0a223346b4e6dec0127b1e6aa892c4ee0424b66a",
+            "pluginName": "sourcecred/git-beta",
+            "type": "COMMIT",
+          },
+          "payload": Object {
+            "hash": "0a223346b4e6dec0127b1e6aa892c4ee0424b66a",
+          },
+          "src": Object {
+            "id": "https://github.com/sourcecred/example-github/pull/3",
+            "pluginName": "sourcecred/github-beta",
+            "type": "PULL_REQUEST",
+          },
+        },
+        "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/pull/3\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"PULL_REQUEST\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/pull/3#issuecomment-369162222\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"COMMENT\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"CONTAINS\\"}": Object {
+          "dst": Object {
+            "id": "https://github.com/sourcecred/example-github/pull/3#issuecomment-369162222",
+            "pluginName": "sourcecred/github-beta",
+            "type": "COMMENT",
+          },
+          "payload": Object {},
+          "src": Object {
+            "id": "https://github.com/sourcecred/example-github/pull/3",
+            "pluginName": "sourcecred/github-beta",
+            "type": "PULL_REQUEST",
+          },
+        },
+        "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"REPOSITORY\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/pull/3\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"PULL_REQUEST\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"CONTAINS\\"}": Object {
+          "dst": Object {
+            "id": "https://github.com/sourcecred/example-github/pull/3",
+            "pluginName": "sourcecred/github-beta",
+            "type": "PULL_REQUEST",
+          },
+          "payload": Object {},
+          "src": Object {
+            "id": "https://github.com/sourcecred/example-github",
+            "pluginName": "sourcecred/github-beta",
+            "type": "REPOSITORY",
+          },
+        },
       },
-    },
-    "{\\"id\\":\\"https://github.com/sourcecred/example-github/pull/3\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"PULL_REQUEST\\"}": Object {
-      "payload": Object {
-        "body": "Oh look, it's a pull request.",
-        "number": 3,
-        "title": "Add README, merge via PR.",
-        "url": "https://github.com/sourcecred/example-github/pull/3",
+    ],
+    "nodes": Array [
+      Object {
+        "type": "sourcecred/sourcecred/AddressMap",
+        "version": "0.1.0",
       },
-    },
-    "{\\"id\\":\\"https://github.com/sourcecred/example-github/pull/3#issuecomment-369162222\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"COMMENT\\"}": Object {
-      "payload": Object {
-        "body": "It seems apropos to reference something from a pull request comment... eg: #2 ",
-        "url": "https://github.com/sourcecred/example-github/pull/3#issuecomment-369162222",
+      Object {
+        "{\\"id\\":\\"https://github.com/decentralion\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"AUTHOR\\"}": Object {
+          "payload": Object {
+            "login": "decentralion",
+            "subtype": "USER",
+            "url": "https://github.com/decentralion",
+          },
+        },
+        "{\\"id\\":\\"https://github.com/sourcecred/example-github\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"REPOSITORY\\"}": Object {
+          "payload": Object {
+            "name": "example-github",
+            "owner": "sourcecred",
+            "url": "https://github.com/sourcecred/example-github",
+          },
+        },
+        "{\\"id\\":\\"https://github.com/sourcecred/example-github/pull/3\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"PULL_REQUEST\\"}": Object {
+          "payload": Object {
+            "body": "Oh look, it's a pull request.",
+            "number": 3,
+            "title": "Add README, merge via PR.",
+            "url": "https://github.com/sourcecred/example-github/pull/3",
+          },
+        },
+        "{\\"id\\":\\"https://github.com/sourcecred/example-github/pull/3#issuecomment-369162222\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"COMMENT\\"}": Object {
+          "payload": Object {
+            "body": "It seems apropos to reference something from a pull request comment... eg: #2 ",
+            "url": "https://github.com/sourcecred/example-github/pull/3#issuecomment-369162222",
+          },
+        },
       },
-    },
+    ],
   },
-}
+]
 `;
 
 exports[`GithubParser reference detection discovers a simple reference 1`] = `
-Object {
-  "edges": Object {
-    "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/decentralion\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"AUTHOR\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/issues/1\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"ISSUE\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"AUTHORS\\"}": Object {
-      "dst": Object {
-        "id": "https://github.com/decentralion",
-        "pluginName": "sourcecred/github-beta",
-        "type": "AUTHOR",
-      },
-      "payload": Object {},
-      "src": Object {
-        "id": "https://github.com/sourcecred/example-github/issues/1",
-        "pluginName": "sourcecred/github-beta",
-        "type": "ISSUE",
-      },
-    },
-    "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/decentralion\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"AUTHOR\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/issues/2#issuecomment-373768703\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"COMMENT\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"AUTHORS\\"}": Object {
-      "dst": Object {
-        "id": "https://github.com/decentralion",
-        "pluginName": "sourcecred/github-beta",
-        "type": "AUTHOR",
-      },
-      "payload": Object {},
-      "src": Object {
-        "id": "https://github.com/sourcecred/example-github/issues/2#issuecomment-373768703",
-        "pluginName": "sourcecred/github-beta",
-        "type": "COMMENT",
-      },
-    },
-    "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/decentralion\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"AUTHOR\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/issues/2#issuecomment-373768850\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"COMMENT\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"AUTHORS\\"}": Object {
-      "dst": Object {
-        "id": "https://github.com/decentralion",
-        "pluginName": "sourcecred/github-beta",
-        "type": "AUTHOR",
-      },
-      "payload": Object {},
-      "src": Object {
-        "id": "https://github.com/sourcecred/example-github/issues/2#issuecomment-373768850",
-        "pluginName": "sourcecred/github-beta",
-        "type": "COMMENT",
-      },
-    },
-    "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/decentralion\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"AUTHOR\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/issues/2#issuecomment-385576185\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"COMMENT\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"AUTHORS\\"}": Object {
-      "dst": Object {
-        "id": "https://github.com/decentralion",
-        "pluginName": "sourcecred/github-beta",
-        "type": "AUTHOR",
-      },
-      "payload": Object {},
-      "src": Object {
-        "id": "https://github.com/sourcecred/example-github/issues/2#issuecomment-385576185",
-        "pluginName": "sourcecred/github-beta",
-        "type": "COMMENT",
-      },
-    },
-    "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/decentralion\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"AUTHOR\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/issues/2#issuecomment-385576220\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"COMMENT\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"AUTHORS\\"}": Object {
-      "dst": Object {
-        "id": "https://github.com/decentralion",
-        "pluginName": "sourcecred/github-beta",
-        "type": "AUTHOR",
-      },
-      "payload": Object {},
-      "src": Object {
-        "id": "https://github.com/sourcecred/example-github/issues/2#issuecomment-385576220",
-        "pluginName": "sourcecred/github-beta",
-        "type": "COMMENT",
-      },
-    },
-    "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/decentralion\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"AUTHOR\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/issues/2#issuecomment-385576248\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"COMMENT\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"AUTHORS\\"}": Object {
-      "dst": Object {
-        "id": "https://github.com/decentralion",
-        "pluginName": "sourcecred/github-beta",
-        "type": "AUTHOR",
-      },
-      "payload": Object {},
-      "src": Object {
-        "id": "https://github.com/sourcecred/example-github/issues/2#issuecomment-385576248",
-        "pluginName": "sourcecred/github-beta",
-        "type": "COMMENT",
-      },
-    },
-    "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/decentralion\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"AUTHOR\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/issues/2#issuecomment-385576273\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"COMMENT\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"AUTHORS\\"}": Object {
-      "dst": Object {
-        "id": "https://github.com/decentralion",
-        "pluginName": "sourcecred/github-beta",
-        "type": "AUTHOR",
-      },
-      "payload": Object {},
-      "src": Object {
-        "id": "https://github.com/sourcecred/example-github/issues/2#issuecomment-385576273",
-        "pluginName": "sourcecred/github-beta",
-        "type": "COMMENT",
-      },
-    },
-    "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/decentralion\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"AUTHOR\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/issues/2#issuecomment-385576920\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"COMMENT\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"AUTHORS\\"}": Object {
-      "dst": Object {
-        "id": "https://github.com/decentralion",
-        "pluginName": "sourcecred/github-beta",
-        "type": "AUTHOR",
-      },
-      "payload": Object {},
-      "src": Object {
-        "id": "https://github.com/sourcecred/example-github/issues/2#issuecomment-385576920",
-        "pluginName": "sourcecred/github-beta",
-        "type": "COMMENT",
-      },
-    },
-    "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/decentralion\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"AUTHOR\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/issues/2#issuecomment-385576936\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"COMMENT\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"AUTHORS\\"}": Object {
-      "dst": Object {
-        "id": "https://github.com/decentralion",
-        "pluginName": "sourcecred/github-beta",
-        "type": "AUTHOR",
-      },
-      "payload": Object {},
-      "src": Object {
-        "id": "https://github.com/sourcecred/example-github/issues/2#issuecomment-385576936",
-        "pluginName": "sourcecred/github-beta",
-        "type": "COMMENT",
-      },
-    },
-    "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/decentralion\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"AUTHOR\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/issues/2\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"ISSUE\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"AUTHORS\\"}": Object {
-      "dst": Object {
-        "id": "https://github.com/decentralion",
-        "pluginName": "sourcecred/github-beta",
-        "type": "AUTHOR",
-      },
-      "payload": Object {},
-      "src": Object {
-        "id": "https://github.com/sourcecred/example-github/issues/2",
-        "pluginName": "sourcecred/github-beta",
-        "type": "ISSUE",
-      },
-    },
-    "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/decentralion\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"AUTHOR\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/issues/6#issuecomment-373768442\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"COMMENT\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"AUTHORS\\"}": Object {
-      "dst": Object {
-        "id": "https://github.com/decentralion",
-        "pluginName": "sourcecred/github-beta",
-        "type": "AUTHOR",
-      },
-      "payload": Object {},
-      "src": Object {
-        "id": "https://github.com/sourcecred/example-github/issues/6#issuecomment-373768442",
-        "pluginName": "sourcecred/github-beta",
-        "type": "COMMENT",
-      },
-    },
-    "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/decentralion\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"AUTHOR\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/issues/6#issuecomment-373768538\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"COMMENT\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"AUTHORS\\"}": Object {
-      "dst": Object {
-        "id": "https://github.com/decentralion",
-        "pluginName": "sourcecred/github-beta",
-        "type": "AUTHOR",
-      },
-      "payload": Object {},
-      "src": Object {
-        "id": "https://github.com/sourcecred/example-github/issues/6#issuecomment-373768538",
-        "pluginName": "sourcecred/github-beta",
-        "type": "COMMENT",
-      },
-    },
-    "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/decentralion\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"AUTHOR\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/issues/6#issuecomment-385223316\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"COMMENT\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"AUTHORS\\"}": Object {
-      "dst": Object {
-        "id": "https://github.com/decentralion",
-        "pluginName": "sourcecred/github-beta",
-        "type": "AUTHOR",
-      },
-      "payload": Object {},
-      "src": Object {
-        "id": "https://github.com/sourcecred/example-github/issues/6#issuecomment-385223316",
-        "pluginName": "sourcecred/github-beta",
-        "type": "COMMENT",
-      },
-    },
-    "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/decentralion\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"AUTHOR\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/issues/6\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"ISSUE\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"AUTHORS\\"}": Object {
-      "dst": Object {
-        "id": "https://github.com/decentralion",
-        "pluginName": "sourcecred/github-beta",
-        "type": "AUTHOR",
-      },
-      "payload": Object {},
-      "src": Object {
-        "id": "https://github.com/sourcecred/example-github/issues/6",
-        "pluginName": "sourcecred/github-beta",
-        "type": "ISSUE",
-      },
-    },
-    "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/issues/2#issuecomment-373768703\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"COMMENT\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/issues/6\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"ISSUE\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"REFERENCES\\"}": Object {
-      "dst": Object {
-        "id": "https://github.com/sourcecred/example-github/issues/6",
-        "pluginName": "sourcecred/github-beta",
-        "type": "ISSUE",
-      },
-      "payload": Object {},
-      "src": Object {
-        "id": "https://github.com/sourcecred/example-github/issues/2#issuecomment-373768703",
-        "pluginName": "sourcecred/github-beta",
-        "type": "COMMENT",
-      },
-    },
-    "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/issues/2#issuecomment-373768850\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"COMMENT\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/issues/6#issuecomment-373768538\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"COMMENT\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"REFERENCES\\"}": Object {
-      "dst": Object {
-        "id": "https://github.com/sourcecred/example-github/issues/6#issuecomment-373768538",
-        "pluginName": "sourcecred/github-beta",
-        "type": "COMMENT",
-      },
-      "payload": Object {},
-      "src": Object {
-        "id": "https://github.com/sourcecred/example-github/issues/2#issuecomment-373768850",
-        "pluginName": "sourcecred/github-beta",
-        "type": "COMMENT",
-      },
-    },
-    "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/issues/2#issuecomment-385576920\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"COMMENT\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/issues/1\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"ISSUE\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"REFERENCES\\"}": Object {
-      "dst": Object {
-        "id": "https://github.com/sourcecred/example-github/issues/1",
-        "pluginName": "sourcecred/github-beta",
-        "type": "ISSUE",
-      },
-      "payload": Object {},
-      "src": Object {
-        "id": "https://github.com/sourcecred/example-github/issues/2#issuecomment-385576920",
-        "pluginName": "sourcecred/github-beta",
-        "type": "COMMENT",
-      },
-    },
-    "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/issues/2#issuecomment-385576920\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"COMMENT\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/issues/2\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"ISSUE\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"REFERENCES\\"}": Object {
-      "dst": Object {
-        "id": "https://github.com/sourcecred/example-github/issues/2",
-        "pluginName": "sourcecred/github-beta",
-        "type": "ISSUE",
-      },
-      "payload": Object {},
-      "src": Object {
-        "id": "https://github.com/sourcecred/example-github/issues/2#issuecomment-385576920",
-        "pluginName": "sourcecred/github-beta",
-        "type": "COMMENT",
-      },
-    },
-    "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/issues/2\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"ISSUE\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/issues/1\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"ISSUE\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"REFERENCES\\"}": Object {
-      "dst": Object {
-        "id": "https://github.com/sourcecred/example-github/issues/1",
-        "pluginName": "sourcecred/github-beta",
-        "type": "ISSUE",
-      },
-      "payload": Object {},
-      "src": Object {
-        "id": "https://github.com/sourcecred/example-github/issues/2",
-        "pluginName": "sourcecred/github-beta",
-        "type": "ISSUE",
-      },
-    },
-    "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/issues/2\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"ISSUE\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/issues/2#issuecomment-373768703\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"COMMENT\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"CONTAINS\\"}": Object {
-      "dst": Object {
-        "id": "https://github.com/sourcecred/example-github/issues/2#issuecomment-373768703",
-        "pluginName": "sourcecred/github-beta",
-        "type": "COMMENT",
-      },
-      "payload": Object {},
-      "src": Object {
-        "id": "https://github.com/sourcecred/example-github/issues/2",
-        "pluginName": "sourcecred/github-beta",
-        "type": "ISSUE",
-      },
-    },
-    "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/issues/2\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"ISSUE\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/issues/2#issuecomment-373768850\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"COMMENT\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"CONTAINS\\"}": Object {
-      "dst": Object {
-        "id": "https://github.com/sourcecred/example-github/issues/2#issuecomment-373768850",
-        "pluginName": "sourcecred/github-beta",
-        "type": "COMMENT",
-      },
-      "payload": Object {},
-      "src": Object {
-        "id": "https://github.com/sourcecred/example-github/issues/2",
-        "pluginName": "sourcecred/github-beta",
-        "type": "ISSUE",
-      },
-    },
-    "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/issues/2\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"ISSUE\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/issues/2#issuecomment-385576185\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"COMMENT\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"CONTAINS\\"}": Object {
-      "dst": Object {
-        "id": "https://github.com/sourcecred/example-github/issues/2#issuecomment-385576185",
-        "pluginName": "sourcecred/github-beta",
-        "type": "COMMENT",
-      },
-      "payload": Object {},
-      "src": Object {
-        "id": "https://github.com/sourcecred/example-github/issues/2",
-        "pluginName": "sourcecred/github-beta",
-        "type": "ISSUE",
-      },
-    },
-    "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/issues/2\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"ISSUE\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/issues/2#issuecomment-385576220\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"COMMENT\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"CONTAINS\\"}": Object {
-      "dst": Object {
-        "id": "https://github.com/sourcecred/example-github/issues/2#issuecomment-385576220",
-        "pluginName": "sourcecred/github-beta",
-        "type": "COMMENT",
-      },
-      "payload": Object {},
-      "src": Object {
-        "id": "https://github.com/sourcecred/example-github/issues/2",
-        "pluginName": "sourcecred/github-beta",
-        "type": "ISSUE",
-      },
-    },
-    "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/issues/2\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"ISSUE\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/issues/2#issuecomment-385576248\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"COMMENT\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"CONTAINS\\"}": Object {
-      "dst": Object {
-        "id": "https://github.com/sourcecred/example-github/issues/2#issuecomment-385576248",
-        "pluginName": "sourcecred/github-beta",
-        "type": "COMMENT",
-      },
-      "payload": Object {},
-      "src": Object {
-        "id": "https://github.com/sourcecred/example-github/issues/2",
-        "pluginName": "sourcecred/github-beta",
-        "type": "ISSUE",
-      },
-    },
-    "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/issues/2\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"ISSUE\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/issues/2#issuecomment-385576273\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"COMMENT\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"CONTAINS\\"}": Object {
-      "dst": Object {
-        "id": "https://github.com/sourcecred/example-github/issues/2#issuecomment-385576273",
-        "pluginName": "sourcecred/github-beta",
-        "type": "COMMENT",
-      },
-      "payload": Object {},
-      "src": Object {
-        "id": "https://github.com/sourcecred/example-github/issues/2",
-        "pluginName": "sourcecred/github-beta",
-        "type": "ISSUE",
-      },
-    },
-    "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/issues/2\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"ISSUE\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/issues/2#issuecomment-385576920\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"COMMENT\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"CONTAINS\\"}": Object {
-      "dst": Object {
-        "id": "https://github.com/sourcecred/example-github/issues/2#issuecomment-385576920",
-        "pluginName": "sourcecred/github-beta",
-        "type": "COMMENT",
-      },
-      "payload": Object {},
-      "src": Object {
-        "id": "https://github.com/sourcecred/example-github/issues/2",
-        "pluginName": "sourcecred/github-beta",
-        "type": "ISSUE",
-      },
-    },
-    "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/issues/2\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"ISSUE\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/issues/2#issuecomment-385576936\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"COMMENT\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"CONTAINS\\"}": Object {
-      "dst": Object {
-        "id": "https://github.com/sourcecred/example-github/issues/2#issuecomment-385576936",
-        "pluginName": "sourcecred/github-beta",
-        "type": "COMMENT",
-      },
-      "payload": Object {},
-      "src": Object {
-        "id": "https://github.com/sourcecred/example-github/issues/2",
-        "pluginName": "sourcecred/github-beta",
-        "type": "ISSUE",
-      },
-    },
-    "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/issues/6#issuecomment-385223316\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"COMMENT\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/issues/2\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"ISSUE\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"REFERENCES\\"}": Object {
-      "dst": Object {
-        "id": "https://github.com/sourcecred/example-github/issues/2",
-        "pluginName": "sourcecred/github-beta",
-        "type": "ISSUE",
-      },
-      "payload": Object {},
-      "src": Object {
-        "id": "https://github.com/sourcecred/example-github/issues/6#issuecomment-385223316",
-        "pluginName": "sourcecred/github-beta",
-        "type": "COMMENT",
-      },
-    },
-    "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/issues/6\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"ISSUE\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/issues/6#issuecomment-373768442\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"COMMENT\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"CONTAINS\\"}": Object {
-      "dst": Object {
-        "id": "https://github.com/sourcecred/example-github/issues/6#issuecomment-373768442",
-        "pluginName": "sourcecred/github-beta",
-        "type": "COMMENT",
-      },
-      "payload": Object {},
-      "src": Object {
-        "id": "https://github.com/sourcecred/example-github/issues/6",
-        "pluginName": "sourcecred/github-beta",
-        "type": "ISSUE",
-      },
-    },
-    "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/issues/6\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"ISSUE\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/issues/6#issuecomment-373768538\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"COMMENT\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"CONTAINS\\"}": Object {
-      "dst": Object {
-        "id": "https://github.com/sourcecred/example-github/issues/6#issuecomment-373768538",
-        "pluginName": "sourcecred/github-beta",
-        "type": "COMMENT",
-      },
-      "payload": Object {},
-      "src": Object {
-        "id": "https://github.com/sourcecred/example-github/issues/6",
-        "pluginName": "sourcecred/github-beta",
-        "type": "ISSUE",
-      },
-    },
-    "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/issues/6\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"ISSUE\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/issues/6#issuecomment-385223316\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"COMMENT\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"CONTAINS\\"}": Object {
-      "dst": Object {
-        "id": "https://github.com/sourcecred/example-github/issues/6#issuecomment-385223316",
-        "pluginName": "sourcecred/github-beta",
-        "type": "COMMENT",
-      },
-      "payload": Object {},
-      "src": Object {
-        "id": "https://github.com/sourcecred/example-github/issues/6",
-        "pluginName": "sourcecred/github-beta",
-        "type": "ISSUE",
-      },
-    },
-    "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"REPOSITORY\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/issues/1\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"ISSUE\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"CONTAINS\\"}": Object {
-      "dst": Object {
-        "id": "https://github.com/sourcecred/example-github/issues/1",
-        "pluginName": "sourcecred/github-beta",
-        "type": "ISSUE",
-      },
-      "payload": Object {},
-      "src": Object {
-        "id": "https://github.com/sourcecred/example-github",
-        "pluginName": "sourcecred/github-beta",
-        "type": "REPOSITORY",
-      },
-    },
-    "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"REPOSITORY\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/issues/2\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"ISSUE\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"CONTAINS\\"}": Object {
-      "dst": Object {
-        "id": "https://github.com/sourcecred/example-github/issues/2",
-        "pluginName": "sourcecred/github-beta",
-        "type": "ISSUE",
-      },
-      "payload": Object {},
-      "src": Object {
-        "id": "https://github.com/sourcecred/example-github",
-        "pluginName": "sourcecred/github-beta",
-        "type": "REPOSITORY",
-      },
-    },
-    "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"REPOSITORY\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/issues/6\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"ISSUE\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"CONTAINS\\"}": Object {
-      "dst": Object {
-        "id": "https://github.com/sourcecred/example-github/issues/6",
-        "pluginName": "sourcecred/github-beta",
-        "type": "ISSUE",
-      },
-      "payload": Object {},
-      "src": Object {
-        "id": "https://github.com/sourcecred/example-github",
-        "pluginName": "sourcecred/github-beta",
-        "type": "REPOSITORY",
-      },
-    },
+Array [
+  Object {
+    "type": "sourcecred/sourcecred/Graph",
+    "version": "0.1.0",
   },
-  "nodes": Object {
-    "{\\"id\\":\\"https://github.com/decentralion\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"AUTHOR\\"}": Object {
-      "payload": Object {
-        "login": "decentralion",
-        "subtype": "USER",
-        "url": "https://github.com/decentralion",
+  Object {
+    "edges": Array [
+      Object {
+        "type": "sourcecred/sourcecred/AddressMap",
+        "version": "0.1.0",
       },
-    },
-    "{\\"id\\":\\"https://github.com/sourcecred/example-github\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"REPOSITORY\\"}": Object {
-      "payload": Object {
-        "name": "example-github",
-        "owner": "sourcecred",
-        "url": "https://github.com/sourcecred/example-github",
+      Object {
+        "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/decentralion\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"AUTHOR\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/issues/1\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"ISSUE\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"AUTHORS\\"}": Object {
+          "dst": Object {
+            "id": "https://github.com/decentralion",
+            "pluginName": "sourcecred/github-beta",
+            "type": "AUTHOR",
+          },
+          "payload": Object {},
+          "src": Object {
+            "id": "https://github.com/sourcecred/example-github/issues/1",
+            "pluginName": "sourcecred/github-beta",
+            "type": "ISSUE",
+          },
+        },
+        "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/decentralion\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"AUTHOR\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/issues/2#issuecomment-373768703\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"COMMENT\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"AUTHORS\\"}": Object {
+          "dst": Object {
+            "id": "https://github.com/decentralion",
+            "pluginName": "sourcecred/github-beta",
+            "type": "AUTHOR",
+          },
+          "payload": Object {},
+          "src": Object {
+            "id": "https://github.com/sourcecred/example-github/issues/2#issuecomment-373768703",
+            "pluginName": "sourcecred/github-beta",
+            "type": "COMMENT",
+          },
+        },
+        "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/decentralion\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"AUTHOR\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/issues/2#issuecomment-373768850\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"COMMENT\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"AUTHORS\\"}": Object {
+          "dst": Object {
+            "id": "https://github.com/decentralion",
+            "pluginName": "sourcecred/github-beta",
+            "type": "AUTHOR",
+          },
+          "payload": Object {},
+          "src": Object {
+            "id": "https://github.com/sourcecred/example-github/issues/2#issuecomment-373768850",
+            "pluginName": "sourcecred/github-beta",
+            "type": "COMMENT",
+          },
+        },
+        "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/decentralion\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"AUTHOR\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/issues/2#issuecomment-385576185\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"COMMENT\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"AUTHORS\\"}": Object {
+          "dst": Object {
+            "id": "https://github.com/decentralion",
+            "pluginName": "sourcecred/github-beta",
+            "type": "AUTHOR",
+          },
+          "payload": Object {},
+          "src": Object {
+            "id": "https://github.com/sourcecred/example-github/issues/2#issuecomment-385576185",
+            "pluginName": "sourcecred/github-beta",
+            "type": "COMMENT",
+          },
+        },
+        "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/decentralion\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"AUTHOR\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/issues/2#issuecomment-385576220\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"COMMENT\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"AUTHORS\\"}": Object {
+          "dst": Object {
+            "id": "https://github.com/decentralion",
+            "pluginName": "sourcecred/github-beta",
+            "type": "AUTHOR",
+          },
+          "payload": Object {},
+          "src": Object {
+            "id": "https://github.com/sourcecred/example-github/issues/2#issuecomment-385576220",
+            "pluginName": "sourcecred/github-beta",
+            "type": "COMMENT",
+          },
+        },
+        "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/decentralion\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"AUTHOR\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/issues/2#issuecomment-385576248\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"COMMENT\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"AUTHORS\\"}": Object {
+          "dst": Object {
+            "id": "https://github.com/decentralion",
+            "pluginName": "sourcecred/github-beta",
+            "type": "AUTHOR",
+          },
+          "payload": Object {},
+          "src": Object {
+            "id": "https://github.com/sourcecred/example-github/issues/2#issuecomment-385576248",
+            "pluginName": "sourcecred/github-beta",
+            "type": "COMMENT",
+          },
+        },
+        "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/decentralion\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"AUTHOR\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/issues/2#issuecomment-385576273\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"COMMENT\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"AUTHORS\\"}": Object {
+          "dst": Object {
+            "id": "https://github.com/decentralion",
+            "pluginName": "sourcecred/github-beta",
+            "type": "AUTHOR",
+          },
+          "payload": Object {},
+          "src": Object {
+            "id": "https://github.com/sourcecred/example-github/issues/2#issuecomment-385576273",
+            "pluginName": "sourcecred/github-beta",
+            "type": "COMMENT",
+          },
+        },
+        "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/decentralion\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"AUTHOR\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/issues/2#issuecomment-385576920\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"COMMENT\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"AUTHORS\\"}": Object {
+          "dst": Object {
+            "id": "https://github.com/decentralion",
+            "pluginName": "sourcecred/github-beta",
+            "type": "AUTHOR",
+          },
+          "payload": Object {},
+          "src": Object {
+            "id": "https://github.com/sourcecred/example-github/issues/2#issuecomment-385576920",
+            "pluginName": "sourcecred/github-beta",
+            "type": "COMMENT",
+          },
+        },
+        "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/decentralion\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"AUTHOR\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/issues/2#issuecomment-385576936\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"COMMENT\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"AUTHORS\\"}": Object {
+          "dst": Object {
+            "id": "https://github.com/decentralion",
+            "pluginName": "sourcecred/github-beta",
+            "type": "AUTHOR",
+          },
+          "payload": Object {},
+          "src": Object {
+            "id": "https://github.com/sourcecred/example-github/issues/2#issuecomment-385576936",
+            "pluginName": "sourcecred/github-beta",
+            "type": "COMMENT",
+          },
+        },
+        "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/decentralion\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"AUTHOR\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/issues/2\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"ISSUE\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"AUTHORS\\"}": Object {
+          "dst": Object {
+            "id": "https://github.com/decentralion",
+            "pluginName": "sourcecred/github-beta",
+            "type": "AUTHOR",
+          },
+          "payload": Object {},
+          "src": Object {
+            "id": "https://github.com/sourcecred/example-github/issues/2",
+            "pluginName": "sourcecred/github-beta",
+            "type": "ISSUE",
+          },
+        },
+        "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/decentralion\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"AUTHOR\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/issues/6#issuecomment-373768442\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"COMMENT\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"AUTHORS\\"}": Object {
+          "dst": Object {
+            "id": "https://github.com/decentralion",
+            "pluginName": "sourcecred/github-beta",
+            "type": "AUTHOR",
+          },
+          "payload": Object {},
+          "src": Object {
+            "id": "https://github.com/sourcecred/example-github/issues/6#issuecomment-373768442",
+            "pluginName": "sourcecred/github-beta",
+            "type": "COMMENT",
+          },
+        },
+        "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/decentralion\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"AUTHOR\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/issues/6#issuecomment-373768538\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"COMMENT\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"AUTHORS\\"}": Object {
+          "dst": Object {
+            "id": "https://github.com/decentralion",
+            "pluginName": "sourcecred/github-beta",
+            "type": "AUTHOR",
+          },
+          "payload": Object {},
+          "src": Object {
+            "id": "https://github.com/sourcecred/example-github/issues/6#issuecomment-373768538",
+            "pluginName": "sourcecred/github-beta",
+            "type": "COMMENT",
+          },
+        },
+        "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/decentralion\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"AUTHOR\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/issues/6#issuecomment-385223316\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"COMMENT\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"AUTHORS\\"}": Object {
+          "dst": Object {
+            "id": "https://github.com/decentralion",
+            "pluginName": "sourcecred/github-beta",
+            "type": "AUTHOR",
+          },
+          "payload": Object {},
+          "src": Object {
+            "id": "https://github.com/sourcecred/example-github/issues/6#issuecomment-385223316",
+            "pluginName": "sourcecred/github-beta",
+            "type": "COMMENT",
+          },
+        },
+        "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/decentralion\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"AUTHOR\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/issues/6\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"ISSUE\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"AUTHORS\\"}": Object {
+          "dst": Object {
+            "id": "https://github.com/decentralion",
+            "pluginName": "sourcecred/github-beta",
+            "type": "AUTHOR",
+          },
+          "payload": Object {},
+          "src": Object {
+            "id": "https://github.com/sourcecred/example-github/issues/6",
+            "pluginName": "sourcecred/github-beta",
+            "type": "ISSUE",
+          },
+        },
+        "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/issues/2#issuecomment-373768703\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"COMMENT\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/issues/6\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"ISSUE\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"REFERENCES\\"}": Object {
+          "dst": Object {
+            "id": "https://github.com/sourcecred/example-github/issues/6",
+            "pluginName": "sourcecred/github-beta",
+            "type": "ISSUE",
+          },
+          "payload": Object {},
+          "src": Object {
+            "id": "https://github.com/sourcecred/example-github/issues/2#issuecomment-373768703",
+            "pluginName": "sourcecred/github-beta",
+            "type": "COMMENT",
+          },
+        },
+        "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/issues/2#issuecomment-373768850\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"COMMENT\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/issues/6#issuecomment-373768538\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"COMMENT\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"REFERENCES\\"}": Object {
+          "dst": Object {
+            "id": "https://github.com/sourcecred/example-github/issues/6#issuecomment-373768538",
+            "pluginName": "sourcecred/github-beta",
+            "type": "COMMENT",
+          },
+          "payload": Object {},
+          "src": Object {
+            "id": "https://github.com/sourcecred/example-github/issues/2#issuecomment-373768850",
+            "pluginName": "sourcecred/github-beta",
+            "type": "COMMENT",
+          },
+        },
+        "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/issues/2#issuecomment-385576920\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"COMMENT\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/issues/1\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"ISSUE\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"REFERENCES\\"}": Object {
+          "dst": Object {
+            "id": "https://github.com/sourcecred/example-github/issues/1",
+            "pluginName": "sourcecred/github-beta",
+            "type": "ISSUE",
+          },
+          "payload": Object {},
+          "src": Object {
+            "id": "https://github.com/sourcecred/example-github/issues/2#issuecomment-385576920",
+            "pluginName": "sourcecred/github-beta",
+            "type": "COMMENT",
+          },
+        },
+        "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/issues/2#issuecomment-385576920\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"COMMENT\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/issues/2\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"ISSUE\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"REFERENCES\\"}": Object {
+          "dst": Object {
+            "id": "https://github.com/sourcecred/example-github/issues/2",
+            "pluginName": "sourcecred/github-beta",
+            "type": "ISSUE",
+          },
+          "payload": Object {},
+          "src": Object {
+            "id": "https://github.com/sourcecred/example-github/issues/2#issuecomment-385576920",
+            "pluginName": "sourcecred/github-beta",
+            "type": "COMMENT",
+          },
+        },
+        "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/issues/2\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"ISSUE\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/issues/1\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"ISSUE\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"REFERENCES\\"}": Object {
+          "dst": Object {
+            "id": "https://github.com/sourcecred/example-github/issues/1",
+            "pluginName": "sourcecred/github-beta",
+            "type": "ISSUE",
+          },
+          "payload": Object {},
+          "src": Object {
+            "id": "https://github.com/sourcecred/example-github/issues/2",
+            "pluginName": "sourcecred/github-beta",
+            "type": "ISSUE",
+          },
+        },
+        "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/issues/2\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"ISSUE\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/issues/2#issuecomment-373768703\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"COMMENT\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"CONTAINS\\"}": Object {
+          "dst": Object {
+            "id": "https://github.com/sourcecred/example-github/issues/2#issuecomment-373768703",
+            "pluginName": "sourcecred/github-beta",
+            "type": "COMMENT",
+          },
+          "payload": Object {},
+          "src": Object {
+            "id": "https://github.com/sourcecred/example-github/issues/2",
+            "pluginName": "sourcecred/github-beta",
+            "type": "ISSUE",
+          },
+        },
+        "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/issues/2\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"ISSUE\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/issues/2#issuecomment-373768850\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"COMMENT\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"CONTAINS\\"}": Object {
+          "dst": Object {
+            "id": "https://github.com/sourcecred/example-github/issues/2#issuecomment-373768850",
+            "pluginName": "sourcecred/github-beta",
+            "type": "COMMENT",
+          },
+          "payload": Object {},
+          "src": Object {
+            "id": "https://github.com/sourcecred/example-github/issues/2",
+            "pluginName": "sourcecred/github-beta",
+            "type": "ISSUE",
+          },
+        },
+        "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/issues/2\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"ISSUE\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/issues/2#issuecomment-385576185\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"COMMENT\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"CONTAINS\\"}": Object {
+          "dst": Object {
+            "id": "https://github.com/sourcecred/example-github/issues/2#issuecomment-385576185",
+            "pluginName": "sourcecred/github-beta",
+            "type": "COMMENT",
+          },
+          "payload": Object {},
+          "src": Object {
+            "id": "https://github.com/sourcecred/example-github/issues/2",
+            "pluginName": "sourcecred/github-beta",
+            "type": "ISSUE",
+          },
+        },
+        "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/issues/2\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"ISSUE\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/issues/2#issuecomment-385576220\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"COMMENT\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"CONTAINS\\"}": Object {
+          "dst": Object {
+            "id": "https://github.com/sourcecred/example-github/issues/2#issuecomment-385576220",
+            "pluginName": "sourcecred/github-beta",
+            "type": "COMMENT",
+          },
+          "payload": Object {},
+          "src": Object {
+            "id": "https://github.com/sourcecred/example-github/issues/2",
+            "pluginName": "sourcecred/github-beta",
+            "type": "ISSUE",
+          },
+        },
+        "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/issues/2\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"ISSUE\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/issues/2#issuecomment-385576248\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"COMMENT\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"CONTAINS\\"}": Object {
+          "dst": Object {
+            "id": "https://github.com/sourcecred/example-github/issues/2#issuecomment-385576248",
+            "pluginName": "sourcecred/github-beta",
+            "type": "COMMENT",
+          },
+          "payload": Object {},
+          "src": Object {
+            "id": "https://github.com/sourcecred/example-github/issues/2",
+            "pluginName": "sourcecred/github-beta",
+            "type": "ISSUE",
+          },
+        },
+        "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/issues/2\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"ISSUE\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/issues/2#issuecomment-385576273\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"COMMENT\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"CONTAINS\\"}": Object {
+          "dst": Object {
+            "id": "https://github.com/sourcecred/example-github/issues/2#issuecomment-385576273",
+            "pluginName": "sourcecred/github-beta",
+            "type": "COMMENT",
+          },
+          "payload": Object {},
+          "src": Object {
+            "id": "https://github.com/sourcecred/example-github/issues/2",
+            "pluginName": "sourcecred/github-beta",
+            "type": "ISSUE",
+          },
+        },
+        "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/issues/2\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"ISSUE\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/issues/2#issuecomment-385576920\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"COMMENT\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"CONTAINS\\"}": Object {
+          "dst": Object {
+            "id": "https://github.com/sourcecred/example-github/issues/2#issuecomment-385576920",
+            "pluginName": "sourcecred/github-beta",
+            "type": "COMMENT",
+          },
+          "payload": Object {},
+          "src": Object {
+            "id": "https://github.com/sourcecred/example-github/issues/2",
+            "pluginName": "sourcecred/github-beta",
+            "type": "ISSUE",
+          },
+        },
+        "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/issues/2\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"ISSUE\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/issues/2#issuecomment-385576936\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"COMMENT\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"CONTAINS\\"}": Object {
+          "dst": Object {
+            "id": "https://github.com/sourcecred/example-github/issues/2#issuecomment-385576936",
+            "pluginName": "sourcecred/github-beta",
+            "type": "COMMENT",
+          },
+          "payload": Object {},
+          "src": Object {
+            "id": "https://github.com/sourcecred/example-github/issues/2",
+            "pluginName": "sourcecred/github-beta",
+            "type": "ISSUE",
+          },
+        },
+        "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/issues/6#issuecomment-385223316\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"COMMENT\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/issues/2\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"ISSUE\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"REFERENCES\\"}": Object {
+          "dst": Object {
+            "id": "https://github.com/sourcecred/example-github/issues/2",
+            "pluginName": "sourcecred/github-beta",
+            "type": "ISSUE",
+          },
+          "payload": Object {},
+          "src": Object {
+            "id": "https://github.com/sourcecred/example-github/issues/6#issuecomment-385223316",
+            "pluginName": "sourcecred/github-beta",
+            "type": "COMMENT",
+          },
+        },
+        "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/issues/6\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"ISSUE\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/issues/6#issuecomment-373768442\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"COMMENT\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"CONTAINS\\"}": Object {
+          "dst": Object {
+            "id": "https://github.com/sourcecred/example-github/issues/6#issuecomment-373768442",
+            "pluginName": "sourcecred/github-beta",
+            "type": "COMMENT",
+          },
+          "payload": Object {},
+          "src": Object {
+            "id": "https://github.com/sourcecred/example-github/issues/6",
+            "pluginName": "sourcecred/github-beta",
+            "type": "ISSUE",
+          },
+        },
+        "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/issues/6\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"ISSUE\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/issues/6#issuecomment-373768538\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"COMMENT\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"CONTAINS\\"}": Object {
+          "dst": Object {
+            "id": "https://github.com/sourcecred/example-github/issues/6#issuecomment-373768538",
+            "pluginName": "sourcecred/github-beta",
+            "type": "COMMENT",
+          },
+          "payload": Object {},
+          "src": Object {
+            "id": "https://github.com/sourcecred/example-github/issues/6",
+            "pluginName": "sourcecred/github-beta",
+            "type": "ISSUE",
+          },
+        },
+        "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/issues/6\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"ISSUE\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/issues/6#issuecomment-385223316\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"COMMENT\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"CONTAINS\\"}": Object {
+          "dst": Object {
+            "id": "https://github.com/sourcecred/example-github/issues/6#issuecomment-385223316",
+            "pluginName": "sourcecred/github-beta",
+            "type": "COMMENT",
+          },
+          "payload": Object {},
+          "src": Object {
+            "id": "https://github.com/sourcecred/example-github/issues/6",
+            "pluginName": "sourcecred/github-beta",
+            "type": "ISSUE",
+          },
+        },
+        "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"REPOSITORY\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/issues/1\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"ISSUE\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"CONTAINS\\"}": Object {
+          "dst": Object {
+            "id": "https://github.com/sourcecred/example-github/issues/1",
+            "pluginName": "sourcecred/github-beta",
+            "type": "ISSUE",
+          },
+          "payload": Object {},
+          "src": Object {
+            "id": "https://github.com/sourcecred/example-github",
+            "pluginName": "sourcecred/github-beta",
+            "type": "REPOSITORY",
+          },
+        },
+        "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"REPOSITORY\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/issues/2\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"ISSUE\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"CONTAINS\\"}": Object {
+          "dst": Object {
+            "id": "https://github.com/sourcecred/example-github/issues/2",
+            "pluginName": "sourcecred/github-beta",
+            "type": "ISSUE",
+          },
+          "payload": Object {},
+          "src": Object {
+            "id": "https://github.com/sourcecred/example-github",
+            "pluginName": "sourcecred/github-beta",
+            "type": "REPOSITORY",
+          },
+        },
+        "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"REPOSITORY\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/issues/6\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"ISSUE\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"CONTAINS\\"}": Object {
+          "dst": Object {
+            "id": "https://github.com/sourcecred/example-github/issues/6",
+            "pluginName": "sourcecred/github-beta",
+            "type": "ISSUE",
+          },
+          "payload": Object {},
+          "src": Object {
+            "id": "https://github.com/sourcecred/example-github",
+            "pluginName": "sourcecred/github-beta",
+            "type": "REPOSITORY",
+          },
+        },
       },
-    },
-    "{\\"id\\":\\"https://github.com/sourcecred/example-github/issues/1\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"ISSUE\\"}": Object {
-      "payload": Object {
-        "body": "This is just an example issue.",
-        "number": 1,
-        "title": "An example issue.",
-        "url": "https://github.com/sourcecred/example-github/issues/1",
+    ],
+    "nodes": Array [
+      Object {
+        "type": "sourcecred/sourcecred/AddressMap",
+        "version": "0.1.0",
       },
-    },
-    "{\\"id\\":\\"https://github.com/sourcecred/example-github/issues/2\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"ISSUE\\"}": Object {
-      "payload": Object {
-        "body": "This issue references another issue, namely #1",
-        "number": 2,
-        "title": "A referencing issue.",
-        "url": "https://github.com/sourcecred/example-github/issues/2",
-      },
-    },
-    "{\\"id\\":\\"https://github.com/sourcecred/example-github/issues/2#issuecomment-373768703\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"COMMENT\\"}": Object {
-      "payload": Object {
-        "body": "It should also be possible to reference by exact url: https://github.com/sourcecred/example-github/issues/6",
-        "url": "https://github.com/sourcecred/example-github/issues/2#issuecomment-373768703",
-      },
-    },
-    "{\\"id\\":\\"https://github.com/sourcecred/example-github/issues/2#issuecomment-373768850\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"COMMENT\\"}": Object {
-      "payload": Object {
-        "body": "We might also reference individual comments directly.
+      Object {
+        "{\\"id\\":\\"https://github.com/decentralion\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"AUTHOR\\"}": Object {
+          "payload": Object {
+            "login": "decentralion",
+            "subtype": "USER",
+            "url": "https://github.com/decentralion",
+          },
+        },
+        "{\\"id\\":\\"https://github.com/sourcecred/example-github\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"REPOSITORY\\"}": Object {
+          "payload": Object {
+            "name": "example-github",
+            "owner": "sourcecred",
+            "url": "https://github.com/sourcecred/example-github",
+          },
+        },
+        "{\\"id\\":\\"https://github.com/sourcecred/example-github/issues/1\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"ISSUE\\"}": Object {
+          "payload": Object {
+            "body": "This is just an example issue.",
+            "number": 1,
+            "title": "An example issue.",
+            "url": "https://github.com/sourcecred/example-github/issues/1",
+          },
+        },
+        "{\\"id\\":\\"https://github.com/sourcecred/example-github/issues/2\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"ISSUE\\"}": Object {
+          "payload": Object {
+            "body": "This issue references another issue, namely #1",
+            "number": 2,
+            "title": "A referencing issue.",
+            "url": "https://github.com/sourcecred/example-github/issues/2",
+          },
+        },
+        "{\\"id\\":\\"https://github.com/sourcecred/example-github/issues/2#issuecomment-373768703\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"COMMENT\\"}": Object {
+          "payload": Object {
+            "body": "It should also be possible to reference by exact url: https://github.com/sourcecred/example-github/issues/6",
+            "url": "https://github.com/sourcecred/example-github/issues/2#issuecomment-373768703",
+          },
+        },
+        "{\\"id\\":\\"https://github.com/sourcecred/example-github/issues/2#issuecomment-373768850\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"COMMENT\\"}": Object {
+          "payload": Object {
+            "body": "We might also reference individual comments directly.
 https://github.com/sourcecred/example-github/issues/6#issuecomment-373768538",
-        "url": "https://github.com/sourcecred/example-github/issues/2#issuecomment-373768850",
-      },
-    },
-    "{\\"id\\":\\"https://github.com/sourcecred/example-github/issues/2#issuecomment-385576185\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"COMMENT\\"}": Object {
-      "payload": Object {
-        "body": "Here's a PR by direct url: https://github.com/sourcecred/example-github/pull/5",
-        "url": "https://github.com/sourcecred/example-github/issues/2#issuecomment-385576185",
-      },
-    },
-    "{\\"id\\":\\"https://github.com/sourcecred/example-github/issues/2#issuecomment-385576220\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"COMMENT\\"}": Object {
-      "payload": Object {
-        "body": "a PR review by url: https://github.com/sourcecred/example-github/pull/5#pullrequestreview-100313899",
-        "url": "https://github.com/sourcecred/example-github/issues/2#issuecomment-385576220",
-      },
-    },
-    "{\\"id\\":\\"https://github.com/sourcecred/example-github/issues/2#issuecomment-385576248\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"COMMENT\\"}": Object {
-      "payload": Object {
-        "body": "a PR Review Comment by url: https://github.com/sourcecred/example-github/pull/5#discussion_r171460198",
-        "url": "https://github.com/sourcecred/example-github/issues/2#issuecomment-385576248",
-      },
-    },
-    "{\\"id\\":\\"https://github.com/sourcecred/example-github/issues/2#issuecomment-385576273\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"COMMENT\\"}": Object {
-      "payload": Object {
-        "body": "a user by url: https://github.com/wchargin",
-        "url": "https://github.com/sourcecred/example-github/issues/2#issuecomment-385576273",
-      },
-    },
-    "{\\"id\\":\\"https://github.com/sourcecred/example-github/issues/2#issuecomment-385576920\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"COMMENT\\"}": Object {
-      "payload": Object {
-        "body": "Here are several references:
+            "url": "https://github.com/sourcecred/example-github/issues/2#issuecomment-373768850",
+          },
+        },
+        "{\\"id\\":\\"https://github.com/sourcecred/example-github/issues/2#issuecomment-385576185\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"COMMENT\\"}": Object {
+          "payload": Object {
+            "body": "Here's a PR by direct url: https://github.com/sourcecred/example-github/pull/5",
+            "url": "https://github.com/sourcecred/example-github/issues/2#issuecomment-385576185",
+          },
+        },
+        "{\\"id\\":\\"https://github.com/sourcecred/example-github/issues/2#issuecomment-385576220\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"COMMENT\\"}": Object {
+          "payload": Object {
+            "body": "a PR review by url: https://github.com/sourcecred/example-github/pull/5#pullrequestreview-100313899",
+            "url": "https://github.com/sourcecred/example-github/issues/2#issuecomment-385576220",
+          },
+        },
+        "{\\"id\\":\\"https://github.com/sourcecred/example-github/issues/2#issuecomment-385576248\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"COMMENT\\"}": Object {
+          "payload": Object {
+            "body": "a PR Review Comment by url: https://github.com/sourcecred/example-github/pull/5#discussion_r171460198",
+            "url": "https://github.com/sourcecred/example-github/issues/2#issuecomment-385576248",
+          },
+        },
+        "{\\"id\\":\\"https://github.com/sourcecred/example-github/issues/2#issuecomment-385576273\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"COMMENT\\"}": Object {
+          "payload": Object {
+            "body": "a user by url: https://github.com/wchargin",
+            "url": "https://github.com/sourcecred/example-github/issues/2#issuecomment-385576273",
+          },
+        },
+        "{\\"id\\":\\"https://github.com/sourcecred/example-github/issues/2#issuecomment-385576920\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"COMMENT\\"}": Object {
+          "payload": Object {
+            "body": "Here are several references:
 #1 
 #2
 #3 
@@ -1032,359 +1120,377 @@ https://github.com/sourcecred/example-github/issues/6#issuecomment-373768538",
 https://github.com/sourcecred/example-github/pull/5#discussion_r171460198
 https://github.com/sourcecred/example-github/pull/5#pullrequestreview-100313899
 ",
-        "url": "https://github.com/sourcecred/example-github/issues/2#issuecomment-385576920",
+            "url": "https://github.com/sourcecred/example-github/issues/2#issuecomment-385576920",
+          },
+        },
+        "{\\"id\\":\\"https://github.com/sourcecred/example-github/issues/2#issuecomment-385576936\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"COMMENT\\"}": Object {
+          "payload": Object {
+            "body": "This comment has no references.",
+            "url": "https://github.com/sourcecred/example-github/issues/2#issuecomment-385576936",
+          },
+        },
+        "{\\"id\\":\\"https://github.com/sourcecred/example-github/issues/6\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"ISSUE\\"}": Object {
+          "payload": Object {
+            "body": "This issue shall shortly have a few comments.",
+            "number": 6,
+            "title": "An issue with comments",
+            "url": "https://github.com/sourcecred/example-github/issues/6",
+          },
+        },
+        "{\\"id\\":\\"https://github.com/sourcecred/example-github/issues/6#issuecomment-373768442\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"COMMENT\\"}": Object {
+          "payload": Object {
+            "body": "A wild COMMENT appeared!",
+            "url": "https://github.com/sourcecred/example-github/issues/6#issuecomment-373768442",
+          },
+        },
+        "{\\"id\\":\\"https://github.com/sourcecred/example-github/issues/6#issuecomment-373768538\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"COMMENT\\"}": Object {
+          "payload": Object {
+            "body": "And the maintainer said, \\"Let there be comments!\\"",
+            "url": "https://github.com/sourcecred/example-github/issues/6#issuecomment-373768538",
+          },
+        },
+        "{\\"id\\":\\"https://github.com/sourcecred/example-github/issues/6#issuecomment-385223316\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"COMMENT\\"}": Object {
+          "payload": Object {
+            "body": "This comment references an #2, which itself references an issue. This comment is thus allows us to test that in-references are not included when requesting a Post's references.",
+            "url": "https://github.com/sourcecred/example-github/issues/6#issuecomment-385223316",
+          },
+        },
       },
-    },
-    "{\\"id\\":\\"https://github.com/sourcecred/example-github/issues/2#issuecomment-385576936\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"COMMENT\\"}": Object {
-      "payload": Object {
-        "body": "This comment has no references.",
-        "url": "https://github.com/sourcecred/example-github/issues/2#issuecomment-385576936",
-      },
-    },
-    "{\\"id\\":\\"https://github.com/sourcecred/example-github/issues/6\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"ISSUE\\"}": Object {
-      "payload": Object {
-        "body": "This issue shall shortly have a few comments.",
-        "number": 6,
-        "title": "An issue with comments",
-        "url": "https://github.com/sourcecred/example-github/issues/6",
-      },
-    },
-    "{\\"id\\":\\"https://github.com/sourcecred/example-github/issues/6#issuecomment-373768442\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"COMMENT\\"}": Object {
-      "payload": Object {
-        "body": "A wild COMMENT appeared!",
-        "url": "https://github.com/sourcecred/example-github/issues/6#issuecomment-373768442",
-      },
-    },
-    "{\\"id\\":\\"https://github.com/sourcecred/example-github/issues/6#issuecomment-373768538\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"COMMENT\\"}": Object {
-      "payload": Object {
-        "body": "And the maintainer said, \\"Let there be comments!\\"",
-        "url": "https://github.com/sourcecred/example-github/issues/6#issuecomment-373768538",
-      },
-    },
-    "{\\"id\\":\\"https://github.com/sourcecred/example-github/issues/6#issuecomment-385223316\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"COMMENT\\"}": Object {
-      "payload": Object {
-        "body": "This comment references an #2, which itself references an issue. This comment is thus allows us to test that in-references are not included when requesting a Post's references.",
-        "url": "https://github.com/sourcecred/example-github/issues/6#issuecomment-385223316",
-      },
-    },
+    ],
   },
-}
+]
 `;
 
 exports[`GithubParser reference detection handles dangling references gracefully 1`] = `
-Object {
-  "edges": Object {
-    "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/decentralion\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"AUTHOR\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/issues/2#issuecomment-373768703\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"COMMENT\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"AUTHORS\\"}": Object {
-      "dst": Object {
-        "id": "https://github.com/decentralion",
-        "pluginName": "sourcecred/github-beta",
-        "type": "AUTHOR",
-      },
-      "payload": Object {},
-      "src": Object {
-        "id": "https://github.com/sourcecred/example-github/issues/2#issuecomment-373768703",
-        "pluginName": "sourcecred/github-beta",
-        "type": "COMMENT",
-      },
-    },
-    "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/decentralion\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"AUTHOR\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/issues/2#issuecomment-373768850\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"COMMENT\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"AUTHORS\\"}": Object {
-      "dst": Object {
-        "id": "https://github.com/decentralion",
-        "pluginName": "sourcecred/github-beta",
-        "type": "AUTHOR",
-      },
-      "payload": Object {},
-      "src": Object {
-        "id": "https://github.com/sourcecred/example-github/issues/2#issuecomment-373768850",
-        "pluginName": "sourcecred/github-beta",
-        "type": "COMMENT",
-      },
-    },
-    "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/decentralion\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"AUTHOR\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/issues/2#issuecomment-385576185\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"COMMENT\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"AUTHORS\\"}": Object {
-      "dst": Object {
-        "id": "https://github.com/decentralion",
-        "pluginName": "sourcecred/github-beta",
-        "type": "AUTHOR",
-      },
-      "payload": Object {},
-      "src": Object {
-        "id": "https://github.com/sourcecred/example-github/issues/2#issuecomment-385576185",
-        "pluginName": "sourcecred/github-beta",
-        "type": "COMMENT",
-      },
-    },
-    "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/decentralion\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"AUTHOR\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/issues/2#issuecomment-385576220\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"COMMENT\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"AUTHORS\\"}": Object {
-      "dst": Object {
-        "id": "https://github.com/decentralion",
-        "pluginName": "sourcecred/github-beta",
-        "type": "AUTHOR",
-      },
-      "payload": Object {},
-      "src": Object {
-        "id": "https://github.com/sourcecred/example-github/issues/2#issuecomment-385576220",
-        "pluginName": "sourcecred/github-beta",
-        "type": "COMMENT",
-      },
-    },
-    "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/decentralion\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"AUTHOR\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/issues/2#issuecomment-385576248\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"COMMENT\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"AUTHORS\\"}": Object {
-      "dst": Object {
-        "id": "https://github.com/decentralion",
-        "pluginName": "sourcecred/github-beta",
-        "type": "AUTHOR",
-      },
-      "payload": Object {},
-      "src": Object {
-        "id": "https://github.com/sourcecred/example-github/issues/2#issuecomment-385576248",
-        "pluginName": "sourcecred/github-beta",
-        "type": "COMMENT",
-      },
-    },
-    "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/decentralion\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"AUTHOR\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/issues/2#issuecomment-385576273\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"COMMENT\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"AUTHORS\\"}": Object {
-      "dst": Object {
-        "id": "https://github.com/decentralion",
-        "pluginName": "sourcecred/github-beta",
-        "type": "AUTHOR",
-      },
-      "payload": Object {},
-      "src": Object {
-        "id": "https://github.com/sourcecred/example-github/issues/2#issuecomment-385576273",
-        "pluginName": "sourcecred/github-beta",
-        "type": "COMMENT",
-      },
-    },
-    "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/decentralion\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"AUTHOR\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/issues/2#issuecomment-385576920\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"COMMENT\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"AUTHORS\\"}": Object {
-      "dst": Object {
-        "id": "https://github.com/decentralion",
-        "pluginName": "sourcecred/github-beta",
-        "type": "AUTHOR",
-      },
-      "payload": Object {},
-      "src": Object {
-        "id": "https://github.com/sourcecred/example-github/issues/2#issuecomment-385576920",
-        "pluginName": "sourcecred/github-beta",
-        "type": "COMMENT",
-      },
-    },
-    "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/decentralion\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"AUTHOR\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/issues/2#issuecomment-385576936\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"COMMENT\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"AUTHORS\\"}": Object {
-      "dst": Object {
-        "id": "https://github.com/decentralion",
-        "pluginName": "sourcecred/github-beta",
-        "type": "AUTHOR",
-      },
-      "payload": Object {},
-      "src": Object {
-        "id": "https://github.com/sourcecred/example-github/issues/2#issuecomment-385576936",
-        "pluginName": "sourcecred/github-beta",
-        "type": "COMMENT",
-      },
-    },
-    "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/decentralion\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"AUTHOR\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/issues/2\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"ISSUE\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"AUTHORS\\"}": Object {
-      "dst": Object {
-        "id": "https://github.com/decentralion",
-        "pluginName": "sourcecred/github-beta",
-        "type": "AUTHOR",
-      },
-      "payload": Object {},
-      "src": Object {
-        "id": "https://github.com/sourcecred/example-github/issues/2",
-        "pluginName": "sourcecred/github-beta",
-        "type": "ISSUE",
-      },
-    },
-    "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/issues/2#issuecomment-385576920\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"COMMENT\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/issues/2\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"ISSUE\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"REFERENCES\\"}": Object {
-      "dst": Object {
-        "id": "https://github.com/sourcecred/example-github/issues/2",
-        "pluginName": "sourcecred/github-beta",
-        "type": "ISSUE",
-      },
-      "payload": Object {},
-      "src": Object {
-        "id": "https://github.com/sourcecred/example-github/issues/2#issuecomment-385576920",
-        "pluginName": "sourcecred/github-beta",
-        "type": "COMMENT",
-      },
-    },
-    "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/issues/2\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"ISSUE\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/issues/2#issuecomment-373768703\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"COMMENT\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"CONTAINS\\"}": Object {
-      "dst": Object {
-        "id": "https://github.com/sourcecred/example-github/issues/2#issuecomment-373768703",
-        "pluginName": "sourcecred/github-beta",
-        "type": "COMMENT",
-      },
-      "payload": Object {},
-      "src": Object {
-        "id": "https://github.com/sourcecred/example-github/issues/2",
-        "pluginName": "sourcecred/github-beta",
-        "type": "ISSUE",
-      },
-    },
-    "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/issues/2\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"ISSUE\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/issues/2#issuecomment-373768850\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"COMMENT\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"CONTAINS\\"}": Object {
-      "dst": Object {
-        "id": "https://github.com/sourcecred/example-github/issues/2#issuecomment-373768850",
-        "pluginName": "sourcecred/github-beta",
-        "type": "COMMENT",
-      },
-      "payload": Object {},
-      "src": Object {
-        "id": "https://github.com/sourcecred/example-github/issues/2",
-        "pluginName": "sourcecred/github-beta",
-        "type": "ISSUE",
-      },
-    },
-    "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/issues/2\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"ISSUE\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/issues/2#issuecomment-385576185\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"COMMENT\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"CONTAINS\\"}": Object {
-      "dst": Object {
-        "id": "https://github.com/sourcecred/example-github/issues/2#issuecomment-385576185",
-        "pluginName": "sourcecred/github-beta",
-        "type": "COMMENT",
-      },
-      "payload": Object {},
-      "src": Object {
-        "id": "https://github.com/sourcecred/example-github/issues/2",
-        "pluginName": "sourcecred/github-beta",
-        "type": "ISSUE",
-      },
-    },
-    "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/issues/2\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"ISSUE\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/issues/2#issuecomment-385576220\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"COMMENT\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"CONTAINS\\"}": Object {
-      "dst": Object {
-        "id": "https://github.com/sourcecred/example-github/issues/2#issuecomment-385576220",
-        "pluginName": "sourcecred/github-beta",
-        "type": "COMMENT",
-      },
-      "payload": Object {},
-      "src": Object {
-        "id": "https://github.com/sourcecred/example-github/issues/2",
-        "pluginName": "sourcecred/github-beta",
-        "type": "ISSUE",
-      },
-    },
-    "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/issues/2\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"ISSUE\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/issues/2#issuecomment-385576248\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"COMMENT\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"CONTAINS\\"}": Object {
-      "dst": Object {
-        "id": "https://github.com/sourcecred/example-github/issues/2#issuecomment-385576248",
-        "pluginName": "sourcecred/github-beta",
-        "type": "COMMENT",
-      },
-      "payload": Object {},
-      "src": Object {
-        "id": "https://github.com/sourcecred/example-github/issues/2",
-        "pluginName": "sourcecred/github-beta",
-        "type": "ISSUE",
-      },
-    },
-    "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/issues/2\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"ISSUE\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/issues/2#issuecomment-385576273\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"COMMENT\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"CONTAINS\\"}": Object {
-      "dst": Object {
-        "id": "https://github.com/sourcecred/example-github/issues/2#issuecomment-385576273",
-        "pluginName": "sourcecred/github-beta",
-        "type": "COMMENT",
-      },
-      "payload": Object {},
-      "src": Object {
-        "id": "https://github.com/sourcecred/example-github/issues/2",
-        "pluginName": "sourcecred/github-beta",
-        "type": "ISSUE",
-      },
-    },
-    "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/issues/2\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"ISSUE\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/issues/2#issuecomment-385576920\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"COMMENT\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"CONTAINS\\"}": Object {
-      "dst": Object {
-        "id": "https://github.com/sourcecred/example-github/issues/2#issuecomment-385576920",
-        "pluginName": "sourcecred/github-beta",
-        "type": "COMMENT",
-      },
-      "payload": Object {},
-      "src": Object {
-        "id": "https://github.com/sourcecred/example-github/issues/2",
-        "pluginName": "sourcecred/github-beta",
-        "type": "ISSUE",
-      },
-    },
-    "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/issues/2\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"ISSUE\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/issues/2#issuecomment-385576936\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"COMMENT\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"CONTAINS\\"}": Object {
-      "dst": Object {
-        "id": "https://github.com/sourcecred/example-github/issues/2#issuecomment-385576936",
-        "pluginName": "sourcecred/github-beta",
-        "type": "COMMENT",
-      },
-      "payload": Object {},
-      "src": Object {
-        "id": "https://github.com/sourcecred/example-github/issues/2",
-        "pluginName": "sourcecred/github-beta",
-        "type": "ISSUE",
-      },
-    },
-    "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"REPOSITORY\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/issues/2\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"ISSUE\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"CONTAINS\\"}": Object {
-      "dst": Object {
-        "id": "https://github.com/sourcecred/example-github/issues/2",
-        "pluginName": "sourcecred/github-beta",
-        "type": "ISSUE",
-      },
-      "payload": Object {},
-      "src": Object {
-        "id": "https://github.com/sourcecred/example-github",
-        "pluginName": "sourcecred/github-beta",
-        "type": "REPOSITORY",
-      },
-    },
+Array [
+  Object {
+    "type": "sourcecred/sourcecred/Graph",
+    "version": "0.1.0",
   },
-  "nodes": Object {
-    "{\\"id\\":\\"https://github.com/decentralion\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"AUTHOR\\"}": Object {
-      "payload": Object {
-        "login": "decentralion",
-        "subtype": "USER",
-        "url": "https://github.com/decentralion",
+  Object {
+    "edges": Array [
+      Object {
+        "type": "sourcecred/sourcecred/AddressMap",
+        "version": "0.1.0",
       },
-    },
-    "{\\"id\\":\\"https://github.com/sourcecred/example-github\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"REPOSITORY\\"}": Object {
-      "payload": Object {
-        "name": "example-github",
-        "owner": "sourcecred",
-        "url": "https://github.com/sourcecred/example-github",
+      Object {
+        "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/decentralion\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"AUTHOR\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/issues/2#issuecomment-373768703\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"COMMENT\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"AUTHORS\\"}": Object {
+          "dst": Object {
+            "id": "https://github.com/decentralion",
+            "pluginName": "sourcecred/github-beta",
+            "type": "AUTHOR",
+          },
+          "payload": Object {},
+          "src": Object {
+            "id": "https://github.com/sourcecred/example-github/issues/2#issuecomment-373768703",
+            "pluginName": "sourcecred/github-beta",
+            "type": "COMMENT",
+          },
+        },
+        "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/decentralion\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"AUTHOR\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/issues/2#issuecomment-373768850\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"COMMENT\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"AUTHORS\\"}": Object {
+          "dst": Object {
+            "id": "https://github.com/decentralion",
+            "pluginName": "sourcecred/github-beta",
+            "type": "AUTHOR",
+          },
+          "payload": Object {},
+          "src": Object {
+            "id": "https://github.com/sourcecred/example-github/issues/2#issuecomment-373768850",
+            "pluginName": "sourcecred/github-beta",
+            "type": "COMMENT",
+          },
+        },
+        "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/decentralion\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"AUTHOR\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/issues/2#issuecomment-385576185\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"COMMENT\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"AUTHORS\\"}": Object {
+          "dst": Object {
+            "id": "https://github.com/decentralion",
+            "pluginName": "sourcecred/github-beta",
+            "type": "AUTHOR",
+          },
+          "payload": Object {},
+          "src": Object {
+            "id": "https://github.com/sourcecred/example-github/issues/2#issuecomment-385576185",
+            "pluginName": "sourcecred/github-beta",
+            "type": "COMMENT",
+          },
+        },
+        "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/decentralion\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"AUTHOR\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/issues/2#issuecomment-385576220\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"COMMENT\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"AUTHORS\\"}": Object {
+          "dst": Object {
+            "id": "https://github.com/decentralion",
+            "pluginName": "sourcecred/github-beta",
+            "type": "AUTHOR",
+          },
+          "payload": Object {},
+          "src": Object {
+            "id": "https://github.com/sourcecred/example-github/issues/2#issuecomment-385576220",
+            "pluginName": "sourcecred/github-beta",
+            "type": "COMMENT",
+          },
+        },
+        "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/decentralion\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"AUTHOR\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/issues/2#issuecomment-385576248\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"COMMENT\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"AUTHORS\\"}": Object {
+          "dst": Object {
+            "id": "https://github.com/decentralion",
+            "pluginName": "sourcecred/github-beta",
+            "type": "AUTHOR",
+          },
+          "payload": Object {},
+          "src": Object {
+            "id": "https://github.com/sourcecred/example-github/issues/2#issuecomment-385576248",
+            "pluginName": "sourcecred/github-beta",
+            "type": "COMMENT",
+          },
+        },
+        "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/decentralion\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"AUTHOR\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/issues/2#issuecomment-385576273\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"COMMENT\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"AUTHORS\\"}": Object {
+          "dst": Object {
+            "id": "https://github.com/decentralion",
+            "pluginName": "sourcecred/github-beta",
+            "type": "AUTHOR",
+          },
+          "payload": Object {},
+          "src": Object {
+            "id": "https://github.com/sourcecred/example-github/issues/2#issuecomment-385576273",
+            "pluginName": "sourcecred/github-beta",
+            "type": "COMMENT",
+          },
+        },
+        "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/decentralion\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"AUTHOR\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/issues/2#issuecomment-385576920\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"COMMENT\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"AUTHORS\\"}": Object {
+          "dst": Object {
+            "id": "https://github.com/decentralion",
+            "pluginName": "sourcecred/github-beta",
+            "type": "AUTHOR",
+          },
+          "payload": Object {},
+          "src": Object {
+            "id": "https://github.com/sourcecred/example-github/issues/2#issuecomment-385576920",
+            "pluginName": "sourcecred/github-beta",
+            "type": "COMMENT",
+          },
+        },
+        "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/decentralion\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"AUTHOR\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/issues/2#issuecomment-385576936\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"COMMENT\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"AUTHORS\\"}": Object {
+          "dst": Object {
+            "id": "https://github.com/decentralion",
+            "pluginName": "sourcecred/github-beta",
+            "type": "AUTHOR",
+          },
+          "payload": Object {},
+          "src": Object {
+            "id": "https://github.com/sourcecred/example-github/issues/2#issuecomment-385576936",
+            "pluginName": "sourcecred/github-beta",
+            "type": "COMMENT",
+          },
+        },
+        "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/decentralion\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"AUTHOR\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/issues/2\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"ISSUE\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"AUTHORS\\"}": Object {
+          "dst": Object {
+            "id": "https://github.com/decentralion",
+            "pluginName": "sourcecred/github-beta",
+            "type": "AUTHOR",
+          },
+          "payload": Object {},
+          "src": Object {
+            "id": "https://github.com/sourcecred/example-github/issues/2",
+            "pluginName": "sourcecred/github-beta",
+            "type": "ISSUE",
+          },
+        },
+        "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/issues/2#issuecomment-385576920\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"COMMENT\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/issues/2\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"ISSUE\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"REFERENCES\\"}": Object {
+          "dst": Object {
+            "id": "https://github.com/sourcecred/example-github/issues/2",
+            "pluginName": "sourcecred/github-beta",
+            "type": "ISSUE",
+          },
+          "payload": Object {},
+          "src": Object {
+            "id": "https://github.com/sourcecred/example-github/issues/2#issuecomment-385576920",
+            "pluginName": "sourcecred/github-beta",
+            "type": "COMMENT",
+          },
+        },
+        "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/issues/2\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"ISSUE\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/issues/2#issuecomment-373768703\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"COMMENT\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"CONTAINS\\"}": Object {
+          "dst": Object {
+            "id": "https://github.com/sourcecred/example-github/issues/2#issuecomment-373768703",
+            "pluginName": "sourcecred/github-beta",
+            "type": "COMMENT",
+          },
+          "payload": Object {},
+          "src": Object {
+            "id": "https://github.com/sourcecred/example-github/issues/2",
+            "pluginName": "sourcecred/github-beta",
+            "type": "ISSUE",
+          },
+        },
+        "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/issues/2\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"ISSUE\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/issues/2#issuecomment-373768850\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"COMMENT\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"CONTAINS\\"}": Object {
+          "dst": Object {
+            "id": "https://github.com/sourcecred/example-github/issues/2#issuecomment-373768850",
+            "pluginName": "sourcecred/github-beta",
+            "type": "COMMENT",
+          },
+          "payload": Object {},
+          "src": Object {
+            "id": "https://github.com/sourcecred/example-github/issues/2",
+            "pluginName": "sourcecred/github-beta",
+            "type": "ISSUE",
+          },
+        },
+        "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/issues/2\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"ISSUE\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/issues/2#issuecomment-385576185\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"COMMENT\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"CONTAINS\\"}": Object {
+          "dst": Object {
+            "id": "https://github.com/sourcecred/example-github/issues/2#issuecomment-385576185",
+            "pluginName": "sourcecred/github-beta",
+            "type": "COMMENT",
+          },
+          "payload": Object {},
+          "src": Object {
+            "id": "https://github.com/sourcecred/example-github/issues/2",
+            "pluginName": "sourcecred/github-beta",
+            "type": "ISSUE",
+          },
+        },
+        "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/issues/2\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"ISSUE\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/issues/2#issuecomment-385576220\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"COMMENT\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"CONTAINS\\"}": Object {
+          "dst": Object {
+            "id": "https://github.com/sourcecred/example-github/issues/2#issuecomment-385576220",
+            "pluginName": "sourcecred/github-beta",
+            "type": "COMMENT",
+          },
+          "payload": Object {},
+          "src": Object {
+            "id": "https://github.com/sourcecred/example-github/issues/2",
+            "pluginName": "sourcecred/github-beta",
+            "type": "ISSUE",
+          },
+        },
+        "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/issues/2\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"ISSUE\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/issues/2#issuecomment-385576248\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"COMMENT\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"CONTAINS\\"}": Object {
+          "dst": Object {
+            "id": "https://github.com/sourcecred/example-github/issues/2#issuecomment-385576248",
+            "pluginName": "sourcecred/github-beta",
+            "type": "COMMENT",
+          },
+          "payload": Object {},
+          "src": Object {
+            "id": "https://github.com/sourcecred/example-github/issues/2",
+            "pluginName": "sourcecred/github-beta",
+            "type": "ISSUE",
+          },
+        },
+        "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/issues/2\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"ISSUE\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/issues/2#issuecomment-385576273\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"COMMENT\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"CONTAINS\\"}": Object {
+          "dst": Object {
+            "id": "https://github.com/sourcecred/example-github/issues/2#issuecomment-385576273",
+            "pluginName": "sourcecred/github-beta",
+            "type": "COMMENT",
+          },
+          "payload": Object {},
+          "src": Object {
+            "id": "https://github.com/sourcecred/example-github/issues/2",
+            "pluginName": "sourcecred/github-beta",
+            "type": "ISSUE",
+          },
+        },
+        "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/issues/2\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"ISSUE\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/issues/2#issuecomment-385576920\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"COMMENT\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"CONTAINS\\"}": Object {
+          "dst": Object {
+            "id": "https://github.com/sourcecred/example-github/issues/2#issuecomment-385576920",
+            "pluginName": "sourcecred/github-beta",
+            "type": "COMMENT",
+          },
+          "payload": Object {},
+          "src": Object {
+            "id": "https://github.com/sourcecred/example-github/issues/2",
+            "pluginName": "sourcecred/github-beta",
+            "type": "ISSUE",
+          },
+        },
+        "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/issues/2\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"ISSUE\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/issues/2#issuecomment-385576936\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"COMMENT\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"CONTAINS\\"}": Object {
+          "dst": Object {
+            "id": "https://github.com/sourcecred/example-github/issues/2#issuecomment-385576936",
+            "pluginName": "sourcecred/github-beta",
+            "type": "COMMENT",
+          },
+          "payload": Object {},
+          "src": Object {
+            "id": "https://github.com/sourcecred/example-github/issues/2",
+            "pluginName": "sourcecred/github-beta",
+            "type": "ISSUE",
+          },
+        },
+        "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"REPOSITORY\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/issues/2\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"ISSUE\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"CONTAINS\\"}": Object {
+          "dst": Object {
+            "id": "https://github.com/sourcecred/example-github/issues/2",
+            "pluginName": "sourcecred/github-beta",
+            "type": "ISSUE",
+          },
+          "payload": Object {},
+          "src": Object {
+            "id": "https://github.com/sourcecred/example-github",
+            "pluginName": "sourcecred/github-beta",
+            "type": "REPOSITORY",
+          },
+        },
       },
-    },
-    "{\\"id\\":\\"https://github.com/sourcecred/example-github/issues/2\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"ISSUE\\"}": Object {
-      "payload": Object {
-        "body": "This issue references another issue, namely #1",
-        "number": 2,
-        "title": "A referencing issue.",
-        "url": "https://github.com/sourcecred/example-github/issues/2",
+    ],
+    "nodes": Array [
+      Object {
+        "type": "sourcecred/sourcecred/AddressMap",
+        "version": "0.1.0",
       },
-    },
-    "{\\"id\\":\\"https://github.com/sourcecred/example-github/issues/2#issuecomment-373768703\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"COMMENT\\"}": Object {
-      "payload": Object {
-        "body": "It should also be possible to reference by exact url: https://github.com/sourcecred/example-github/issues/6",
-        "url": "https://github.com/sourcecred/example-github/issues/2#issuecomment-373768703",
-      },
-    },
-    "{\\"id\\":\\"https://github.com/sourcecred/example-github/issues/2#issuecomment-373768850\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"COMMENT\\"}": Object {
-      "payload": Object {
-        "body": "We might also reference individual comments directly.
+      Object {
+        "{\\"id\\":\\"https://github.com/decentralion\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"AUTHOR\\"}": Object {
+          "payload": Object {
+            "login": "decentralion",
+            "subtype": "USER",
+            "url": "https://github.com/decentralion",
+          },
+        },
+        "{\\"id\\":\\"https://github.com/sourcecred/example-github\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"REPOSITORY\\"}": Object {
+          "payload": Object {
+            "name": "example-github",
+            "owner": "sourcecred",
+            "url": "https://github.com/sourcecred/example-github",
+          },
+        },
+        "{\\"id\\":\\"https://github.com/sourcecred/example-github/issues/2\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"ISSUE\\"}": Object {
+          "payload": Object {
+            "body": "This issue references another issue, namely #1",
+            "number": 2,
+            "title": "A referencing issue.",
+            "url": "https://github.com/sourcecred/example-github/issues/2",
+          },
+        },
+        "{\\"id\\":\\"https://github.com/sourcecred/example-github/issues/2#issuecomment-373768703\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"COMMENT\\"}": Object {
+          "payload": Object {
+            "body": "It should also be possible to reference by exact url: https://github.com/sourcecred/example-github/issues/6",
+            "url": "https://github.com/sourcecred/example-github/issues/2#issuecomment-373768703",
+          },
+        },
+        "{\\"id\\":\\"https://github.com/sourcecred/example-github/issues/2#issuecomment-373768850\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"COMMENT\\"}": Object {
+          "payload": Object {
+            "body": "We might also reference individual comments directly.
 https://github.com/sourcecred/example-github/issues/6#issuecomment-373768538",
-        "url": "https://github.com/sourcecred/example-github/issues/2#issuecomment-373768850",
-      },
-    },
-    "{\\"id\\":\\"https://github.com/sourcecred/example-github/issues/2#issuecomment-385576185\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"COMMENT\\"}": Object {
-      "payload": Object {
-        "body": "Here's a PR by direct url: https://github.com/sourcecred/example-github/pull/5",
-        "url": "https://github.com/sourcecred/example-github/issues/2#issuecomment-385576185",
-      },
-    },
-    "{\\"id\\":\\"https://github.com/sourcecred/example-github/issues/2#issuecomment-385576220\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"COMMENT\\"}": Object {
-      "payload": Object {
-        "body": "a PR review by url: https://github.com/sourcecred/example-github/pull/5#pullrequestreview-100313899",
-        "url": "https://github.com/sourcecred/example-github/issues/2#issuecomment-385576220",
-      },
-    },
-    "{\\"id\\":\\"https://github.com/sourcecred/example-github/issues/2#issuecomment-385576248\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"COMMENT\\"}": Object {
-      "payload": Object {
-        "body": "a PR Review Comment by url: https://github.com/sourcecred/example-github/pull/5#discussion_r171460198",
-        "url": "https://github.com/sourcecred/example-github/issues/2#issuecomment-385576248",
-      },
-    },
-    "{\\"id\\":\\"https://github.com/sourcecred/example-github/issues/2#issuecomment-385576273\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"COMMENT\\"}": Object {
-      "payload": Object {
-        "body": "a user by url: https://github.com/wchargin",
-        "url": "https://github.com/sourcecred/example-github/issues/2#issuecomment-385576273",
-      },
-    },
-    "{\\"id\\":\\"https://github.com/sourcecred/example-github/issues/2#issuecomment-385576920\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"COMMENT\\"}": Object {
-      "payload": Object {
-        "body": "Here are several references:
+            "url": "https://github.com/sourcecred/example-github/issues/2#issuecomment-373768850",
+          },
+        },
+        "{\\"id\\":\\"https://github.com/sourcecred/example-github/issues/2#issuecomment-385576185\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"COMMENT\\"}": Object {
+          "payload": Object {
+            "body": "Here's a PR by direct url: https://github.com/sourcecred/example-github/pull/5",
+            "url": "https://github.com/sourcecred/example-github/issues/2#issuecomment-385576185",
+          },
+        },
+        "{\\"id\\":\\"https://github.com/sourcecred/example-github/issues/2#issuecomment-385576220\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"COMMENT\\"}": Object {
+          "payload": Object {
+            "body": "a PR review by url: https://github.com/sourcecred/example-github/pull/5#pullrequestreview-100313899",
+            "url": "https://github.com/sourcecred/example-github/issues/2#issuecomment-385576220",
+          },
+        },
+        "{\\"id\\":\\"https://github.com/sourcecred/example-github/issues/2#issuecomment-385576248\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"COMMENT\\"}": Object {
+          "payload": Object {
+            "body": "a PR Review Comment by url: https://github.com/sourcecred/example-github/pull/5#discussion_r171460198",
+            "url": "https://github.com/sourcecred/example-github/issues/2#issuecomment-385576248",
+          },
+        },
+        "{\\"id\\":\\"https://github.com/sourcecred/example-github/issues/2#issuecomment-385576273\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"COMMENT\\"}": Object {
+          "payload": Object {
+            "body": "a user by url: https://github.com/wchargin",
+            "url": "https://github.com/sourcecred/example-github/issues/2#issuecomment-385576273",
+          },
+        },
+        "{\\"id\\":\\"https://github.com/sourcecred/example-github/issues/2#issuecomment-385576920\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"COMMENT\\"}": Object {
+          "payload": Object {
+            "body": "Here are several references:
 #1 
 #2
 #3 
@@ -1392,956 +1498,974 @@ https://github.com/sourcecred/example-github/issues/6#issuecomment-373768538",
 https://github.com/sourcecred/example-github/pull/5#discussion_r171460198
 https://github.com/sourcecred/example-github/pull/5#pullrequestreview-100313899
 ",
-        "url": "https://github.com/sourcecred/example-github/issues/2#issuecomment-385576920",
+            "url": "https://github.com/sourcecred/example-github/issues/2#issuecomment-385576920",
+          },
+        },
+        "{\\"id\\":\\"https://github.com/sourcecred/example-github/issues/2#issuecomment-385576936\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"COMMENT\\"}": Object {
+          "payload": Object {
+            "body": "This comment has no references.",
+            "url": "https://github.com/sourcecred/example-github/issues/2#issuecomment-385576936",
+          },
+        },
       },
-    },
-    "{\\"id\\":\\"https://github.com/sourcecred/example-github/issues/2#issuecomment-385576936\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"COMMENT\\"}": Object {
-      "payload": Object {
-        "body": "This comment has no references.",
-        "url": "https://github.com/sourcecred/example-github/issues/2#issuecomment-385576936",
-      },
-    },
+    ],
   },
-}
+]
 `;
 
 exports[`GithubParser whole repo parsing parses the entire example-github as expected 1`] = `
-Object {
-  "edges": Object {
-    "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/decentralion\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"AUTHOR\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/issues/1\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"ISSUE\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"AUTHORS\\"}": Object {
-      "dst": Object {
-        "id": "https://github.com/decentralion",
-        "pluginName": "sourcecred/github-beta",
-        "type": "AUTHOR",
-      },
-      "payload": Object {},
-      "src": Object {
-        "id": "https://github.com/sourcecred/example-github/issues/1",
-        "pluginName": "sourcecred/github-beta",
-        "type": "ISSUE",
-      },
-    },
-    "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/decentralion\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"AUTHOR\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/issues/2#issuecomment-373768703\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"COMMENT\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"AUTHORS\\"}": Object {
-      "dst": Object {
-        "id": "https://github.com/decentralion",
-        "pluginName": "sourcecred/github-beta",
-        "type": "AUTHOR",
-      },
-      "payload": Object {},
-      "src": Object {
-        "id": "https://github.com/sourcecred/example-github/issues/2#issuecomment-373768703",
-        "pluginName": "sourcecred/github-beta",
-        "type": "COMMENT",
-      },
-    },
-    "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/decentralion\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"AUTHOR\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/issues/2#issuecomment-373768850\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"COMMENT\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"AUTHORS\\"}": Object {
-      "dst": Object {
-        "id": "https://github.com/decentralion",
-        "pluginName": "sourcecred/github-beta",
-        "type": "AUTHOR",
-      },
-      "payload": Object {},
-      "src": Object {
-        "id": "https://github.com/sourcecred/example-github/issues/2#issuecomment-373768850",
-        "pluginName": "sourcecred/github-beta",
-        "type": "COMMENT",
-      },
-    },
-    "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/decentralion\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"AUTHOR\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/issues/2#issuecomment-385576185\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"COMMENT\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"AUTHORS\\"}": Object {
-      "dst": Object {
-        "id": "https://github.com/decentralion",
-        "pluginName": "sourcecred/github-beta",
-        "type": "AUTHOR",
-      },
-      "payload": Object {},
-      "src": Object {
-        "id": "https://github.com/sourcecred/example-github/issues/2#issuecomment-385576185",
-        "pluginName": "sourcecred/github-beta",
-        "type": "COMMENT",
-      },
-    },
-    "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/decentralion\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"AUTHOR\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/issues/2#issuecomment-385576220\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"COMMENT\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"AUTHORS\\"}": Object {
-      "dst": Object {
-        "id": "https://github.com/decentralion",
-        "pluginName": "sourcecred/github-beta",
-        "type": "AUTHOR",
-      },
-      "payload": Object {},
-      "src": Object {
-        "id": "https://github.com/sourcecred/example-github/issues/2#issuecomment-385576220",
-        "pluginName": "sourcecred/github-beta",
-        "type": "COMMENT",
-      },
-    },
-    "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/decentralion\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"AUTHOR\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/issues/2#issuecomment-385576248\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"COMMENT\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"AUTHORS\\"}": Object {
-      "dst": Object {
-        "id": "https://github.com/decentralion",
-        "pluginName": "sourcecred/github-beta",
-        "type": "AUTHOR",
-      },
-      "payload": Object {},
-      "src": Object {
-        "id": "https://github.com/sourcecred/example-github/issues/2#issuecomment-385576248",
-        "pluginName": "sourcecred/github-beta",
-        "type": "COMMENT",
-      },
-    },
-    "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/decentralion\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"AUTHOR\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/issues/2#issuecomment-385576273\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"COMMENT\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"AUTHORS\\"}": Object {
-      "dst": Object {
-        "id": "https://github.com/decentralion",
-        "pluginName": "sourcecred/github-beta",
-        "type": "AUTHOR",
-      },
-      "payload": Object {},
-      "src": Object {
-        "id": "https://github.com/sourcecred/example-github/issues/2#issuecomment-385576273",
-        "pluginName": "sourcecred/github-beta",
-        "type": "COMMENT",
-      },
-    },
-    "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/decentralion\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"AUTHOR\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/issues/2#issuecomment-385576920\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"COMMENT\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"AUTHORS\\"}": Object {
-      "dst": Object {
-        "id": "https://github.com/decentralion",
-        "pluginName": "sourcecred/github-beta",
-        "type": "AUTHOR",
-      },
-      "payload": Object {},
-      "src": Object {
-        "id": "https://github.com/sourcecred/example-github/issues/2#issuecomment-385576920",
-        "pluginName": "sourcecred/github-beta",
-        "type": "COMMENT",
-      },
-    },
-    "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/decentralion\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"AUTHOR\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/issues/2#issuecomment-385576936\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"COMMENT\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"AUTHORS\\"}": Object {
-      "dst": Object {
-        "id": "https://github.com/decentralion",
-        "pluginName": "sourcecred/github-beta",
-        "type": "AUTHOR",
-      },
-      "payload": Object {},
-      "src": Object {
-        "id": "https://github.com/sourcecred/example-github/issues/2#issuecomment-385576936",
-        "pluginName": "sourcecred/github-beta",
-        "type": "COMMENT",
-      },
-    },
-    "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/decentralion\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"AUTHOR\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/issues/2\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"ISSUE\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"AUTHORS\\"}": Object {
-      "dst": Object {
-        "id": "https://github.com/decentralion",
-        "pluginName": "sourcecred/github-beta",
-        "type": "AUTHOR",
-      },
-      "payload": Object {},
-      "src": Object {
-        "id": "https://github.com/sourcecred/example-github/issues/2",
-        "pluginName": "sourcecred/github-beta",
-        "type": "ISSUE",
-      },
-    },
-    "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/decentralion\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"AUTHOR\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/issues/4\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"ISSUE\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"AUTHORS\\"}": Object {
-      "dst": Object {
-        "id": "https://github.com/decentralion",
-        "pluginName": "sourcecred/github-beta",
-        "type": "AUTHOR",
-      },
-      "payload": Object {},
-      "src": Object {
-        "id": "https://github.com/sourcecred/example-github/issues/4",
-        "pluginName": "sourcecred/github-beta",
-        "type": "ISSUE",
-      },
-    },
-    "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/decentralion\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"AUTHOR\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/issues/6#issuecomment-373768442\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"COMMENT\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"AUTHORS\\"}": Object {
-      "dst": Object {
-        "id": "https://github.com/decentralion",
-        "pluginName": "sourcecred/github-beta",
-        "type": "AUTHOR",
-      },
-      "payload": Object {},
-      "src": Object {
-        "id": "https://github.com/sourcecred/example-github/issues/6#issuecomment-373768442",
-        "pluginName": "sourcecred/github-beta",
-        "type": "COMMENT",
-      },
-    },
-    "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/decentralion\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"AUTHOR\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/issues/6#issuecomment-373768538\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"COMMENT\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"AUTHORS\\"}": Object {
-      "dst": Object {
-        "id": "https://github.com/decentralion",
-        "pluginName": "sourcecred/github-beta",
-        "type": "AUTHOR",
-      },
-      "payload": Object {},
-      "src": Object {
-        "id": "https://github.com/sourcecred/example-github/issues/6#issuecomment-373768538",
-        "pluginName": "sourcecred/github-beta",
-        "type": "COMMENT",
-      },
-    },
-    "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/decentralion\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"AUTHOR\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/issues/6#issuecomment-385223316\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"COMMENT\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"AUTHORS\\"}": Object {
-      "dst": Object {
-        "id": "https://github.com/decentralion",
-        "pluginName": "sourcecred/github-beta",
-        "type": "AUTHOR",
-      },
-      "payload": Object {},
-      "src": Object {
-        "id": "https://github.com/sourcecred/example-github/issues/6#issuecomment-385223316",
-        "pluginName": "sourcecred/github-beta",
-        "type": "COMMENT",
-      },
-    },
-    "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/decentralion\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"AUTHOR\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/issues/6\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"ISSUE\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"AUTHORS\\"}": Object {
-      "dst": Object {
-        "id": "https://github.com/decentralion",
-        "pluginName": "sourcecred/github-beta",
-        "type": "AUTHOR",
-      },
-      "payload": Object {},
-      "src": Object {
-        "id": "https://github.com/sourcecred/example-github/issues/6",
-        "pluginName": "sourcecred/github-beta",
-        "type": "ISSUE",
-      },
-    },
-    "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/decentralion\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"AUTHOR\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/issues/7\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"ISSUE\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"AUTHORS\\"}": Object {
-      "dst": Object {
-        "id": "https://github.com/decentralion",
-        "pluginName": "sourcecred/github-beta",
-        "type": "AUTHOR",
-      },
-      "payload": Object {},
-      "src": Object {
-        "id": "https://github.com/sourcecred/example-github/issues/7",
-        "pluginName": "sourcecred/github-beta",
-        "type": "ISSUE",
-      },
-    },
-    "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/decentralion\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"AUTHOR\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/issues/8\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"ISSUE\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"AUTHORS\\"}": Object {
-      "dst": Object {
-        "id": "https://github.com/decentralion",
-        "pluginName": "sourcecred/github-beta",
-        "type": "AUTHOR",
-      },
-      "payload": Object {},
-      "src": Object {
-        "id": "https://github.com/sourcecred/example-github/issues/8",
-        "pluginName": "sourcecred/github-beta",
-        "type": "ISSUE",
-      },
-    },
-    "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/decentralion\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"AUTHOR\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/pull/3#issuecomment-369162222\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"COMMENT\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"AUTHORS\\"}": Object {
-      "dst": Object {
-        "id": "https://github.com/decentralion",
-        "pluginName": "sourcecred/github-beta",
-        "type": "AUTHOR",
-      },
-      "payload": Object {},
-      "src": Object {
-        "id": "https://github.com/sourcecred/example-github/pull/3#issuecomment-369162222",
-        "pluginName": "sourcecred/github-beta",
-        "type": "COMMENT",
-      },
-    },
-    "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/decentralion\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"AUTHOR\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/pull/3\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"PULL_REQUEST\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"AUTHORS\\"}": Object {
-      "dst": Object {
-        "id": "https://github.com/decentralion",
-        "pluginName": "sourcecred/github-beta",
-        "type": "AUTHOR",
-      },
-      "payload": Object {},
-      "src": Object {
-        "id": "https://github.com/sourcecred/example-github/pull/3",
-        "pluginName": "sourcecred/github-beta",
-        "type": "PULL_REQUEST",
-      },
-    },
-    "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/decentralion\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"AUTHOR\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/pull/5\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"PULL_REQUEST\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"AUTHORS\\"}": Object {
-      "dst": Object {
-        "id": "https://github.com/decentralion",
-        "pluginName": "sourcecred/github-beta",
-        "type": "AUTHOR",
-      },
-      "payload": Object {},
-      "src": Object {
-        "id": "https://github.com/sourcecred/example-github/pull/5",
-        "pluginName": "sourcecred/github-beta",
-        "type": "PULL_REQUEST",
-      },
-    },
-    "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/decentralion\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"AUTHOR\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/pull/9\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"PULL_REQUEST\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"AUTHORS\\"}": Object {
-      "dst": Object {
-        "id": "https://github.com/decentralion",
-        "pluginName": "sourcecred/github-beta",
-        "type": "AUTHOR",
-      },
-      "payload": Object {},
-      "src": Object {
-        "id": "https://github.com/sourcecred/example-github/pull/9",
-        "pluginName": "sourcecred/github-beta",
-        "type": "PULL_REQUEST",
-      },
-    },
-    "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/issues/2#issuecomment-373768703\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"COMMENT\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/issues/6\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"ISSUE\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"REFERENCES\\"}": Object {
-      "dst": Object {
-        "id": "https://github.com/sourcecred/example-github/issues/6",
-        "pluginName": "sourcecred/github-beta",
-        "type": "ISSUE",
-      },
-      "payload": Object {},
-      "src": Object {
-        "id": "https://github.com/sourcecred/example-github/issues/2#issuecomment-373768703",
-        "pluginName": "sourcecred/github-beta",
-        "type": "COMMENT",
-      },
-    },
-    "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/issues/2#issuecomment-373768850\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"COMMENT\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/issues/6#issuecomment-373768538\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"COMMENT\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"REFERENCES\\"}": Object {
-      "dst": Object {
-        "id": "https://github.com/sourcecred/example-github/issues/6#issuecomment-373768538",
-        "pluginName": "sourcecred/github-beta",
-        "type": "COMMENT",
-      },
-      "payload": Object {},
-      "src": Object {
-        "id": "https://github.com/sourcecred/example-github/issues/2#issuecomment-373768850",
-        "pluginName": "sourcecred/github-beta",
-        "type": "COMMENT",
-      },
-    },
-    "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/issues/2#issuecomment-385576185\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"COMMENT\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/pull/5\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"PULL_REQUEST\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"REFERENCES\\"}": Object {
-      "dst": Object {
-        "id": "https://github.com/sourcecred/example-github/pull/5",
-        "pluginName": "sourcecred/github-beta",
-        "type": "PULL_REQUEST",
-      },
-      "payload": Object {},
-      "src": Object {
-        "id": "https://github.com/sourcecred/example-github/issues/2#issuecomment-385576185",
-        "pluginName": "sourcecred/github-beta",
-        "type": "COMMENT",
-      },
-    },
-    "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/issues/2#issuecomment-385576220\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"COMMENT\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/pull/5#pullrequestreview-100313899\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"PULL_REQUEST_REVIEW\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"REFERENCES\\"}": Object {
-      "dst": Object {
-        "id": "https://github.com/sourcecred/example-github/pull/5#pullrequestreview-100313899",
-        "pluginName": "sourcecred/github-beta",
-        "type": "PULL_REQUEST_REVIEW",
-      },
-      "payload": Object {},
-      "src": Object {
-        "id": "https://github.com/sourcecred/example-github/issues/2#issuecomment-385576220",
-        "pluginName": "sourcecred/github-beta",
-        "type": "COMMENT",
-      },
-    },
-    "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/issues/2#issuecomment-385576248\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"COMMENT\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/pull/5#discussion_r171460198\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"PULL_REQUEST_REVIEW_COMMENT\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"REFERENCES\\"}": Object {
-      "dst": Object {
-        "id": "https://github.com/sourcecred/example-github/pull/5#discussion_r171460198",
-        "pluginName": "sourcecred/github-beta",
-        "type": "PULL_REQUEST_REVIEW_COMMENT",
-      },
-      "payload": Object {},
-      "src": Object {
-        "id": "https://github.com/sourcecred/example-github/issues/2#issuecomment-385576248",
-        "pluginName": "sourcecred/github-beta",
-        "type": "COMMENT",
-      },
-    },
-    "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/issues/2#issuecomment-385576273\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"COMMENT\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/wchargin\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"AUTHOR\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"REFERENCES\\"}": Object {
-      "dst": Object {
-        "id": "https://github.com/wchargin",
-        "pluginName": "sourcecred/github-beta",
-        "type": "AUTHOR",
-      },
-      "payload": Object {},
-      "src": Object {
-        "id": "https://github.com/sourcecred/example-github/issues/2#issuecomment-385576273",
-        "pluginName": "sourcecred/github-beta",
-        "type": "COMMENT",
-      },
-    },
-    "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/issues/2#issuecomment-385576920\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"COMMENT\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/issues/1\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"ISSUE\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"REFERENCES\\"}": Object {
-      "dst": Object {
-        "id": "https://github.com/sourcecred/example-github/issues/1",
-        "pluginName": "sourcecred/github-beta",
-        "type": "ISSUE",
-      },
-      "payload": Object {},
-      "src": Object {
-        "id": "https://github.com/sourcecred/example-github/issues/2#issuecomment-385576920",
-        "pluginName": "sourcecred/github-beta",
-        "type": "COMMENT",
-      },
-    },
-    "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/issues/2#issuecomment-385576920\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"COMMENT\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/issues/2\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"ISSUE\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"REFERENCES\\"}": Object {
-      "dst": Object {
-        "id": "https://github.com/sourcecred/example-github/issues/2",
-        "pluginName": "sourcecred/github-beta",
-        "type": "ISSUE",
-      },
-      "payload": Object {},
-      "src": Object {
-        "id": "https://github.com/sourcecred/example-github/issues/2#issuecomment-385576920",
-        "pluginName": "sourcecred/github-beta",
-        "type": "COMMENT",
-      },
-    },
-    "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/issues/2#issuecomment-385576920\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"COMMENT\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/pull/3\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"PULL_REQUEST\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"REFERENCES\\"}": Object {
-      "dst": Object {
-        "id": "https://github.com/sourcecred/example-github/pull/3",
-        "pluginName": "sourcecred/github-beta",
-        "type": "PULL_REQUEST",
-      },
-      "payload": Object {},
-      "src": Object {
-        "id": "https://github.com/sourcecred/example-github/issues/2#issuecomment-385576920",
-        "pluginName": "sourcecred/github-beta",
-        "type": "COMMENT",
-      },
-    },
-    "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/issues/2#issuecomment-385576920\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"COMMENT\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/pull/5#discussion_r171460198\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"PULL_REQUEST_REVIEW_COMMENT\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"REFERENCES\\"}": Object {
-      "dst": Object {
-        "id": "https://github.com/sourcecred/example-github/pull/5#discussion_r171460198",
-        "pluginName": "sourcecred/github-beta",
-        "type": "PULL_REQUEST_REVIEW_COMMENT",
-      },
-      "payload": Object {},
-      "src": Object {
-        "id": "https://github.com/sourcecred/example-github/issues/2#issuecomment-385576920",
-        "pluginName": "sourcecred/github-beta",
-        "type": "COMMENT",
-      },
-    },
-    "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/issues/2#issuecomment-385576920\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"COMMENT\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/pull/5#pullrequestreview-100313899\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"PULL_REQUEST_REVIEW\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"REFERENCES\\"}": Object {
-      "dst": Object {
-        "id": "https://github.com/sourcecred/example-github/pull/5#pullrequestreview-100313899",
-        "pluginName": "sourcecred/github-beta",
-        "type": "PULL_REQUEST_REVIEW",
-      },
-      "payload": Object {},
-      "src": Object {
-        "id": "https://github.com/sourcecred/example-github/issues/2#issuecomment-385576920",
-        "pluginName": "sourcecred/github-beta",
-        "type": "COMMENT",
-      },
-    },
-    "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/issues/2\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"ISSUE\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/issues/1\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"ISSUE\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"REFERENCES\\"}": Object {
-      "dst": Object {
-        "id": "https://github.com/sourcecred/example-github/issues/1",
-        "pluginName": "sourcecred/github-beta",
-        "type": "ISSUE",
-      },
-      "payload": Object {},
-      "src": Object {
-        "id": "https://github.com/sourcecred/example-github/issues/2",
-        "pluginName": "sourcecred/github-beta",
-        "type": "ISSUE",
-      },
-    },
-    "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/issues/2\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"ISSUE\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/issues/2#issuecomment-373768703\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"COMMENT\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"CONTAINS\\"}": Object {
-      "dst": Object {
-        "id": "https://github.com/sourcecred/example-github/issues/2#issuecomment-373768703",
-        "pluginName": "sourcecred/github-beta",
-        "type": "COMMENT",
-      },
-      "payload": Object {},
-      "src": Object {
-        "id": "https://github.com/sourcecred/example-github/issues/2",
-        "pluginName": "sourcecred/github-beta",
-        "type": "ISSUE",
-      },
-    },
-    "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/issues/2\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"ISSUE\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/issues/2#issuecomment-373768850\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"COMMENT\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"CONTAINS\\"}": Object {
-      "dst": Object {
-        "id": "https://github.com/sourcecred/example-github/issues/2#issuecomment-373768850",
-        "pluginName": "sourcecred/github-beta",
-        "type": "COMMENT",
-      },
-      "payload": Object {},
-      "src": Object {
-        "id": "https://github.com/sourcecred/example-github/issues/2",
-        "pluginName": "sourcecred/github-beta",
-        "type": "ISSUE",
-      },
-    },
-    "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/issues/2\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"ISSUE\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/issues/2#issuecomment-385576185\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"COMMENT\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"CONTAINS\\"}": Object {
-      "dst": Object {
-        "id": "https://github.com/sourcecred/example-github/issues/2#issuecomment-385576185",
-        "pluginName": "sourcecred/github-beta",
-        "type": "COMMENT",
-      },
-      "payload": Object {},
-      "src": Object {
-        "id": "https://github.com/sourcecred/example-github/issues/2",
-        "pluginName": "sourcecred/github-beta",
-        "type": "ISSUE",
-      },
-    },
-    "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/issues/2\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"ISSUE\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/issues/2#issuecomment-385576220\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"COMMENT\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"CONTAINS\\"}": Object {
-      "dst": Object {
-        "id": "https://github.com/sourcecred/example-github/issues/2#issuecomment-385576220",
-        "pluginName": "sourcecred/github-beta",
-        "type": "COMMENT",
-      },
-      "payload": Object {},
-      "src": Object {
-        "id": "https://github.com/sourcecred/example-github/issues/2",
-        "pluginName": "sourcecred/github-beta",
-        "type": "ISSUE",
-      },
-    },
-    "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/issues/2\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"ISSUE\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/issues/2#issuecomment-385576248\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"COMMENT\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"CONTAINS\\"}": Object {
-      "dst": Object {
-        "id": "https://github.com/sourcecred/example-github/issues/2#issuecomment-385576248",
-        "pluginName": "sourcecred/github-beta",
-        "type": "COMMENT",
-      },
-      "payload": Object {},
-      "src": Object {
-        "id": "https://github.com/sourcecred/example-github/issues/2",
-        "pluginName": "sourcecred/github-beta",
-        "type": "ISSUE",
-      },
-    },
-    "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/issues/2\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"ISSUE\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/issues/2#issuecomment-385576273\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"COMMENT\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"CONTAINS\\"}": Object {
-      "dst": Object {
-        "id": "https://github.com/sourcecred/example-github/issues/2#issuecomment-385576273",
-        "pluginName": "sourcecred/github-beta",
-        "type": "COMMENT",
-      },
-      "payload": Object {},
-      "src": Object {
-        "id": "https://github.com/sourcecred/example-github/issues/2",
-        "pluginName": "sourcecred/github-beta",
-        "type": "ISSUE",
-      },
-    },
-    "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/issues/2\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"ISSUE\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/issues/2#issuecomment-385576920\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"COMMENT\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"CONTAINS\\"}": Object {
-      "dst": Object {
-        "id": "https://github.com/sourcecred/example-github/issues/2#issuecomment-385576920",
-        "pluginName": "sourcecred/github-beta",
-        "type": "COMMENT",
-      },
-      "payload": Object {},
-      "src": Object {
-        "id": "https://github.com/sourcecred/example-github/issues/2",
-        "pluginName": "sourcecred/github-beta",
-        "type": "ISSUE",
-      },
-    },
-    "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/issues/2\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"ISSUE\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/issues/2#issuecomment-385576936\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"COMMENT\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"CONTAINS\\"}": Object {
-      "dst": Object {
-        "id": "https://github.com/sourcecred/example-github/issues/2#issuecomment-385576936",
-        "pluginName": "sourcecred/github-beta",
-        "type": "COMMENT",
-      },
-      "payload": Object {},
-      "src": Object {
-        "id": "https://github.com/sourcecred/example-github/issues/2",
-        "pluginName": "sourcecred/github-beta",
-        "type": "ISSUE",
-      },
-    },
-    "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/issues/6#issuecomment-385223316\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"COMMENT\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/issues/2\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"ISSUE\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"REFERENCES\\"}": Object {
-      "dst": Object {
-        "id": "https://github.com/sourcecred/example-github/issues/2",
-        "pluginName": "sourcecred/github-beta",
-        "type": "ISSUE",
-      },
-      "payload": Object {},
-      "src": Object {
-        "id": "https://github.com/sourcecred/example-github/issues/6#issuecomment-385223316",
-        "pluginName": "sourcecred/github-beta",
-        "type": "COMMENT",
-      },
-    },
-    "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/issues/6\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"ISSUE\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/issues/6#issuecomment-373768442\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"COMMENT\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"CONTAINS\\"}": Object {
-      "dst": Object {
-        "id": "https://github.com/sourcecred/example-github/issues/6#issuecomment-373768442",
-        "pluginName": "sourcecred/github-beta",
-        "type": "COMMENT",
-      },
-      "payload": Object {},
-      "src": Object {
-        "id": "https://github.com/sourcecred/example-github/issues/6",
-        "pluginName": "sourcecred/github-beta",
-        "type": "ISSUE",
-      },
-    },
-    "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/issues/6\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"ISSUE\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/issues/6#issuecomment-373768538\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"COMMENT\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"CONTAINS\\"}": Object {
-      "dst": Object {
-        "id": "https://github.com/sourcecred/example-github/issues/6#issuecomment-373768538",
-        "pluginName": "sourcecred/github-beta",
-        "type": "COMMENT",
-      },
-      "payload": Object {},
-      "src": Object {
-        "id": "https://github.com/sourcecred/example-github/issues/6",
-        "pluginName": "sourcecred/github-beta",
-        "type": "ISSUE",
-      },
-    },
-    "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/issues/6\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"ISSUE\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/issues/6#issuecomment-385223316\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"COMMENT\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"CONTAINS\\"}": Object {
-      "dst": Object {
-        "id": "https://github.com/sourcecred/example-github/issues/6#issuecomment-385223316",
-        "pluginName": "sourcecred/github-beta",
-        "type": "COMMENT",
-      },
-      "payload": Object {},
-      "src": Object {
-        "id": "https://github.com/sourcecred/example-github/issues/6",
-        "pluginName": "sourcecred/github-beta",
-        "type": "ISSUE",
-      },
-    },
-    "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/pull/3#issuecomment-369162222\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"COMMENT\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/issues/2\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"ISSUE\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"REFERENCES\\"}": Object {
-      "dst": Object {
-        "id": "https://github.com/sourcecred/example-github/issues/2",
-        "pluginName": "sourcecred/github-beta",
-        "type": "ISSUE",
-      },
-      "payload": Object {},
-      "src": Object {
-        "id": "https://github.com/sourcecred/example-github/pull/3#issuecomment-369162222",
-        "pluginName": "sourcecred/github-beta",
-        "type": "COMMENT",
-      },
-    },
-    "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/pull/3\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"PULL_REQUEST\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"0a223346b4e6dec0127b1e6aa892c4ee0424b66a\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/git-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"COMMIT\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"MERGED_AS\\"}": Object {
-      "dst": Object {
-        "id": "0a223346b4e6dec0127b1e6aa892c4ee0424b66a",
-        "pluginName": "sourcecred/git-beta",
-        "type": "COMMIT",
-      },
-      "payload": Object {
-        "hash": "0a223346b4e6dec0127b1e6aa892c4ee0424b66a",
-      },
-      "src": Object {
-        "id": "https://github.com/sourcecred/example-github/pull/3",
-        "pluginName": "sourcecred/github-beta",
-        "type": "PULL_REQUEST",
-      },
-    },
-    "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/pull/3\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"PULL_REQUEST\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/pull/3#issuecomment-369162222\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"COMMENT\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"CONTAINS\\"}": Object {
-      "dst": Object {
-        "id": "https://github.com/sourcecred/example-github/pull/3#issuecomment-369162222",
-        "pluginName": "sourcecred/github-beta",
-        "type": "COMMENT",
-      },
-      "payload": Object {},
-      "src": Object {
-        "id": "https://github.com/sourcecred/example-github/pull/3",
-        "pluginName": "sourcecred/github-beta",
-        "type": "PULL_REQUEST",
-      },
-    },
-    "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/pull/5#pullrequestreview-100313899\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"PULL_REQUEST_REVIEW\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/pull/5#discussion_r171460198\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"PULL_REQUEST_REVIEW_COMMENT\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"CONTAINS\\"}": Object {
-      "dst": Object {
-        "id": "https://github.com/sourcecred/example-github/pull/5#discussion_r171460198",
-        "pluginName": "sourcecred/github-beta",
-        "type": "PULL_REQUEST_REVIEW_COMMENT",
-      },
-      "payload": Object {},
-      "src": Object {
-        "id": "https://github.com/sourcecred/example-github/pull/5#pullrequestreview-100313899",
-        "pluginName": "sourcecred/github-beta",
-        "type": "PULL_REQUEST_REVIEW",
-      },
-    },
-    "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/pull/5\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"PULL_REQUEST\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"6d5b3aa31ebb68a06ceb46bbd6cf49b6ccd6f5e6\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/git-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"COMMIT\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"MERGED_AS\\"}": Object {
-      "dst": Object {
-        "id": "6d5b3aa31ebb68a06ceb46bbd6cf49b6ccd6f5e6",
-        "pluginName": "sourcecred/git-beta",
-        "type": "COMMIT",
-      },
-      "payload": Object {
-        "hash": "6d5b3aa31ebb68a06ceb46bbd6cf49b6ccd6f5e6",
-      },
-      "src": Object {
-        "id": "https://github.com/sourcecred/example-github/pull/5",
-        "pluginName": "sourcecred/github-beta",
-        "type": "PULL_REQUEST",
-      },
-    },
-    "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/pull/5\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"PULL_REQUEST\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/pull/5#pullrequestreview-100313899\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"PULL_REQUEST_REVIEW\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"CONTAINS\\"}": Object {
-      "dst": Object {
-        "id": "https://github.com/sourcecred/example-github/pull/5#pullrequestreview-100313899",
-        "pluginName": "sourcecred/github-beta",
-        "type": "PULL_REQUEST_REVIEW",
-      },
-      "payload": Object {},
-      "src": Object {
-        "id": "https://github.com/sourcecred/example-github/pull/5",
-        "pluginName": "sourcecred/github-beta",
-        "type": "PULL_REQUEST",
-      },
-    },
-    "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/pull/5\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"PULL_REQUEST\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/pull/5#pullrequestreview-100314038\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"PULL_REQUEST_REVIEW\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"CONTAINS\\"}": Object {
-      "dst": Object {
-        "id": "https://github.com/sourcecred/example-github/pull/5#pullrequestreview-100314038",
-        "pluginName": "sourcecred/github-beta",
-        "type": "PULL_REQUEST_REVIEW",
-      },
-      "payload": Object {},
-      "src": Object {
-        "id": "https://github.com/sourcecred/example-github/pull/5",
-        "pluginName": "sourcecred/github-beta",
-        "type": "PULL_REQUEST",
-      },
-    },
-    "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/pull/5\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"PULL_REQUEST\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/wchargin\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"AUTHOR\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"REFERENCES\\"}": Object {
-      "dst": Object {
-        "id": "https://github.com/wchargin",
-        "pluginName": "sourcecred/github-beta",
-        "type": "AUTHOR",
-      },
-      "payload": Object {},
-      "src": Object {
-        "id": "https://github.com/sourcecred/example-github/pull/5",
-        "pluginName": "sourcecred/github-beta",
-        "type": "PULL_REQUEST",
-      },
-    },
-    "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/pull/9\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"PULL_REQUEST\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/wchargin\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"AUTHOR\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"REFERENCES\\"}": Object {
-      "dst": Object {
-        "id": "https://github.com/wchargin",
-        "pluginName": "sourcecred/github-beta",
-        "type": "AUTHOR",
-      },
-      "payload": Object {},
-      "src": Object {
-        "id": "https://github.com/sourcecred/example-github/pull/9",
-        "pluginName": "sourcecred/github-beta",
-        "type": "PULL_REQUEST",
-      },
-    },
-    "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"REPOSITORY\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/issues/1\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"ISSUE\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"CONTAINS\\"}": Object {
-      "dst": Object {
-        "id": "https://github.com/sourcecred/example-github/issues/1",
-        "pluginName": "sourcecred/github-beta",
-        "type": "ISSUE",
-      },
-      "payload": Object {},
-      "src": Object {
-        "id": "https://github.com/sourcecred/example-github",
-        "pluginName": "sourcecred/github-beta",
-        "type": "REPOSITORY",
-      },
-    },
-    "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"REPOSITORY\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/issues/2\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"ISSUE\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"CONTAINS\\"}": Object {
-      "dst": Object {
-        "id": "https://github.com/sourcecred/example-github/issues/2",
-        "pluginName": "sourcecred/github-beta",
-        "type": "ISSUE",
-      },
-      "payload": Object {},
-      "src": Object {
-        "id": "https://github.com/sourcecred/example-github",
-        "pluginName": "sourcecred/github-beta",
-        "type": "REPOSITORY",
-      },
-    },
-    "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"REPOSITORY\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/issues/4\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"ISSUE\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"CONTAINS\\"}": Object {
-      "dst": Object {
-        "id": "https://github.com/sourcecred/example-github/issues/4",
-        "pluginName": "sourcecred/github-beta",
-        "type": "ISSUE",
-      },
-      "payload": Object {},
-      "src": Object {
-        "id": "https://github.com/sourcecred/example-github",
-        "pluginName": "sourcecred/github-beta",
-        "type": "REPOSITORY",
-      },
-    },
-    "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"REPOSITORY\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/issues/6\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"ISSUE\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"CONTAINS\\"}": Object {
-      "dst": Object {
-        "id": "https://github.com/sourcecred/example-github/issues/6",
-        "pluginName": "sourcecred/github-beta",
-        "type": "ISSUE",
-      },
-      "payload": Object {},
-      "src": Object {
-        "id": "https://github.com/sourcecred/example-github",
-        "pluginName": "sourcecred/github-beta",
-        "type": "REPOSITORY",
-      },
-    },
-    "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"REPOSITORY\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/issues/7\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"ISSUE\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"CONTAINS\\"}": Object {
-      "dst": Object {
-        "id": "https://github.com/sourcecred/example-github/issues/7",
-        "pluginName": "sourcecred/github-beta",
-        "type": "ISSUE",
-      },
-      "payload": Object {},
-      "src": Object {
-        "id": "https://github.com/sourcecred/example-github",
-        "pluginName": "sourcecred/github-beta",
-        "type": "REPOSITORY",
-      },
-    },
-    "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"REPOSITORY\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/issues/8\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"ISSUE\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"CONTAINS\\"}": Object {
-      "dst": Object {
-        "id": "https://github.com/sourcecred/example-github/issues/8",
-        "pluginName": "sourcecred/github-beta",
-        "type": "ISSUE",
-      },
-      "payload": Object {},
-      "src": Object {
-        "id": "https://github.com/sourcecred/example-github",
-        "pluginName": "sourcecred/github-beta",
-        "type": "REPOSITORY",
-      },
-    },
-    "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"REPOSITORY\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/pull/3\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"PULL_REQUEST\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"CONTAINS\\"}": Object {
-      "dst": Object {
-        "id": "https://github.com/sourcecred/example-github/pull/3",
-        "pluginName": "sourcecred/github-beta",
-        "type": "PULL_REQUEST",
-      },
-      "payload": Object {},
-      "src": Object {
-        "id": "https://github.com/sourcecred/example-github",
-        "pluginName": "sourcecred/github-beta",
-        "type": "REPOSITORY",
-      },
-    },
-    "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"REPOSITORY\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/pull/5\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"PULL_REQUEST\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"CONTAINS\\"}": Object {
-      "dst": Object {
-        "id": "https://github.com/sourcecred/example-github/pull/5",
-        "pluginName": "sourcecred/github-beta",
-        "type": "PULL_REQUEST",
-      },
-      "payload": Object {},
-      "src": Object {
-        "id": "https://github.com/sourcecred/example-github",
-        "pluginName": "sourcecred/github-beta",
-        "type": "REPOSITORY",
-      },
-    },
-    "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"REPOSITORY\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/pull/9\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"PULL_REQUEST\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"CONTAINS\\"}": Object {
-      "dst": Object {
-        "id": "https://github.com/sourcecred/example-github/pull/9",
-        "pluginName": "sourcecred/github-beta",
-        "type": "PULL_REQUEST",
-      },
-      "payload": Object {},
-      "src": Object {
-        "id": "https://github.com/sourcecred/example-github",
-        "pluginName": "sourcecred/github-beta",
-        "type": "REPOSITORY",
-      },
-    },
-    "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/wchargin\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"AUTHOR\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/pull/5#discussion_r171460198\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"PULL_REQUEST_REVIEW_COMMENT\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"AUTHORS\\"}": Object {
-      "dst": Object {
-        "id": "https://github.com/wchargin",
-        "pluginName": "sourcecred/github-beta",
-        "type": "AUTHOR",
-      },
-      "payload": Object {},
-      "src": Object {
-        "id": "https://github.com/sourcecred/example-github/pull/5#discussion_r171460198",
-        "pluginName": "sourcecred/github-beta",
-        "type": "PULL_REQUEST_REVIEW_COMMENT",
-      },
-    },
-    "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/wchargin\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"AUTHOR\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/pull/5#pullrequestreview-100313899\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"PULL_REQUEST_REVIEW\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"AUTHORS\\"}": Object {
-      "dst": Object {
-        "id": "https://github.com/wchargin",
-        "pluginName": "sourcecred/github-beta",
-        "type": "AUTHOR",
-      },
-      "payload": Object {},
-      "src": Object {
-        "id": "https://github.com/sourcecred/example-github/pull/5#pullrequestreview-100313899",
-        "pluginName": "sourcecred/github-beta",
-        "type": "PULL_REQUEST_REVIEW",
-      },
-    },
-    "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/wchargin\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"AUTHOR\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/pull/5#pullrequestreview-100314038\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"PULL_REQUEST_REVIEW\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"AUTHORS\\"}": Object {
-      "dst": Object {
-        "id": "https://github.com/wchargin",
-        "pluginName": "sourcecred/github-beta",
-        "type": "AUTHOR",
-      },
-      "payload": Object {},
-      "src": Object {
-        "id": "https://github.com/sourcecred/example-github/pull/5#pullrequestreview-100314038",
-        "pluginName": "sourcecred/github-beta",
-        "type": "PULL_REQUEST_REVIEW",
-      },
-    },
+Array [
+  Object {
+    "type": "sourcecred/sourcecred/Graph",
+    "version": "0.1.0",
   },
-  "nodes": Object {
-    "{\\"id\\":\\"https://github.com/decentralion\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"AUTHOR\\"}": Object {
-      "payload": Object {
-        "login": "decentralion",
-        "subtype": "USER",
-        "url": "https://github.com/decentralion",
+  Object {
+    "edges": Array [
+      Object {
+        "type": "sourcecred/sourcecred/AddressMap",
+        "version": "0.1.0",
       },
-    },
-    "{\\"id\\":\\"https://github.com/sourcecred/example-github\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"REPOSITORY\\"}": Object {
-      "payload": Object {
-        "name": "example-github",
-        "owner": "sourcecred",
-        "url": "https://github.com/sourcecred/example-github",
+      Object {
+        "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/decentralion\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"AUTHOR\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/issues/1\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"ISSUE\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"AUTHORS\\"}": Object {
+          "dst": Object {
+            "id": "https://github.com/decentralion",
+            "pluginName": "sourcecred/github-beta",
+            "type": "AUTHOR",
+          },
+          "payload": Object {},
+          "src": Object {
+            "id": "https://github.com/sourcecred/example-github/issues/1",
+            "pluginName": "sourcecred/github-beta",
+            "type": "ISSUE",
+          },
+        },
+        "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/decentralion\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"AUTHOR\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/issues/2#issuecomment-373768703\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"COMMENT\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"AUTHORS\\"}": Object {
+          "dst": Object {
+            "id": "https://github.com/decentralion",
+            "pluginName": "sourcecred/github-beta",
+            "type": "AUTHOR",
+          },
+          "payload": Object {},
+          "src": Object {
+            "id": "https://github.com/sourcecred/example-github/issues/2#issuecomment-373768703",
+            "pluginName": "sourcecred/github-beta",
+            "type": "COMMENT",
+          },
+        },
+        "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/decentralion\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"AUTHOR\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/issues/2#issuecomment-373768850\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"COMMENT\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"AUTHORS\\"}": Object {
+          "dst": Object {
+            "id": "https://github.com/decentralion",
+            "pluginName": "sourcecred/github-beta",
+            "type": "AUTHOR",
+          },
+          "payload": Object {},
+          "src": Object {
+            "id": "https://github.com/sourcecred/example-github/issues/2#issuecomment-373768850",
+            "pluginName": "sourcecred/github-beta",
+            "type": "COMMENT",
+          },
+        },
+        "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/decentralion\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"AUTHOR\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/issues/2#issuecomment-385576185\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"COMMENT\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"AUTHORS\\"}": Object {
+          "dst": Object {
+            "id": "https://github.com/decentralion",
+            "pluginName": "sourcecred/github-beta",
+            "type": "AUTHOR",
+          },
+          "payload": Object {},
+          "src": Object {
+            "id": "https://github.com/sourcecred/example-github/issues/2#issuecomment-385576185",
+            "pluginName": "sourcecred/github-beta",
+            "type": "COMMENT",
+          },
+        },
+        "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/decentralion\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"AUTHOR\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/issues/2#issuecomment-385576220\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"COMMENT\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"AUTHORS\\"}": Object {
+          "dst": Object {
+            "id": "https://github.com/decentralion",
+            "pluginName": "sourcecred/github-beta",
+            "type": "AUTHOR",
+          },
+          "payload": Object {},
+          "src": Object {
+            "id": "https://github.com/sourcecred/example-github/issues/2#issuecomment-385576220",
+            "pluginName": "sourcecred/github-beta",
+            "type": "COMMENT",
+          },
+        },
+        "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/decentralion\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"AUTHOR\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/issues/2#issuecomment-385576248\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"COMMENT\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"AUTHORS\\"}": Object {
+          "dst": Object {
+            "id": "https://github.com/decentralion",
+            "pluginName": "sourcecred/github-beta",
+            "type": "AUTHOR",
+          },
+          "payload": Object {},
+          "src": Object {
+            "id": "https://github.com/sourcecred/example-github/issues/2#issuecomment-385576248",
+            "pluginName": "sourcecred/github-beta",
+            "type": "COMMENT",
+          },
+        },
+        "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/decentralion\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"AUTHOR\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/issues/2#issuecomment-385576273\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"COMMENT\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"AUTHORS\\"}": Object {
+          "dst": Object {
+            "id": "https://github.com/decentralion",
+            "pluginName": "sourcecred/github-beta",
+            "type": "AUTHOR",
+          },
+          "payload": Object {},
+          "src": Object {
+            "id": "https://github.com/sourcecred/example-github/issues/2#issuecomment-385576273",
+            "pluginName": "sourcecred/github-beta",
+            "type": "COMMENT",
+          },
+        },
+        "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/decentralion\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"AUTHOR\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/issues/2#issuecomment-385576920\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"COMMENT\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"AUTHORS\\"}": Object {
+          "dst": Object {
+            "id": "https://github.com/decentralion",
+            "pluginName": "sourcecred/github-beta",
+            "type": "AUTHOR",
+          },
+          "payload": Object {},
+          "src": Object {
+            "id": "https://github.com/sourcecred/example-github/issues/2#issuecomment-385576920",
+            "pluginName": "sourcecred/github-beta",
+            "type": "COMMENT",
+          },
+        },
+        "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/decentralion\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"AUTHOR\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/issues/2#issuecomment-385576936\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"COMMENT\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"AUTHORS\\"}": Object {
+          "dst": Object {
+            "id": "https://github.com/decentralion",
+            "pluginName": "sourcecred/github-beta",
+            "type": "AUTHOR",
+          },
+          "payload": Object {},
+          "src": Object {
+            "id": "https://github.com/sourcecred/example-github/issues/2#issuecomment-385576936",
+            "pluginName": "sourcecred/github-beta",
+            "type": "COMMENT",
+          },
+        },
+        "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/decentralion\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"AUTHOR\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/issues/2\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"ISSUE\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"AUTHORS\\"}": Object {
+          "dst": Object {
+            "id": "https://github.com/decentralion",
+            "pluginName": "sourcecred/github-beta",
+            "type": "AUTHOR",
+          },
+          "payload": Object {},
+          "src": Object {
+            "id": "https://github.com/sourcecred/example-github/issues/2",
+            "pluginName": "sourcecred/github-beta",
+            "type": "ISSUE",
+          },
+        },
+        "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/decentralion\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"AUTHOR\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/issues/4\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"ISSUE\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"AUTHORS\\"}": Object {
+          "dst": Object {
+            "id": "https://github.com/decentralion",
+            "pluginName": "sourcecred/github-beta",
+            "type": "AUTHOR",
+          },
+          "payload": Object {},
+          "src": Object {
+            "id": "https://github.com/sourcecred/example-github/issues/4",
+            "pluginName": "sourcecred/github-beta",
+            "type": "ISSUE",
+          },
+        },
+        "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/decentralion\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"AUTHOR\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/issues/6#issuecomment-373768442\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"COMMENT\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"AUTHORS\\"}": Object {
+          "dst": Object {
+            "id": "https://github.com/decentralion",
+            "pluginName": "sourcecred/github-beta",
+            "type": "AUTHOR",
+          },
+          "payload": Object {},
+          "src": Object {
+            "id": "https://github.com/sourcecred/example-github/issues/6#issuecomment-373768442",
+            "pluginName": "sourcecred/github-beta",
+            "type": "COMMENT",
+          },
+        },
+        "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/decentralion\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"AUTHOR\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/issues/6#issuecomment-373768538\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"COMMENT\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"AUTHORS\\"}": Object {
+          "dst": Object {
+            "id": "https://github.com/decentralion",
+            "pluginName": "sourcecred/github-beta",
+            "type": "AUTHOR",
+          },
+          "payload": Object {},
+          "src": Object {
+            "id": "https://github.com/sourcecred/example-github/issues/6#issuecomment-373768538",
+            "pluginName": "sourcecred/github-beta",
+            "type": "COMMENT",
+          },
+        },
+        "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/decentralion\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"AUTHOR\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/issues/6#issuecomment-385223316\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"COMMENT\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"AUTHORS\\"}": Object {
+          "dst": Object {
+            "id": "https://github.com/decentralion",
+            "pluginName": "sourcecred/github-beta",
+            "type": "AUTHOR",
+          },
+          "payload": Object {},
+          "src": Object {
+            "id": "https://github.com/sourcecred/example-github/issues/6#issuecomment-385223316",
+            "pluginName": "sourcecred/github-beta",
+            "type": "COMMENT",
+          },
+        },
+        "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/decentralion\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"AUTHOR\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/issues/6\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"ISSUE\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"AUTHORS\\"}": Object {
+          "dst": Object {
+            "id": "https://github.com/decentralion",
+            "pluginName": "sourcecred/github-beta",
+            "type": "AUTHOR",
+          },
+          "payload": Object {},
+          "src": Object {
+            "id": "https://github.com/sourcecred/example-github/issues/6",
+            "pluginName": "sourcecred/github-beta",
+            "type": "ISSUE",
+          },
+        },
+        "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/decentralion\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"AUTHOR\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/issues/7\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"ISSUE\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"AUTHORS\\"}": Object {
+          "dst": Object {
+            "id": "https://github.com/decentralion",
+            "pluginName": "sourcecred/github-beta",
+            "type": "AUTHOR",
+          },
+          "payload": Object {},
+          "src": Object {
+            "id": "https://github.com/sourcecred/example-github/issues/7",
+            "pluginName": "sourcecred/github-beta",
+            "type": "ISSUE",
+          },
+        },
+        "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/decentralion\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"AUTHOR\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/issues/8\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"ISSUE\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"AUTHORS\\"}": Object {
+          "dst": Object {
+            "id": "https://github.com/decentralion",
+            "pluginName": "sourcecred/github-beta",
+            "type": "AUTHOR",
+          },
+          "payload": Object {},
+          "src": Object {
+            "id": "https://github.com/sourcecred/example-github/issues/8",
+            "pluginName": "sourcecred/github-beta",
+            "type": "ISSUE",
+          },
+        },
+        "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/decentralion\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"AUTHOR\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/pull/3#issuecomment-369162222\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"COMMENT\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"AUTHORS\\"}": Object {
+          "dst": Object {
+            "id": "https://github.com/decentralion",
+            "pluginName": "sourcecred/github-beta",
+            "type": "AUTHOR",
+          },
+          "payload": Object {},
+          "src": Object {
+            "id": "https://github.com/sourcecred/example-github/pull/3#issuecomment-369162222",
+            "pluginName": "sourcecred/github-beta",
+            "type": "COMMENT",
+          },
+        },
+        "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/decentralion\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"AUTHOR\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/pull/3\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"PULL_REQUEST\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"AUTHORS\\"}": Object {
+          "dst": Object {
+            "id": "https://github.com/decentralion",
+            "pluginName": "sourcecred/github-beta",
+            "type": "AUTHOR",
+          },
+          "payload": Object {},
+          "src": Object {
+            "id": "https://github.com/sourcecred/example-github/pull/3",
+            "pluginName": "sourcecred/github-beta",
+            "type": "PULL_REQUEST",
+          },
+        },
+        "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/decentralion\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"AUTHOR\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/pull/5\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"PULL_REQUEST\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"AUTHORS\\"}": Object {
+          "dst": Object {
+            "id": "https://github.com/decentralion",
+            "pluginName": "sourcecred/github-beta",
+            "type": "AUTHOR",
+          },
+          "payload": Object {},
+          "src": Object {
+            "id": "https://github.com/sourcecred/example-github/pull/5",
+            "pluginName": "sourcecred/github-beta",
+            "type": "PULL_REQUEST",
+          },
+        },
+        "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/decentralion\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"AUTHOR\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/pull/9\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"PULL_REQUEST\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"AUTHORS\\"}": Object {
+          "dst": Object {
+            "id": "https://github.com/decentralion",
+            "pluginName": "sourcecred/github-beta",
+            "type": "AUTHOR",
+          },
+          "payload": Object {},
+          "src": Object {
+            "id": "https://github.com/sourcecred/example-github/pull/9",
+            "pluginName": "sourcecred/github-beta",
+            "type": "PULL_REQUEST",
+          },
+        },
+        "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/issues/2#issuecomment-373768703\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"COMMENT\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/issues/6\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"ISSUE\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"REFERENCES\\"}": Object {
+          "dst": Object {
+            "id": "https://github.com/sourcecred/example-github/issues/6",
+            "pluginName": "sourcecred/github-beta",
+            "type": "ISSUE",
+          },
+          "payload": Object {},
+          "src": Object {
+            "id": "https://github.com/sourcecred/example-github/issues/2#issuecomment-373768703",
+            "pluginName": "sourcecred/github-beta",
+            "type": "COMMENT",
+          },
+        },
+        "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/issues/2#issuecomment-373768850\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"COMMENT\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/issues/6#issuecomment-373768538\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"COMMENT\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"REFERENCES\\"}": Object {
+          "dst": Object {
+            "id": "https://github.com/sourcecred/example-github/issues/6#issuecomment-373768538",
+            "pluginName": "sourcecred/github-beta",
+            "type": "COMMENT",
+          },
+          "payload": Object {},
+          "src": Object {
+            "id": "https://github.com/sourcecred/example-github/issues/2#issuecomment-373768850",
+            "pluginName": "sourcecred/github-beta",
+            "type": "COMMENT",
+          },
+        },
+        "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/issues/2#issuecomment-385576185\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"COMMENT\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/pull/5\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"PULL_REQUEST\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"REFERENCES\\"}": Object {
+          "dst": Object {
+            "id": "https://github.com/sourcecred/example-github/pull/5",
+            "pluginName": "sourcecred/github-beta",
+            "type": "PULL_REQUEST",
+          },
+          "payload": Object {},
+          "src": Object {
+            "id": "https://github.com/sourcecred/example-github/issues/2#issuecomment-385576185",
+            "pluginName": "sourcecred/github-beta",
+            "type": "COMMENT",
+          },
+        },
+        "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/issues/2#issuecomment-385576220\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"COMMENT\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/pull/5#pullrequestreview-100313899\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"PULL_REQUEST_REVIEW\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"REFERENCES\\"}": Object {
+          "dst": Object {
+            "id": "https://github.com/sourcecred/example-github/pull/5#pullrequestreview-100313899",
+            "pluginName": "sourcecred/github-beta",
+            "type": "PULL_REQUEST_REVIEW",
+          },
+          "payload": Object {},
+          "src": Object {
+            "id": "https://github.com/sourcecred/example-github/issues/2#issuecomment-385576220",
+            "pluginName": "sourcecred/github-beta",
+            "type": "COMMENT",
+          },
+        },
+        "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/issues/2#issuecomment-385576248\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"COMMENT\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/pull/5#discussion_r171460198\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"PULL_REQUEST_REVIEW_COMMENT\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"REFERENCES\\"}": Object {
+          "dst": Object {
+            "id": "https://github.com/sourcecred/example-github/pull/5#discussion_r171460198",
+            "pluginName": "sourcecred/github-beta",
+            "type": "PULL_REQUEST_REVIEW_COMMENT",
+          },
+          "payload": Object {},
+          "src": Object {
+            "id": "https://github.com/sourcecred/example-github/issues/2#issuecomment-385576248",
+            "pluginName": "sourcecred/github-beta",
+            "type": "COMMENT",
+          },
+        },
+        "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/issues/2#issuecomment-385576273\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"COMMENT\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/wchargin\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"AUTHOR\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"REFERENCES\\"}": Object {
+          "dst": Object {
+            "id": "https://github.com/wchargin",
+            "pluginName": "sourcecred/github-beta",
+            "type": "AUTHOR",
+          },
+          "payload": Object {},
+          "src": Object {
+            "id": "https://github.com/sourcecred/example-github/issues/2#issuecomment-385576273",
+            "pluginName": "sourcecred/github-beta",
+            "type": "COMMENT",
+          },
+        },
+        "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/issues/2#issuecomment-385576920\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"COMMENT\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/issues/1\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"ISSUE\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"REFERENCES\\"}": Object {
+          "dst": Object {
+            "id": "https://github.com/sourcecred/example-github/issues/1",
+            "pluginName": "sourcecred/github-beta",
+            "type": "ISSUE",
+          },
+          "payload": Object {},
+          "src": Object {
+            "id": "https://github.com/sourcecred/example-github/issues/2#issuecomment-385576920",
+            "pluginName": "sourcecred/github-beta",
+            "type": "COMMENT",
+          },
+        },
+        "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/issues/2#issuecomment-385576920\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"COMMENT\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/issues/2\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"ISSUE\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"REFERENCES\\"}": Object {
+          "dst": Object {
+            "id": "https://github.com/sourcecred/example-github/issues/2",
+            "pluginName": "sourcecred/github-beta",
+            "type": "ISSUE",
+          },
+          "payload": Object {},
+          "src": Object {
+            "id": "https://github.com/sourcecred/example-github/issues/2#issuecomment-385576920",
+            "pluginName": "sourcecred/github-beta",
+            "type": "COMMENT",
+          },
+        },
+        "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/issues/2#issuecomment-385576920\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"COMMENT\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/pull/3\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"PULL_REQUEST\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"REFERENCES\\"}": Object {
+          "dst": Object {
+            "id": "https://github.com/sourcecred/example-github/pull/3",
+            "pluginName": "sourcecred/github-beta",
+            "type": "PULL_REQUEST",
+          },
+          "payload": Object {},
+          "src": Object {
+            "id": "https://github.com/sourcecred/example-github/issues/2#issuecomment-385576920",
+            "pluginName": "sourcecred/github-beta",
+            "type": "COMMENT",
+          },
+        },
+        "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/issues/2#issuecomment-385576920\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"COMMENT\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/pull/5#discussion_r171460198\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"PULL_REQUEST_REVIEW_COMMENT\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"REFERENCES\\"}": Object {
+          "dst": Object {
+            "id": "https://github.com/sourcecred/example-github/pull/5#discussion_r171460198",
+            "pluginName": "sourcecred/github-beta",
+            "type": "PULL_REQUEST_REVIEW_COMMENT",
+          },
+          "payload": Object {},
+          "src": Object {
+            "id": "https://github.com/sourcecred/example-github/issues/2#issuecomment-385576920",
+            "pluginName": "sourcecred/github-beta",
+            "type": "COMMENT",
+          },
+        },
+        "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/issues/2#issuecomment-385576920\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"COMMENT\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/pull/5#pullrequestreview-100313899\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"PULL_REQUEST_REVIEW\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"REFERENCES\\"}": Object {
+          "dst": Object {
+            "id": "https://github.com/sourcecred/example-github/pull/5#pullrequestreview-100313899",
+            "pluginName": "sourcecred/github-beta",
+            "type": "PULL_REQUEST_REVIEW",
+          },
+          "payload": Object {},
+          "src": Object {
+            "id": "https://github.com/sourcecred/example-github/issues/2#issuecomment-385576920",
+            "pluginName": "sourcecred/github-beta",
+            "type": "COMMENT",
+          },
+        },
+        "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/issues/2\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"ISSUE\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/issues/1\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"ISSUE\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"REFERENCES\\"}": Object {
+          "dst": Object {
+            "id": "https://github.com/sourcecred/example-github/issues/1",
+            "pluginName": "sourcecred/github-beta",
+            "type": "ISSUE",
+          },
+          "payload": Object {},
+          "src": Object {
+            "id": "https://github.com/sourcecred/example-github/issues/2",
+            "pluginName": "sourcecred/github-beta",
+            "type": "ISSUE",
+          },
+        },
+        "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/issues/2\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"ISSUE\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/issues/2#issuecomment-373768703\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"COMMENT\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"CONTAINS\\"}": Object {
+          "dst": Object {
+            "id": "https://github.com/sourcecred/example-github/issues/2#issuecomment-373768703",
+            "pluginName": "sourcecred/github-beta",
+            "type": "COMMENT",
+          },
+          "payload": Object {},
+          "src": Object {
+            "id": "https://github.com/sourcecred/example-github/issues/2",
+            "pluginName": "sourcecred/github-beta",
+            "type": "ISSUE",
+          },
+        },
+        "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/issues/2\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"ISSUE\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/issues/2#issuecomment-373768850\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"COMMENT\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"CONTAINS\\"}": Object {
+          "dst": Object {
+            "id": "https://github.com/sourcecred/example-github/issues/2#issuecomment-373768850",
+            "pluginName": "sourcecred/github-beta",
+            "type": "COMMENT",
+          },
+          "payload": Object {},
+          "src": Object {
+            "id": "https://github.com/sourcecred/example-github/issues/2",
+            "pluginName": "sourcecred/github-beta",
+            "type": "ISSUE",
+          },
+        },
+        "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/issues/2\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"ISSUE\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/issues/2#issuecomment-385576185\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"COMMENT\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"CONTAINS\\"}": Object {
+          "dst": Object {
+            "id": "https://github.com/sourcecred/example-github/issues/2#issuecomment-385576185",
+            "pluginName": "sourcecred/github-beta",
+            "type": "COMMENT",
+          },
+          "payload": Object {},
+          "src": Object {
+            "id": "https://github.com/sourcecred/example-github/issues/2",
+            "pluginName": "sourcecred/github-beta",
+            "type": "ISSUE",
+          },
+        },
+        "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/issues/2\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"ISSUE\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/issues/2#issuecomment-385576220\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"COMMENT\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"CONTAINS\\"}": Object {
+          "dst": Object {
+            "id": "https://github.com/sourcecred/example-github/issues/2#issuecomment-385576220",
+            "pluginName": "sourcecred/github-beta",
+            "type": "COMMENT",
+          },
+          "payload": Object {},
+          "src": Object {
+            "id": "https://github.com/sourcecred/example-github/issues/2",
+            "pluginName": "sourcecred/github-beta",
+            "type": "ISSUE",
+          },
+        },
+        "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/issues/2\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"ISSUE\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/issues/2#issuecomment-385576248\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"COMMENT\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"CONTAINS\\"}": Object {
+          "dst": Object {
+            "id": "https://github.com/sourcecred/example-github/issues/2#issuecomment-385576248",
+            "pluginName": "sourcecred/github-beta",
+            "type": "COMMENT",
+          },
+          "payload": Object {},
+          "src": Object {
+            "id": "https://github.com/sourcecred/example-github/issues/2",
+            "pluginName": "sourcecred/github-beta",
+            "type": "ISSUE",
+          },
+        },
+        "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/issues/2\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"ISSUE\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/issues/2#issuecomment-385576273\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"COMMENT\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"CONTAINS\\"}": Object {
+          "dst": Object {
+            "id": "https://github.com/sourcecred/example-github/issues/2#issuecomment-385576273",
+            "pluginName": "sourcecred/github-beta",
+            "type": "COMMENT",
+          },
+          "payload": Object {},
+          "src": Object {
+            "id": "https://github.com/sourcecred/example-github/issues/2",
+            "pluginName": "sourcecred/github-beta",
+            "type": "ISSUE",
+          },
+        },
+        "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/issues/2\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"ISSUE\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/issues/2#issuecomment-385576920\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"COMMENT\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"CONTAINS\\"}": Object {
+          "dst": Object {
+            "id": "https://github.com/sourcecred/example-github/issues/2#issuecomment-385576920",
+            "pluginName": "sourcecred/github-beta",
+            "type": "COMMENT",
+          },
+          "payload": Object {},
+          "src": Object {
+            "id": "https://github.com/sourcecred/example-github/issues/2",
+            "pluginName": "sourcecred/github-beta",
+            "type": "ISSUE",
+          },
+        },
+        "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/issues/2\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"ISSUE\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/issues/2#issuecomment-385576936\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"COMMENT\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"CONTAINS\\"}": Object {
+          "dst": Object {
+            "id": "https://github.com/sourcecred/example-github/issues/2#issuecomment-385576936",
+            "pluginName": "sourcecred/github-beta",
+            "type": "COMMENT",
+          },
+          "payload": Object {},
+          "src": Object {
+            "id": "https://github.com/sourcecred/example-github/issues/2",
+            "pluginName": "sourcecred/github-beta",
+            "type": "ISSUE",
+          },
+        },
+        "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/issues/6#issuecomment-385223316\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"COMMENT\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/issues/2\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"ISSUE\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"REFERENCES\\"}": Object {
+          "dst": Object {
+            "id": "https://github.com/sourcecred/example-github/issues/2",
+            "pluginName": "sourcecred/github-beta",
+            "type": "ISSUE",
+          },
+          "payload": Object {},
+          "src": Object {
+            "id": "https://github.com/sourcecred/example-github/issues/6#issuecomment-385223316",
+            "pluginName": "sourcecred/github-beta",
+            "type": "COMMENT",
+          },
+        },
+        "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/issues/6\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"ISSUE\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/issues/6#issuecomment-373768442\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"COMMENT\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"CONTAINS\\"}": Object {
+          "dst": Object {
+            "id": "https://github.com/sourcecred/example-github/issues/6#issuecomment-373768442",
+            "pluginName": "sourcecred/github-beta",
+            "type": "COMMENT",
+          },
+          "payload": Object {},
+          "src": Object {
+            "id": "https://github.com/sourcecred/example-github/issues/6",
+            "pluginName": "sourcecred/github-beta",
+            "type": "ISSUE",
+          },
+        },
+        "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/issues/6\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"ISSUE\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/issues/6#issuecomment-373768538\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"COMMENT\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"CONTAINS\\"}": Object {
+          "dst": Object {
+            "id": "https://github.com/sourcecred/example-github/issues/6#issuecomment-373768538",
+            "pluginName": "sourcecred/github-beta",
+            "type": "COMMENT",
+          },
+          "payload": Object {},
+          "src": Object {
+            "id": "https://github.com/sourcecred/example-github/issues/6",
+            "pluginName": "sourcecred/github-beta",
+            "type": "ISSUE",
+          },
+        },
+        "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/issues/6\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"ISSUE\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/issues/6#issuecomment-385223316\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"COMMENT\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"CONTAINS\\"}": Object {
+          "dst": Object {
+            "id": "https://github.com/sourcecred/example-github/issues/6#issuecomment-385223316",
+            "pluginName": "sourcecred/github-beta",
+            "type": "COMMENT",
+          },
+          "payload": Object {},
+          "src": Object {
+            "id": "https://github.com/sourcecred/example-github/issues/6",
+            "pluginName": "sourcecred/github-beta",
+            "type": "ISSUE",
+          },
+        },
+        "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/pull/3#issuecomment-369162222\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"COMMENT\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/issues/2\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"ISSUE\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"REFERENCES\\"}": Object {
+          "dst": Object {
+            "id": "https://github.com/sourcecred/example-github/issues/2",
+            "pluginName": "sourcecred/github-beta",
+            "type": "ISSUE",
+          },
+          "payload": Object {},
+          "src": Object {
+            "id": "https://github.com/sourcecred/example-github/pull/3#issuecomment-369162222",
+            "pluginName": "sourcecred/github-beta",
+            "type": "COMMENT",
+          },
+        },
+        "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/pull/3\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"PULL_REQUEST\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"0a223346b4e6dec0127b1e6aa892c4ee0424b66a\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/git-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"COMMIT\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"MERGED_AS\\"}": Object {
+          "dst": Object {
+            "id": "0a223346b4e6dec0127b1e6aa892c4ee0424b66a",
+            "pluginName": "sourcecred/git-beta",
+            "type": "COMMIT",
+          },
+          "payload": Object {
+            "hash": "0a223346b4e6dec0127b1e6aa892c4ee0424b66a",
+          },
+          "src": Object {
+            "id": "https://github.com/sourcecred/example-github/pull/3",
+            "pluginName": "sourcecred/github-beta",
+            "type": "PULL_REQUEST",
+          },
+        },
+        "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/pull/3\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"PULL_REQUEST\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/pull/3#issuecomment-369162222\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"COMMENT\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"CONTAINS\\"}": Object {
+          "dst": Object {
+            "id": "https://github.com/sourcecred/example-github/pull/3#issuecomment-369162222",
+            "pluginName": "sourcecred/github-beta",
+            "type": "COMMENT",
+          },
+          "payload": Object {},
+          "src": Object {
+            "id": "https://github.com/sourcecred/example-github/pull/3",
+            "pluginName": "sourcecred/github-beta",
+            "type": "PULL_REQUEST",
+          },
+        },
+        "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/pull/5#pullrequestreview-100313899\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"PULL_REQUEST_REVIEW\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/pull/5#discussion_r171460198\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"PULL_REQUEST_REVIEW_COMMENT\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"CONTAINS\\"}": Object {
+          "dst": Object {
+            "id": "https://github.com/sourcecred/example-github/pull/5#discussion_r171460198",
+            "pluginName": "sourcecred/github-beta",
+            "type": "PULL_REQUEST_REVIEW_COMMENT",
+          },
+          "payload": Object {},
+          "src": Object {
+            "id": "https://github.com/sourcecred/example-github/pull/5#pullrequestreview-100313899",
+            "pluginName": "sourcecred/github-beta",
+            "type": "PULL_REQUEST_REVIEW",
+          },
+        },
+        "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/pull/5\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"PULL_REQUEST\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"6d5b3aa31ebb68a06ceb46bbd6cf49b6ccd6f5e6\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/git-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"COMMIT\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"MERGED_AS\\"}": Object {
+          "dst": Object {
+            "id": "6d5b3aa31ebb68a06ceb46bbd6cf49b6ccd6f5e6",
+            "pluginName": "sourcecred/git-beta",
+            "type": "COMMIT",
+          },
+          "payload": Object {
+            "hash": "6d5b3aa31ebb68a06ceb46bbd6cf49b6ccd6f5e6",
+          },
+          "src": Object {
+            "id": "https://github.com/sourcecred/example-github/pull/5",
+            "pluginName": "sourcecred/github-beta",
+            "type": "PULL_REQUEST",
+          },
+        },
+        "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/pull/5\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"PULL_REQUEST\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/pull/5#pullrequestreview-100313899\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"PULL_REQUEST_REVIEW\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"CONTAINS\\"}": Object {
+          "dst": Object {
+            "id": "https://github.com/sourcecred/example-github/pull/5#pullrequestreview-100313899",
+            "pluginName": "sourcecred/github-beta",
+            "type": "PULL_REQUEST_REVIEW",
+          },
+          "payload": Object {},
+          "src": Object {
+            "id": "https://github.com/sourcecred/example-github/pull/5",
+            "pluginName": "sourcecred/github-beta",
+            "type": "PULL_REQUEST",
+          },
+        },
+        "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/pull/5\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"PULL_REQUEST\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/pull/5#pullrequestreview-100314038\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"PULL_REQUEST_REVIEW\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"CONTAINS\\"}": Object {
+          "dst": Object {
+            "id": "https://github.com/sourcecred/example-github/pull/5#pullrequestreview-100314038",
+            "pluginName": "sourcecred/github-beta",
+            "type": "PULL_REQUEST_REVIEW",
+          },
+          "payload": Object {},
+          "src": Object {
+            "id": "https://github.com/sourcecred/example-github/pull/5",
+            "pluginName": "sourcecred/github-beta",
+            "type": "PULL_REQUEST",
+          },
+        },
+        "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/pull/5\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"PULL_REQUEST\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/wchargin\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"AUTHOR\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"REFERENCES\\"}": Object {
+          "dst": Object {
+            "id": "https://github.com/wchargin",
+            "pluginName": "sourcecred/github-beta",
+            "type": "AUTHOR",
+          },
+          "payload": Object {},
+          "src": Object {
+            "id": "https://github.com/sourcecred/example-github/pull/5",
+            "pluginName": "sourcecred/github-beta",
+            "type": "PULL_REQUEST",
+          },
+        },
+        "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/pull/9\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"PULL_REQUEST\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/wchargin\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"AUTHOR\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"REFERENCES\\"}": Object {
+          "dst": Object {
+            "id": "https://github.com/wchargin",
+            "pluginName": "sourcecred/github-beta",
+            "type": "AUTHOR",
+          },
+          "payload": Object {},
+          "src": Object {
+            "id": "https://github.com/sourcecred/example-github/pull/9",
+            "pluginName": "sourcecred/github-beta",
+            "type": "PULL_REQUEST",
+          },
+        },
+        "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"REPOSITORY\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/issues/1\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"ISSUE\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"CONTAINS\\"}": Object {
+          "dst": Object {
+            "id": "https://github.com/sourcecred/example-github/issues/1",
+            "pluginName": "sourcecred/github-beta",
+            "type": "ISSUE",
+          },
+          "payload": Object {},
+          "src": Object {
+            "id": "https://github.com/sourcecred/example-github",
+            "pluginName": "sourcecred/github-beta",
+            "type": "REPOSITORY",
+          },
+        },
+        "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"REPOSITORY\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/issues/2\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"ISSUE\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"CONTAINS\\"}": Object {
+          "dst": Object {
+            "id": "https://github.com/sourcecred/example-github/issues/2",
+            "pluginName": "sourcecred/github-beta",
+            "type": "ISSUE",
+          },
+          "payload": Object {},
+          "src": Object {
+            "id": "https://github.com/sourcecred/example-github",
+            "pluginName": "sourcecred/github-beta",
+            "type": "REPOSITORY",
+          },
+        },
+        "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"REPOSITORY\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/issues/4\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"ISSUE\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"CONTAINS\\"}": Object {
+          "dst": Object {
+            "id": "https://github.com/sourcecred/example-github/issues/4",
+            "pluginName": "sourcecred/github-beta",
+            "type": "ISSUE",
+          },
+          "payload": Object {},
+          "src": Object {
+            "id": "https://github.com/sourcecred/example-github",
+            "pluginName": "sourcecred/github-beta",
+            "type": "REPOSITORY",
+          },
+        },
+        "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"REPOSITORY\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/issues/6\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"ISSUE\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"CONTAINS\\"}": Object {
+          "dst": Object {
+            "id": "https://github.com/sourcecred/example-github/issues/6",
+            "pluginName": "sourcecred/github-beta",
+            "type": "ISSUE",
+          },
+          "payload": Object {},
+          "src": Object {
+            "id": "https://github.com/sourcecred/example-github",
+            "pluginName": "sourcecred/github-beta",
+            "type": "REPOSITORY",
+          },
+        },
+        "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"REPOSITORY\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/issues/7\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"ISSUE\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"CONTAINS\\"}": Object {
+          "dst": Object {
+            "id": "https://github.com/sourcecred/example-github/issues/7",
+            "pluginName": "sourcecred/github-beta",
+            "type": "ISSUE",
+          },
+          "payload": Object {},
+          "src": Object {
+            "id": "https://github.com/sourcecred/example-github",
+            "pluginName": "sourcecred/github-beta",
+            "type": "REPOSITORY",
+          },
+        },
+        "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"REPOSITORY\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/issues/8\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"ISSUE\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"CONTAINS\\"}": Object {
+          "dst": Object {
+            "id": "https://github.com/sourcecred/example-github/issues/8",
+            "pluginName": "sourcecred/github-beta",
+            "type": "ISSUE",
+          },
+          "payload": Object {},
+          "src": Object {
+            "id": "https://github.com/sourcecred/example-github",
+            "pluginName": "sourcecred/github-beta",
+            "type": "REPOSITORY",
+          },
+        },
+        "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"REPOSITORY\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/pull/3\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"PULL_REQUEST\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"CONTAINS\\"}": Object {
+          "dst": Object {
+            "id": "https://github.com/sourcecred/example-github/pull/3",
+            "pluginName": "sourcecred/github-beta",
+            "type": "PULL_REQUEST",
+          },
+          "payload": Object {},
+          "src": Object {
+            "id": "https://github.com/sourcecred/example-github",
+            "pluginName": "sourcecred/github-beta",
+            "type": "REPOSITORY",
+          },
+        },
+        "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"REPOSITORY\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/pull/5\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"PULL_REQUEST\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"CONTAINS\\"}": Object {
+          "dst": Object {
+            "id": "https://github.com/sourcecred/example-github/pull/5",
+            "pluginName": "sourcecred/github-beta",
+            "type": "PULL_REQUEST",
+          },
+          "payload": Object {},
+          "src": Object {
+            "id": "https://github.com/sourcecred/example-github",
+            "pluginName": "sourcecred/github-beta",
+            "type": "REPOSITORY",
+          },
+        },
+        "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"REPOSITORY\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/pull/9\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"PULL_REQUEST\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"CONTAINS\\"}": Object {
+          "dst": Object {
+            "id": "https://github.com/sourcecred/example-github/pull/9",
+            "pluginName": "sourcecred/github-beta",
+            "type": "PULL_REQUEST",
+          },
+          "payload": Object {},
+          "src": Object {
+            "id": "https://github.com/sourcecred/example-github",
+            "pluginName": "sourcecred/github-beta",
+            "type": "REPOSITORY",
+          },
+        },
+        "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/wchargin\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"AUTHOR\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/pull/5#discussion_r171460198\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"PULL_REQUEST_REVIEW_COMMENT\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"AUTHORS\\"}": Object {
+          "dst": Object {
+            "id": "https://github.com/wchargin",
+            "pluginName": "sourcecred/github-beta",
+            "type": "AUTHOR",
+          },
+          "payload": Object {},
+          "src": Object {
+            "id": "https://github.com/sourcecred/example-github/pull/5#discussion_r171460198",
+            "pluginName": "sourcecred/github-beta",
+            "type": "PULL_REQUEST_REVIEW_COMMENT",
+          },
+        },
+        "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/wchargin\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"AUTHOR\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/pull/5#pullrequestreview-100313899\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"PULL_REQUEST_REVIEW\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"AUTHORS\\"}": Object {
+          "dst": Object {
+            "id": "https://github.com/wchargin",
+            "pluginName": "sourcecred/github-beta",
+            "type": "AUTHOR",
+          },
+          "payload": Object {},
+          "src": Object {
+            "id": "https://github.com/sourcecred/example-github/pull/5#pullrequestreview-100313899",
+            "pluginName": "sourcecred/github-beta",
+            "type": "PULL_REQUEST_REVIEW",
+          },
+        },
+        "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/wchargin\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"AUTHOR\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/pull/5#pullrequestreview-100314038\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"PULL_REQUEST_REVIEW\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"AUTHORS\\"}": Object {
+          "dst": Object {
+            "id": "https://github.com/wchargin",
+            "pluginName": "sourcecred/github-beta",
+            "type": "AUTHOR",
+          },
+          "payload": Object {},
+          "src": Object {
+            "id": "https://github.com/sourcecred/example-github/pull/5#pullrequestreview-100314038",
+            "pluginName": "sourcecred/github-beta",
+            "type": "PULL_REQUEST_REVIEW",
+          },
+        },
       },
-    },
-    "{\\"id\\":\\"https://github.com/sourcecred/example-github/issues/1\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"ISSUE\\"}": Object {
-      "payload": Object {
-        "body": "This is just an example issue.",
-        "number": 1,
-        "title": "An example issue.",
-        "url": "https://github.com/sourcecred/example-github/issues/1",
+    ],
+    "nodes": Array [
+      Object {
+        "type": "sourcecred/sourcecred/AddressMap",
+        "version": "0.1.0",
       },
-    },
-    "{\\"id\\":\\"https://github.com/sourcecred/example-github/issues/2\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"ISSUE\\"}": Object {
-      "payload": Object {
-        "body": "This issue references another issue, namely #1",
-        "number": 2,
-        "title": "A referencing issue.",
-        "url": "https://github.com/sourcecred/example-github/issues/2",
-      },
-    },
-    "{\\"id\\":\\"https://github.com/sourcecred/example-github/issues/2#issuecomment-373768703\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"COMMENT\\"}": Object {
-      "payload": Object {
-        "body": "It should also be possible to reference by exact url: https://github.com/sourcecred/example-github/issues/6",
-        "url": "https://github.com/sourcecred/example-github/issues/2#issuecomment-373768703",
-      },
-    },
-    "{\\"id\\":\\"https://github.com/sourcecred/example-github/issues/2#issuecomment-373768850\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"COMMENT\\"}": Object {
-      "payload": Object {
-        "body": "We might also reference individual comments directly.
+      Object {
+        "{\\"id\\":\\"https://github.com/decentralion\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"AUTHOR\\"}": Object {
+          "payload": Object {
+            "login": "decentralion",
+            "subtype": "USER",
+            "url": "https://github.com/decentralion",
+          },
+        },
+        "{\\"id\\":\\"https://github.com/sourcecred/example-github\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"REPOSITORY\\"}": Object {
+          "payload": Object {
+            "name": "example-github",
+            "owner": "sourcecred",
+            "url": "https://github.com/sourcecred/example-github",
+          },
+        },
+        "{\\"id\\":\\"https://github.com/sourcecred/example-github/issues/1\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"ISSUE\\"}": Object {
+          "payload": Object {
+            "body": "This is just an example issue.",
+            "number": 1,
+            "title": "An example issue.",
+            "url": "https://github.com/sourcecred/example-github/issues/1",
+          },
+        },
+        "{\\"id\\":\\"https://github.com/sourcecred/example-github/issues/2\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"ISSUE\\"}": Object {
+          "payload": Object {
+            "body": "This issue references another issue, namely #1",
+            "number": 2,
+            "title": "A referencing issue.",
+            "url": "https://github.com/sourcecred/example-github/issues/2",
+          },
+        },
+        "{\\"id\\":\\"https://github.com/sourcecred/example-github/issues/2#issuecomment-373768703\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"COMMENT\\"}": Object {
+          "payload": Object {
+            "body": "It should also be possible to reference by exact url: https://github.com/sourcecred/example-github/issues/6",
+            "url": "https://github.com/sourcecred/example-github/issues/2#issuecomment-373768703",
+          },
+        },
+        "{\\"id\\":\\"https://github.com/sourcecred/example-github/issues/2#issuecomment-373768850\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"COMMENT\\"}": Object {
+          "payload": Object {
+            "body": "We might also reference individual comments directly.
 https://github.com/sourcecred/example-github/issues/6#issuecomment-373768538",
-        "url": "https://github.com/sourcecred/example-github/issues/2#issuecomment-373768850",
-      },
-    },
-    "{\\"id\\":\\"https://github.com/sourcecred/example-github/issues/2#issuecomment-385576185\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"COMMENT\\"}": Object {
-      "payload": Object {
-        "body": "Here's a PR by direct url: https://github.com/sourcecred/example-github/pull/5",
-        "url": "https://github.com/sourcecred/example-github/issues/2#issuecomment-385576185",
-      },
-    },
-    "{\\"id\\":\\"https://github.com/sourcecred/example-github/issues/2#issuecomment-385576220\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"COMMENT\\"}": Object {
-      "payload": Object {
-        "body": "a PR review by url: https://github.com/sourcecred/example-github/pull/5#pullrequestreview-100313899",
-        "url": "https://github.com/sourcecred/example-github/issues/2#issuecomment-385576220",
-      },
-    },
-    "{\\"id\\":\\"https://github.com/sourcecred/example-github/issues/2#issuecomment-385576248\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"COMMENT\\"}": Object {
-      "payload": Object {
-        "body": "a PR Review Comment by url: https://github.com/sourcecred/example-github/pull/5#discussion_r171460198",
-        "url": "https://github.com/sourcecred/example-github/issues/2#issuecomment-385576248",
-      },
-    },
-    "{\\"id\\":\\"https://github.com/sourcecred/example-github/issues/2#issuecomment-385576273\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"COMMENT\\"}": Object {
-      "payload": Object {
-        "body": "a user by url: https://github.com/wchargin",
-        "url": "https://github.com/sourcecred/example-github/issues/2#issuecomment-385576273",
-      },
-    },
-    "{\\"id\\":\\"https://github.com/sourcecred/example-github/issues/2#issuecomment-385576920\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"COMMENT\\"}": Object {
-      "payload": Object {
-        "body": "Here are several references:
+            "url": "https://github.com/sourcecred/example-github/issues/2#issuecomment-373768850",
+          },
+        },
+        "{\\"id\\":\\"https://github.com/sourcecred/example-github/issues/2#issuecomment-385576185\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"COMMENT\\"}": Object {
+          "payload": Object {
+            "body": "Here's a PR by direct url: https://github.com/sourcecred/example-github/pull/5",
+            "url": "https://github.com/sourcecred/example-github/issues/2#issuecomment-385576185",
+          },
+        },
+        "{\\"id\\":\\"https://github.com/sourcecred/example-github/issues/2#issuecomment-385576220\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"COMMENT\\"}": Object {
+          "payload": Object {
+            "body": "a PR review by url: https://github.com/sourcecred/example-github/pull/5#pullrequestreview-100313899",
+            "url": "https://github.com/sourcecred/example-github/issues/2#issuecomment-385576220",
+          },
+        },
+        "{\\"id\\":\\"https://github.com/sourcecred/example-github/issues/2#issuecomment-385576248\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"COMMENT\\"}": Object {
+          "payload": Object {
+            "body": "a PR Review Comment by url: https://github.com/sourcecred/example-github/pull/5#discussion_r171460198",
+            "url": "https://github.com/sourcecred/example-github/issues/2#issuecomment-385576248",
+          },
+        },
+        "{\\"id\\":\\"https://github.com/sourcecred/example-github/issues/2#issuecomment-385576273\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"COMMENT\\"}": Object {
+          "payload": Object {
+            "body": "a user by url: https://github.com/wchargin",
+            "url": "https://github.com/sourcecred/example-github/issues/2#issuecomment-385576273",
+          },
+        },
+        "{\\"id\\":\\"https://github.com/sourcecred/example-github/issues/2#issuecomment-385576920\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"COMMENT\\"}": Object {
+          "payload": Object {
+            "body": "Here are several references:
 #1 
 #2
 #3 
@@ -2349,127 +2473,129 @@ https://github.com/sourcecred/example-github/issues/6#issuecomment-373768538",
 https://github.com/sourcecred/example-github/pull/5#discussion_r171460198
 https://github.com/sourcecred/example-github/pull/5#pullrequestreview-100313899
 ",
-        "url": "https://github.com/sourcecred/example-github/issues/2#issuecomment-385576920",
-      },
-    },
-    "{\\"id\\":\\"https://github.com/sourcecred/example-github/issues/2#issuecomment-385576936\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"COMMENT\\"}": Object {
-      "payload": Object {
-        "body": "This comment has no references.",
-        "url": "https://github.com/sourcecred/example-github/issues/2#issuecomment-385576936",
-      },
-    },
-    "{\\"id\\":\\"https://github.com/sourcecred/example-github/issues/4\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"ISSUE\\"}": Object {
-      "payload": Object {
-        "body": "Alas, its life as an open issue had only just begun.",
-        "number": 4,
-        "title": "A closed pull request",
-        "url": "https://github.com/sourcecred/example-github/issues/4",
-      },
-    },
-    "{\\"id\\":\\"https://github.com/sourcecred/example-github/issues/6\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"ISSUE\\"}": Object {
-      "payload": Object {
-        "body": "This issue shall shortly have a few comments.",
-        "number": 6,
-        "title": "An issue with comments",
-        "url": "https://github.com/sourcecred/example-github/issues/6",
-      },
-    },
-    "{\\"id\\":\\"https://github.com/sourcecred/example-github/issues/6#issuecomment-373768442\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"COMMENT\\"}": Object {
-      "payload": Object {
-        "body": "A wild COMMENT appeared!",
-        "url": "https://github.com/sourcecred/example-github/issues/6#issuecomment-373768442",
-      },
-    },
-    "{\\"id\\":\\"https://github.com/sourcecred/example-github/issues/6#issuecomment-373768538\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"COMMENT\\"}": Object {
-      "payload": Object {
-        "body": "And the maintainer said, \\"Let there be comments!\\"",
-        "url": "https://github.com/sourcecred/example-github/issues/6#issuecomment-373768538",
-      },
-    },
-    "{\\"id\\":\\"https://github.com/sourcecred/example-github/issues/6#issuecomment-385223316\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"COMMENT\\"}": Object {
-      "payload": Object {
-        "body": "This comment references an #2, which itself references an issue. This comment is thus allows us to test that in-references are not included when requesting a Post's references.",
-        "url": "https://github.com/sourcecred/example-github/issues/6#issuecomment-385223316",
-      },
-    },
-    "{\\"id\\":\\"https://github.com/sourcecred/example-github/issues/7\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"ISSUE\\"}": Object {
-      "payload": Object {
-        "body": "Deal with this, naive string display algorithms!!!!!",
-        "number": 7,
-        "title": "An issue with an extremely long title, which even has a VerySuperFragicalisticialiManyCharacterUberLongTriplePlusGood word in it, and should really be truncated intelligently or something",
-        "url": "https://github.com/sourcecred/example-github/issues/7",
-      },
-    },
-    "{\\"id\\":\\"https://github.com/sourcecred/example-github/issues/8\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"ISSUE\\"}": Object {
-      "payload": Object {
-        "body": "Issue with Unicode: ȴሲ𣐳楢👍 :heart: 𐤔𐤁𐤀𐤑𐤍𐤉𐤔𐤌𐤄𐤍𐤍 ❤️
+            "url": "https://github.com/sourcecred/example-github/issues/2#issuecomment-385576920",
+          },
+        },
+        "{\\"id\\":\\"https://github.com/sourcecred/example-github/issues/2#issuecomment-385576936\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"COMMENT\\"}": Object {
+          "payload": Object {
+            "body": "This comment has no references.",
+            "url": "https://github.com/sourcecred/example-github/issues/2#issuecomment-385576936",
+          },
+        },
+        "{\\"id\\":\\"https://github.com/sourcecred/example-github/issues/4\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"ISSUE\\"}": Object {
+          "payload": Object {
+            "body": "Alas, its life as an open issue had only just begun.",
+            "number": 4,
+            "title": "A closed pull request",
+            "url": "https://github.com/sourcecred/example-github/issues/4",
+          },
+        },
+        "{\\"id\\":\\"https://github.com/sourcecred/example-github/issues/6\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"ISSUE\\"}": Object {
+          "payload": Object {
+            "body": "This issue shall shortly have a few comments.",
+            "number": 6,
+            "title": "An issue with comments",
+            "url": "https://github.com/sourcecred/example-github/issues/6",
+          },
+        },
+        "{\\"id\\":\\"https://github.com/sourcecred/example-github/issues/6#issuecomment-373768442\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"COMMENT\\"}": Object {
+          "payload": Object {
+            "body": "A wild COMMENT appeared!",
+            "url": "https://github.com/sourcecred/example-github/issues/6#issuecomment-373768442",
+          },
+        },
+        "{\\"id\\":\\"https://github.com/sourcecred/example-github/issues/6#issuecomment-373768538\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"COMMENT\\"}": Object {
+          "payload": Object {
+            "body": "And the maintainer said, \\"Let there be comments!\\"",
+            "url": "https://github.com/sourcecred/example-github/issues/6#issuecomment-373768538",
+          },
+        },
+        "{\\"id\\":\\"https://github.com/sourcecred/example-github/issues/6#issuecomment-385223316\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"COMMENT\\"}": Object {
+          "payload": Object {
+            "body": "This comment references an #2, which itself references an issue. This comment is thus allows us to test that in-references are not included when requesting a Post's references.",
+            "url": "https://github.com/sourcecred/example-github/issues/6#issuecomment-385223316",
+          },
+        },
+        "{\\"id\\":\\"https://github.com/sourcecred/example-github/issues/7\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"ISSUE\\"}": Object {
+          "payload": Object {
+            "body": "Deal with this, naive string display algorithms!!!!!",
+            "number": 7,
+            "title": "An issue with an extremely long title, which even has a VerySuperFragicalisticialiManyCharacterUberLongTriplePlusGood word in it, and should really be truncated intelligently or something",
+            "url": "https://github.com/sourcecred/example-github/issues/7",
+          },
+        },
+        "{\\"id\\":\\"https://github.com/sourcecred/example-github/issues/8\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"ISSUE\\"}": Object {
+          "payload": Object {
+            "body": "Issue with Unicode: ȴሲ𣐳楢👍 :heart: 𐤔𐤁𐤀𐤑𐤍𐤉𐤔𐤌𐤄𐤍𐤍 ❤️
 Issue with Unicode: ȴሲ𣐳楢👍 :heart: 𐤔𐤁𐤀𐤑𐤍𐤉𐤔𐤌𐤄𐤍𐤍 ❤️",
-        "number": 8,
-        "title": "Issue with Unicode: ȴሲ𣐳楢👍 :heart: 𐤔𐤁𐤀𐤑𐤍𐤉𐤔𐤌𐤄𐤍𐤍 ❤️",
-        "url": "https://github.com/sourcecred/example-github/issues/8",
-      },
-    },
-    "{\\"id\\":\\"https://github.com/sourcecred/example-github/pull/3\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"PULL_REQUEST\\"}": Object {
-      "payload": Object {
-        "body": "Oh look, it's a pull request.",
-        "number": 3,
-        "title": "Add README, merge via PR.",
-        "url": "https://github.com/sourcecred/example-github/pull/3",
-      },
-    },
-    "{\\"id\\":\\"https://github.com/sourcecred/example-github/pull/3#issuecomment-369162222\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"COMMENT\\"}": Object {
-      "payload": Object {
-        "body": "It seems apropos to reference something from a pull request comment... eg: #2 ",
-        "url": "https://github.com/sourcecred/example-github/pull/3#issuecomment-369162222",
-      },
-    },
-    "{\\"id\\":\\"https://github.com/sourcecred/example-github/pull/5\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"PULL_REQUEST\\"}": Object {
-      "payload": Object {
-        "body": "@wchargin could you please do the following:
+            "number": 8,
+            "title": "Issue with Unicode: ȴሲ𣐳楢👍 :heart: 𐤔𐤁𐤀𐤑𐤍𐤉𐤔𐤌𐤄𐤍𐤍 ❤️",
+            "url": "https://github.com/sourcecred/example-github/issues/8",
+          },
+        },
+        "{\\"id\\":\\"https://github.com/sourcecred/example-github/pull/3\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"PULL_REQUEST\\"}": Object {
+          "payload": Object {
+            "body": "Oh look, it's a pull request.",
+            "number": 3,
+            "title": "Add README, merge via PR.",
+            "url": "https://github.com/sourcecred/example-github/pull/3",
+          },
+        },
+        "{\\"id\\":\\"https://github.com/sourcecred/example-github/pull/3#issuecomment-369162222\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"COMMENT\\"}": Object {
+          "payload": Object {
+            "body": "It seems apropos to reference something from a pull request comment... eg: #2 ",
+            "url": "https://github.com/sourcecred/example-github/pull/3#issuecomment-369162222",
+          },
+        },
+        "{\\"id\\":\\"https://github.com/sourcecred/example-github/pull/5\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"PULL_REQUEST\\"}": Object {
+          "payload": Object {
+            "body": "@wchargin could you please do the following:
 - add a commit comment
 - add a review comment requesting some trivial change
 - i'll change it
 - then approve the pr",
-        "number": 5,
-        "title": "This pull request will be more contentious. I can feel it...",
-        "url": "https://github.com/sourcecred/example-github/pull/5",
+            "number": 5,
+            "title": "This pull request will be more contentious. I can feel it...",
+            "url": "https://github.com/sourcecred/example-github/pull/5",
+          },
+        },
+        "{\\"id\\":\\"https://github.com/sourcecred/example-github/pull/5#discussion_r171460198\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"PULL_REQUEST_REVIEW_COMMENT\\"}": Object {
+          "payload": Object {
+            "body": "seems a bit capricious",
+            "url": "https://github.com/sourcecred/example-github/pull/5#discussion_r171460198",
+          },
+        },
+        "{\\"id\\":\\"https://github.com/sourcecred/example-github/pull/5#pullrequestreview-100313899\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"PULL_REQUEST_REVIEW\\"}": Object {
+          "payload": Object {
+            "body": "hmmm.jpg",
+            "state": "CHANGES_REQUESTED",
+            "url": "https://github.com/sourcecred/example-github/pull/5#pullrequestreview-100313899",
+          },
+        },
+        "{\\"id\\":\\"https://github.com/sourcecred/example-github/pull/5#pullrequestreview-100314038\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"PULL_REQUEST_REVIEW\\"}": Object {
+          "payload": Object {
+            "body": "I'm sold",
+            "state": "APPROVED",
+            "url": "https://github.com/sourcecred/example-github/pull/5#pullrequestreview-100314038",
+          },
+        },
+        "{\\"id\\":\\"https://github.com/sourcecred/example-github/pull/9\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"PULL_REQUEST\\"}": Object {
+          "payload": Object {
+            "body": "Nominally paired with @wchargin",
+            "number": 9,
+            "title": "An unmerged pull request",
+            "url": "https://github.com/sourcecred/example-github/pull/9",
+          },
+        },
+        "{\\"id\\":\\"https://github.com/wchargin\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"AUTHOR\\"}": Object {
+          "payload": Object {
+            "login": "wchargin",
+            "subtype": "USER",
+            "url": "https://github.com/wchargin",
+          },
+        },
       },
-    },
-    "{\\"id\\":\\"https://github.com/sourcecred/example-github/pull/5#discussion_r171460198\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"PULL_REQUEST_REVIEW_COMMENT\\"}": Object {
-      "payload": Object {
-        "body": "seems a bit capricious",
-        "url": "https://github.com/sourcecred/example-github/pull/5#discussion_r171460198",
-      },
-    },
-    "{\\"id\\":\\"https://github.com/sourcecred/example-github/pull/5#pullrequestreview-100313899\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"PULL_REQUEST_REVIEW\\"}": Object {
-      "payload": Object {
-        "body": "hmmm.jpg",
-        "state": "CHANGES_REQUESTED",
-        "url": "https://github.com/sourcecred/example-github/pull/5#pullrequestreview-100313899",
-      },
-    },
-    "{\\"id\\":\\"https://github.com/sourcecred/example-github/pull/5#pullrequestreview-100314038\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"PULL_REQUEST_REVIEW\\"}": Object {
-      "payload": Object {
-        "body": "I'm sold",
-        "state": "APPROVED",
-        "url": "https://github.com/sourcecred/example-github/pull/5#pullrequestreview-100314038",
-      },
-    },
-    "{\\"id\\":\\"https://github.com/sourcecred/example-github/pull/9\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"PULL_REQUEST\\"}": Object {
-      "payload": Object {
-        "body": "Nominally paired with @wchargin",
-        "number": 9,
-        "title": "An unmerged pull request",
-        "url": "https://github.com/sourcecred/example-github/pull/9",
-      },
-    },
-    "{\\"id\\":\\"https://github.com/wchargin\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"AUTHOR\\"}": Object {
-      "payload": Object {
-        "login": "wchargin",
-        "subtype": "USER",
-        "url": "https://github.com/wchargin",
-      },
-    },
+    ],
   },
-}
+]
 `;


### PR DESCRIPTION
This commit adds explicit versioning to the `Graph` and `AddressMap`
JSON representations, using the new `compat` module. This will make it
safer to change the serialization format for these classes.

(Note: I don't expect we'll add backcompat handlers for these classes
soon, but having versioning means that we can change the serialization
format in a way that breaks old data cleanly and explicitly, rather than
introducing undefined behavior.)

Test plan: The changes are slight, and well-captured by the snapshot
tests. Note that after this commit, the SourceCred commands will fail on
old data, so old data will need to be regenerated.