### PR TITLE
Use indexed edges in graph internals

### DIFF
--- a/src/core/__snapshots__/graph.test.js.snap
+++ b/src/core/__snapshots__/graph.test.js.snap
@@ -4,7 +4,7 @@ exports[`graph #Graph JSON functions should serialize a simple graph 1`] = `
 Array [
   Object {
     "type": "sourcecred/sourcecred/Graph",
-    "version": "0.1.0",
+    "version": "0.2.0",
   },
   Object {
     "edges": Array [
@@ -14,140 +14,90 @@ Array [
       },
       Object {
         "{\\"id\\":\\"crab-self-assessment\\",\\"pluginName\\":\\"hill_cooking_pot\\",\\"type\\":\\"SILLY\\"}": Object {
-          "dst": Object {
-            "id": "razorclaw_crab#2",
-            "pluginName": "hill_cooking_pot",
-            "type": "FOOD",
-          },
+          "dstIndex": 2,
           "payload": Object {
             "evaluation": "not effective at avoiding hero",
           },
-          "src": Object {
-            "id": "razorclaw_crab#2",
-            "pluginName": "hill_cooking_pot",
-            "type": "FOOD",
-          },
+          "srcIndex": 2,
         },
         "{\\"id\\":\\"hero_of_time#0@again_cooks@seafood_fruit_mix#3\\",\\"pluginName\\":\\"hill_cooking_pot\\",\\"type\\":\\"ACTION\\"}": Object {
-          "dst": Object {
-            "id": "hero_of_time#0",
-            "pluginName": "hill_cooking_pot",
-            "type": "PC",
-          },
+          "dstIndex": 0,
           "payload": Object {
             "crit": true,
             "saveScummed": true,
           },
-          "src": Object {
-            "id": "seafood_fruit_mix#3",
-            "pluginName": "hill_cooking_pot",
-            "type": "FOOD",
-          },
+          "srcIndex": 3,
         },
         "{\\"id\\":\\"hero_of_time#0@cooks@seafood_fruit_mix#3\\",\\"pluginName\\":\\"hill_cooking_pot\\",\\"type\\":\\"ACTION\\"}": Object {
-          "dst": Object {
-            "id": "hero_of_time#0",
-            "pluginName": "hill_cooking_pot",
-            "type": "PC",
-          },
+          "dstIndex": 0,
           "payload": Object {
             "crit": false,
           },
-          "src": Object {
-            "id": "seafood_fruit_mix#3",
-            "pluginName": "hill_cooking_pot",
-            "type": "FOOD",
-          },
+          "srcIndex": 3,
         },
         "{\\"id\\":\\"hero_of_time#0@eats@seafood_fruit_mix#3\\",\\"pluginName\\":\\"hill_cooking_pot\\",\\"type\\":\\"ACTION\\"}": Object {
-          "dst": Object {
-            "id": "seafood_fruit_mix#3",
-            "pluginName": "hill_cooking_pot",
-            "type": "FOOD",
-          },
+          "dstIndex": 3,
           "payload": Object {},
-          "src": Object {
-            "id": "hero_of_time#0",
-            "pluginName": "hill_cooking_pot",
-            "type": "PC",
-          },
+          "srcIndex": 0,
         },
         "{\\"id\\":\\"hero_of_time#0@grabs@razorclaw_crab#2\\",\\"pluginName\\":\\"hill_cooking_pot\\",\\"type\\":\\"ACTION\\"}": Object {
-          "dst": Object {
-            "id": "hero_of_time#0",
-            "pluginName": "hill_cooking_pot",
-            "type": "PC",
-          },
+          "dstIndex": 0,
           "payload": Object {},
-          "src": Object {
-            "id": "razorclaw_crab#2",
-            "pluginName": "hill_cooking_pot",
-            "type": "FOOD",
-          },
+          "srcIndex": 2,
         },
         "{\\"id\\":\\"hero_of_time#0@picks@mighty_bananas#1\\",\\"pluginName\\":\\"hill_cooking_pot\\",\\"type\\":\\"ACTION\\"}": Object {
-          "dst": Object {
-            "id": "hero_of_time#0",
-            "pluginName": "hill_cooking_pot",
-            "type": "PC",
-          },
+          "dstIndex": 0,
           "payload": Object {},
-          "src": Object {
-            "id": "mighty_bananas#1",
-            "pluginName": "hill_cooking_pot",
-            "type": "FOOD",
-          },
+          "srcIndex": 1,
         },
         "{\\"id\\":\\"mighty_bananas#1@included_in@seafood_fruit_mix#3\\",\\"pluginName\\":\\"hill_cooking_pot\\",\\"type\\":\\"INGREDIENT\\"}": Object {
-          "dst": Object {
-            "id": "mighty_bananas#1",
-            "pluginName": "hill_cooking_pot",
-            "type": "FOOD",
-          },
+          "dstIndex": 1,
           "payload": Object {},
-          "src": Object {
-            "id": "seafood_fruit_mix#3",
-            "pluginName": "hill_cooking_pot",
-            "type": "FOOD",
-          },
+          "srcIndex": 3,
         },
         "{\\"id\\":\\"razorclaw_crab#2@included_in@seafood_fruit_mix#3\\",\\"pluginName\\":\\"hill_cooking_pot\\",\\"type\\":\\"INGREDIENT\\"}": Object {
-          "dst": Object {
-            "id": "razorclaw_crab#2",
-            "pluginName": "hill_cooking_pot",
-            "type": "FOOD",
-          },
+          "dstIndex": 2,
           "payload": Object {},
-          "src": Object {
-            "id": "seafood_fruit_mix#3",
-            "pluginName": "hill_cooking_pot",
-            "type": "FOOD",
-          },
+          "srcIndex": 3,
         },
       },
     ],
     "nodes": Array [
       Object {
-        "type": "sourcecred/sourcecred/AddressMap",
-        "version": "0.1.0",
+        "address": Object {
+          "id": "hero_of_time#0",
+          "pluginName": "hill_cooking_pot",
+          "type": "PC",
+        },
+        "payload": Object {},
       },
       Object {
-        "{\\"id\\":\\"hero_of_time#0\\",\\"pluginName\\":\\"hill_cooking_pot\\",\\"type\\":\\"PC\\"}": Object {
-          "payload": Object {},
+        "address": Object {
+          "id": "mighty_bananas#1",
+          "pluginName": "hill_cooking_pot",
+          "type": "FOOD",
         },
-        "{\\"id\\":\\"mighty_bananas#1\\",\\"pluginName\\":\\"hill_cooking_pot\\",\\"type\\":\\"FOOD\\"}": Object {
-          "payload": Object {},
+        "payload": Object {},
+      },
+      Object {
+        "address": Object {
+          "id": "razorclaw_crab#2",
+          "pluginName": "hill_cooking_pot",
+          "type": "FOOD",
         },
-        "{\\"id\\":\\"razorclaw_crab#2\\",\\"pluginName\\":\\"hill_cooking_pot\\",\\"type\\":\\"FOOD\\"}": Object {
-          "payload": Object {},
+        "payload": Object {},
+      },
+      Object {
+        "address": Object {
+          "id": "seafood_fruit_mix#3",
+          "pluginName": "hill_cooking_pot",
+          "type": "FOOD",
         },
-        "{\\"id\\":\\"seafood_fruit_mix#3\\",\\"pluginName\\":\\"hill_cooking_pot\\",\\"type\\":\\"FOOD\\"}": Object {
-          "payload": Object {
-            "effect": Array [
-              "attack_power",
-              1,
-            ],
-          },
+        "payload": Object {
+          "effect": Array [
+            "attack_power",
+            1,
+          ],
         },
       },
     ],

--- a/src/core/__snapshots__/graph.test.js.snap
+++ b/src/core/__snapshots__/graph.test.js.snap
@@ -100,6 +100,14 @@ Array [
           ],
         },
       },
+      Object {
+        "address": Object {
+          "id": "~000#missingno",
+          "pluginName": "hill_cooking_pot",
+          "type": "EXPERIMENT",
+        },
+        "payload": null,
+      },
     ],
   },
 ]

--- a/src/core/graph.js
+++ b/src/core/graph.js
@@ -7,6 +7,8 @@ import {AddressMap} from "./address";
 import {toCompat, fromCompat} from "../util/compat";
 import type {Compatible} from "../util/compat";
 
+type Integer = number;
+
 export type Node<+T> = {|
   +address: Address,
   +payload: T,
@@ -19,31 +21,42 @@ export type Edge<+T> = {|
   +payload: T,
 |};
 
-const COMPAT_TYPE = "sourcecred/sourcecred/Graph";
-const COMPAT_VERSION = "0.1.0";
+type IndexedEdge<+T> = {|
+  +address: Address,
+  +srcIndex: Integer,
+  +dstIndex: Integer,
+  +payload: T,
+|};
 
-export type GraphJSON<NP, EP> = Compatible<{|
-  +nodes: AddressMapJSON<Node<NP>>,
-  +edges: AddressMapJSON<Edge<EP>>,
-|}>;
+const COMPAT_TYPE = "sourcecred/sourcecred/Graph";
+const COMPAT_VERSION = "0.2.0";
+
+type NodesSortedByStringifiedAddress<NP> = {|
+  +address: Address,
+  +payload?: NP,
+|}[];
+export type GraphJSON<NP, EP> = {|
+  +nodes: NodesSortedByStringifiedAddress<NP>,
+  +edges: AddressMapJSON<IndexedEdge<EP>>,
+|};
+
+type MaybeNode<+NP> = {|+address: Address, +node: Node<NP> | void|};
 
 export class Graph<NP, EP> {
-  _nodes: AddressMap<Node<NP>>;
-  _edges: AddressMap<Edge<EP>>;
-
-  // The keyset of each of the following fields should equal the keyset
-  // of `_nodes`. If `e` is an edge from `u` to `v`, then `e.address`
-  // should appear exactly once in `_outEdges[u.address]` and exactly
-  // once in `_inEdges[v.address]` (and every entry in `_inEdges` and
-  // `_outEdges` should be of this form).
-  _outEdges: AddressMap<{|+address: Address, +edges: Address[]|}>;
-  _inEdges: AddressMap<{|+address: Address, +edges: Address[]|}>;
+  // Invariant: sizes of `_nodeIndices`, `_nodes`, `_outEdges`, and
+  // `_inEdges` are all equal.
+  _nodeIndices: AddressMap<{|+address: Address, +index: Integer|}>;
+  _nodes: MaybeNode<NP>[];
+  _edges: AddressMap<IndexedEdge<EP>>;
+  _outEdges: Address[][];
+  _inEdges: Address[][];
 
   constructor() {
-    this._nodes = new AddressMap();
+    this._nodeIndices = new AddressMap();
+    this._nodes = [];
     this._edges = new AddressMap();
-    this._outEdges = new AddressMap();
-    this._inEdges = new AddressMap();
+    this._outEdges = [];
+    this._inEdges = [];
   }
 
   copy(): Graph<$Supertype<NP>, $Supertype<EP>> {
@@ -51,21 +64,87 @@ export class Graph<NP, EP> {
   }
 
   equals(that: Graph<NP, EP>): boolean {
-    return this._nodes.equals(that._nodes) && this._edges.equals(that._edges);
+    const theseNodes = this.nodes();
+    const thoseNodes = that.nodes();
+    if (theseNodes.length !== thoseNodes.length) {
+      return false;
+    }
+    for (const node of theseNodes) {
+      if (!deepEqual(node, that.node(node.address))) {
+        return false;
+      }
+    }
+
+    const theseEdges = this.edges();
+    const thoseEdges = that.edges();
+    if (theseEdges.length !== thoseEdges.length) {
+      return false;
+    }
+    for (const edge of theseEdges) {
+      if (!deepEqual(edge, that.edge(edge.address))) {
+        return false;
+      }
+    }
+
+    return true;
   }
 
-  toJSON(): GraphJSON<NP, EP> {
+  toJSON(): Compatible<GraphJSON<NP, EP>> {
+    const partialNodes: {|
+      key: string,
+      oldIndex: Integer,
+      data: {|
+        +address: Address,
+        +payload?: NP,
+      |},
+    |}[] = this._nodes
+      .map((maybeNode, oldIndex) => {
+        const key = stringify(maybeNode.address);
+        const data = maybeNode.node || {address: maybeNode.address};
+        return {key, oldIndex, data};
+      })
+      .filter(({oldIndex: idx}) => {
+        // Eliminate dangling nodes with neither in- nor out-edges:
+        // e.g., nodes that exist as a result of an `addNode` followed
+        // by a `removeNode` and no additional incident edges.
+        return (
+          this._nodes[idx].node !== undefined ||
+          this._outEdges[idx].length > 0 ||
+          this._inEdges[idx].length > 0
+        );
+      });
+    partialNodes.sort((a, b) => {
+      const ka = a.key;
+      const kb = b.key;
+      return ka < kb ? -1 : ka > kb ? +1 : 0;
+    });
+    const oldIndexToNewIndex: Integer[] = Array(this._nodes.length).fill(
+      undefined
+    );
+    partialNodes.forEach(({oldIndex}, newIndex) => {
+      oldIndexToNewIndex[oldIndex] = newIndex;
+    });
+    const edges = new AddressMap();
+    this._edges.getAll().forEach((oldIndexedEdge) => {
+      const newIndexedEdge = {
+        address: oldIndexedEdge.address,
+        payload: oldIndexedEdge.payload,
+        srcIndex: oldIndexToNewIndex[oldIndexedEdge.srcIndex],
+        dstIndex: oldIndexToNewIndex[oldIndexedEdge.dstIndex],
+      };
+      edges.add(newIndexedEdge);
+    });
     return toCompat(
       {type: COMPAT_TYPE, version: COMPAT_VERSION},
       {
-        nodes: this._nodes.toJSON(),
-        edges: this._edges.toJSON(),
+        nodes: partialNodes.map((x) => x.data),
+        edges: edges.toJSON(),
       }
     );
   }
 
-  static fromJSON<NP, EP>(json: GraphJSON<NP, EP>): Graph<NP, EP> {
-    const compatJson = fromCompat(
+  static fromJSON<NP, EP>(json: Compatible<GraphJSON<NP, EP>>): Graph<NP, EP> {
+    const compatJson: GraphJSON<NP, EP> = fromCompat(
       {
         type: COMPAT_TYPE,
         version: COMPAT_VERSION,
@@ -73,34 +152,44 @@ export class Graph<NP, EP> {
       json
     );
     const result = new Graph();
-    AddressMap.fromJSON(compatJson.nodes)
-      .getAll()
-      .forEach((node) => {
+    compatJson.nodes.forEach((partialNode) => {
+      if ("payload" in partialNode) {
+        const node: Node<NP> = (partialNode: any);
         result.addNode(node);
-      });
+      } else {
+        result._addNodeAddress(partialNode.address);
+      }
+    });
     AddressMap.fromJSON(compatJson.edges)
       .getAll()
-      .forEach((edge) => {
-        result.addEdge(edge);
+      .forEach((indexedEdge) => {
+        result._addIndexedEdge(indexedEdge);
       });
     return result;
   }
 
-  _lookupEdges(
-    map: AddressMap<{|+address: Address, +edges: Address[]|}>,
-    key: Address
-  ): Address[] {
-    const result = map.get(key);
-    return result ? result.edges : [];
+  _addNodeAddress(address: Address): Integer {
+    const indexDatum = this._nodeIndices.get(address);
+    if (indexDatum != null) {
+      return indexDatum.index;
+    } else {
+      const index = this._nodes.length;
+      this._nodeIndices.add({address, index});
+      this._nodes.push({address, node: undefined});
+      this._outEdges.push([]);
+      this._inEdges.push([]);
+      return index;
+    }
   }
 
-  addNode(node: Node<NP>): Graph<NP, EP> {
+  addNode(node: Node<NP>): this {
     if (node == null) {
       throw new Error(`node is ${String(node)}`);
     }
-    const existingNode = this.node(node.address);
-    if (existingNode !== undefined) {
-      if (deepEqual(existingNode, node)) {
+    const index = this._addNodeAddress(node.address);
+    const maybeNode = this._nodes[index];
+    if (maybeNode.node !== undefined) {
+      if (deepEqual(maybeNode.node, node)) {
         return this;
       } else {
         throw new Error(
@@ -110,60 +199,61 @@ export class Graph<NP, EP> {
         );
       }
     }
-    this._nodes.add(node);
-    this._outEdges.add({
-      address: node.address,
-      edges: this._lookupEdges(this._outEdges, node.address),
-    });
-    this._inEdges.add({
-      address: node.address,
-      edges: this._lookupEdges(this._inEdges, node.address),
-    });
+    this._nodes[index] = {address: maybeNode.address, node};
     return this;
   }
 
   removeNode(address: Address): this {
-    this._nodes.remove(address);
+    const indexDatum = this._nodeIndices.get(address);
+    if (indexDatum != null) {
+      this._nodes[indexDatum.index] = {address, node: undefined};
+    }
     return this;
   }
 
-  addEdge(edge: Edge<EP>): Graph<NP, EP> {
+  addEdge(edge: Edge<EP>): this {
     if (edge == null) {
       throw new Error(`edge is ${String(edge)}`);
     }
-    const existingEdge = this.edge(edge.address);
-    if (existingEdge !== undefined) {
-      if (deepEqual(existingEdge, edge)) {
+    const srcIndex = this._addNodeAddress(edge.src);
+    const dstIndex = this._addNodeAddress(edge.dst);
+    const indexedEdge = {
+      address: edge.address,
+      srcIndex,
+      dstIndex,
+      payload: edge.payload,
+    };
+    return this._addIndexedEdge(indexedEdge);
+  }
+
+  _addIndexedEdge(indexedEdge: IndexedEdge<EP>): this {
+    const existingIndexedEdge = this._edges.get(indexedEdge.address);
+    if (existingIndexedEdge !== undefined) {
+      if (deepEqual(existingIndexedEdge, indexedEdge)) {
         return this;
       } else {
         throw new Error(
           `edge at address ${JSON.stringify(
-            edge.address
+            indexedEdge.address
           )} exists with distinct contents`
         );
       }
     }
-    this._edges.add(edge);
-
-    const theseOutEdges = this._lookupEdges(this._outEdges, edge.src);
-    theseOutEdges.push(edge.address);
-    this._outEdges.add({address: edge.src, edges: theseOutEdges});
-
-    const theseInEdges = this._lookupEdges(this._inEdges, edge.dst);
-    theseInEdges.push(edge.address);
-    this._inEdges.add({address: edge.dst, edges: theseInEdges});
-
+    this._edges.add(indexedEdge);
+    this._outEdges[indexedEdge.srcIndex].push(indexedEdge.address);
+    this._inEdges[indexedEdge.dstIndex].push(indexedEdge.address);
     return this;
   }
 
   removeEdge(address: Address): this {
     // TODO(perf): This is linear in the degree of the endpoints of the
     // edge. Consider storing in non-list form.
-    const edge = this.edge(address);
-    if (edge) {
+    const indexedEdge = this._edges.get(address);
+    if (indexedEdge) {
+      this._edges.remove(address);
       [
-        this._lookupEdges(this._inEdges, edge.dst),
-        this._lookupEdges(this._outEdges, edge.src),
+        this._outEdges[indexedEdge.srcIndex],
+        this._inEdges[indexedEdge.dstIndex],
       ].forEach((edges) => {
         const index = edges.findIndex((ea) => deepEqual(ea, address));
         if (index !== -1) {
@@ -171,16 +261,32 @@ export class Graph<NP, EP> {
         }
       });
     }
-    this._edges.remove(address);
     return this;
   }
 
   node(address: Address): Node<NP> {
-    return this._nodes.get(address);
+    const indexDatum = this._nodeIndices.get(address);
+    if (indexDatum == null) {
+      // We've never heard of this node.
+      return (undefined: any);
+    } else {
+      const node: Node<NP> | void = this._nodes[indexDatum.index].node;
+      return ((node: any): Node<NP>);
+    }
   }
 
   edge(address: Address): Edge<EP> {
-    return this._edges.get(address);
+    const indexedEdge = this._edges.get(address);
+    if (!indexedEdge) {
+      // Lie.
+      return (undefined: any);
+    }
+    return {
+      address: indexedEdge.address,
+      src: this._nodes[indexedEdge.srcIndex].address,
+      dst: this._nodes[indexedEdge.dstIndex].address,
+      payload: indexedEdge.payload,
+    };
   }
 
   /**
@@ -202,33 +308,33 @@ export class Graph<NP, EP> {
       +edgeType?: string,
       +direction?: "IN" | "OUT" | "ANY",
     |}
-  ): {+edge: Edge<EP>, +neighbor: Address}[] {
+  ): {|+edge: Edge<EP>, +neighbor: Address|}[] {
     if (nodeAddress == null) {
       throw new Error(`address is ${String(nodeAddress)}`);
     }
 
-    let result: {+edge: Edge<EP>, +neighbor: Address}[] = [];
+    const indexDatum = this._nodeIndices.get(nodeAddress);
+    if (indexDatum == null) {
+      return [];
+    }
+    const nodeIndex = indexDatum.index;
+
+    let result: {|+edge: Edge<EP>, +neighbor: Address|}[] = [];
     const direction = (options != null && options.direction) || "ANY";
 
     if (direction === "ANY" || direction === "IN") {
-      let inNeighbors = this._lookupEdges(this._inEdges, nodeAddress).map(
-        (e) => {
-          const edge = this.edge(e);
-          return {edge, neighbor: edge.src};
-        }
-      );
-
+      let inNeighbors = this._inEdges[nodeIndex].map((edgeAddress) => {
+        const edge = this.edge(edgeAddress);
+        return {edge, neighbor: edge.src};
+      });
       result = result.concat(inNeighbors);
     }
 
     if (direction === "ANY" || direction === "OUT") {
-      let outNeighbors = this._lookupEdges(this._outEdges, nodeAddress).map(
-        (e) => {
-          const edge = this.edge(e);
-          return {edge, neighbor: edge.dst};
-        }
-      );
-
+      let outNeighbors = this._outEdges[nodeIndex].map((edgeAddress) => {
+        const edge = this.edge(edgeAddress);
+        return {edge, neighbor: edge.dst};
+      });
       if (direction === "ANY") {
         // If direction is ANY, we already counted self-referencing edges as
         // an inNeighbor
@@ -236,9 +342,9 @@ export class Graph<NP, EP> {
           ({edge}) => !deepEqual(edge.src, edge.dst)
         );
       }
-
       result = result.concat(outNeighbors);
     }
+
     if (options != null && options.edgeType != null) {
       const edgeType = options.edgeType;
       result = result.filter(({edge}) => edge.address.type === edgeType);
@@ -256,7 +362,11 @@ export class Graph<NP, EP> {
    * If filter is provided, it will return only nodes with the requested type.
    */
   nodes(filter?: {type?: string}): Node<NP>[] {
-    let nodes = this._nodes.getAll();
+    /*:: declare function nonNulls<T>(x: (T | void)[]): T[]; */
+    let nodes = this._nodes.map((x) => x.node).filter((x) => {
+      return Boolean(x);
+    });
+    /*:: nodes = nonNulls(nodes); */
     if (filter != null && filter.type != null) {
       const typeFilter = filter.type;
       nodes = nodes.filter((n) => n.address.type === typeFilter);
@@ -270,7 +380,12 @@ export class Graph<NP, EP> {
    * If filter is provided, it will return only edges with the requested type.
    */
   edges(filter?: {type?: string}): Edge<EP>[] {
-    let edges = this._edges.getAll();
+    let edges = this._edges.getAll().map((indexedEdge) => ({
+      address: indexedEdge.address,
+      src: this._nodes[indexedEdge.srcIndex].address,
+      dst: this._nodes[indexedEdge.dstIndex].address,
+      payload: indexedEdge.payload,
+    }));
     if (filter != null && filter.type != null) {
       const typeFilter = filter.type;
       edges = edges.filter((e) => e.address.type === typeFilter);

--- a/src/core/graph.test.js
+++ b/src/core/graph.test.js
@@ -155,6 +155,7 @@ describe("graph", () => {
           demoData.bananasNode(),
           demoData.crabNode(),
           demoData.mealNode(),
+          demoData.nullPayloadNode(),
         ];
         const actual = demoData.advancedMealGraph().nodes();
         expectSameSorted(expected, actual);
@@ -921,12 +922,13 @@ describe("graph", () => {
 
       /**
        * Decompose the given graph into edge graphs: for each edge `e`,
-       * create a graph with just that edge and its two endpoints.
+       * create a graph with just that edge and its two endpoints, and
+       * for each isolated node createa graph with just that node.
        */
       function edgeDecomposition<NP, EP>(
         originalGraph: Graph<NP, EP>
       ): Graph<NP, EP>[] {
-        return originalGraph.edges().map((edge) => {
+        const edgeGraphs = originalGraph.edges().map((edge) => {
           const miniGraph = new Graph();
           miniGraph.addNode(originalGraph.node(edge.src));
           if (miniGraph.node(edge.dst) === undefined) {
@@ -936,6 +938,13 @@ describe("graph", () => {
           miniGraph.addEdge(edge);
           return miniGraph;
         });
+        const nodeGraphs = originalGraph
+          .nodes()
+          .filter(
+            (node) => originalGraph.neighborhood(node.address).length === 0
+          )
+          .map((node) => new Graph().addNode(node));
+        return [].concat(edgeGraphs, nodeGraphs);
       }
 
       it("conservatively recomposes a neighborhood decomposition", () => {

--- a/src/core/graph.test.js
+++ b/src/core/graph.test.js
@@ -1088,6 +1088,15 @@ describe("graph", () => {
           JSON.stringify(demoData.advancedMealGraph().toJSON())
         );
       });
+      it("should canonicalize away phantom nodes", () => {
+        const g1 = new Graph().addNode(demoData.heroNode());
+        const g2 = new Graph()
+          .addNode(demoData.heroNode())
+          .addNode(demoData.mealNode())
+          .removeNode(demoData.mealNode().address);
+        expect(g1.equals(g2)).toBe(true);
+        expect(g2.toJSON()).toEqual(g1.toJSON());
+      });
       it("should canonicalize away node insertion order", () => {
         const g1 = new Graph()
           .addNode(demoData.heroNode())

--- a/src/core/graphDemoData.js
+++ b/src/core/graphDemoData.js
@@ -109,7 +109,23 @@ export const duplicateCookEdge = () => ({
   },
 });
 
+// This node is added to and then removed from the advanced meal graph.
+export const phantomNode = () => ({
+  address: makeAddress("restless_cricket#9", "EXPERIMENT"),
+  payload: {},
+});
+
+// This node's payload is literally `null`; it should not be confused
+// with a nonexistent node.
+export const nullPayloadNode = () => ({
+  address: makeAddress("~000#missingno", "EXPERIMENT"),
+  payload: null,
+});
+
 export const advancedMealGraph = () =>
   simpleMealGraph()
     .addEdge(crabLoopEdge())
-    .addEdge(duplicateCookEdge());
+    .addEdge(duplicateCookEdge())
+    .addNode(phantomNode())
+    .removeNode(phantomNode().address)
+    .addNode(nullPayloadNode());

--- a/src/plugins/git/__snapshots__/createGraph.test.js.snap
+++ b/src/plugins/git/__snapshots__/createGraph.test.js.snap
@@ -4,7 +4,7 @@ exports[`createGraph processes a simple repository 1`] = `
 Array [
   Object {
     "type": "sourcecred/sourcecred/Graph",
-    "version": "0.1.0",
+    "version": "0.2.0",
   },
   Object {
     "edges": Array [
@@ -14,1144 +14,492 @@ Array [
       },
       Object {
         "{\\"id\\":\\"2f7155e359fd0ecb96ffdca66fa45b6ed5792809:README.txt\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"type\\":\\"INCLUDES\\"}": Object {
-          "dst": Object {
-            "id": "2f7155e359fd0ecb96ffdca66fa45b6ed5792809:README.txt",
-            "pluginName": "sourcecred/git-beta",
-            "type": "TREE_ENTRY",
-          },
+          "dstIndex": 2,
           "payload": Object {
             "name": "README.txt",
           },
-          "src": Object {
-            "id": "2f7155e359fd0ecb96ffdca66fa45b6ed5792809",
-            "pluginName": "sourcecred/git-beta",
-            "type": "TREE",
-          },
+          "srcIndex": 1,
         },
         "{\\"id\\":\\"2f7155e359fd0ecb96ffdca66fa45b6ed5792809:science.txt\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"type\\":\\"INCLUDES\\"}": Object {
-          "dst": Object {
-            "id": "2f7155e359fd0ecb96ffdca66fa45b6ed5792809:science.txt",
-            "pluginName": "sourcecred/git-beta",
-            "type": "TREE_ENTRY",
-          },
+          "dstIndex": 3,
           "payload": Object {
             "name": "science.txt",
           },
-          "src": Object {
-            "id": "2f7155e359fd0ecb96ffdca66fa45b6ed5792809",
-            "pluginName": "sourcecred/git-beta",
-            "type": "TREE",
-          },
+          "srcIndex": 1,
         },
         "{\\"id\\":\\"3715ddfb8d4c4fd2a6f6af75488c82f84c92ec2f^1\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"type\\":\\"HAS_PARENT\\"}": Object {
-          "dst": Object {
-            "id": "69c5aad50eec8f2a0a07c988c3b283a6490eb45b",
-            "pluginName": "sourcecred/git-beta",
-            "type": "COMMIT",
-          },
+          "dstIndex": 18,
           "payload": Object {
             "parentIndex": 1,
           },
-          "src": Object {
-            "id": "3715ddfb8d4c4fd2a6f6af75488c82f84c92ec2f",
-            "pluginName": "sourcecred/git-beta",
-            "type": "COMMIT",
-          },
+          "srcIndex": 4,
         },
         "{\\"id\\":\\"3dfb84795e07341b05fad3a0d5a55f8304b2d7d8:.gitmodules\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"type\\":\\"INCLUDES\\"}": Object {
-          "dst": Object {
-            "id": "3dfb84795e07341b05fad3a0d5a55f8304b2d7d8:.gitmodules",
-            "pluginName": "sourcecred/git-beta",
-            "type": "TREE_ENTRY",
-          },
+          "dstIndex": 6,
           "payload": Object {
             "name": ".gitmodules",
           },
-          "src": Object {
-            "id": "3dfb84795e07341b05fad3a0d5a55f8304b2d7d8",
-            "pluginName": "sourcecred/git-beta",
-            "type": "TREE",
-          },
+          "srcIndex": 5,
         },
         "{\\"id\\":\\"3dfb84795e07341b05fad3a0d5a55f8304b2d7d8:README.txt\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"type\\":\\"INCLUDES\\"}": Object {
-          "dst": Object {
-            "id": "3dfb84795e07341b05fad3a0d5a55f8304b2d7d8:README.txt",
-            "pluginName": "sourcecred/git-beta",
-            "type": "TREE_ENTRY",
-          },
+          "dstIndex": 7,
           "payload": Object {
             "name": "README.txt",
           },
-          "src": Object {
-            "id": "3dfb84795e07341b05fad3a0d5a55f8304b2d7d8",
-            "pluginName": "sourcecred/git-beta",
-            "type": "TREE",
-          },
+          "srcIndex": 5,
         },
         "{\\"id\\":\\"3dfb84795e07341b05fad3a0d5a55f8304b2d7d8:pygravitydefier\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"type\\":\\"INCLUDES\\"}": Object {
-          "dst": Object {
-            "id": "3dfb84795e07341b05fad3a0d5a55f8304b2d7d8:pygravitydefier",
-            "pluginName": "sourcecred/git-beta",
-            "type": "TREE_ENTRY",
-          },
+          "dstIndex": 8,
           "payload": Object {
             "name": "pygravitydefier",
           },
-          "src": Object {
-            "id": "3dfb84795e07341b05fad3a0d5a55f8304b2d7d8",
-            "pluginName": "sourcecred/git-beta",
-            "type": "TREE",
-          },
+          "srcIndex": 5,
         },
         "{\\"id\\":\\"3dfb84795e07341b05fad3a0d5a55f8304b2d7d8:science.txt\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"type\\":\\"INCLUDES\\"}": Object {
-          "dst": Object {
-            "id": "3dfb84795e07341b05fad3a0d5a55f8304b2d7d8:science.txt",
-            "pluginName": "sourcecred/git-beta",
-            "type": "TREE_ENTRY",
-          },
+          "dstIndex": 9,
           "payload": Object {
             "name": "science.txt",
           },
-          "src": Object {
-            "id": "3dfb84795e07341b05fad3a0d5a55f8304b2d7d8",
-            "pluginName": "sourcecred/git-beta",
-            "type": "TREE",
-          },
+          "srcIndex": 5,
         },
         "{\\"id\\":\\"569e1d383759903134df75230d63c0090196d4cb:.gitmodules\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"type\\":\\"INCLUDES\\"}": Object {
-          "dst": Object {
-            "id": "569e1d383759903134df75230d63c0090196d4cb:.gitmodules",
-            "pluginName": "sourcecred/git-beta",
-            "type": "TREE_ENTRY",
-          },
+          "dstIndex": 11,
           "payload": Object {
             "name": ".gitmodules",
           },
-          "src": Object {
-            "id": "569e1d383759903134df75230d63c0090196d4cb",
-            "pluginName": "sourcecred/git-beta",
-            "type": "TREE",
-          },
+          "srcIndex": 10,
         },
         "{\\"id\\":\\"569e1d383759903134df75230d63c0090196d4cb:README.txt\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"type\\":\\"INCLUDES\\"}": Object {
-          "dst": Object {
-            "id": "569e1d383759903134df75230d63c0090196d4cb:README.txt",
-            "pluginName": "sourcecred/git-beta",
-            "type": "TREE_ENTRY",
-          },
+          "dstIndex": 12,
           "payload": Object {
             "name": "README.txt",
           },
-          "src": Object {
-            "id": "569e1d383759903134df75230d63c0090196d4cb",
-            "pluginName": "sourcecred/git-beta",
-            "type": "TREE",
-          },
+          "srcIndex": 10,
         },
         "{\\"id\\":\\"569e1d383759903134df75230d63c0090196d4cb:TODOS.txt\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"type\\":\\"INCLUDES\\"}": Object {
-          "dst": Object {
-            "id": "569e1d383759903134df75230d63c0090196d4cb:TODOS.txt",
-            "pluginName": "sourcecred/git-beta",
-            "type": "TREE_ENTRY",
-          },
+          "dstIndex": 13,
           "payload": Object {
             "name": "TODOS.txt",
           },
-          "src": Object {
-            "id": "569e1d383759903134df75230d63c0090196d4cb",
-            "pluginName": "sourcecred/git-beta",
-            "type": "TREE",
-          },
+          "srcIndex": 10,
         },
         "{\\"id\\":\\"569e1d383759903134df75230d63c0090196d4cb:pygravitydefier\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"type\\":\\"INCLUDES\\"}": Object {
-          "dst": Object {
-            "id": "569e1d383759903134df75230d63c0090196d4cb:pygravitydefier",
-            "pluginName": "sourcecred/git-beta",
-            "type": "TREE_ENTRY",
-          },
+          "dstIndex": 14,
           "payload": Object {
             "name": "pygravitydefier",
           },
-          "src": Object {
-            "id": "569e1d383759903134df75230d63c0090196d4cb",
-            "pluginName": "sourcecred/git-beta",
-            "type": "TREE",
-          },
+          "srcIndex": 10,
         },
         "{\\"id\\":\\"569e1d383759903134df75230d63c0090196d4cb:science.txt\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"type\\":\\"INCLUDES\\"}": Object {
-          "dst": Object {
-            "id": "569e1d383759903134df75230d63c0090196d4cb:science.txt",
-            "pluginName": "sourcecred/git-beta",
-            "type": "TREE_ENTRY",
-          },
+          "dstIndex": 15,
           "payload": Object {
             "name": "science.txt",
           },
-          "src": Object {
-            "id": "569e1d383759903134df75230d63c0090196d4cb",
-            "pluginName": "sourcecred/git-beta",
-            "type": "TREE",
-          },
+          "srcIndex": 10,
         },
         "{\\"id\\":\\"569e1d383759903134df75230d63c0090196d4cb:src\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"type\\":\\"INCLUDES\\"}": Object {
-          "dst": Object {
-            "id": "569e1d383759903134df75230d63c0090196d4cb:src",
-            "pluginName": "sourcecred/git-beta",
-            "type": "TREE_ENTRY",
-          },
+          "dstIndex": 16,
           "payload": Object {
             "name": "src",
           },
-          "src": Object {
-            "id": "569e1d383759903134df75230d63c0090196d4cb",
-            "pluginName": "sourcecred/git-beta",
-            "type": "TREE",
-          },
+          "srcIndex": 10,
         },
         "{\\"id\\":\\"69c5aad50eec8f2a0a07c988c3b283a6490eb45b^1\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"type\\":\\"HAS_PARENT\\"}": Object {
-          "dst": Object {
-            "id": "e8b7a8f19701cd5a25e4a097d513ead60e5f8bcc",
-            "pluginName": "sourcecred/git-beta",
-            "type": "COMMIT",
-          },
+          "dstIndex": 55,
           "payload": Object {
             "parentIndex": 1,
           },
-          "src": Object {
-            "id": "69c5aad50eec8f2a0a07c988c3b283a6490eb45b",
-            "pluginName": "sourcecred/git-beta",
-            "type": "COMMIT",
-          },
+          "srcIndex": 18,
         },
         "{\\"id\\":\\"78fc9c83023386854c6bfdc5761c0e58f68e226f:index.py\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"type\\":\\"INCLUDES\\"}": Object {
-          "dst": Object {
-            "id": "78fc9c83023386854c6bfdc5761c0e58f68e226f:index.py",
-            "pluginName": "sourcecred/git-beta",
-            "type": "TREE_ENTRY",
-          },
+          "dstIndex": 20,
           "payload": Object {
             "name": "index.py",
           },
-          "src": Object {
-            "id": "78fc9c83023386854c6bfdc5761c0e58f68e226f",
-            "pluginName": "sourcecred/git-beta",
-            "type": "TREE",
-          },
+          "srcIndex": 19,
         },
         "{\\"id\\":\\"78fc9c83023386854c6bfdc5761c0e58f68e226f:quantum_gravity.py\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"type\\":\\"INCLUDES\\"}": Object {
-          "dst": Object {
-            "id": "78fc9c83023386854c6bfdc5761c0e58f68e226f:quantum_gravity.py",
-            "pluginName": "sourcecred/git-beta",
-            "type": "TREE_ENTRY",
-          },
+          "dstIndex": 21,
           "payload": Object {
             "name": "quantum_gravity.py",
           },
-          "src": Object {
-            "id": "78fc9c83023386854c6bfdc5761c0e58f68e226f",
-            "pluginName": "sourcecred/git-beta",
-            "type": "TREE",
-          },
+          "srcIndex": 19,
         },
         "{\\"id\\":\\"7b79d579b62994faba3b69fdf8aa442586c32681:index.py\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"type\\":\\"INCLUDES\\"}": Object {
-          "dst": Object {
-            "id": "7b79d579b62994faba3b69fdf8aa442586c32681:index.py",
-            "pluginName": "sourcecred/git-beta",
-            "type": "TREE_ENTRY",
-          },
+          "dstIndex": 23,
           "payload": Object {
             "name": "index.py",
           },
-          "src": Object {
-            "id": "7b79d579b62994faba3b69fdf8aa442586c32681",
-            "pluginName": "sourcecred/git-beta",
-            "type": "TREE",
-          },
+          "srcIndex": 22,
         },
         "{\\"id\\":\\"7b79d579b62994faba3b69fdf8aa442586c32681:quantum_gravity.py\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"type\\":\\"INCLUDES\\"}": Object {
-          "dst": Object {
-            "id": "7b79d579b62994faba3b69fdf8aa442586c32681:quantum_gravity.py",
-            "pluginName": "sourcecred/git-beta",
-            "type": "TREE_ENTRY",
-          },
+          "dstIndex": 24,
           "payload": Object {
             "name": "quantum_gravity.py",
           },
-          "src": Object {
-            "id": "7b79d579b62994faba3b69fdf8aa442586c32681",
-            "pluginName": "sourcecred/git-beta",
-            "type": "TREE",
-          },
+          "srcIndex": 22,
         },
         "{\\"id\\":\\"7be3ecfee5314ffa9b2d93fc4377792b2d6d70ed:.gitmodules\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"type\\":\\"INCLUDES\\"}": Object {
-          "dst": Object {
-            "id": "7be3ecfee5314ffa9b2d93fc4377792b2d6d70ed:.gitmodules",
-            "pluginName": "sourcecred/git-beta",
-            "type": "TREE_ENTRY",
-          },
+          "dstIndex": 26,
           "payload": Object {
             "name": ".gitmodules",
           },
-          "src": Object {
-            "id": "7be3ecfee5314ffa9b2d93fc4377792b2d6d70ed",
-            "pluginName": "sourcecred/git-beta",
-            "type": "TREE",
-          },
+          "srcIndex": 25,
         },
         "{\\"id\\":\\"7be3ecfee5314ffa9b2d93fc4377792b2d6d70ed:README.txt\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"type\\":\\"INCLUDES\\"}": Object {
-          "dst": Object {
-            "id": "7be3ecfee5314ffa9b2d93fc4377792b2d6d70ed:README.txt",
-            "pluginName": "sourcecred/git-beta",
-            "type": "TREE_ENTRY",
-          },
+          "dstIndex": 27,
           "payload": Object {
             "name": "README.txt",
           },
-          "src": Object {
-            "id": "7be3ecfee5314ffa9b2d93fc4377792b2d6d70ed",
-            "pluginName": "sourcecred/git-beta",
-            "type": "TREE",
-          },
+          "srcIndex": 25,
         },
         "{\\"id\\":\\"7be3ecfee5314ffa9b2d93fc4377792b2d6d70ed:pygravitydefier\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"type\\":\\"INCLUDES\\"}": Object {
-          "dst": Object {
-            "id": "7be3ecfee5314ffa9b2d93fc4377792b2d6d70ed:pygravitydefier",
-            "pluginName": "sourcecred/git-beta",
-            "type": "TREE_ENTRY",
-          },
+          "dstIndex": 28,
           "payload": Object {
             "name": "pygravitydefier",
           },
-          "src": Object {
-            "id": "7be3ecfee5314ffa9b2d93fc4377792b2d6d70ed",
-            "pluginName": "sourcecred/git-beta",
-            "type": "TREE",
-          },
+          "srcIndex": 25,
         },
         "{\\"id\\":\\"7be3ecfee5314ffa9b2d93fc4377792b2d6d70ed:science.txt\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"type\\":\\"INCLUDES\\"}": Object {
-          "dst": Object {
-            "id": "7be3ecfee5314ffa9b2d93fc4377792b2d6d70ed:science.txt",
-            "pluginName": "sourcecred/git-beta",
-            "type": "TREE_ENTRY",
-          },
+          "dstIndex": 29,
           "payload": Object {
             "name": "science.txt",
           },
-          "src": Object {
-            "id": "7be3ecfee5314ffa9b2d93fc4377792b2d6d70ed",
-            "pluginName": "sourcecred/git-beta",
-            "type": "TREE",
-          },
+          "srcIndex": 25,
         },
         "{\\"id\\":\\"7be3ecfee5314ffa9b2d93fc4377792b2d6d70ed:src\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"type\\":\\"INCLUDES\\"}": Object {
-          "dst": Object {
-            "id": "7be3ecfee5314ffa9b2d93fc4377792b2d6d70ed:src",
-            "pluginName": "sourcecred/git-beta",
-            "type": "TREE_ENTRY",
-          },
+          "dstIndex": 30,
           "payload": Object {
             "name": "src",
           },
-          "src": Object {
-            "id": "7be3ecfee5314ffa9b2d93fc4377792b2d6d70ed",
-            "pluginName": "sourcecred/git-beta",
-            "type": "TREE",
-          },
+          "srcIndex": 25,
         },
         "{\\"id\\":\\"819fc546cea489476ce8dc90785e9ba7753d0a8f:.gitmodules\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"type\\":\\"INCLUDES\\"}": Object {
-          "dst": Object {
-            "id": "819fc546cea489476ce8dc90785e9ba7753d0a8f:.gitmodules",
-            "pluginName": "sourcecred/git-beta",
-            "type": "TREE_ENTRY",
-          },
+          "dstIndex": 32,
           "payload": Object {
             "name": ".gitmodules",
           },
-          "src": Object {
-            "id": "819fc546cea489476ce8dc90785e9ba7753d0a8f",
-            "pluginName": "sourcecred/git-beta",
-            "type": "TREE",
-          },
+          "srcIndex": 31,
         },
         "{\\"id\\":\\"819fc546cea489476ce8dc90785e9ba7753d0a8f:README.txt\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"type\\":\\"INCLUDES\\"}": Object {
-          "dst": Object {
-            "id": "819fc546cea489476ce8dc90785e9ba7753d0a8f:README.txt",
-            "pluginName": "sourcecred/git-beta",
-            "type": "TREE_ENTRY",
-          },
+          "dstIndex": 33,
           "payload": Object {
             "name": "README.txt",
           },
-          "src": Object {
-            "id": "819fc546cea489476ce8dc90785e9ba7753d0a8f",
-            "pluginName": "sourcecred/git-beta",
-            "type": "TREE",
-          },
+          "srcIndex": 31,
         },
         "{\\"id\\":\\"819fc546cea489476ce8dc90785e9ba7753d0a8f:TODOS.txt\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"type\\":\\"INCLUDES\\"}": Object {
-          "dst": Object {
-            "id": "819fc546cea489476ce8dc90785e9ba7753d0a8f:TODOS.txt",
-            "pluginName": "sourcecred/git-beta",
-            "type": "TREE_ENTRY",
-          },
+          "dstIndex": 34,
           "payload": Object {
             "name": "TODOS.txt",
           },
-          "src": Object {
-            "id": "819fc546cea489476ce8dc90785e9ba7753d0a8f",
-            "pluginName": "sourcecred/git-beta",
-            "type": "TREE",
-          },
+          "srcIndex": 31,
         },
         "{\\"id\\":\\"819fc546cea489476ce8dc90785e9ba7753d0a8f:pygravitydefier\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"type\\":\\"INCLUDES\\"}": Object {
-          "dst": Object {
-            "id": "819fc546cea489476ce8dc90785e9ba7753d0a8f:pygravitydefier",
-            "pluginName": "sourcecred/git-beta",
-            "type": "TREE_ENTRY",
-          },
+          "dstIndex": 35,
           "payload": Object {
             "name": "pygravitydefier",
           },
-          "src": Object {
-            "id": "819fc546cea489476ce8dc90785e9ba7753d0a8f",
-            "pluginName": "sourcecred/git-beta",
-            "type": "TREE",
-          },
+          "srcIndex": 31,
         },
         "{\\"id\\":\\"819fc546cea489476ce8dc90785e9ba7753d0a8f:science.txt\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"type\\":\\"INCLUDES\\"}": Object {
-          "dst": Object {
-            "id": "819fc546cea489476ce8dc90785e9ba7753d0a8f:science.txt",
-            "pluginName": "sourcecred/git-beta",
-            "type": "TREE_ENTRY",
-          },
+          "dstIndex": 36,
           "payload": Object {
             "name": "science.txt",
           },
-          "src": Object {
-            "id": "819fc546cea489476ce8dc90785e9ba7753d0a8f",
-            "pluginName": "sourcecred/git-beta",
-            "type": "TREE",
-          },
+          "srcIndex": 31,
         },
         "{\\"id\\":\\"819fc546cea489476ce8dc90785e9ba7753d0a8f:src\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"type\\":\\"INCLUDES\\"}": Object {
-          "dst": Object {
-            "id": "819fc546cea489476ce8dc90785e9ba7753d0a8f:src",
-            "pluginName": "sourcecred/git-beta",
-            "type": "TREE_ENTRY",
-          },
+          "dstIndex": 37,
           "payload": Object {
             "name": "src",
           },
-          "src": Object {
-            "id": "819fc546cea489476ce8dc90785e9ba7753d0a8f",
-            "pluginName": "sourcecred/git-beta",
-            "type": "TREE",
-          },
+          "srcIndex": 31,
         },
         "{\\"id\\":\\"8d287c3bfbf8455ef30187bf5153ffc1b6eef268^1\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"type\\":\\"HAS_PARENT\\"}": Object {
-          "dst": Object {
-            "id": "c08ee3a4edea384d5291ffcbf06724a13ed72325",
-            "pluginName": "sourcecred/git-beta",
-            "type": "COMMIT",
-          },
+          "dstIndex": 51,
           "payload": Object {
             "parentIndex": 1,
           },
-          "src": Object {
-            "id": "8d287c3bfbf8455ef30187bf5153ffc1b6eef268",
-            "pluginName": "sourcecred/git-beta",
-            "type": "COMMIT",
-          },
+          "srcIndex": 40,
         },
         "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"2f7155e359fd0ecb96ffdca66fa45b6ed5792809:README.txt\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/git-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"TREE_ENTRY\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"0fb31858c8e3710be77e1dbb8880acf8a5543d82\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/git-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"BLOB\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"type\\":\\"HAS_CONTENTS\\"}": Object {
-          "dst": Object {
-            "id": "0fb31858c8e3710be77e1dbb8880acf8a5543d82",
-            "pluginName": "sourcecred/git-beta",
-            "type": "BLOB",
-          },
+          "dstIndex": 0,
           "payload": Object {},
-          "src": Object {
-            "id": "2f7155e359fd0ecb96ffdca66fa45b6ed5792809:README.txt",
-            "pluginName": "sourcecred/git-beta",
-            "type": "TREE_ENTRY",
-          },
+          "srcIndex": 2,
         },
         "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"2f7155e359fd0ecb96ffdca66fa45b6ed5792809:science.txt\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/git-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"TREE_ENTRY\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"f1f2514ca6d7a6a1a0511957021b1995bf9ace1c\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/git-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"BLOB\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"type\\":\\"HAS_CONTENTS\\"}": Object {
-          "dst": Object {
-            "id": "f1f2514ca6d7a6a1a0511957021b1995bf9ace1c",
-            "pluginName": "sourcecred/git-beta",
-            "type": "BLOB",
-          },
+          "dstIndex": 56,
           "payload": Object {},
-          "src": Object {
-            "id": "2f7155e359fd0ecb96ffdca66fa45b6ed5792809:science.txt",
-            "pluginName": "sourcecred/git-beta",
-            "type": "TREE_ENTRY",
-          },
+          "srcIndex": 3,
         },
         "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"3715ddfb8d4c4fd2a6f6af75488c82f84c92ec2f\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/git-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"COMMIT\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"7be3ecfee5314ffa9b2d93fc4377792b2d6d70ed\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/git-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"TREE\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"type\\":\\"HAS_TREE\\"}": Object {
-          "dst": Object {
-            "id": "7be3ecfee5314ffa9b2d93fc4377792b2d6d70ed",
-            "pluginName": "sourcecred/git-beta",
-            "type": "TREE",
-          },
+          "dstIndex": 25,
           "payload": Object {},
-          "src": Object {
-            "id": "3715ddfb8d4c4fd2a6f6af75488c82f84c92ec2f",
-            "pluginName": "sourcecred/git-beta",
-            "type": "COMMIT",
-          },
+          "srcIndex": 4,
         },
         "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"3dfb84795e07341b05fad3a0d5a55f8304b2d7d8:.gitmodules\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/git-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"TREE_ENTRY\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"8c6cac301e763aa6d36466e0a775eb804be2c311\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/git-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"BLOB\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"type\\":\\"HAS_CONTENTS\\"}": Object {
-          "dst": Object {
-            "id": "8c6cac301e763aa6d36466e0a775eb804be2c311",
-            "pluginName": "sourcecred/git-beta",
-            "type": "BLOB",
-          },
+          "dstIndex": 39,
           "payload": Object {},
-          "src": Object {
-            "id": "3dfb84795e07341b05fad3a0d5a55f8304b2d7d8:.gitmodules",
-            "pluginName": "sourcecred/git-beta",
-            "type": "TREE_ENTRY",
-          },
+          "srcIndex": 6,
         },
         "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"3dfb84795e07341b05fad3a0d5a55f8304b2d7d8:README.txt\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/git-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"TREE_ENTRY\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"0fb31858c8e3710be77e1dbb8880acf8a5543d82\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/git-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"BLOB\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"type\\":\\"HAS_CONTENTS\\"}": Object {
-          "dst": Object {
-            "id": "0fb31858c8e3710be77e1dbb8880acf8a5543d82",
-            "pluginName": "sourcecred/git-beta",
-            "type": "BLOB",
-          },
+          "dstIndex": 0,
           "payload": Object {},
-          "src": Object {
-            "id": "3dfb84795e07341b05fad3a0d5a55f8304b2d7d8:README.txt",
-            "pluginName": "sourcecred/git-beta",
-            "type": "TREE_ENTRY",
-          },
+          "srcIndex": 7,
         },
         "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"3dfb84795e07341b05fad3a0d5a55f8304b2d7d8:pygravitydefier\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/git-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"TREE_ENTRY\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-git-submodule.git@762c062fbdc7ec198cd693e95d55b374a08ff3e3\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/git-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"SUBMODULE_COMMIT\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"type\\":\\"HAS_CONTENTS\\"}": Object {
-          "dst": Object {
-            "id": "https://github.com/sourcecred/example-git-submodule.git@762c062fbdc7ec198cd693e95d55b374a08ff3e3",
-            "pluginName": "sourcecred/git-beta",
-            "type": "SUBMODULE_COMMIT",
-          },
+          "dstIndex": 58,
           "payload": Object {},
-          "src": Object {
-            "id": "3dfb84795e07341b05fad3a0d5a55f8304b2d7d8:pygravitydefier",
-            "pluginName": "sourcecred/git-beta",
-            "type": "TREE_ENTRY",
-          },
+          "srcIndex": 8,
         },
         "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"3dfb84795e07341b05fad3a0d5a55f8304b2d7d8:science.txt\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/git-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"TREE_ENTRY\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"f1f2514ca6d7a6a1a0511957021b1995bf9ace1c\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/git-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"BLOB\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"type\\":\\"HAS_CONTENTS\\"}": Object {
-          "dst": Object {
-            "id": "f1f2514ca6d7a6a1a0511957021b1995bf9ace1c",
-            "pluginName": "sourcecred/git-beta",
-            "type": "BLOB",
-          },
+          "dstIndex": 56,
           "payload": Object {},
-          "src": Object {
-            "id": "3dfb84795e07341b05fad3a0d5a55f8304b2d7d8:science.txt",
-            "pluginName": "sourcecred/git-beta",
-            "type": "TREE_ENTRY",
-          },
+          "srcIndex": 9,
         },
         "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"569e1d383759903134df75230d63c0090196d4cb:.gitmodules\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/git-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"TREE_ENTRY\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"8c6cac301e763aa6d36466e0a775eb804be2c311\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/git-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"BLOB\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"type\\":\\"HAS_CONTENTS\\"}": Object {
-          "dst": Object {
-            "id": "8c6cac301e763aa6d36466e0a775eb804be2c311",
-            "pluginName": "sourcecred/git-beta",
-            "type": "BLOB",
-          },
+          "dstIndex": 39,
           "payload": Object {},
-          "src": Object {
-            "id": "569e1d383759903134df75230d63c0090196d4cb:.gitmodules",
-            "pluginName": "sourcecred/git-beta",
-            "type": "TREE_ENTRY",
-          },
+          "srcIndex": 11,
         },
         "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"569e1d383759903134df75230d63c0090196d4cb:README.txt\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/git-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"TREE_ENTRY\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"0fb31858c8e3710be77e1dbb8880acf8a5543d82\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/git-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"BLOB\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"type\\":\\"HAS_CONTENTS\\"}": Object {
-          "dst": Object {
-            "id": "0fb31858c8e3710be77e1dbb8880acf8a5543d82",
-            "pluginName": "sourcecred/git-beta",
-            "type": "BLOB",
-          },
+          "dstIndex": 0,
           "payload": Object {},
-          "src": Object {
-            "id": "569e1d383759903134df75230d63c0090196d4cb:README.txt",
-            "pluginName": "sourcecred/git-beta",
-            "type": "TREE_ENTRY",
-          },
+          "srcIndex": 12,
         },
         "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"569e1d383759903134df75230d63c0090196d4cb:TODOS.txt\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/git-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"TREE_ENTRY\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"ddec7477206c30c31b81482e56b877a0b3c2638b\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/git-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"BLOB\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"type\\":\\"HAS_CONTENTS\\"}": Object {
-          "dst": Object {
-            "id": "ddec7477206c30c31b81482e56b877a0b3c2638b",
-            "pluginName": "sourcecred/git-beta",
-            "type": "BLOB",
-          },
+          "dstIndex": 54,
           "payload": Object {},
-          "src": Object {
-            "id": "569e1d383759903134df75230d63c0090196d4cb:TODOS.txt",
-            "pluginName": "sourcecred/git-beta",
-            "type": "TREE_ENTRY",
-          },
+          "srcIndex": 13,
         },
         "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"569e1d383759903134df75230d63c0090196d4cb:pygravitydefier\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/git-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"TREE_ENTRY\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-git-submodule.git@762c062fbdc7ec198cd693e95d55b374a08ff3e3\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/git-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"SUBMODULE_COMMIT\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"type\\":\\"HAS_CONTENTS\\"}": Object {
-          "dst": Object {
-            "id": "https://github.com/sourcecred/example-git-submodule.git@762c062fbdc7ec198cd693e95d55b374a08ff3e3",
-            "pluginName": "sourcecred/git-beta",
-            "type": "SUBMODULE_COMMIT",
-          },
+          "dstIndex": 58,
           "payload": Object {},
-          "src": Object {
-            "id": "569e1d383759903134df75230d63c0090196d4cb:pygravitydefier",
-            "pluginName": "sourcecred/git-beta",
-            "type": "TREE_ENTRY",
-          },
+          "srcIndex": 14,
         },
         "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"569e1d383759903134df75230d63c0090196d4cb:science.txt\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/git-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"TREE_ENTRY\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"f1f2514ca6d7a6a1a0511957021b1995bf9ace1c\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/git-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"BLOB\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"type\\":\\"HAS_CONTENTS\\"}": Object {
-          "dst": Object {
-            "id": "f1f2514ca6d7a6a1a0511957021b1995bf9ace1c",
-            "pluginName": "sourcecred/git-beta",
-            "type": "BLOB",
-          },
+          "dstIndex": 56,
           "payload": Object {},
-          "src": Object {
-            "id": "569e1d383759903134df75230d63c0090196d4cb:science.txt",
-            "pluginName": "sourcecred/git-beta",
-            "type": "TREE_ENTRY",
-          },
+          "srcIndex": 15,
         },
         "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"569e1d383759903134df75230d63c0090196d4cb:src\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/git-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"TREE_ENTRY\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"7b79d579b62994faba3b69fdf8aa442586c32681\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/git-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"TREE\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"type\\":\\"HAS_CONTENTS\\"}": Object {
-          "dst": Object {
-            "id": "7b79d579b62994faba3b69fdf8aa442586c32681",
-            "pluginName": "sourcecred/git-beta",
-            "type": "TREE",
-          },
+          "dstIndex": 22,
           "payload": Object {},
-          "src": Object {
-            "id": "569e1d383759903134df75230d63c0090196d4cb:src",
-            "pluginName": "sourcecred/git-beta",
-            "type": "TREE_ENTRY",
-          },
+          "srcIndex": 16,
         },
         "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"69c5aad50eec8f2a0a07c988c3b283a6490eb45b\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/git-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"COMMIT\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"bbf3b8b3d26a4f884b5c022d46851f593d329192\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/git-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"TREE\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"type\\":\\"HAS_TREE\\"}": Object {
-          "dst": Object {
-            "id": "bbf3b8b3d26a4f884b5c022d46851f593d329192",
-            "pluginName": "sourcecred/git-beta",
-            "type": "TREE",
-          },
+          "dstIndex": 42,
           "payload": Object {},
-          "src": Object {
-            "id": "69c5aad50eec8f2a0a07c988c3b283a6490eb45b",
-            "pluginName": "sourcecred/git-beta",
-            "type": "COMMIT",
-          },
+          "srcIndex": 18,
         },
         "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"78fc9c83023386854c6bfdc5761c0e58f68e226f:index.py\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/git-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"TREE_ENTRY\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"674b0b476989384510304846248b3acd16206782\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/git-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"BLOB\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"type\\":\\"HAS_CONTENTS\\"}": Object {
-          "dst": Object {
-            "id": "674b0b476989384510304846248b3acd16206782",
-            "pluginName": "sourcecred/git-beta",
-            "type": "BLOB",
-          },
+          "dstIndex": 17,
           "payload": Object {},
-          "src": Object {
-            "id": "78fc9c83023386854c6bfdc5761c0e58f68e226f:index.py",
-            "pluginName": "sourcecred/git-beta",
-            "type": "TREE_ENTRY",
-          },
+          "srcIndex": 20,
         },
         "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"78fc9c83023386854c6bfdc5761c0e58f68e226f:quantum_gravity.py\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/git-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"TREE_ENTRY\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"aea4f28abb23abde151b0ead4063227f8bf6c0b0\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/git-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"BLOB\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"type\\":\\"HAS_CONTENTS\\"}": Object {
-          "dst": Object {
-            "id": "aea4f28abb23abde151b0ead4063227f8bf6c0b0",
-            "pluginName": "sourcecred/git-beta",
-            "type": "BLOB",
-          },
+          "dstIndex": 41,
           "payload": Object {},
-          "src": Object {
-            "id": "78fc9c83023386854c6bfdc5761c0e58f68e226f:quantum_gravity.py",
-            "pluginName": "sourcecred/git-beta",
-            "type": "TREE_ENTRY",
-          },
+          "srcIndex": 21,
         },
         "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"7b79d579b62994faba3b69fdf8aa442586c32681:index.py\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/git-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"TREE_ENTRY\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"674b0b476989384510304846248b3acd16206782\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/git-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"BLOB\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"type\\":\\"HAS_CONTENTS\\"}": Object {
-          "dst": Object {
-            "id": "674b0b476989384510304846248b3acd16206782",
-            "pluginName": "sourcecred/git-beta",
-            "type": "BLOB",
-          },
+          "dstIndex": 17,
           "payload": Object {},
-          "src": Object {
-            "id": "7b79d579b62994faba3b69fdf8aa442586c32681:index.py",
-            "pluginName": "sourcecred/git-beta",
-            "type": "TREE_ENTRY",
-          },
+          "srcIndex": 23,
         },
         "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"7b79d579b62994faba3b69fdf8aa442586c32681:quantum_gravity.py\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/git-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"TREE_ENTRY\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"887ad856bbc1373da146106c86cb581ad78cdafe\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/git-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"BLOB\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"type\\":\\"HAS_CONTENTS\\"}": Object {
-          "dst": Object {
-            "id": "887ad856bbc1373da146106c86cb581ad78cdafe",
-            "pluginName": "sourcecred/git-beta",
-            "type": "BLOB",
-          },
+          "dstIndex": 38,
           "payload": Object {},
-          "src": Object {
-            "id": "7b79d579b62994faba3b69fdf8aa442586c32681:quantum_gravity.py",
-            "pluginName": "sourcecred/git-beta",
-            "type": "TREE_ENTRY",
-          },
+          "srcIndex": 24,
         },
         "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"7be3ecfee5314ffa9b2d93fc4377792b2d6d70ed:.gitmodules\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/git-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"TREE_ENTRY\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"8c6cac301e763aa6d36466e0a775eb804be2c311\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/git-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"BLOB\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"type\\":\\"HAS_CONTENTS\\"}": Object {
-          "dst": Object {
-            "id": "8c6cac301e763aa6d36466e0a775eb804be2c311",
-            "pluginName": "sourcecred/git-beta",
-            "type": "BLOB",
-          },
+          "dstIndex": 39,
           "payload": Object {},
-          "src": Object {
-            "id": "7be3ecfee5314ffa9b2d93fc4377792b2d6d70ed:.gitmodules",
-            "pluginName": "sourcecred/git-beta",
-            "type": "TREE_ENTRY",
-          },
+          "srcIndex": 26,
         },
         "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"7be3ecfee5314ffa9b2d93fc4377792b2d6d70ed:README.txt\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/git-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"TREE_ENTRY\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"0fb31858c8e3710be77e1dbb8880acf8a5543d82\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/git-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"BLOB\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"type\\":\\"HAS_CONTENTS\\"}": Object {
-          "dst": Object {
-            "id": "0fb31858c8e3710be77e1dbb8880acf8a5543d82",
-            "pluginName": "sourcecred/git-beta",
-            "type": "BLOB",
-          },
+          "dstIndex": 0,
           "payload": Object {},
-          "src": Object {
-            "id": "7be3ecfee5314ffa9b2d93fc4377792b2d6d70ed:README.txt",
-            "pluginName": "sourcecred/git-beta",
-            "type": "TREE_ENTRY",
-          },
+          "srcIndex": 27,
         },
         "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"7be3ecfee5314ffa9b2d93fc4377792b2d6d70ed:pygravitydefier\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/git-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"TREE_ENTRY\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-git-submodule.git@29ef158bc982733e2ba429fcf73e2f7562244188\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/git-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"SUBMODULE_COMMIT\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"type\\":\\"HAS_CONTENTS\\"}": Object {
-          "dst": Object {
-            "id": "https://github.com/sourcecred/example-git-submodule.git@29ef158bc982733e2ba429fcf73e2f7562244188",
-            "pluginName": "sourcecred/git-beta",
-            "type": "SUBMODULE_COMMIT",
-          },
+          "dstIndex": 57,
           "payload": Object {},
-          "src": Object {
-            "id": "7be3ecfee5314ffa9b2d93fc4377792b2d6d70ed:pygravitydefier",
-            "pluginName": "sourcecred/git-beta",
-            "type": "TREE_ENTRY",
-          },
+          "srcIndex": 28,
         },
         "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"7be3ecfee5314ffa9b2d93fc4377792b2d6d70ed:science.txt\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/git-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"TREE_ENTRY\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"f1f2514ca6d7a6a1a0511957021b1995bf9ace1c\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/git-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"BLOB\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"type\\":\\"HAS_CONTENTS\\"}": Object {
-          "dst": Object {
-            "id": "f1f2514ca6d7a6a1a0511957021b1995bf9ace1c",
-            "pluginName": "sourcecred/git-beta",
-            "type": "BLOB",
-          },
+          "dstIndex": 56,
           "payload": Object {},
-          "src": Object {
-            "id": "7be3ecfee5314ffa9b2d93fc4377792b2d6d70ed:science.txt",
-            "pluginName": "sourcecred/git-beta",
-            "type": "TREE_ENTRY",
-          },
+          "srcIndex": 29,
         },
         "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"7be3ecfee5314ffa9b2d93fc4377792b2d6d70ed:src\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/git-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"TREE_ENTRY\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"78fc9c83023386854c6bfdc5761c0e58f68e226f\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/git-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"TREE\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"type\\":\\"HAS_CONTENTS\\"}": Object {
-          "dst": Object {
-            "id": "78fc9c83023386854c6bfdc5761c0e58f68e226f",
-            "pluginName": "sourcecred/git-beta",
-            "type": "TREE",
-          },
+          "dstIndex": 19,
           "payload": Object {},
-          "src": Object {
-            "id": "7be3ecfee5314ffa9b2d93fc4377792b2d6d70ed:src",
-            "pluginName": "sourcecred/git-beta",
-            "type": "TREE_ENTRY",
-          },
+          "srcIndex": 30,
         },
         "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"819fc546cea489476ce8dc90785e9ba7753d0a8f:.gitmodules\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/git-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"TREE_ENTRY\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"8c6cac301e763aa6d36466e0a775eb804be2c311\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/git-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"BLOB\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"type\\":\\"HAS_CONTENTS\\"}": Object {
-          "dst": Object {
-            "id": "8c6cac301e763aa6d36466e0a775eb804be2c311",
-            "pluginName": "sourcecred/git-beta",
-            "type": "BLOB",
-          },
+          "dstIndex": 39,
           "payload": Object {},
-          "src": Object {
-            "id": "819fc546cea489476ce8dc90785e9ba7753d0a8f:.gitmodules",
-            "pluginName": "sourcecred/git-beta",
-            "type": "TREE_ENTRY",
-          },
+          "srcIndex": 32,
         },
         "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"819fc546cea489476ce8dc90785e9ba7753d0a8f:README.txt\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/git-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"TREE_ENTRY\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"0fb31858c8e3710be77e1dbb8880acf8a5543d82\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/git-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"BLOB\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"type\\":\\"HAS_CONTENTS\\"}": Object {
-          "dst": Object {
-            "id": "0fb31858c8e3710be77e1dbb8880acf8a5543d82",
-            "pluginName": "sourcecred/git-beta",
-            "type": "BLOB",
-          },
+          "dstIndex": 0,
           "payload": Object {},
-          "src": Object {
-            "id": "819fc546cea489476ce8dc90785e9ba7753d0a8f:README.txt",
-            "pluginName": "sourcecred/git-beta",
-            "type": "TREE_ENTRY",
-          },
+          "srcIndex": 33,
         },
         "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"819fc546cea489476ce8dc90785e9ba7753d0a8f:TODOS.txt\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/git-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"TREE_ENTRY\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"ddec7477206c30c31b81482e56b877a0b3c2638b\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/git-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"BLOB\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"type\\":\\"HAS_CONTENTS\\"}": Object {
-          "dst": Object {
-            "id": "ddec7477206c30c31b81482e56b877a0b3c2638b",
-            "pluginName": "sourcecred/git-beta",
-            "type": "BLOB",
-          },
+          "dstIndex": 54,
           "payload": Object {},
-          "src": Object {
-            "id": "819fc546cea489476ce8dc90785e9ba7753d0a8f:TODOS.txt",
-            "pluginName": "sourcecred/git-beta",
-            "type": "TREE_ENTRY",
-          },
+          "srcIndex": 34,
         },
         "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"819fc546cea489476ce8dc90785e9ba7753d0a8f:pygravitydefier\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/git-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"TREE_ENTRY\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-git-submodule.git@29ef158bc982733e2ba429fcf73e2f7562244188\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/git-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"SUBMODULE_COMMIT\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"type\\":\\"HAS_CONTENTS\\"}": Object {
-          "dst": Object {
-            "id": "https://github.com/sourcecred/example-git-submodule.git@29ef158bc982733e2ba429fcf73e2f7562244188",
-            "pluginName": "sourcecred/git-beta",
-            "type": "SUBMODULE_COMMIT",
-          },
+          "dstIndex": 57,
           "payload": Object {},
-          "src": Object {
-            "id": "819fc546cea489476ce8dc90785e9ba7753d0a8f:pygravitydefier",
-            "pluginName": "sourcecred/git-beta",
-            "type": "TREE_ENTRY",
-          },
+          "srcIndex": 35,
         },
         "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"819fc546cea489476ce8dc90785e9ba7753d0a8f:science.txt\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/git-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"TREE_ENTRY\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"f1f2514ca6d7a6a1a0511957021b1995bf9ace1c\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/git-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"BLOB\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"type\\":\\"HAS_CONTENTS\\"}": Object {
-          "dst": Object {
-            "id": "f1f2514ca6d7a6a1a0511957021b1995bf9ace1c",
-            "pluginName": "sourcecred/git-beta",
-            "type": "BLOB",
-          },
+          "dstIndex": 56,
           "payload": Object {},
-          "src": Object {
-            "id": "819fc546cea489476ce8dc90785e9ba7753d0a8f:science.txt",
-            "pluginName": "sourcecred/git-beta",
-            "type": "TREE_ENTRY",
-          },
+          "srcIndex": 36,
         },
         "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"819fc546cea489476ce8dc90785e9ba7753d0a8f:src\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/git-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"TREE_ENTRY\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"7b79d579b62994faba3b69fdf8aa442586c32681\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/git-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"TREE\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"type\\":\\"HAS_CONTENTS\\"}": Object {
-          "dst": Object {
-            "id": "7b79d579b62994faba3b69fdf8aa442586c32681",
-            "pluginName": "sourcecred/git-beta",
-            "type": "TREE",
-          },
+          "dstIndex": 22,
           "payload": Object {},
-          "src": Object {
-            "id": "819fc546cea489476ce8dc90785e9ba7753d0a8f:src",
-            "pluginName": "sourcecred/git-beta",
-            "type": "TREE_ENTRY",
-          },
+          "srcIndex": 37,
         },
         "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"8d287c3bfbf8455ef30187bf5153ffc1b6eef268\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/git-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"COMMIT\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"3dfb84795e07341b05fad3a0d5a55f8304b2d7d8\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/git-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"TREE\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"type\\":\\"HAS_TREE\\"}": Object {
-          "dst": Object {
-            "id": "3dfb84795e07341b05fad3a0d5a55f8304b2d7d8",
-            "pluginName": "sourcecred/git-beta",
-            "type": "TREE",
-          },
+          "dstIndex": 5,
           "payload": Object {},
-          "src": Object {
-            "id": "8d287c3bfbf8455ef30187bf5153ffc1b6eef268",
-            "pluginName": "sourcecred/git-beta",
-            "type": "COMMIT",
-          },
+          "srcIndex": 40,
         },
         "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"bbf3b8b3d26a4f884b5c022d46851f593d329192:.gitmodules\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/git-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"TREE_ENTRY\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"8c6cac301e763aa6d36466e0a775eb804be2c311\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/git-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"BLOB\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"type\\":\\"HAS_CONTENTS\\"}": Object {
-          "dst": Object {
-            "id": "8c6cac301e763aa6d36466e0a775eb804be2c311",
-            "pluginName": "sourcecred/git-beta",
-            "type": "BLOB",
-          },
+          "dstIndex": 39,
           "payload": Object {},
-          "src": Object {
-            "id": "bbf3b8b3d26a4f884b5c022d46851f593d329192:.gitmodules",
-            "pluginName": "sourcecred/git-beta",
-            "type": "TREE_ENTRY",
-          },
+          "srcIndex": 43,
         },
         "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"bbf3b8b3d26a4f884b5c022d46851f593d329192:README.txt\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/git-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"TREE_ENTRY\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"0fb31858c8e3710be77e1dbb8880acf8a5543d82\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/git-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"BLOB\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"type\\":\\"HAS_CONTENTS\\"}": Object {
-          "dst": Object {
-            "id": "0fb31858c8e3710be77e1dbb8880acf8a5543d82",
-            "pluginName": "sourcecred/git-beta",
-            "type": "BLOB",
-          },
+          "dstIndex": 0,
           "payload": Object {},
-          "src": Object {
-            "id": "bbf3b8b3d26a4f884b5c022d46851f593d329192:README.txt",
-            "pluginName": "sourcecred/git-beta",
-            "type": "TREE_ENTRY",
-          },
+          "srcIndex": 44,
         },
         "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"bbf3b8b3d26a4f884b5c022d46851f593d329192:TODOS.txt\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/git-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"TREE_ENTRY\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"ddec7477206c30c31b81482e56b877a0b3c2638b\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/git-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"BLOB\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"type\\":\\"HAS_CONTENTS\\"}": Object {
-          "dst": Object {
-            "id": "ddec7477206c30c31b81482e56b877a0b3c2638b",
-            "pluginName": "sourcecred/git-beta",
-            "type": "BLOB",
-          },
+          "dstIndex": 54,
           "payload": Object {},
-          "src": Object {
-            "id": "bbf3b8b3d26a4f884b5c022d46851f593d329192:TODOS.txt",
-            "pluginName": "sourcecred/git-beta",
-            "type": "TREE_ENTRY",
-          },
+          "srcIndex": 45,
         },
         "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"bbf3b8b3d26a4f884b5c022d46851f593d329192:pygravitydefier\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/git-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"TREE_ENTRY\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-git-submodule.git@29ef158bc982733e2ba429fcf73e2f7562244188\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/git-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"SUBMODULE_COMMIT\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"type\\":\\"HAS_CONTENTS\\"}": Object {
-          "dst": Object {
-            "id": "https://github.com/sourcecred/example-git-submodule.git@29ef158bc982733e2ba429fcf73e2f7562244188",
-            "pluginName": "sourcecred/git-beta",
-            "type": "SUBMODULE_COMMIT",
-          },
+          "dstIndex": 57,
           "payload": Object {},
-          "src": Object {
-            "id": "bbf3b8b3d26a4f884b5c022d46851f593d329192:pygravitydefier",
-            "pluginName": "sourcecred/git-beta",
-            "type": "TREE_ENTRY",
-          },
+          "srcIndex": 46,
         },
         "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"bbf3b8b3d26a4f884b5c022d46851f593d329192:science.txt\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/git-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"TREE_ENTRY\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"f1f2514ca6d7a6a1a0511957021b1995bf9ace1c\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/git-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"BLOB\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"type\\":\\"HAS_CONTENTS\\"}": Object {
-          "dst": Object {
-            "id": "f1f2514ca6d7a6a1a0511957021b1995bf9ace1c",
-            "pluginName": "sourcecred/git-beta",
-            "type": "BLOB",
-          },
+          "dstIndex": 56,
           "payload": Object {},
-          "src": Object {
-            "id": "bbf3b8b3d26a4f884b5c022d46851f593d329192:science.txt",
-            "pluginName": "sourcecred/git-beta",
-            "type": "TREE_ENTRY",
-          },
+          "srcIndex": 47,
         },
         "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"bbf3b8b3d26a4f884b5c022d46851f593d329192:src\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/git-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"TREE_ENTRY\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"78fc9c83023386854c6bfdc5761c0e58f68e226f\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/git-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"TREE\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"type\\":\\"HAS_CONTENTS\\"}": Object {
-          "dst": Object {
-            "id": "78fc9c83023386854c6bfdc5761c0e58f68e226f",
-            "pluginName": "sourcecred/git-beta",
-            "type": "TREE",
-          },
+          "dstIndex": 19,
           "payload": Object {},
-          "src": Object {
-            "id": "bbf3b8b3d26a4f884b5c022d46851f593d329192:src",
-            "pluginName": "sourcecred/git-beta",
-            "type": "TREE_ENTRY",
-          },
+          "srcIndex": 48,
         },
         "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"bdff5d94193170015d6cbb549b7b630649428b1f:README.txt\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/git-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"TREE_ENTRY\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"0fb31858c8e3710be77e1dbb8880acf8a5543d82\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/git-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"BLOB\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"type\\":\\"HAS_CONTENTS\\"}": Object {
-          "dst": Object {
-            "id": "0fb31858c8e3710be77e1dbb8880acf8a5543d82",
-            "pluginName": "sourcecred/git-beta",
-            "type": "BLOB",
-          },
+          "dstIndex": 0,
           "payload": Object {},
-          "src": Object {
-            "id": "bdff5d94193170015d6cbb549b7b630649428b1f:README.txt",
-            "pluginName": "sourcecred/git-beta",
-            "type": "TREE_ENTRY",
-          },
+          "srcIndex": 50,
         },
         "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"c08ee3a4edea384d5291ffcbf06724a13ed72325\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/git-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"COMMIT\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"2f7155e359fd0ecb96ffdca66fa45b6ed5792809\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/git-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"TREE\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"type\\":\\"HAS_TREE\\"}": Object {
-          "dst": Object {
-            "id": "2f7155e359fd0ecb96ffdca66fa45b6ed5792809",
-            "pluginName": "sourcecred/git-beta",
-            "type": "TREE",
-          },
+          "dstIndex": 1,
           "payload": Object {},
-          "src": Object {
-            "id": "c08ee3a4edea384d5291ffcbf06724a13ed72325",
-            "pluginName": "sourcecred/git-beta",
-            "type": "COMMIT",
-          },
+          "srcIndex": 51,
         },
         "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"c2b51945e7457546912a8ce158ed9d294558d294\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/git-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"COMMIT\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"bdff5d94193170015d6cbb549b7b630649428b1f\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/git-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"TREE\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"type\\":\\"HAS_TREE\\"}": Object {
-          "dst": Object {
-            "id": "bdff5d94193170015d6cbb549b7b630649428b1f",
-            "pluginName": "sourcecred/git-beta",
-            "type": "TREE",
-          },
+          "dstIndex": 49,
           "payload": Object {},
-          "src": Object {
-            "id": "c2b51945e7457546912a8ce158ed9d294558d294",
-            "pluginName": "sourcecred/git-beta",
-            "type": "COMMIT",
-          },
+          "srcIndex": 52,
         },
         "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"d160cca97611e9dfed642522ad44408d0292e8ea\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/git-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"COMMIT\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"569e1d383759903134df75230d63c0090196d4cb\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/git-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"TREE\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"type\\":\\"HAS_TREE\\"}": Object {
-          "dst": Object {
-            "id": "569e1d383759903134df75230d63c0090196d4cb",
-            "pluginName": "sourcecred/git-beta",
-            "type": "TREE",
-          },
+          "dstIndex": 10,
           "payload": Object {},
-          "src": Object {
-            "id": "d160cca97611e9dfed642522ad44408d0292e8ea",
-            "pluginName": "sourcecred/git-beta",
-            "type": "COMMIT",
-          },
+          "srcIndex": 53,
         },
         "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"e8b7a8f19701cd5a25e4a097d513ead60e5f8bcc\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/git-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"COMMIT\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"819fc546cea489476ce8dc90785e9ba7753d0a8f\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/git-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"TREE\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"type\\":\\"HAS_TREE\\"}": Object {
-          "dst": Object {
-            "id": "819fc546cea489476ce8dc90785e9ba7753d0a8f",
-            "pluginName": "sourcecred/git-beta",
-            "type": "TREE",
-          },
+          "dstIndex": 31,
           "payload": Object {},
-          "src": Object {
-            "id": "e8b7a8f19701cd5a25e4a097d513ead60e5f8bcc",
-            "pluginName": "sourcecred/git-beta",
-            "type": "COMMIT",
-          },
+          "srcIndex": 55,
         },
         "{\\"id\\":\\"bbf3b8b3d26a4f884b5c022d46851f593d329192:.gitmodules\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"type\\":\\"INCLUDES\\"}": Object {
-          "dst": Object {
-            "id": "bbf3b8b3d26a4f884b5c022d46851f593d329192:.gitmodules",
-            "pluginName": "sourcecred/git-beta",
-            "type": "TREE_ENTRY",
-          },
+          "dstIndex": 43,
           "payload": Object {
             "name": ".gitmodules",
           },
-          "src": Object {
-            "id": "bbf3b8b3d26a4f884b5c022d46851f593d329192",
-            "pluginName": "sourcecred/git-beta",
-            "type": "TREE",
-          },
+          "srcIndex": 42,
         },
         "{\\"id\\":\\"bbf3b8b3d26a4f884b5c022d46851f593d329192:README.txt\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"type\\":\\"INCLUDES\\"}": Object {
-          "dst": Object {
-            "id": "bbf3b8b3d26a4f884b5c022d46851f593d329192:README.txt",
-            "pluginName": "sourcecred/git-beta",
-            "type": "TREE_ENTRY",
-          },
+          "dstIndex": 44,
           "payload": Object {
             "name": "README.txt",
           },
-          "src": Object {
-            "id": "bbf3b8b3d26a4f884b5c022d46851f593d329192",
-            "pluginName": "sourcecred/git-beta",
-            "type": "TREE",
-          },
+          "srcIndex": 42,
         },
         "{\\"id\\":\\"bbf3b8b3d26a4f884b5c022d46851f593d329192:TODOS.txt\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"type\\":\\"INCLUDES\\"}": Object {
-          "dst": Object {
-            "id": "bbf3b8b3d26a4f884b5c022d46851f593d329192:TODOS.txt",
-            "pluginName": "sourcecred/git-beta",
-            "type": "TREE_ENTRY",
-          },
+          "dstIndex": 45,
           "payload": Object {
             "name": "TODOS.txt",
           },
-          "src": Object {
-            "id": "bbf3b8b3d26a4f884b5c022d46851f593d329192",
-            "pluginName": "sourcecred/git-beta",
-            "type": "TREE",
-          },
+          "srcIndex": 42,
         },
         "{\\"id\\":\\"bbf3b8b3d26a4f884b5c022d46851f593d329192:pygravitydefier\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"type\\":\\"INCLUDES\\"}": Object {
-          "dst": Object {
-            "id": "bbf3b8b3d26a4f884b5c022d46851f593d329192:pygravitydefier",
-            "pluginName": "sourcecred/git-beta",
-            "type": "TREE_ENTRY",
-          },
+          "dstIndex": 46,
           "payload": Object {
             "name": "pygravitydefier",
           },
-          "src": Object {
-            "id": "bbf3b8b3d26a4f884b5c022d46851f593d329192",
-            "pluginName": "sourcecred/git-beta",
-            "type": "TREE",
-          },
+          "srcIndex": 42,
         },
         "{\\"id\\":\\"bbf3b8b3d26a4f884b5c022d46851f593d329192:science.txt\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"type\\":\\"INCLUDES\\"}": Object {
-          "dst": Object {
-            "id": "bbf3b8b3d26a4f884b5c022d46851f593d329192:science.txt",
-            "pluginName": "sourcecred/git-beta",
-            "type": "TREE_ENTRY",
-          },
+          "dstIndex": 47,
           "payload": Object {
             "name": "science.txt",
           },
-          "src": Object {
-            "id": "bbf3b8b3d26a4f884b5c022d46851f593d329192",
-            "pluginName": "sourcecred/git-beta",
-            "type": "TREE",
-          },
+          "srcIndex": 42,
         },
         "{\\"id\\":\\"bbf3b8b3d26a4f884b5c022d46851f593d329192:src\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"type\\":\\"INCLUDES\\"}": Object {
-          "dst": Object {
-            "id": "bbf3b8b3d26a4f884b5c022d46851f593d329192:src",
-            "pluginName": "sourcecred/git-beta",
-            "type": "TREE_ENTRY",
-          },
+          "dstIndex": 48,
           "payload": Object {
             "name": "src",
           },
-          "src": Object {
-            "id": "bbf3b8b3d26a4f884b5c022d46851f593d329192",
-            "pluginName": "sourcecred/git-beta",
-            "type": "TREE",
-          },
+          "srcIndex": 42,
         },
         "{\\"id\\":\\"bdff5d94193170015d6cbb549b7b630649428b1f:README.txt\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"type\\":\\"INCLUDES\\"}": Object {
-          "dst": Object {
-            "id": "bdff5d94193170015d6cbb549b7b630649428b1f:README.txt",
-            "pluginName": "sourcecred/git-beta",
-            "type": "TREE_ENTRY",
-          },
+          "dstIndex": 50,
           "payload": Object {
             "name": "README.txt",
           },
-          "src": Object {
-            "id": "bdff5d94193170015d6cbb549b7b630649428b1f",
-            "pluginName": "sourcecred/git-beta",
-            "type": "TREE",
-          },
+          "srcIndex": 49,
         },
         "{\\"id\\":\\"c08ee3a4edea384d5291ffcbf06724a13ed72325^1\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"type\\":\\"HAS_PARENT\\"}": Object {
-          "dst": Object {
-            "id": "c2b51945e7457546912a8ce158ed9d294558d294",
-            "pluginName": "sourcecred/git-beta",
-            "type": "COMMIT",
-          },
+          "dstIndex": 52,
           "payload": Object {
             "parentIndex": 1,
           },
-          "src": Object {
-            "id": "c08ee3a4edea384d5291ffcbf06724a13ed72325",
-            "pluginName": "sourcecred/git-beta",
-            "type": "COMMIT",
-          },
+          "srcIndex": 51,
         },
         "{\\"id\\":\\"d160cca97611e9dfed642522ad44408d0292e8ea^1\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"type\\":\\"HAS_PARENT\\"}": Object {
-          "dst": Object {
-            "id": "8d287c3bfbf8455ef30187bf5153ffc1b6eef268",
-            "pluginName": "sourcecred/git-beta",
-            "type": "COMMIT",
-          },
+          "dstIndex": 40,
           "payload": Object {
             "parentIndex": 1,
           },
-          "src": Object {
-            "id": "d160cca97611e9dfed642522ad44408d0292e8ea",
-            "pluginName": "sourcecred/git-beta",
-            "type": "COMMIT",
-          },
+          "srcIndex": 53,
         },
         "{\\"id\\":\\"e8b7a8f19701cd5a25e4a097d513ead60e5f8bcc^1\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"type\\":\\"HAS_PARENT\\"}": Object {
-          "dst": Object {
-            "id": "d160cca97611e9dfed642522ad44408d0292e8ea",
-            "pluginName": "sourcecred/git-beta",
-            "type": "COMMIT",
-          },
+          "dstIndex": 53,
           "payload": Object {
             "parentIndex": 1,
           },
-          "src": Object {
-            "id": "e8b7a8f19701cd5a25e4a097d513ead60e5f8bcc",
-            "pluginName": "sourcecred/git-beta",
-            "type": "COMMIT",
-          },
+          "srcIndex": 55,
         },
         "{\\"id\\":\\"{\\\\\\"childCommit\\\\\\":\\\\\\"69c5aad50eec8f2a0a07c988c3b283a6490eb45b\\\\\\",\\\\\\"parentCommit\\\\\\":\\\\\\"e8b7a8f19701cd5a25e4a097d513ead60e5f8bcc\\\\\\",\\\\\\"path\\\\\\":[\\\\\\"src\\\\\\",\\\\\\"quantum_gravity.py\\\\\\"]}\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"type\\":\\"BECOMES\\"}": Object {
-          "dst": Object {
-            "id": "78fc9c83023386854c6bfdc5761c0e58f68e226f:quantum_gravity.py",
-            "pluginName": "sourcecred/git-beta",
-            "type": "TREE_ENTRY",
-          },
+          "dstIndex": 21,
           "payload": Object {
             "childCommit": "69c5aad50eec8f2a0a07c988c3b283a6490eb45b",
             "parentCommit": "e8b7a8f19701cd5a25e4a097d513ead60e5f8bcc",
@@ -1160,18 +508,10 @@ Array [
               "quantum_gravity.py",
             ],
           },
-          "src": Object {
-            "id": "7b79d579b62994faba3b69fdf8aa442586c32681:quantum_gravity.py",
-            "pluginName": "sourcecred/git-beta",
-            "type": "TREE_ENTRY",
-          },
+          "srcIndex": 24,
         },
         "{\\"id\\":\\"{\\\\\\"childCommit\\\\\\":\\\\\\"69c5aad50eec8f2a0a07c988c3b283a6490eb45b\\\\\\",\\\\\\"parentCommit\\\\\\":\\\\\\"e8b7a8f19701cd5a25e4a097d513ead60e5f8bcc\\\\\\",\\\\\\"path\\\\\\":[\\\\\\"src\\\\\\"]}\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"type\\":\\"BECOMES\\"}": Object {
-          "dst": Object {
-            "id": "bbf3b8b3d26a4f884b5c022d46851f593d329192:src",
-            "pluginName": "sourcecred/git-beta",
-            "type": "TREE_ENTRY",
-          },
+          "dstIndex": 48,
           "payload": Object {
             "childCommit": "69c5aad50eec8f2a0a07c988c3b283a6490eb45b",
             "parentCommit": "e8b7a8f19701cd5a25e4a097d513ead60e5f8bcc",
@@ -1179,18 +519,10 @@ Array [
               "src",
             ],
           },
-          "src": Object {
-            "id": "819fc546cea489476ce8dc90785e9ba7753d0a8f:src",
-            "pluginName": "sourcecred/git-beta",
-            "type": "TREE_ENTRY",
-          },
+          "srcIndex": 37,
         },
         "{\\"id\\":\\"{\\\\\\"childCommit\\\\\\":\\\\\\"e8b7a8f19701cd5a25e4a097d513ead60e5f8bcc\\\\\\",\\\\\\"parentCommit\\\\\\":\\\\\\"d160cca97611e9dfed642522ad44408d0292e8ea\\\\\\",\\\\\\"path\\\\\\":[\\\\\\"pygravitydefier\\\\\\"]}\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"type\\":\\"BECOMES\\"}": Object {
-          "dst": Object {
-            "id": "819fc546cea489476ce8dc90785e9ba7753d0a8f:pygravitydefier",
-            "pluginName": "sourcecred/git-beta",
-            "type": "TREE_ENTRY",
-          },
+          "dstIndex": 35,
           "payload": Object {
             "childCommit": "e8b7a8f19701cd5a25e4a097d513ead60e5f8bcc",
             "parentCommit": "d160cca97611e9dfed642522ad44408d0292e8ea",
@@ -1198,270 +530,555 @@ Array [
               "pygravitydefier",
             ],
           },
-          "src": Object {
-            "id": "569e1d383759903134df75230d63c0090196d4cb:pygravitydefier",
-            "pluginName": "sourcecred/git-beta",
-            "type": "TREE_ENTRY",
-          },
+          "srcIndex": 14,
         },
       },
     ],
     "nodes": Array [
       Object {
-        "type": "sourcecred/sourcecred/AddressMap",
-        "version": "0.1.0",
+        "address": Object {
+          "id": "0fb31858c8e3710be77e1dbb8880acf8a5543d82",
+          "pluginName": "sourcecred/git-beta",
+          "type": "BLOB",
+        },
+        "payload": Object {},
       },
       Object {
-        "{\\"id\\":\\"0fb31858c8e3710be77e1dbb8880acf8a5543d82\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"type\\":\\"BLOB\\"}": Object {
-          "payload": Object {},
+        "address": Object {
+          "id": "2f7155e359fd0ecb96ffdca66fa45b6ed5792809",
+          "pluginName": "sourcecred/git-beta",
+          "type": "TREE",
         },
-        "{\\"id\\":\\"2f7155e359fd0ecb96ffdca66fa45b6ed5792809\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"type\\":\\"TREE\\"}": Object {
-          "payload": Object {},
+        "payload": Object {},
+      },
+      Object {
+        "address": Object {
+          "id": "2f7155e359fd0ecb96ffdca66fa45b6ed5792809:README.txt",
+          "pluginName": "sourcecred/git-beta",
+          "type": "TREE_ENTRY",
         },
-        "{\\"id\\":\\"2f7155e359fd0ecb96ffdca66fa45b6ed5792809:README.txt\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"type\\":\\"TREE_ENTRY\\"}": Object {
-          "payload": Object {
-            "name": "README.txt",
-          },
+        "payload": Object {
+          "name": "README.txt",
         },
-        "{\\"id\\":\\"2f7155e359fd0ecb96ffdca66fa45b6ed5792809:science.txt\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"type\\":\\"TREE_ENTRY\\"}": Object {
-          "payload": Object {
-            "name": "science.txt",
-          },
+      },
+      Object {
+        "address": Object {
+          "id": "2f7155e359fd0ecb96ffdca66fa45b6ed5792809:science.txt",
+          "pluginName": "sourcecred/git-beta",
+          "type": "TREE_ENTRY",
         },
-        "{\\"id\\":\\"3715ddfb8d4c4fd2a6f6af75488c82f84c92ec2f\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"type\\":\\"COMMIT\\"}": Object {
-          "payload": Object {},
+        "payload": Object {
+          "name": "science.txt",
         },
-        "{\\"id\\":\\"3dfb84795e07341b05fad3a0d5a55f8304b2d7d8\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"type\\":\\"TREE\\"}": Object {
-          "payload": Object {},
+      },
+      Object {
+        "address": Object {
+          "id": "3715ddfb8d4c4fd2a6f6af75488c82f84c92ec2f",
+          "pluginName": "sourcecred/git-beta",
+          "type": "COMMIT",
         },
-        "{\\"id\\":\\"3dfb84795e07341b05fad3a0d5a55f8304b2d7d8:.gitmodules\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"type\\":\\"TREE_ENTRY\\"}": Object {
-          "payload": Object {
-            "name": ".gitmodules",
-          },
+        "payload": Object {},
+      },
+      Object {
+        "address": Object {
+          "id": "3dfb84795e07341b05fad3a0d5a55f8304b2d7d8",
+          "pluginName": "sourcecred/git-beta",
+          "type": "TREE",
         },
-        "{\\"id\\":\\"3dfb84795e07341b05fad3a0d5a55f8304b2d7d8:README.txt\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"type\\":\\"TREE_ENTRY\\"}": Object {
-          "payload": Object {
-            "name": "README.txt",
-          },
+        "payload": Object {},
+      },
+      Object {
+        "address": Object {
+          "id": "3dfb84795e07341b05fad3a0d5a55f8304b2d7d8:.gitmodules",
+          "pluginName": "sourcecred/git-beta",
+          "type": "TREE_ENTRY",
         },
-        "{\\"id\\":\\"3dfb84795e07341b05fad3a0d5a55f8304b2d7d8:pygravitydefier\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"type\\":\\"TREE_ENTRY\\"}": Object {
-          "payload": Object {
-            "name": "pygravitydefier",
-          },
+        "payload": Object {
+          "name": ".gitmodules",
         },
-        "{\\"id\\":\\"3dfb84795e07341b05fad3a0d5a55f8304b2d7d8:science.txt\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"type\\":\\"TREE_ENTRY\\"}": Object {
-          "payload": Object {
-            "name": "science.txt",
-          },
+      },
+      Object {
+        "address": Object {
+          "id": "3dfb84795e07341b05fad3a0d5a55f8304b2d7d8:README.txt",
+          "pluginName": "sourcecred/git-beta",
+          "type": "TREE_ENTRY",
         },
-        "{\\"id\\":\\"569e1d383759903134df75230d63c0090196d4cb\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"type\\":\\"TREE\\"}": Object {
-          "payload": Object {},
+        "payload": Object {
+          "name": "README.txt",
         },
-        "{\\"id\\":\\"569e1d383759903134df75230d63c0090196d4cb:.gitmodules\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"type\\":\\"TREE_ENTRY\\"}": Object {
-          "payload": Object {
-            "name": ".gitmodules",
-          },
+      },
+      Object {
+        "address": Object {
+          "id": "3dfb84795e07341b05fad3a0d5a55f8304b2d7d8:pygravitydefier",
+          "pluginName": "sourcecred/git-beta",
+          "type": "TREE_ENTRY",
         },
-        "{\\"id\\":\\"569e1d383759903134df75230d63c0090196d4cb:README.txt\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"type\\":\\"TREE_ENTRY\\"}": Object {
-          "payload": Object {
-            "name": "README.txt",
-          },
+        "payload": Object {
+          "name": "pygravitydefier",
         },
-        "{\\"id\\":\\"569e1d383759903134df75230d63c0090196d4cb:TODOS.txt\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"type\\":\\"TREE_ENTRY\\"}": Object {
-          "payload": Object {
-            "name": "TODOS.txt",
-          },
+      },
+      Object {
+        "address": Object {
+          "id": "3dfb84795e07341b05fad3a0d5a55f8304b2d7d8:science.txt",
+          "pluginName": "sourcecred/git-beta",
+          "type": "TREE_ENTRY",
         },
-        "{\\"id\\":\\"569e1d383759903134df75230d63c0090196d4cb:pygravitydefier\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"type\\":\\"TREE_ENTRY\\"}": Object {
-          "payload": Object {
-            "name": "pygravitydefier",
-          },
+        "payload": Object {
+          "name": "science.txt",
         },
-        "{\\"id\\":\\"569e1d383759903134df75230d63c0090196d4cb:science.txt\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"type\\":\\"TREE_ENTRY\\"}": Object {
-          "payload": Object {
-            "name": "science.txt",
-          },
+      },
+      Object {
+        "address": Object {
+          "id": "569e1d383759903134df75230d63c0090196d4cb",
+          "pluginName": "sourcecred/git-beta",
+          "type": "TREE",
         },
-        "{\\"id\\":\\"569e1d383759903134df75230d63c0090196d4cb:src\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"type\\":\\"TREE_ENTRY\\"}": Object {
-          "payload": Object {
-            "name": "src",
-          },
+        "payload": Object {},
+      },
+      Object {
+        "address": Object {
+          "id": "569e1d383759903134df75230d63c0090196d4cb:.gitmodules",
+          "pluginName": "sourcecred/git-beta",
+          "type": "TREE_ENTRY",
         },
-        "{\\"id\\":\\"674b0b476989384510304846248b3acd16206782\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"type\\":\\"BLOB\\"}": Object {
-          "payload": Object {},
+        "payload": Object {
+          "name": ".gitmodules",
         },
-        "{\\"id\\":\\"69c5aad50eec8f2a0a07c988c3b283a6490eb45b\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"type\\":\\"COMMIT\\"}": Object {
-          "payload": Object {},
+      },
+      Object {
+        "address": Object {
+          "id": "569e1d383759903134df75230d63c0090196d4cb:README.txt",
+          "pluginName": "sourcecred/git-beta",
+          "type": "TREE_ENTRY",
         },
-        "{\\"id\\":\\"78fc9c83023386854c6bfdc5761c0e58f68e226f\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"type\\":\\"TREE\\"}": Object {
-          "payload": Object {},
+        "payload": Object {
+          "name": "README.txt",
         },
-        "{\\"id\\":\\"78fc9c83023386854c6bfdc5761c0e58f68e226f:index.py\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"type\\":\\"TREE_ENTRY\\"}": Object {
-          "payload": Object {
-            "name": "index.py",
-          },
+      },
+      Object {
+        "address": Object {
+          "id": "569e1d383759903134df75230d63c0090196d4cb:TODOS.txt",
+          "pluginName": "sourcecred/git-beta",
+          "type": "TREE_ENTRY",
         },
-        "{\\"id\\":\\"78fc9c83023386854c6bfdc5761c0e58f68e226f:quantum_gravity.py\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"type\\":\\"TREE_ENTRY\\"}": Object {
-          "payload": Object {
-            "name": "quantum_gravity.py",
-          },
+        "payload": Object {
+          "name": "TODOS.txt",
         },
-        "{\\"id\\":\\"7b79d579b62994faba3b69fdf8aa442586c32681\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"type\\":\\"TREE\\"}": Object {
-          "payload": Object {},
+      },
+      Object {
+        "address": Object {
+          "id": "569e1d383759903134df75230d63c0090196d4cb:pygravitydefier",
+          "pluginName": "sourcecred/git-beta",
+          "type": "TREE_ENTRY",
         },
-        "{\\"id\\":\\"7b79d579b62994faba3b69fdf8aa442586c32681:index.py\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"type\\":\\"TREE_ENTRY\\"}": Object {
-          "payload": Object {
-            "name": "index.py",
-          },
+        "payload": Object {
+          "name": "pygravitydefier",
         },
-        "{\\"id\\":\\"7b79d579b62994faba3b69fdf8aa442586c32681:quantum_gravity.py\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"type\\":\\"TREE_ENTRY\\"}": Object {
-          "payload": Object {
-            "name": "quantum_gravity.py",
-          },
+      },
+      Object {
+        "address": Object {
+          "id": "569e1d383759903134df75230d63c0090196d4cb:science.txt",
+          "pluginName": "sourcecred/git-beta",
+          "type": "TREE_ENTRY",
         },
-        "{\\"id\\":\\"7be3ecfee5314ffa9b2d93fc4377792b2d6d70ed\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"type\\":\\"TREE\\"}": Object {
-          "payload": Object {},
+        "payload": Object {
+          "name": "science.txt",
         },
-        "{\\"id\\":\\"7be3ecfee5314ffa9b2d93fc4377792b2d6d70ed:.gitmodules\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"type\\":\\"TREE_ENTRY\\"}": Object {
-          "payload": Object {
-            "name": ".gitmodules",
-          },
+      },
+      Object {
+        "address": Object {
+          "id": "569e1d383759903134df75230d63c0090196d4cb:src",
+          "pluginName": "sourcecred/git-beta",
+          "type": "TREE_ENTRY",
         },
-        "{\\"id\\":\\"7be3ecfee5314ffa9b2d93fc4377792b2d6d70ed:README.txt\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"type\\":\\"TREE_ENTRY\\"}": Object {
-          "payload": Object {
-            "name": "README.txt",
-          },
+        "payload": Object {
+          "name": "src",
         },
-        "{\\"id\\":\\"7be3ecfee5314ffa9b2d93fc4377792b2d6d70ed:pygravitydefier\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"type\\":\\"TREE_ENTRY\\"}": Object {
-          "payload": Object {
-            "name": "pygravitydefier",
-          },
+      },
+      Object {
+        "address": Object {
+          "id": "674b0b476989384510304846248b3acd16206782",
+          "pluginName": "sourcecred/git-beta",
+          "type": "BLOB",
         },
-        "{\\"id\\":\\"7be3ecfee5314ffa9b2d93fc4377792b2d6d70ed:science.txt\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"type\\":\\"TREE_ENTRY\\"}": Object {
-          "payload": Object {
-            "name": "science.txt",
-          },
+        "payload": Object {},
+      },
+      Object {
+        "address": Object {
+          "id": "69c5aad50eec8f2a0a07c988c3b283a6490eb45b",
+          "pluginName": "sourcecred/git-beta",
+          "type": "COMMIT",
         },
-        "{\\"id\\":\\"7be3ecfee5314ffa9b2d93fc4377792b2d6d70ed:src\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"type\\":\\"TREE_ENTRY\\"}": Object {
-          "payload": Object {
-            "name": "src",
-          },
+        "payload": Object {},
+      },
+      Object {
+        "address": Object {
+          "id": "78fc9c83023386854c6bfdc5761c0e58f68e226f",
+          "pluginName": "sourcecred/git-beta",
+          "type": "TREE",
         },
-        "{\\"id\\":\\"819fc546cea489476ce8dc90785e9ba7753d0a8f\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"type\\":\\"TREE\\"}": Object {
-          "payload": Object {},
+        "payload": Object {},
+      },
+      Object {
+        "address": Object {
+          "id": "78fc9c83023386854c6bfdc5761c0e58f68e226f:index.py",
+          "pluginName": "sourcecred/git-beta",
+          "type": "TREE_ENTRY",
         },
-        "{\\"id\\":\\"819fc546cea489476ce8dc90785e9ba7753d0a8f:.gitmodules\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"type\\":\\"TREE_ENTRY\\"}": Object {
-          "payload": Object {
-            "name": ".gitmodules",
-          },
+        "payload": Object {
+          "name": "index.py",
         },
-        "{\\"id\\":\\"819fc546cea489476ce8dc90785e9ba7753d0a8f:README.txt\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"type\\":\\"TREE_ENTRY\\"}": Object {
-          "payload": Object {
-            "name": "README.txt",
-          },
+      },
+      Object {
+        "address": Object {
+          "id": "78fc9c83023386854c6bfdc5761c0e58f68e226f:quantum_gravity.py",
+          "pluginName": "sourcecred/git-beta",
+          "type": "TREE_ENTRY",
         },
-        "{\\"id\\":\\"819fc546cea489476ce8dc90785e9ba7753d0a8f:TODOS.txt\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"type\\":\\"TREE_ENTRY\\"}": Object {
-          "payload": Object {
-            "name": "TODOS.txt",
-          },
+        "payload": Object {
+          "name": "quantum_gravity.py",
         },
-        "{\\"id\\":\\"819fc546cea489476ce8dc90785e9ba7753d0a8f:pygravitydefier\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"type\\":\\"TREE_ENTRY\\"}": Object {
-          "payload": Object {
-            "name": "pygravitydefier",
-          },
+      },
+      Object {
+        "address": Object {
+          "id": "7b79d579b62994faba3b69fdf8aa442586c32681",
+          "pluginName": "sourcecred/git-beta",
+          "type": "TREE",
         },
-        "{\\"id\\":\\"819fc546cea489476ce8dc90785e9ba7753d0a8f:science.txt\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"type\\":\\"TREE_ENTRY\\"}": Object {
-          "payload": Object {
-            "name": "science.txt",
-          },
+        "payload": Object {},
+      },
+      Object {
+        "address": Object {
+          "id": "7b79d579b62994faba3b69fdf8aa442586c32681:index.py",
+          "pluginName": "sourcecred/git-beta",
+          "type": "TREE_ENTRY",
         },
-        "{\\"id\\":\\"819fc546cea489476ce8dc90785e9ba7753d0a8f:src\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"type\\":\\"TREE_ENTRY\\"}": Object {
-          "payload": Object {
-            "name": "src",
-          },
+        "payload": Object {
+          "name": "index.py",
         },
-        "{\\"id\\":\\"887ad856bbc1373da146106c86cb581ad78cdafe\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"type\\":\\"BLOB\\"}": Object {
-          "payload": Object {},
+      },
+      Object {
+        "address": Object {
+          "id": "7b79d579b62994faba3b69fdf8aa442586c32681:quantum_gravity.py",
+          "pluginName": "sourcecred/git-beta",
+          "type": "TREE_ENTRY",
         },
-        "{\\"id\\":\\"8c6cac301e763aa6d36466e0a775eb804be2c311\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"type\\":\\"BLOB\\"}": Object {
-          "payload": Object {},
+        "payload": Object {
+          "name": "quantum_gravity.py",
         },
-        "{\\"id\\":\\"8d287c3bfbf8455ef30187bf5153ffc1b6eef268\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"type\\":\\"COMMIT\\"}": Object {
-          "payload": Object {},
+      },
+      Object {
+        "address": Object {
+          "id": "7be3ecfee5314ffa9b2d93fc4377792b2d6d70ed",
+          "pluginName": "sourcecred/git-beta",
+          "type": "TREE",
         },
-        "{\\"id\\":\\"aea4f28abb23abde151b0ead4063227f8bf6c0b0\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"type\\":\\"BLOB\\"}": Object {
-          "payload": Object {},
+        "payload": Object {},
+      },
+      Object {
+        "address": Object {
+          "id": "7be3ecfee5314ffa9b2d93fc4377792b2d6d70ed:.gitmodules",
+          "pluginName": "sourcecred/git-beta",
+          "type": "TREE_ENTRY",
         },
-        "{\\"id\\":\\"bbf3b8b3d26a4f884b5c022d46851f593d329192\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"type\\":\\"TREE\\"}": Object {
-          "payload": Object {},
+        "payload": Object {
+          "name": ".gitmodules",
         },
-        "{\\"id\\":\\"bbf3b8b3d26a4f884b5c022d46851f593d329192:.gitmodules\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"type\\":\\"TREE_ENTRY\\"}": Object {
-          "payload": Object {
-            "name": ".gitmodules",
-          },
+      },
+      Object {
+        "address": Object {
+          "id": "7be3ecfee5314ffa9b2d93fc4377792b2d6d70ed:README.txt",
+          "pluginName": "sourcecred/git-beta",
+          "type": "TREE_ENTRY",
         },
-        "{\\"id\\":\\"bbf3b8b3d26a4f884b5c022d46851f593d329192:README.txt\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"type\\":\\"TREE_ENTRY\\"}": Object {
-          "payload": Object {
-            "name": "README.txt",
-          },
+        "payload": Object {
+          "name": "README.txt",
         },
-        "{\\"id\\":\\"bbf3b8b3d26a4f884b5c022d46851f593d329192:TODOS.txt\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"type\\":\\"TREE_ENTRY\\"}": Object {
-          "payload": Object {
-            "name": "TODOS.txt",
-          },
+      },
+      Object {
+        "address": Object {
+          "id": "7be3ecfee5314ffa9b2d93fc4377792b2d6d70ed:pygravitydefier",
+          "pluginName": "sourcecred/git-beta",
+          "type": "TREE_ENTRY",
         },
-        "{\\"id\\":\\"bbf3b8b3d26a4f884b5c022d46851f593d329192:pygravitydefier\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"type\\":\\"TREE_ENTRY\\"}": Object {
-          "payload": Object {
-            "name": "pygravitydefier",
-          },
+        "payload": Object {
+          "name": "pygravitydefier",
         },
-        "{\\"id\\":\\"bbf3b8b3d26a4f884b5c022d46851f593d329192:science.txt\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"type\\":\\"TREE_ENTRY\\"}": Object {
-          "payload": Object {
-            "name": "science.txt",
-          },
+      },
+      Object {
+        "address": Object {
+          "id": "7be3ecfee5314ffa9b2d93fc4377792b2d6d70ed:science.txt",
+          "pluginName": "sourcecred/git-beta",
+          "type": "TREE_ENTRY",
         },
-        "{\\"id\\":\\"bbf3b8b3d26a4f884b5c022d46851f593d329192:src\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"type\\":\\"TREE_ENTRY\\"}": Object {
-          "payload": Object {
-            "name": "src",
-          },
+        "payload": Object {
+          "name": "science.txt",
         },
-        "{\\"id\\":\\"bdff5d94193170015d6cbb549b7b630649428b1f\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"type\\":\\"TREE\\"}": Object {
-          "payload": Object {},
+      },
+      Object {
+        "address": Object {
+          "id": "7be3ecfee5314ffa9b2d93fc4377792b2d6d70ed:src",
+          "pluginName": "sourcecred/git-beta",
+          "type": "TREE_ENTRY",
         },
-        "{\\"id\\":\\"bdff5d94193170015d6cbb549b7b630649428b1f:README.txt\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"type\\":\\"TREE_ENTRY\\"}": Object {
-          "payload": Object {
-            "name": "README.txt",
-          },
+        "payload": Object {
+          "name": "src",
         },
-        "{\\"id\\":\\"c08ee3a4edea384d5291ffcbf06724a13ed72325\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"type\\":\\"COMMIT\\"}": Object {
-          "payload": Object {},
+      },
+      Object {
+        "address": Object {
+          "id": "819fc546cea489476ce8dc90785e9ba7753d0a8f",
+          "pluginName": "sourcecred/git-beta",
+          "type": "TREE",
         },
-        "{\\"id\\":\\"c2b51945e7457546912a8ce158ed9d294558d294\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"type\\":\\"COMMIT\\"}": Object {
-          "payload": Object {},
+        "payload": Object {},
+      },
+      Object {
+        "address": Object {
+          "id": "819fc546cea489476ce8dc90785e9ba7753d0a8f:.gitmodules",
+          "pluginName": "sourcecred/git-beta",
+          "type": "TREE_ENTRY",
         },
-        "{\\"id\\":\\"d160cca97611e9dfed642522ad44408d0292e8ea\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"type\\":\\"COMMIT\\"}": Object {
-          "payload": Object {},
+        "payload": Object {
+          "name": ".gitmodules",
         },
-        "{\\"id\\":\\"ddec7477206c30c31b81482e56b877a0b3c2638b\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"type\\":\\"BLOB\\"}": Object {
-          "payload": Object {},
+      },
+      Object {
+        "address": Object {
+          "id": "819fc546cea489476ce8dc90785e9ba7753d0a8f:README.txt",
+          "pluginName": "sourcecred/git-beta",
+          "type": "TREE_ENTRY",
         },
-        "{\\"id\\":\\"e8b7a8f19701cd5a25e4a097d513ead60e5f8bcc\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"type\\":\\"COMMIT\\"}": Object {
-          "payload": Object {},
+        "payload": Object {
+          "name": "README.txt",
         },
-        "{\\"id\\":\\"f1f2514ca6d7a6a1a0511957021b1995bf9ace1c\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"type\\":\\"BLOB\\"}": Object {
-          "payload": Object {},
+      },
+      Object {
+        "address": Object {
+          "id": "819fc546cea489476ce8dc90785e9ba7753d0a8f:TODOS.txt",
+          "pluginName": "sourcecred/git-beta",
+          "type": "TREE_ENTRY",
         },
-        "{\\"id\\":\\"https://github.com/sourcecred/example-git-submodule.git@29ef158bc982733e2ba429fcf73e2f7562244188\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"type\\":\\"SUBMODULE_COMMIT\\"}": Object {
-          "payload": Object {
-            "hash": "29ef158bc982733e2ba429fcf73e2f7562244188",
-            "url": "https://github.com/sourcecred/example-git-submodule.git",
-          },
+        "payload": Object {
+          "name": "TODOS.txt",
         },
-        "{\\"id\\":\\"https://github.com/sourcecred/example-git-submodule.git@762c062fbdc7ec198cd693e95d55b374a08ff3e3\\",\\"pluginName\\":\\"sourcecred/git-beta\\",\\"type\\":\\"SUBMODULE_COMMIT\\"}": Object {
-          "payload": Object {
-            "hash": "762c062fbdc7ec198cd693e95d55b374a08ff3e3",
-            "url": "https://github.com/sourcecred/example-git-submodule.git",
-          },
+      },
+      Object {
+        "address": Object {
+          "id": "819fc546cea489476ce8dc90785e9ba7753d0a8f:pygravitydefier",
+          "pluginName": "sourcecred/git-beta",
+          "type": "TREE_ENTRY",
+        },
+        "payload": Object {
+          "name": "pygravitydefier",
+        },
+      },
+      Object {
+        "address": Object {
+          "id": "819fc546cea489476ce8dc90785e9ba7753d0a8f:science.txt",
+          "pluginName": "sourcecred/git-beta",
+          "type": "TREE_ENTRY",
+        },
+        "payload": Object {
+          "name": "science.txt",
+        },
+      },
+      Object {
+        "address": Object {
+          "id": "819fc546cea489476ce8dc90785e9ba7753d0a8f:src",
+          "pluginName": "sourcecred/git-beta",
+          "type": "TREE_ENTRY",
+        },
+        "payload": Object {
+          "name": "src",
+        },
+      },
+      Object {
+        "address": Object {
+          "id": "887ad856bbc1373da146106c86cb581ad78cdafe",
+          "pluginName": "sourcecred/git-beta",
+          "type": "BLOB",
+        },
+        "payload": Object {},
+      },
+      Object {
+        "address": Object {
+          "id": "8c6cac301e763aa6d36466e0a775eb804be2c311",
+          "pluginName": "sourcecred/git-beta",
+          "type": "BLOB",
+        },
+        "payload": Object {},
+      },
+      Object {
+        "address": Object {
+          "id": "8d287c3bfbf8455ef30187bf5153ffc1b6eef268",
+          "pluginName": "sourcecred/git-beta",
+          "type": "COMMIT",
+        },
+        "payload": Object {},
+      },
+      Object {
+        "address": Object {
+          "id": "aea4f28abb23abde151b0ead4063227f8bf6c0b0",
+          "pluginName": "sourcecred/git-beta",
+          "type": "BLOB",
+        },
+        "payload": Object {},
+      },
+      Object {
+        "address": Object {
+          "id": "bbf3b8b3d26a4f884b5c022d46851f593d329192",
+          "pluginName": "sourcecred/git-beta",
+          "type": "TREE",
+        },
+        "payload": Object {},
+      },
+      Object {
+        "address": Object {
+          "id": "bbf3b8b3d26a4f884b5c022d46851f593d329192:.gitmodules",
+          "pluginName": "sourcecred/git-beta",
+          "type": "TREE_ENTRY",
+        },
+        "payload": Object {
+          "name": ".gitmodules",
+        },
+      },
+      Object {
+        "address": Object {
+          "id": "bbf3b8b3d26a4f884b5c022d46851f593d329192:README.txt",
+          "pluginName": "sourcecred/git-beta",
+          "type": "TREE_ENTRY",
+        },
+        "payload": Object {
+          "name": "README.txt",
+        },
+      },
+      Object {
+        "address": Object {
+          "id": "bbf3b8b3d26a4f884b5c022d46851f593d329192:TODOS.txt",
+          "pluginName": "sourcecred/git-beta",
+          "type": "TREE_ENTRY",
+        },
+        "payload": Object {
+          "name": "TODOS.txt",
+        },
+      },
+      Object {
+        "address": Object {
+          "id": "bbf3b8b3d26a4f884b5c022d46851f593d329192:pygravitydefier",
+          "pluginName": "sourcecred/git-beta",
+          "type": "TREE_ENTRY",
+        },
+        "payload": Object {
+          "name": "pygravitydefier",
+        },
+      },
+      Object {
+        "address": Object {
+          "id": "bbf3b8b3d26a4f884b5c022d46851f593d329192:science.txt",
+          "pluginName": "sourcecred/git-beta",
+          "type": "TREE_ENTRY",
+        },
+        "payload": Object {
+          "name": "science.txt",
+        },
+      },
+      Object {
+        "address": Object {
+          "id": "bbf3b8b3d26a4f884b5c022d46851f593d329192:src",
+          "pluginName": "sourcecred/git-beta",
+          "type": "TREE_ENTRY",
+        },
+        "payload": Object {
+          "name": "src",
+        },
+      },
+      Object {
+        "address": Object {
+          "id": "bdff5d94193170015d6cbb549b7b630649428b1f",
+          "pluginName": "sourcecred/git-beta",
+          "type": "TREE",
+        },
+        "payload": Object {},
+      },
+      Object {
+        "address": Object {
+          "id": "bdff5d94193170015d6cbb549b7b630649428b1f:README.txt",
+          "pluginName": "sourcecred/git-beta",
+          "type": "TREE_ENTRY",
+        },
+        "payload": Object {
+          "name": "README.txt",
+        },
+      },
+      Object {
+        "address": Object {
+          "id": "c08ee3a4edea384d5291ffcbf06724a13ed72325",
+          "pluginName": "sourcecred/git-beta",
+          "type": "COMMIT",
+        },
+        "payload": Object {},
+      },
+      Object {
+        "address": Object {
+          "id": "c2b51945e7457546912a8ce158ed9d294558d294",
+          "pluginName": "sourcecred/git-beta",
+          "type": "COMMIT",
+        },
+        "payload": Object {},
+      },
+      Object {
+        "address": Object {
+          "id": "d160cca97611e9dfed642522ad44408d0292e8ea",
+          "pluginName": "sourcecred/git-beta",
+          "type": "COMMIT",
+        },
+        "payload": Object {},
+      },
+      Object {
+        "address": Object {
+          "id": "ddec7477206c30c31b81482e56b877a0b3c2638b",
+          "pluginName": "sourcecred/git-beta",
+          "type": "BLOB",
+        },
+        "payload": Object {},
+      },
+      Object {
+        "address": Object {
+          "id": "e8b7a8f19701cd5a25e4a097d513ead60e5f8bcc",
+          "pluginName": "sourcecred/git-beta",
+          "type": "COMMIT",
+        },
+        "payload": Object {},
+      },
+      Object {
+        "address": Object {
+          "id": "f1f2514ca6d7a6a1a0511957021b1995bf9ace1c",
+          "pluginName": "sourcecred/git-beta",
+          "type": "BLOB",
+        },
+        "payload": Object {},
+      },
+      Object {
+        "address": Object {
+          "id": "https://github.com/sourcecred/example-git-submodule.git@29ef158bc982733e2ba429fcf73e2f7562244188",
+          "pluginName": "sourcecred/git-beta",
+          "type": "SUBMODULE_COMMIT",
+        },
+        "payload": Object {
+          "hash": "29ef158bc982733e2ba429fcf73e2f7562244188",
+          "url": "https://github.com/sourcecred/example-git-submodule.git",
+        },
+      },
+      Object {
+        "address": Object {
+          "id": "https://github.com/sourcecred/example-git-submodule.git@762c062fbdc7ec198cd693e95d55b374a08ff3e3",
+          "pluginName": "sourcecred/git-beta",
+          "type": "SUBMODULE_COMMIT",
+        },
+        "payload": Object {
+          "hash": "762c062fbdc7ec198cd693e95d55b374a08ff3e3",
+          "url": "https://github.com/sourcecred/example-git-submodule.git",
         },
       },
     ],

--- a/src/plugins/github/__snapshots__/parser.test.js.snap
+++ b/src/plugins/github/__snapshots__/parser.test.js.snap
@@ -4,7 +4,7 @@ exports[`GithubParser issue parsing parses a simple issue (https://github.com/so
 Array [
   Object {
     "type": "sourcecred/sourcecred/Graph",
-    "version": "0.1.0",
+    "version": "0.2.0",
   },
   Object {
     "edges": Array [
@@ -14,60 +14,53 @@ Array [
       },
       Object {
         "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/decentralion\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"AUTHOR\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/issues/1\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"ISSUE\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"AUTHORS\\"}": Object {
-          "dst": Object {
-            "id": "https://github.com/decentralion",
-            "pluginName": "sourcecred/github-beta",
-            "type": "AUTHOR",
-          },
+          "dstIndex": 0,
           "payload": Object {},
-          "src": Object {
-            "id": "https://github.com/sourcecred/example-github/issues/1",
-            "pluginName": "sourcecred/github-beta",
-            "type": "ISSUE",
-          },
+          "srcIndex": 2,
         },
         "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"REPOSITORY\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/issues/1\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"ISSUE\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"CONTAINS\\"}": Object {
-          "dst": Object {
-            "id": "https://github.com/sourcecred/example-github/issues/1",
-            "pluginName": "sourcecred/github-beta",
-            "type": "ISSUE",
-          },
+          "dstIndex": 2,
           "payload": Object {},
-          "src": Object {
-            "id": "https://github.com/sourcecred/example-github",
-            "pluginName": "sourcecred/github-beta",
-            "type": "REPOSITORY",
-          },
+          "srcIndex": 1,
         },
       },
     ],
     "nodes": Array [
       Object {
-        "type": "sourcecred/sourcecred/AddressMap",
-        "version": "0.1.0",
+        "address": Object {
+          "id": "https://github.com/decentralion",
+          "pluginName": "sourcecred/github-beta",
+          "type": "AUTHOR",
+        },
+        "payload": Object {
+          "login": "decentralion",
+          "subtype": "USER",
+          "url": "https://github.com/decentralion",
+        },
       },
       Object {
-        "{\\"id\\":\\"https://github.com/decentralion\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"AUTHOR\\"}": Object {
-          "payload": Object {
-            "login": "decentralion",
-            "subtype": "USER",
-            "url": "https://github.com/decentralion",
-          },
+        "address": Object {
+          "id": "https://github.com/sourcecred/example-github",
+          "pluginName": "sourcecred/github-beta",
+          "type": "REPOSITORY",
         },
-        "{\\"id\\":\\"https://github.com/sourcecred/example-github\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"REPOSITORY\\"}": Object {
-          "payload": Object {
-            "name": "example-github",
-            "owner": "sourcecred",
-            "url": "https://github.com/sourcecred/example-github",
-          },
+        "payload": Object {
+          "name": "example-github",
+          "owner": "sourcecred",
+          "url": "https://github.com/sourcecred/example-github",
         },
-        "{\\"id\\":\\"https://github.com/sourcecred/example-github/issues/1\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"ISSUE\\"}": Object {
-          "payload": Object {
-            "body": "This is just an example issue.",
-            "number": 1,
-            "title": "An example issue.",
-            "url": "https://github.com/sourcecred/example-github/issues/1",
-          },
+      },
+      Object {
+        "address": Object {
+          "id": "https://github.com/sourcecred/example-github/issues/1",
+          "pluginName": "sourcecred/github-beta",
+          "type": "ISSUE",
+        },
+        "payload": Object {
+          "body": "This is just an example issue.",
+          "number": 1,
+          "title": "An example issue.",
+          "url": "https://github.com/sourcecred/example-github/issues/1",
         },
       },
     ],
@@ -79,7 +72,7 @@ exports[`GithubParser issue parsing parses an issue with comments (https://githu
 Array [
   Object {
     "type": "sourcecred/sourcecred/Graph",
-    "version": "0.1.0",
+    "version": "0.2.0",
   },
   Object {
     "edges": Array [
@@ -89,156 +82,116 @@ Array [
       },
       Object {
         "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/decentralion\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"AUTHOR\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/issues/6#issuecomment-373768442\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"COMMENT\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"AUTHORS\\"}": Object {
-          "dst": Object {
-            "id": "https://github.com/decentralion",
-            "pluginName": "sourcecred/github-beta",
-            "type": "AUTHOR",
-          },
+          "dstIndex": 0,
           "payload": Object {},
-          "src": Object {
-            "id": "https://github.com/sourcecred/example-github/issues/6#issuecomment-373768442",
-            "pluginName": "sourcecred/github-beta",
-            "type": "COMMENT",
-          },
+          "srcIndex": 3,
         },
         "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/decentralion\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"AUTHOR\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/issues/6#issuecomment-373768538\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"COMMENT\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"AUTHORS\\"}": Object {
-          "dst": Object {
-            "id": "https://github.com/decentralion",
-            "pluginName": "sourcecred/github-beta",
-            "type": "AUTHOR",
-          },
+          "dstIndex": 0,
           "payload": Object {},
-          "src": Object {
-            "id": "https://github.com/sourcecred/example-github/issues/6#issuecomment-373768538",
-            "pluginName": "sourcecred/github-beta",
-            "type": "COMMENT",
-          },
+          "srcIndex": 4,
         },
         "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/decentralion\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"AUTHOR\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/issues/6#issuecomment-385223316\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"COMMENT\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"AUTHORS\\"}": Object {
-          "dst": Object {
-            "id": "https://github.com/decentralion",
-            "pluginName": "sourcecred/github-beta",
-            "type": "AUTHOR",
-          },
+          "dstIndex": 0,
           "payload": Object {},
-          "src": Object {
-            "id": "https://github.com/sourcecred/example-github/issues/6#issuecomment-385223316",
-            "pluginName": "sourcecred/github-beta",
-            "type": "COMMENT",
-          },
+          "srcIndex": 5,
         },
         "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/decentralion\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"AUTHOR\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/issues/6\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"ISSUE\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"AUTHORS\\"}": Object {
-          "dst": Object {
-            "id": "https://github.com/decentralion",
-            "pluginName": "sourcecred/github-beta",
-            "type": "AUTHOR",
-          },
+          "dstIndex": 0,
           "payload": Object {},
-          "src": Object {
-            "id": "https://github.com/sourcecred/example-github/issues/6",
-            "pluginName": "sourcecred/github-beta",
-            "type": "ISSUE",
-          },
+          "srcIndex": 2,
         },
         "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/issues/6\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"ISSUE\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/issues/6#issuecomment-373768442\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"COMMENT\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"CONTAINS\\"}": Object {
-          "dst": Object {
-            "id": "https://github.com/sourcecred/example-github/issues/6#issuecomment-373768442",
-            "pluginName": "sourcecred/github-beta",
-            "type": "COMMENT",
-          },
+          "dstIndex": 3,
           "payload": Object {},
-          "src": Object {
-            "id": "https://github.com/sourcecred/example-github/issues/6",
-            "pluginName": "sourcecred/github-beta",
-            "type": "ISSUE",
-          },
+          "srcIndex": 2,
         },
         "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/issues/6\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"ISSUE\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/issues/6#issuecomment-373768538\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"COMMENT\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"CONTAINS\\"}": Object {
-          "dst": Object {
-            "id": "https://github.com/sourcecred/example-github/issues/6#issuecomment-373768538",
-            "pluginName": "sourcecred/github-beta",
-            "type": "COMMENT",
-          },
+          "dstIndex": 4,
           "payload": Object {},
-          "src": Object {
-            "id": "https://github.com/sourcecred/example-github/issues/6",
-            "pluginName": "sourcecred/github-beta",
-            "type": "ISSUE",
-          },
+          "srcIndex": 2,
         },
         "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/issues/6\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"ISSUE\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/issues/6#issuecomment-385223316\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"COMMENT\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"CONTAINS\\"}": Object {
-          "dst": Object {
-            "id": "https://github.com/sourcecred/example-github/issues/6#issuecomment-385223316",
-            "pluginName": "sourcecred/github-beta",
-            "type": "COMMENT",
-          },
+          "dstIndex": 5,
           "payload": Object {},
-          "src": Object {
-            "id": "https://github.com/sourcecred/example-github/issues/6",
-            "pluginName": "sourcecred/github-beta",
-            "type": "ISSUE",
-          },
+          "srcIndex": 2,
         },
         "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"REPOSITORY\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/issues/6\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"ISSUE\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"CONTAINS\\"}": Object {
-          "dst": Object {
-            "id": "https://github.com/sourcecred/example-github/issues/6",
-            "pluginName": "sourcecred/github-beta",
-            "type": "ISSUE",
-          },
+          "dstIndex": 2,
           "payload": Object {},
-          "src": Object {
-            "id": "https://github.com/sourcecred/example-github",
-            "pluginName": "sourcecred/github-beta",
-            "type": "REPOSITORY",
-          },
+          "srcIndex": 1,
         },
       },
     ],
     "nodes": Array [
       Object {
-        "type": "sourcecred/sourcecred/AddressMap",
-        "version": "0.1.0",
+        "address": Object {
+          "id": "https://github.com/decentralion",
+          "pluginName": "sourcecred/github-beta",
+          "type": "AUTHOR",
+        },
+        "payload": Object {
+          "login": "decentralion",
+          "subtype": "USER",
+          "url": "https://github.com/decentralion",
+        },
       },
       Object {
-        "{\\"id\\":\\"https://github.com/decentralion\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"AUTHOR\\"}": Object {
-          "payload": Object {
-            "login": "decentralion",
-            "subtype": "USER",
-            "url": "https://github.com/decentralion",
-          },
+        "address": Object {
+          "id": "https://github.com/sourcecred/example-github",
+          "pluginName": "sourcecred/github-beta",
+          "type": "REPOSITORY",
         },
-        "{\\"id\\":\\"https://github.com/sourcecred/example-github\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"REPOSITORY\\"}": Object {
-          "payload": Object {
-            "name": "example-github",
-            "owner": "sourcecred",
-            "url": "https://github.com/sourcecred/example-github",
-          },
+        "payload": Object {
+          "name": "example-github",
+          "owner": "sourcecred",
+          "url": "https://github.com/sourcecred/example-github",
         },
-        "{\\"id\\":\\"https://github.com/sourcecred/example-github/issues/6\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"ISSUE\\"}": Object {
-          "payload": Object {
-            "body": "This issue shall shortly have a few comments.",
-            "number": 6,
-            "title": "An issue with comments",
-            "url": "https://github.com/sourcecred/example-github/issues/6",
-          },
+      },
+      Object {
+        "address": Object {
+          "id": "https://github.com/sourcecred/example-github/issues/6",
+          "pluginName": "sourcecred/github-beta",
+          "type": "ISSUE",
         },
-        "{\\"id\\":\\"https://github.com/sourcecred/example-github/issues/6#issuecomment-373768442\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"COMMENT\\"}": Object {
-          "payload": Object {
-            "body": "A wild COMMENT appeared!",
-            "url": "https://github.com/sourcecred/example-github/issues/6#issuecomment-373768442",
-          },
+        "payload": Object {
+          "body": "This issue shall shortly have a few comments.",
+          "number": 6,
+          "title": "An issue with comments",
+          "url": "https://github.com/sourcecred/example-github/issues/6",
         },
-        "{\\"id\\":\\"https://github.com/sourcecred/example-github/issues/6#issuecomment-373768538\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"COMMENT\\"}": Object {
-          "payload": Object {
-            "body": "And the maintainer said, \\"Let there be comments!\\"",
-            "url": "https://github.com/sourcecred/example-github/issues/6#issuecomment-373768538",
-          },
+      },
+      Object {
+        "address": Object {
+          "id": "https://github.com/sourcecred/example-github/issues/6#issuecomment-373768442",
+          "pluginName": "sourcecred/github-beta",
+          "type": "COMMENT",
         },
-        "{\\"id\\":\\"https://github.com/sourcecred/example-github/issues/6#issuecomment-385223316\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"COMMENT\\"}": Object {
-          "payload": Object {
-            "body": "This comment references an #2, which itself references an issue. This comment is thus allows us to test that in-references are not included when requesting a Post's references.",
-            "url": "https://github.com/sourcecred/example-github/issues/6#issuecomment-385223316",
-          },
+        "payload": Object {
+          "body": "A wild COMMENT appeared!",
+          "url": "https://github.com/sourcecred/example-github/issues/6#issuecomment-373768442",
+        },
+      },
+      Object {
+        "address": Object {
+          "id": "https://github.com/sourcecred/example-github/issues/6#issuecomment-373768538",
+          "pluginName": "sourcecred/github-beta",
+          "type": "COMMENT",
+        },
+        "payload": Object {
+          "body": "And the maintainer said, \\"Let there be comments!\\"",
+          "url": "https://github.com/sourcecred/example-github/issues/6#issuecomment-373768538",
+        },
+      },
+      Object {
+        "address": Object {
+          "id": "https://github.com/sourcecred/example-github/issues/6#issuecomment-385223316",
+          "pluginName": "sourcecred/github-beta",
+          "type": "COMMENT",
+        },
+        "payload": Object {
+          "body": "This comment references an #2, which itself references an issue. This comment is thus allows us to test that in-references are not included when requesting a Post's references.",
+          "url": "https://github.com/sourcecred/example-github/issues/6#issuecomment-385223316",
         },
       },
     ],
@@ -250,7 +203,7 @@ exports[`GithubParser pull request parsing parses a pr with review comments (htt
 Array [
   Object {
     "type": "sourcecred/sourcecred/Graph",
-    "version": "0.1.0",
+    "version": "0.2.0",
   },
   Object {
     "edges": Array [
@@ -260,197 +213,153 @@ Array [
       },
       Object {
         "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/decentralion\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"AUTHOR\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/pull/5\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"PULL_REQUEST\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"AUTHORS\\"}": Object {
-          "dst": Object {
-            "id": "https://github.com/decentralion",
-            "pluginName": "sourcecred/github-beta",
-            "type": "AUTHOR",
-          },
+          "dstIndex": 1,
           "payload": Object {},
-          "src": Object {
-            "id": "https://github.com/sourcecred/example-github/pull/5",
-            "pluginName": "sourcecred/github-beta",
-            "type": "PULL_REQUEST",
-          },
+          "srcIndex": 3,
         },
         "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/pull/5#pullrequestreview-100313899\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"PULL_REQUEST_REVIEW\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/pull/5#discussion_r171460198\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"PULL_REQUEST_REVIEW_COMMENT\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"CONTAINS\\"}": Object {
-          "dst": Object {
-            "id": "https://github.com/sourcecred/example-github/pull/5#discussion_r171460198",
-            "pluginName": "sourcecred/github-beta",
-            "type": "PULL_REQUEST_REVIEW_COMMENT",
-          },
+          "dstIndex": 4,
           "payload": Object {},
-          "src": Object {
-            "id": "https://github.com/sourcecred/example-github/pull/5#pullrequestreview-100313899",
-            "pluginName": "sourcecred/github-beta",
-            "type": "PULL_REQUEST_REVIEW",
-          },
+          "srcIndex": 5,
         },
         "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/pull/5\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"PULL_REQUEST\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"6d5b3aa31ebb68a06ceb46bbd6cf49b6ccd6f5e6\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/git-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"COMMIT\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"MERGED_AS\\"}": Object {
-          "dst": Object {
-            "id": "6d5b3aa31ebb68a06ceb46bbd6cf49b6ccd6f5e6",
-            "pluginName": "sourcecred/git-beta",
-            "type": "COMMIT",
-          },
+          "dstIndex": 0,
           "payload": Object {
             "hash": "6d5b3aa31ebb68a06ceb46bbd6cf49b6ccd6f5e6",
           },
-          "src": Object {
-            "id": "https://github.com/sourcecred/example-github/pull/5",
-            "pluginName": "sourcecred/github-beta",
-            "type": "PULL_REQUEST",
-          },
+          "srcIndex": 3,
         },
         "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/pull/5\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"PULL_REQUEST\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/pull/5#pullrequestreview-100313899\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"PULL_REQUEST_REVIEW\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"CONTAINS\\"}": Object {
-          "dst": Object {
-            "id": "https://github.com/sourcecred/example-github/pull/5#pullrequestreview-100313899",
-            "pluginName": "sourcecred/github-beta",
-            "type": "PULL_REQUEST_REVIEW",
-          },
+          "dstIndex": 5,
           "payload": Object {},
-          "src": Object {
-            "id": "https://github.com/sourcecred/example-github/pull/5",
-            "pluginName": "sourcecred/github-beta",
-            "type": "PULL_REQUEST",
-          },
+          "srcIndex": 3,
         },
         "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/pull/5\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"PULL_REQUEST\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/pull/5#pullrequestreview-100314038\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"PULL_REQUEST_REVIEW\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"CONTAINS\\"}": Object {
-          "dst": Object {
-            "id": "https://github.com/sourcecred/example-github/pull/5#pullrequestreview-100314038",
-            "pluginName": "sourcecred/github-beta",
-            "type": "PULL_REQUEST_REVIEW",
-          },
+          "dstIndex": 6,
           "payload": Object {},
-          "src": Object {
-            "id": "https://github.com/sourcecred/example-github/pull/5",
-            "pluginName": "sourcecred/github-beta",
-            "type": "PULL_REQUEST",
-          },
+          "srcIndex": 3,
         },
         "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/pull/5\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"PULL_REQUEST\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/wchargin\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"AUTHOR\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"REFERENCES\\"}": Object {
-          "dst": Object {
-            "id": "https://github.com/wchargin",
-            "pluginName": "sourcecred/github-beta",
-            "type": "AUTHOR",
-          },
+          "dstIndex": 7,
           "payload": Object {},
-          "src": Object {
-            "id": "https://github.com/sourcecred/example-github/pull/5",
-            "pluginName": "sourcecred/github-beta",
-            "type": "PULL_REQUEST",
-          },
+          "srcIndex": 3,
         },
         "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"REPOSITORY\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/pull/5\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"PULL_REQUEST\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"CONTAINS\\"}": Object {
-          "dst": Object {
-            "id": "https://github.com/sourcecred/example-github/pull/5",
-            "pluginName": "sourcecred/github-beta",
-            "type": "PULL_REQUEST",
-          },
+          "dstIndex": 3,
           "payload": Object {},
-          "src": Object {
-            "id": "https://github.com/sourcecred/example-github",
-            "pluginName": "sourcecred/github-beta",
-            "type": "REPOSITORY",
-          },
+          "srcIndex": 2,
         },
         "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/wchargin\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"AUTHOR\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/pull/5#discussion_r171460198\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"PULL_REQUEST_REVIEW_COMMENT\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"AUTHORS\\"}": Object {
-          "dst": Object {
-            "id": "https://github.com/wchargin",
-            "pluginName": "sourcecred/github-beta",
-            "type": "AUTHOR",
-          },
+          "dstIndex": 7,
           "payload": Object {},
-          "src": Object {
-            "id": "https://github.com/sourcecred/example-github/pull/5#discussion_r171460198",
-            "pluginName": "sourcecred/github-beta",
-            "type": "PULL_REQUEST_REVIEW_COMMENT",
-          },
+          "srcIndex": 4,
         },
         "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/wchargin\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"AUTHOR\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/pull/5#pullrequestreview-100313899\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"PULL_REQUEST_REVIEW\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"AUTHORS\\"}": Object {
-          "dst": Object {
-            "id": "https://github.com/wchargin",
-            "pluginName": "sourcecred/github-beta",
-            "type": "AUTHOR",
-          },
+          "dstIndex": 7,
           "payload": Object {},
-          "src": Object {
-            "id": "https://github.com/sourcecred/example-github/pull/5#pullrequestreview-100313899",
-            "pluginName": "sourcecred/github-beta",
-            "type": "PULL_REQUEST_REVIEW",
-          },
+          "srcIndex": 5,
         },
         "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/wchargin\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"AUTHOR\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/pull/5#pullrequestreview-100314038\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"PULL_REQUEST_REVIEW\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"AUTHORS\\"}": Object {
-          "dst": Object {
-            "id": "https://github.com/wchargin",
-            "pluginName": "sourcecred/github-beta",
-            "type": "AUTHOR",
-          },
+          "dstIndex": 7,
           "payload": Object {},
-          "src": Object {
-            "id": "https://github.com/sourcecred/example-github/pull/5#pullrequestreview-100314038",
-            "pluginName": "sourcecred/github-beta",
-            "type": "PULL_REQUEST_REVIEW",
-          },
+          "srcIndex": 6,
         },
       },
     ],
     "nodes": Array [
       Object {
-        "type": "sourcecred/sourcecred/AddressMap",
-        "version": "0.1.0",
+        "address": Object {
+          "id": "6d5b3aa31ebb68a06ceb46bbd6cf49b6ccd6f5e6",
+          "pluginName": "sourcecred/git-beta",
+          "type": "COMMIT",
+        },
       },
       Object {
-        "{\\"id\\":\\"https://github.com/decentralion\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"AUTHOR\\"}": Object {
-          "payload": Object {
-            "login": "decentralion",
-            "subtype": "USER",
-            "url": "https://github.com/decentralion",
-          },
+        "address": Object {
+          "id": "https://github.com/decentralion",
+          "pluginName": "sourcecred/github-beta",
+          "type": "AUTHOR",
         },
-        "{\\"id\\":\\"https://github.com/sourcecred/example-github\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"REPOSITORY\\"}": Object {
-          "payload": Object {
-            "name": "example-github",
-            "owner": "sourcecred",
-            "url": "https://github.com/sourcecred/example-github",
-          },
+        "payload": Object {
+          "login": "decentralion",
+          "subtype": "USER",
+          "url": "https://github.com/decentralion",
         },
-        "{\\"id\\":\\"https://github.com/sourcecred/example-github/pull/5\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"PULL_REQUEST\\"}": Object {
-          "payload": Object {
-            "body": "@wchargin could you please do the following:
+      },
+      Object {
+        "address": Object {
+          "id": "https://github.com/sourcecred/example-github",
+          "pluginName": "sourcecred/github-beta",
+          "type": "REPOSITORY",
+        },
+        "payload": Object {
+          "name": "example-github",
+          "owner": "sourcecred",
+          "url": "https://github.com/sourcecred/example-github",
+        },
+      },
+      Object {
+        "address": Object {
+          "id": "https://github.com/sourcecred/example-github/pull/5",
+          "pluginName": "sourcecred/github-beta",
+          "type": "PULL_REQUEST",
+        },
+        "payload": Object {
+          "body": "@wchargin could you please do the following:
 - add a commit comment
 - add a review comment requesting some trivial change
 - i'll change it
 - then approve the pr",
-            "number": 5,
-            "title": "This pull request will be more contentious. I can feel it...",
-            "url": "https://github.com/sourcecred/example-github/pull/5",
-          },
+          "number": 5,
+          "title": "This pull request will be more contentious. I can feel it...",
+          "url": "https://github.com/sourcecred/example-github/pull/5",
         },
-        "{\\"id\\":\\"https://github.com/sourcecred/example-github/pull/5#discussion_r171460198\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"PULL_REQUEST_REVIEW_COMMENT\\"}": Object {
-          "payload": Object {
-            "body": "seems a bit capricious",
-            "url": "https://github.com/sourcecred/example-github/pull/5#discussion_r171460198",
-          },
+      },
+      Object {
+        "address": Object {
+          "id": "https://github.com/sourcecred/example-github/pull/5#discussion_r171460198",
+          "pluginName": "sourcecred/github-beta",
+          "type": "PULL_REQUEST_REVIEW_COMMENT",
         },
-        "{\\"id\\":\\"https://github.com/sourcecred/example-github/pull/5#pullrequestreview-100313899\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"PULL_REQUEST_REVIEW\\"}": Object {
-          "payload": Object {
-            "body": "hmmm.jpg",
-            "state": "CHANGES_REQUESTED",
-            "url": "https://github.com/sourcecred/example-github/pull/5#pullrequestreview-100313899",
-          },
+        "payload": Object {
+          "body": "seems a bit capricious",
+          "url": "https://github.com/sourcecred/example-github/pull/5#discussion_r171460198",
         },
-        "{\\"id\\":\\"https://github.com/sourcecred/example-github/pull/5#pullrequestreview-100314038\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"PULL_REQUEST_REVIEW\\"}": Object {
-          "payload": Object {
-            "body": "I'm sold",
-            "state": "APPROVED",
-            "url": "https://github.com/sourcecred/example-github/pull/5#pullrequestreview-100314038",
-          },
+      },
+      Object {
+        "address": Object {
+          "id": "https://github.com/sourcecred/example-github/pull/5#pullrequestreview-100313899",
+          "pluginName": "sourcecred/github-beta",
+          "type": "PULL_REQUEST_REVIEW",
         },
-        "{\\"id\\":\\"https://github.com/wchargin\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"AUTHOR\\"}": Object {
-          "payload": Object {
-            "login": "wchargin",
-            "subtype": "USER",
-            "url": "https://github.com/wchargin",
-          },
+        "payload": Object {
+          "body": "hmmm.jpg",
+          "state": "CHANGES_REQUESTED",
+          "url": "https://github.com/sourcecred/example-github/pull/5#pullrequestreview-100313899",
+        },
+      },
+      Object {
+        "address": Object {
+          "id": "https://github.com/sourcecred/example-github/pull/5#pullrequestreview-100314038",
+          "pluginName": "sourcecred/github-beta",
+          "type": "PULL_REQUEST_REVIEW",
+        },
+        "payload": Object {
+          "body": "I'm sold",
+          "state": "APPROVED",
+          "url": "https://github.com/sourcecred/example-github/pull/5#pullrequestreview-100314038",
+        },
+      },
+      Object {
+        "address": Object {
+          "id": "https://github.com/wchargin",
+          "pluginName": "sourcecred/github-beta",
+          "type": "AUTHOR",
+        },
+        "payload": Object {
+          "login": "wchargin",
+          "subtype": "USER",
+          "url": "https://github.com/wchargin",
         },
       },
     ],
@@ -462,7 +371,7 @@ exports[`GithubParser pull request parsing parses a simple pull request (https:/
 Array [
   Object {
     "type": "sourcecred/sourcecred/Graph",
-    "version": "0.1.0",
+    "version": "0.2.0",
   },
   Object {
     "edges": Array [
@@ -472,107 +381,88 @@ Array [
       },
       Object {
         "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/decentralion\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"AUTHOR\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/pull/3#issuecomment-369162222\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"COMMENT\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"AUTHORS\\"}": Object {
-          "dst": Object {
-            "id": "https://github.com/decentralion",
-            "pluginName": "sourcecred/github-beta",
-            "type": "AUTHOR",
-          },
+          "dstIndex": 1,
           "payload": Object {},
-          "src": Object {
-            "id": "https://github.com/sourcecred/example-github/pull/3#issuecomment-369162222",
-            "pluginName": "sourcecred/github-beta",
-            "type": "COMMENT",
-          },
+          "srcIndex": 4,
         },
         "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/decentralion\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"AUTHOR\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/pull/3\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"PULL_REQUEST\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"AUTHORS\\"}": Object {
-          "dst": Object {
-            "id": "https://github.com/decentralion",
-            "pluginName": "sourcecred/github-beta",
-            "type": "AUTHOR",
-          },
+          "dstIndex": 1,
           "payload": Object {},
-          "src": Object {
-            "id": "https://github.com/sourcecred/example-github/pull/3",
-            "pluginName": "sourcecred/github-beta",
-            "type": "PULL_REQUEST",
-          },
+          "srcIndex": 3,
         },
         "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/pull/3\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"PULL_REQUEST\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"0a223346b4e6dec0127b1e6aa892c4ee0424b66a\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/git-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"COMMIT\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"MERGED_AS\\"}": Object {
-          "dst": Object {
-            "id": "0a223346b4e6dec0127b1e6aa892c4ee0424b66a",
-            "pluginName": "sourcecred/git-beta",
-            "type": "COMMIT",
-          },
+          "dstIndex": 0,
           "payload": Object {
             "hash": "0a223346b4e6dec0127b1e6aa892c4ee0424b66a",
           },
-          "src": Object {
-            "id": "https://github.com/sourcecred/example-github/pull/3",
-            "pluginName": "sourcecred/github-beta",
-            "type": "PULL_REQUEST",
-          },
+          "srcIndex": 3,
         },
         "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/pull/3\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"PULL_REQUEST\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/pull/3#issuecomment-369162222\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"COMMENT\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"CONTAINS\\"}": Object {
-          "dst": Object {
-            "id": "https://github.com/sourcecred/example-github/pull/3#issuecomment-369162222",
-            "pluginName": "sourcecred/github-beta",
-            "type": "COMMENT",
-          },
+          "dstIndex": 4,
           "payload": Object {},
-          "src": Object {
-            "id": "https://github.com/sourcecred/example-github/pull/3",
-            "pluginName": "sourcecred/github-beta",
-            "type": "PULL_REQUEST",
-          },
+          "srcIndex": 3,
         },
         "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"REPOSITORY\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/pull/3\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"PULL_REQUEST\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"CONTAINS\\"}": Object {
-          "dst": Object {
-            "id": "https://github.com/sourcecred/example-github/pull/3",
-            "pluginName": "sourcecred/github-beta",
-            "type": "PULL_REQUEST",
-          },
+          "dstIndex": 3,
           "payload": Object {},
-          "src": Object {
-            "id": "https://github.com/sourcecred/example-github",
-            "pluginName": "sourcecred/github-beta",
-            "type": "REPOSITORY",
-          },
+          "srcIndex": 2,
         },
       },
     ],
     "nodes": Array [
       Object {
-        "type": "sourcecred/sourcecred/AddressMap",
-        "version": "0.1.0",
+        "address": Object {
+          "id": "0a223346b4e6dec0127b1e6aa892c4ee0424b66a",
+          "pluginName": "sourcecred/git-beta",
+          "type": "COMMIT",
+        },
       },
       Object {
-        "{\\"id\\":\\"https://github.com/decentralion\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"AUTHOR\\"}": Object {
-          "payload": Object {
-            "login": "decentralion",
-            "subtype": "USER",
-            "url": "https://github.com/decentralion",
-          },
+        "address": Object {
+          "id": "https://github.com/decentralion",
+          "pluginName": "sourcecred/github-beta",
+          "type": "AUTHOR",
         },
-        "{\\"id\\":\\"https://github.com/sourcecred/example-github\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"REPOSITORY\\"}": Object {
-          "payload": Object {
-            "name": "example-github",
-            "owner": "sourcecred",
-            "url": "https://github.com/sourcecred/example-github",
-          },
+        "payload": Object {
+          "login": "decentralion",
+          "subtype": "USER",
+          "url": "https://github.com/decentralion",
         },
-        "{\\"id\\":\\"https://github.com/sourcecred/example-github/pull/3\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"PULL_REQUEST\\"}": Object {
-          "payload": Object {
-            "body": "Oh look, it's a pull request.",
-            "number": 3,
-            "title": "Add README, merge via PR.",
-            "url": "https://github.com/sourcecred/example-github/pull/3",
-          },
+      },
+      Object {
+        "address": Object {
+          "id": "https://github.com/sourcecred/example-github",
+          "pluginName": "sourcecred/github-beta",
+          "type": "REPOSITORY",
         },
-        "{\\"id\\":\\"https://github.com/sourcecred/example-github/pull/3#issuecomment-369162222\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"COMMENT\\"}": Object {
-          "payload": Object {
-            "body": "It seems apropos to reference something from a pull request comment... eg: #2 ",
-            "url": "https://github.com/sourcecred/example-github/pull/3#issuecomment-369162222",
-          },
+        "payload": Object {
+          "name": "example-github",
+          "owner": "sourcecred",
+          "url": "https://github.com/sourcecred/example-github",
+        },
+      },
+      Object {
+        "address": Object {
+          "id": "https://github.com/sourcecred/example-github/pull/3",
+          "pluginName": "sourcecred/github-beta",
+          "type": "PULL_REQUEST",
+        },
+        "payload": Object {
+          "body": "Oh look, it's a pull request.",
+          "number": 3,
+          "title": "Add README, merge via PR.",
+          "url": "https://github.com/sourcecred/example-github/pull/3",
+        },
+      },
+      Object {
+        "address": Object {
+          "id": "https://github.com/sourcecred/example-github/pull/3#issuecomment-369162222",
+          "pluginName": "sourcecred/github-beta",
+          "type": "COMMENT",
+        },
+        "payload": Object {
+          "body": "It seems apropos to reference something from a pull request comment... eg: #2 ",
+          "url": "https://github.com/sourcecred/example-github/pull/3#issuecomment-369162222",
         },
       },
     ],
@@ -584,7 +474,7 @@ exports[`GithubParser reference detection discovers a simple reference 1`] = `
 Array [
   Object {
     "type": "sourcecred/sourcecred/Graph",
-    "version": "0.1.0",
+    "version": "0.2.0",
   },
   Object {
     "edges": Array [
@@ -594,525 +484,303 @@ Array [
       },
       Object {
         "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/decentralion\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"AUTHOR\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/issues/1\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"ISSUE\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"AUTHORS\\"}": Object {
-          "dst": Object {
-            "id": "https://github.com/decentralion",
-            "pluginName": "sourcecred/github-beta",
-            "type": "AUTHOR",
-          },
+          "dstIndex": 0,
           "payload": Object {},
-          "src": Object {
-            "id": "https://github.com/sourcecred/example-github/issues/1",
-            "pluginName": "sourcecred/github-beta",
-            "type": "ISSUE",
-          },
+          "srcIndex": 2,
         },
         "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/decentralion\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"AUTHOR\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/issues/2#issuecomment-373768703\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"COMMENT\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"AUTHORS\\"}": Object {
-          "dst": Object {
-            "id": "https://github.com/decentralion",
-            "pluginName": "sourcecred/github-beta",
-            "type": "AUTHOR",
-          },
+          "dstIndex": 0,
           "payload": Object {},
-          "src": Object {
-            "id": "https://github.com/sourcecred/example-github/issues/2#issuecomment-373768703",
-            "pluginName": "sourcecred/github-beta",
-            "type": "COMMENT",
-          },
+          "srcIndex": 4,
         },
         "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/decentralion\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"AUTHOR\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/issues/2#issuecomment-373768850\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"COMMENT\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"AUTHORS\\"}": Object {
-          "dst": Object {
-            "id": "https://github.com/decentralion",
-            "pluginName": "sourcecred/github-beta",
-            "type": "AUTHOR",
-          },
+          "dstIndex": 0,
           "payload": Object {},
-          "src": Object {
-            "id": "https://github.com/sourcecred/example-github/issues/2#issuecomment-373768850",
-            "pluginName": "sourcecred/github-beta",
-            "type": "COMMENT",
-          },
+          "srcIndex": 5,
         },
         "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/decentralion\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"AUTHOR\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/issues/2#issuecomment-385576185\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"COMMENT\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"AUTHORS\\"}": Object {
-          "dst": Object {
-            "id": "https://github.com/decentralion",
-            "pluginName": "sourcecred/github-beta",
-            "type": "AUTHOR",
-          },
+          "dstIndex": 0,
           "payload": Object {},
-          "src": Object {
-            "id": "https://github.com/sourcecred/example-github/issues/2#issuecomment-385576185",
-            "pluginName": "sourcecred/github-beta",
-            "type": "COMMENT",
-          },
+          "srcIndex": 6,
         },
         "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/decentralion\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"AUTHOR\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/issues/2#issuecomment-385576220\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"COMMENT\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"AUTHORS\\"}": Object {
-          "dst": Object {
-            "id": "https://github.com/decentralion",
-            "pluginName": "sourcecred/github-beta",
-            "type": "AUTHOR",
-          },
+          "dstIndex": 0,
           "payload": Object {},
-          "src": Object {
-            "id": "https://github.com/sourcecred/example-github/issues/2#issuecomment-385576220",
-            "pluginName": "sourcecred/github-beta",
-            "type": "COMMENT",
-          },
+          "srcIndex": 7,
         },
         "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/decentralion\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"AUTHOR\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/issues/2#issuecomment-385576248\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"COMMENT\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"AUTHORS\\"}": Object {
-          "dst": Object {
-            "id": "https://github.com/decentralion",
-            "pluginName": "sourcecred/github-beta",
-            "type": "AUTHOR",
-          },
+          "dstIndex": 0,
           "payload": Object {},
-          "src": Object {
-            "id": "https://github.com/sourcecred/example-github/issues/2#issuecomment-385576248",
-            "pluginName": "sourcecred/github-beta",
-            "type": "COMMENT",
-          },
+          "srcIndex": 8,
         },
         "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/decentralion\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"AUTHOR\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/issues/2#issuecomment-385576273\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"COMMENT\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"AUTHORS\\"}": Object {
-          "dst": Object {
-            "id": "https://github.com/decentralion",
-            "pluginName": "sourcecred/github-beta",
-            "type": "AUTHOR",
-          },
+          "dstIndex": 0,
           "payload": Object {},
-          "src": Object {
-            "id": "https://github.com/sourcecred/example-github/issues/2#issuecomment-385576273",
-            "pluginName": "sourcecred/github-beta",
-            "type": "COMMENT",
-          },
+          "srcIndex": 9,
         },
         "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/decentralion\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"AUTHOR\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/issues/2#issuecomment-385576920\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"COMMENT\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"AUTHORS\\"}": Object {
-          "dst": Object {
-            "id": "https://github.com/decentralion",
-            "pluginName": "sourcecred/github-beta",
-            "type": "AUTHOR",
-          },
+          "dstIndex": 0,
           "payload": Object {},
-          "src": Object {
-            "id": "https://github.com/sourcecred/example-github/issues/2#issuecomment-385576920",
-            "pluginName": "sourcecred/github-beta",
-            "type": "COMMENT",
-          },
+          "srcIndex": 10,
         },
         "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/decentralion\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"AUTHOR\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/issues/2#issuecomment-385576936\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"COMMENT\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"AUTHORS\\"}": Object {
-          "dst": Object {
-            "id": "https://github.com/decentralion",
-            "pluginName": "sourcecred/github-beta",
-            "type": "AUTHOR",
-          },
+          "dstIndex": 0,
           "payload": Object {},
-          "src": Object {
-            "id": "https://github.com/sourcecred/example-github/issues/2#issuecomment-385576936",
-            "pluginName": "sourcecred/github-beta",
-            "type": "COMMENT",
-          },
+          "srcIndex": 11,
         },
         "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/decentralion\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"AUTHOR\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/issues/2\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"ISSUE\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"AUTHORS\\"}": Object {
-          "dst": Object {
-            "id": "https://github.com/decentralion",
-            "pluginName": "sourcecred/github-beta",
-            "type": "AUTHOR",
-          },
+          "dstIndex": 0,
           "payload": Object {},
-          "src": Object {
-            "id": "https://github.com/sourcecred/example-github/issues/2",
-            "pluginName": "sourcecred/github-beta",
-            "type": "ISSUE",
-          },
+          "srcIndex": 3,
         },
         "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/decentralion\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"AUTHOR\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/issues/6#issuecomment-373768442\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"COMMENT\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"AUTHORS\\"}": Object {
-          "dst": Object {
-            "id": "https://github.com/decentralion",
-            "pluginName": "sourcecred/github-beta",
-            "type": "AUTHOR",
-          },
+          "dstIndex": 0,
           "payload": Object {},
-          "src": Object {
-            "id": "https://github.com/sourcecred/example-github/issues/6#issuecomment-373768442",
-            "pluginName": "sourcecred/github-beta",
-            "type": "COMMENT",
-          },
+          "srcIndex": 13,
         },
         "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/decentralion\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"AUTHOR\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/issues/6#issuecomment-373768538\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"COMMENT\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"AUTHORS\\"}": Object {
-          "dst": Object {
-            "id": "https://github.com/decentralion",
-            "pluginName": "sourcecred/github-beta",
-            "type": "AUTHOR",
-          },
+          "dstIndex": 0,
           "payload": Object {},
-          "src": Object {
-            "id": "https://github.com/sourcecred/example-github/issues/6#issuecomment-373768538",
-            "pluginName": "sourcecred/github-beta",
-            "type": "COMMENT",
-          },
+          "srcIndex": 14,
         },
         "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/decentralion\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"AUTHOR\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/issues/6#issuecomment-385223316\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"COMMENT\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"AUTHORS\\"}": Object {
-          "dst": Object {
-            "id": "https://github.com/decentralion",
-            "pluginName": "sourcecred/github-beta",
-            "type": "AUTHOR",
-          },
+          "dstIndex": 0,
           "payload": Object {},
-          "src": Object {
-            "id": "https://github.com/sourcecred/example-github/issues/6#issuecomment-385223316",
-            "pluginName": "sourcecred/github-beta",
-            "type": "COMMENT",
-          },
+          "srcIndex": 15,
         },
         "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/decentralion\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"AUTHOR\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/issues/6\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"ISSUE\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"AUTHORS\\"}": Object {
-          "dst": Object {
-            "id": "https://github.com/decentralion",
-            "pluginName": "sourcecred/github-beta",
-            "type": "AUTHOR",
-          },
+          "dstIndex": 0,
           "payload": Object {},
-          "src": Object {
-            "id": "https://github.com/sourcecred/example-github/issues/6",
-            "pluginName": "sourcecred/github-beta",
-            "type": "ISSUE",
-          },
+          "srcIndex": 12,
         },
         "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/issues/2#issuecomment-373768703\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"COMMENT\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/issues/6\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"ISSUE\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"REFERENCES\\"}": Object {
-          "dst": Object {
-            "id": "https://github.com/sourcecred/example-github/issues/6",
-            "pluginName": "sourcecred/github-beta",
-            "type": "ISSUE",
-          },
+          "dstIndex": 12,
           "payload": Object {},
-          "src": Object {
-            "id": "https://github.com/sourcecred/example-github/issues/2#issuecomment-373768703",
-            "pluginName": "sourcecred/github-beta",
-            "type": "COMMENT",
-          },
+          "srcIndex": 4,
         },
         "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/issues/2#issuecomment-373768850\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"COMMENT\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/issues/6#issuecomment-373768538\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"COMMENT\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"REFERENCES\\"}": Object {
-          "dst": Object {
-            "id": "https://github.com/sourcecred/example-github/issues/6#issuecomment-373768538",
-            "pluginName": "sourcecred/github-beta",
-            "type": "COMMENT",
-          },
+          "dstIndex": 14,
           "payload": Object {},
-          "src": Object {
-            "id": "https://github.com/sourcecred/example-github/issues/2#issuecomment-373768850",
-            "pluginName": "sourcecred/github-beta",
-            "type": "COMMENT",
-          },
+          "srcIndex": 5,
         },
         "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/issues/2#issuecomment-385576920\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"COMMENT\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/issues/1\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"ISSUE\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"REFERENCES\\"}": Object {
-          "dst": Object {
-            "id": "https://github.com/sourcecred/example-github/issues/1",
-            "pluginName": "sourcecred/github-beta",
-            "type": "ISSUE",
-          },
+          "dstIndex": 2,
           "payload": Object {},
-          "src": Object {
-            "id": "https://github.com/sourcecred/example-github/issues/2#issuecomment-385576920",
-            "pluginName": "sourcecred/github-beta",
-            "type": "COMMENT",
-          },
+          "srcIndex": 10,
         },
         "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/issues/2#issuecomment-385576920\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"COMMENT\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/issues/2\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"ISSUE\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"REFERENCES\\"}": Object {
-          "dst": Object {
-            "id": "https://github.com/sourcecred/example-github/issues/2",
-            "pluginName": "sourcecred/github-beta",
-            "type": "ISSUE",
-          },
+          "dstIndex": 3,
           "payload": Object {},
-          "src": Object {
-            "id": "https://github.com/sourcecred/example-github/issues/2#issuecomment-385576920",
-            "pluginName": "sourcecred/github-beta",
-            "type": "COMMENT",
-          },
+          "srcIndex": 10,
         },
         "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/issues/2\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"ISSUE\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/issues/1\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"ISSUE\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"REFERENCES\\"}": Object {
-          "dst": Object {
-            "id": "https://github.com/sourcecred/example-github/issues/1",
-            "pluginName": "sourcecred/github-beta",
-            "type": "ISSUE",
-          },
+          "dstIndex": 2,
           "payload": Object {},
-          "src": Object {
-            "id": "https://github.com/sourcecred/example-github/issues/2",
-            "pluginName": "sourcecred/github-beta",
-            "type": "ISSUE",
-          },
+          "srcIndex": 3,
         },
         "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/issues/2\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"ISSUE\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/issues/2#issuecomment-373768703\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"COMMENT\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"CONTAINS\\"}": Object {
-          "dst": Object {
-            "id": "https://github.com/sourcecred/example-github/issues/2#issuecomment-373768703",
-            "pluginName": "sourcecred/github-beta",
-            "type": "COMMENT",
-          },
+          "dstIndex": 4,
           "payload": Object {},
-          "src": Object {
-            "id": "https://github.com/sourcecred/example-github/issues/2",
-            "pluginName": "sourcecred/github-beta",
-            "type": "ISSUE",
-          },
+          "srcIndex": 3,
         },
         "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/issues/2\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"ISSUE\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/issues/2#issuecomment-373768850\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"COMMENT\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"CONTAINS\\"}": Object {
-          "dst": Object {
-            "id": "https://github.com/sourcecred/example-github/issues/2#issuecomment-373768850",
-            "pluginName": "sourcecred/github-beta",
-            "type": "COMMENT",
-          },
+          "dstIndex": 5,
           "payload": Object {},
-          "src": Object {
-            "id": "https://github.com/sourcecred/example-github/issues/2",
-            "pluginName": "sourcecred/github-beta",
-            "type": "ISSUE",
-          },
+          "srcIndex": 3,
         },
         "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/issues/2\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"ISSUE\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/issues/2#issuecomment-385576185\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"COMMENT\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"CONTAINS\\"}": Object {
-          "dst": Object {
-            "id": "https://github.com/sourcecred/example-github/issues/2#issuecomment-385576185",
-            "pluginName": "sourcecred/github-beta",
-            "type": "COMMENT",
-          },
+          "dstIndex": 6,
           "payload": Object {},
-          "src": Object {
-            "id": "https://github.com/sourcecred/example-github/issues/2",
-            "pluginName": "sourcecred/github-beta",
-            "type": "ISSUE",
-          },
+          "srcIndex": 3,
         },
         "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/issues/2\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"ISSUE\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/issues/2#issuecomment-385576220\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"COMMENT\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"CONTAINS\\"}": Object {
-          "dst": Object {
-            "id": "https://github.com/sourcecred/example-github/issues/2#issuecomment-385576220",
-            "pluginName": "sourcecred/github-beta",
-            "type": "COMMENT",
-          },
+          "dstIndex": 7,
           "payload": Object {},
-          "src": Object {
-            "id": "https://github.com/sourcecred/example-github/issues/2",
-            "pluginName": "sourcecred/github-beta",
-            "type": "ISSUE",
-          },
+          "srcIndex": 3,
         },
         "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/issues/2\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"ISSUE\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/issues/2#issuecomment-385576248\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"COMMENT\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"CONTAINS\\"}": Object {
-          "dst": Object {
-            "id": "https://github.com/sourcecred/example-github/issues/2#issuecomment-385576248",
-            "pluginName": "sourcecred/github-beta",
-            "type": "COMMENT",
-          },
+          "dstIndex": 8,
           "payload": Object {},
-          "src": Object {
-            "id": "https://github.com/sourcecred/example-github/issues/2",
-            "pluginName": "sourcecred/github-beta",
-            "type": "ISSUE",
-          },
+          "srcIndex": 3,
         },
         "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/issues/2\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"ISSUE\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/issues/2#issuecomment-385576273\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"COMMENT\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"CONTAINS\\"}": Object {
-          "dst": Object {
-            "id": "https://github.com/sourcecred/example-github/issues/2#issuecomment-385576273",
-            "pluginName": "sourcecred/github-beta",
-            "type": "COMMENT",
-          },
+          "dstIndex": 9,
           "payload": Object {},
-          "src": Object {
-            "id": "https://github.com/sourcecred/example-github/issues/2",
-            "pluginName": "sourcecred/github-beta",
-            "type": "ISSUE",
-          },
+          "srcIndex": 3,
         },
         "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/issues/2\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"ISSUE\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/issues/2#issuecomment-385576920\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"COMMENT\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"CONTAINS\\"}": Object {
-          "dst": Object {
-            "id": "https://github.com/sourcecred/example-github/issues/2#issuecomment-385576920",
-            "pluginName": "sourcecred/github-beta",
-            "type": "COMMENT",
-          },
+          "dstIndex": 10,
           "payload": Object {},
-          "src": Object {
-            "id": "https://github.com/sourcecred/example-github/issues/2",
-            "pluginName": "sourcecred/github-beta",
-            "type": "ISSUE",
-          },
+          "srcIndex": 3,
         },
         "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/issues/2\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"ISSUE\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/issues/2#issuecomment-385576936\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"COMMENT\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"CONTAINS\\"}": Object {
-          "dst": Object {
-            "id": "https://github.com/sourcecred/example-github/issues/2#issuecomment-385576936",
-            "pluginName": "sourcecred/github-beta",
-            "type": "COMMENT",
-          },
+          "dstIndex": 11,
           "payload": Object {},
-          "src": Object {
-            "id": "https://github.com/sourcecred/example-github/issues/2",
-            "pluginName": "sourcecred/github-beta",
-            "type": "ISSUE",
-          },
+          "srcIndex": 3,
         },
         "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/issues/6#issuecomment-385223316\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"COMMENT\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/issues/2\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"ISSUE\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"REFERENCES\\"}": Object {
-          "dst": Object {
-            "id": "https://github.com/sourcecred/example-github/issues/2",
-            "pluginName": "sourcecred/github-beta",
-            "type": "ISSUE",
-          },
+          "dstIndex": 3,
           "payload": Object {},
-          "src": Object {
-            "id": "https://github.com/sourcecred/example-github/issues/6#issuecomment-385223316",
-            "pluginName": "sourcecred/github-beta",
-            "type": "COMMENT",
-          },
+          "srcIndex": 15,
         },
         "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/issues/6\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"ISSUE\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/issues/6#issuecomment-373768442\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"COMMENT\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"CONTAINS\\"}": Object {
-          "dst": Object {
-            "id": "https://github.com/sourcecred/example-github/issues/6#issuecomment-373768442",
-            "pluginName": "sourcecred/github-beta",
-            "type": "COMMENT",
-          },
+          "dstIndex": 13,
           "payload": Object {},
-          "src": Object {
-            "id": "https://github.com/sourcecred/example-github/issues/6",
-            "pluginName": "sourcecred/github-beta",
-            "type": "ISSUE",
-          },
+          "srcIndex": 12,
         },
         "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/issues/6\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"ISSUE\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/issues/6#issuecomment-373768538\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"COMMENT\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"CONTAINS\\"}": Object {
-          "dst": Object {
-            "id": "https://github.com/sourcecred/example-github/issues/6#issuecomment-373768538",
-            "pluginName": "sourcecred/github-beta",
-            "type": "COMMENT",
-          },
+          "dstIndex": 14,
           "payload": Object {},
-          "src": Object {
-            "id": "https://github.com/sourcecred/example-github/issues/6",
-            "pluginName": "sourcecred/github-beta",
-            "type": "ISSUE",
-          },
+          "srcIndex": 12,
         },
         "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/issues/6\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"ISSUE\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/issues/6#issuecomment-385223316\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"COMMENT\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"CONTAINS\\"}": Object {
-          "dst": Object {
-            "id": "https://github.com/sourcecred/example-github/issues/6#issuecomment-385223316",
-            "pluginName": "sourcecred/github-beta",
-            "type": "COMMENT",
-          },
+          "dstIndex": 15,
           "payload": Object {},
-          "src": Object {
-            "id": "https://github.com/sourcecred/example-github/issues/6",
-            "pluginName": "sourcecred/github-beta",
-            "type": "ISSUE",
-          },
+          "srcIndex": 12,
         },
         "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"REPOSITORY\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/issues/1\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"ISSUE\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"CONTAINS\\"}": Object {
-          "dst": Object {
-            "id": "https://github.com/sourcecred/example-github/issues/1",
-            "pluginName": "sourcecred/github-beta",
-            "type": "ISSUE",
-          },
+          "dstIndex": 2,
           "payload": Object {},
-          "src": Object {
-            "id": "https://github.com/sourcecred/example-github",
-            "pluginName": "sourcecred/github-beta",
-            "type": "REPOSITORY",
-          },
+          "srcIndex": 1,
         },
         "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"REPOSITORY\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/issues/2\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"ISSUE\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"CONTAINS\\"}": Object {
-          "dst": Object {
-            "id": "https://github.com/sourcecred/example-github/issues/2",
-            "pluginName": "sourcecred/github-beta",
-            "type": "ISSUE",
-          },
+          "dstIndex": 3,
           "payload": Object {},
-          "src": Object {
-            "id": "https://github.com/sourcecred/example-github",
-            "pluginName": "sourcecred/github-beta",
-            "type": "REPOSITORY",
-          },
+          "srcIndex": 1,
         },
         "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"REPOSITORY\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/issues/6\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"ISSUE\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"CONTAINS\\"}": Object {
-          "dst": Object {
-            "id": "https://github.com/sourcecred/example-github/issues/6",
-            "pluginName": "sourcecred/github-beta",
-            "type": "ISSUE",
-          },
+          "dstIndex": 12,
           "payload": Object {},
-          "src": Object {
-            "id": "https://github.com/sourcecred/example-github",
-            "pluginName": "sourcecred/github-beta",
-            "type": "REPOSITORY",
-          },
+          "srcIndex": 1,
         },
       },
     ],
     "nodes": Array [
       Object {
-        "type": "sourcecred/sourcecred/AddressMap",
-        "version": "0.1.0",
+        "address": Object {
+          "id": "https://github.com/decentralion",
+          "pluginName": "sourcecred/github-beta",
+          "type": "AUTHOR",
+        },
+        "payload": Object {
+          "login": "decentralion",
+          "subtype": "USER",
+          "url": "https://github.com/decentralion",
+        },
       },
       Object {
-        "{\\"id\\":\\"https://github.com/decentralion\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"AUTHOR\\"}": Object {
-          "payload": Object {
-            "login": "decentralion",
-            "subtype": "USER",
-            "url": "https://github.com/decentralion",
-          },
+        "address": Object {
+          "id": "https://github.com/sourcecred/example-github",
+          "pluginName": "sourcecred/github-beta",
+          "type": "REPOSITORY",
         },
-        "{\\"id\\":\\"https://github.com/sourcecred/example-github\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"REPOSITORY\\"}": Object {
-          "payload": Object {
-            "name": "example-github",
-            "owner": "sourcecred",
-            "url": "https://github.com/sourcecred/example-github",
-          },
+        "payload": Object {
+          "name": "example-github",
+          "owner": "sourcecred",
+          "url": "https://github.com/sourcecred/example-github",
         },
-        "{\\"id\\":\\"https://github.com/sourcecred/example-github/issues/1\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"ISSUE\\"}": Object {
-          "payload": Object {
-            "body": "This is just an example issue.",
-            "number": 1,
-            "title": "An example issue.",
-            "url": "https://github.com/sourcecred/example-github/issues/1",
-          },
+      },
+      Object {
+        "address": Object {
+          "id": "https://github.com/sourcecred/example-github/issues/1",
+          "pluginName": "sourcecred/github-beta",
+          "type": "ISSUE",
         },
-        "{\\"id\\":\\"https://github.com/sourcecred/example-github/issues/2\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"ISSUE\\"}": Object {
-          "payload": Object {
-            "body": "This issue references another issue, namely #1",
-            "number": 2,
-            "title": "A referencing issue.",
-            "url": "https://github.com/sourcecred/example-github/issues/2",
-          },
+        "payload": Object {
+          "body": "This is just an example issue.",
+          "number": 1,
+          "title": "An example issue.",
+          "url": "https://github.com/sourcecred/example-github/issues/1",
         },
-        "{\\"id\\":\\"https://github.com/sourcecred/example-github/issues/2#issuecomment-373768703\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"COMMENT\\"}": Object {
-          "payload": Object {
-            "body": "It should also be possible to reference by exact url: https://github.com/sourcecred/example-github/issues/6",
-            "url": "https://github.com/sourcecred/example-github/issues/2#issuecomment-373768703",
-          },
+      },
+      Object {
+        "address": Object {
+          "id": "https://github.com/sourcecred/example-github/issues/2",
+          "pluginName": "sourcecred/github-beta",
+          "type": "ISSUE",
         },
-        "{\\"id\\":\\"https://github.com/sourcecred/example-github/issues/2#issuecomment-373768850\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"COMMENT\\"}": Object {
-          "payload": Object {
-            "body": "We might also reference individual comments directly.
+        "payload": Object {
+          "body": "This issue references another issue, namely #1",
+          "number": 2,
+          "title": "A referencing issue.",
+          "url": "https://github.com/sourcecred/example-github/issues/2",
+        },
+      },
+      Object {
+        "address": Object {
+          "id": "https://github.com/sourcecred/example-github/issues/2#issuecomment-373768703",
+          "pluginName": "sourcecred/github-beta",
+          "type": "COMMENT",
+        },
+        "payload": Object {
+          "body": "It should also be possible to reference by exact url: https://github.com/sourcecred/example-github/issues/6",
+          "url": "https://github.com/sourcecred/example-github/issues/2#issuecomment-373768703",
+        },
+      },
+      Object {
+        "address": Object {
+          "id": "https://github.com/sourcecred/example-github/issues/2#issuecomment-373768850",
+          "pluginName": "sourcecred/github-beta",
+          "type": "COMMENT",
+        },
+        "payload": Object {
+          "body": "We might also reference individual comments directly.
 https://github.com/sourcecred/example-github/issues/6#issuecomment-373768538",
-            "url": "https://github.com/sourcecred/example-github/issues/2#issuecomment-373768850",
-          },
+          "url": "https://github.com/sourcecred/example-github/issues/2#issuecomment-373768850",
         },
-        "{\\"id\\":\\"https://github.com/sourcecred/example-github/issues/2#issuecomment-385576185\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"COMMENT\\"}": Object {
-          "payload": Object {
-            "body": "Here's a PR by direct url: https://github.com/sourcecred/example-github/pull/5",
-            "url": "https://github.com/sourcecred/example-github/issues/2#issuecomment-385576185",
-          },
+      },
+      Object {
+        "address": Object {
+          "id": "https://github.com/sourcecred/example-github/issues/2#issuecomment-385576185",
+          "pluginName": "sourcecred/github-beta",
+          "type": "COMMENT",
         },
-        "{\\"id\\":\\"https://github.com/sourcecred/example-github/issues/2#issuecomment-385576220\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"COMMENT\\"}": Object {
-          "payload": Object {
-            "body": "a PR review by url: https://github.com/sourcecred/example-github/pull/5#pullrequestreview-100313899",
-            "url": "https://github.com/sourcecred/example-github/issues/2#issuecomment-385576220",
-          },
+        "payload": Object {
+          "body": "Here's a PR by direct url: https://github.com/sourcecred/example-github/pull/5",
+          "url": "https://github.com/sourcecred/example-github/issues/2#issuecomment-385576185",
         },
-        "{\\"id\\":\\"https://github.com/sourcecred/example-github/issues/2#issuecomment-385576248\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"COMMENT\\"}": Object {
-          "payload": Object {
-            "body": "a PR Review Comment by url: https://github.com/sourcecred/example-github/pull/5#discussion_r171460198",
-            "url": "https://github.com/sourcecred/example-github/issues/2#issuecomment-385576248",
-          },
+      },
+      Object {
+        "address": Object {
+          "id": "https://github.com/sourcecred/example-github/issues/2#issuecomment-385576220",
+          "pluginName": "sourcecred/github-beta",
+          "type": "COMMENT",
         },
-        "{\\"id\\":\\"https://github.com/sourcecred/example-github/issues/2#issuecomment-385576273\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"COMMENT\\"}": Object {
-          "payload": Object {
-            "body": "a user by url: https://github.com/wchargin",
-            "url": "https://github.com/sourcecred/example-github/issues/2#issuecomment-385576273",
-          },
+        "payload": Object {
+          "body": "a PR review by url: https://github.com/sourcecred/example-github/pull/5#pullrequestreview-100313899",
+          "url": "https://github.com/sourcecred/example-github/issues/2#issuecomment-385576220",
         },
-        "{\\"id\\":\\"https://github.com/sourcecred/example-github/issues/2#issuecomment-385576920\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"COMMENT\\"}": Object {
-          "payload": Object {
-            "body": "Here are several references:
+      },
+      Object {
+        "address": Object {
+          "id": "https://github.com/sourcecred/example-github/issues/2#issuecomment-385576248",
+          "pluginName": "sourcecred/github-beta",
+          "type": "COMMENT",
+        },
+        "payload": Object {
+          "body": "a PR Review Comment by url: https://github.com/sourcecred/example-github/pull/5#discussion_r171460198",
+          "url": "https://github.com/sourcecred/example-github/issues/2#issuecomment-385576248",
+        },
+      },
+      Object {
+        "address": Object {
+          "id": "https://github.com/sourcecred/example-github/issues/2#issuecomment-385576273",
+          "pluginName": "sourcecred/github-beta",
+          "type": "COMMENT",
+        },
+        "payload": Object {
+          "body": "a user by url: https://github.com/wchargin",
+          "url": "https://github.com/sourcecred/example-github/issues/2#issuecomment-385576273",
+        },
+      },
+      Object {
+        "address": Object {
+          "id": "https://github.com/sourcecred/example-github/issues/2#issuecomment-385576920",
+          "pluginName": "sourcecred/github-beta",
+          "type": "COMMENT",
+        },
+        "payload": Object {
+          "body": "Here are several references:
 #1 
 #2
 #3 
@@ -1120,40 +788,64 @@ https://github.com/sourcecred/example-github/issues/6#issuecomment-373768538",
 https://github.com/sourcecred/example-github/pull/5#discussion_r171460198
 https://github.com/sourcecred/example-github/pull/5#pullrequestreview-100313899
 ",
-            "url": "https://github.com/sourcecred/example-github/issues/2#issuecomment-385576920",
-          },
+          "url": "https://github.com/sourcecred/example-github/issues/2#issuecomment-385576920",
         },
-        "{\\"id\\":\\"https://github.com/sourcecred/example-github/issues/2#issuecomment-385576936\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"COMMENT\\"}": Object {
-          "payload": Object {
-            "body": "This comment has no references.",
-            "url": "https://github.com/sourcecred/example-github/issues/2#issuecomment-385576936",
-          },
+      },
+      Object {
+        "address": Object {
+          "id": "https://github.com/sourcecred/example-github/issues/2#issuecomment-385576936",
+          "pluginName": "sourcecred/github-beta",
+          "type": "COMMENT",
         },
-        "{\\"id\\":\\"https://github.com/sourcecred/example-github/issues/6\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"ISSUE\\"}": Object {
-          "payload": Object {
-            "body": "This issue shall shortly have a few comments.",
-            "number": 6,
-            "title": "An issue with comments",
-            "url": "https://github.com/sourcecred/example-github/issues/6",
-          },
+        "payload": Object {
+          "body": "This comment has no references.",
+          "url": "https://github.com/sourcecred/example-github/issues/2#issuecomment-385576936",
         },
-        "{\\"id\\":\\"https://github.com/sourcecred/example-github/issues/6#issuecomment-373768442\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"COMMENT\\"}": Object {
-          "payload": Object {
-            "body": "A wild COMMENT appeared!",
-            "url": "https://github.com/sourcecred/example-github/issues/6#issuecomment-373768442",
-          },
+      },
+      Object {
+        "address": Object {
+          "id": "https://github.com/sourcecred/example-github/issues/6",
+          "pluginName": "sourcecred/github-beta",
+          "type": "ISSUE",
         },
-        "{\\"id\\":\\"https://github.com/sourcecred/example-github/issues/6#issuecomment-373768538\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"COMMENT\\"}": Object {
-          "payload": Object {
-            "body": "And the maintainer said, \\"Let there be comments!\\"",
-            "url": "https://github.com/sourcecred/example-github/issues/6#issuecomment-373768538",
-          },
+        "payload": Object {
+          "body": "This issue shall shortly have a few comments.",
+          "number": 6,
+          "title": "An issue with comments",
+          "url": "https://github.com/sourcecred/example-github/issues/6",
         },
-        "{\\"id\\":\\"https://github.com/sourcecred/example-github/issues/6#issuecomment-385223316\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"COMMENT\\"}": Object {
-          "payload": Object {
-            "body": "This comment references an #2, which itself references an issue. This comment is thus allows us to test that in-references are not included when requesting a Post's references.",
-            "url": "https://github.com/sourcecred/example-github/issues/6#issuecomment-385223316",
-          },
+      },
+      Object {
+        "address": Object {
+          "id": "https://github.com/sourcecred/example-github/issues/6#issuecomment-373768442",
+          "pluginName": "sourcecred/github-beta",
+          "type": "COMMENT",
+        },
+        "payload": Object {
+          "body": "A wild COMMENT appeared!",
+          "url": "https://github.com/sourcecred/example-github/issues/6#issuecomment-373768442",
+        },
+      },
+      Object {
+        "address": Object {
+          "id": "https://github.com/sourcecred/example-github/issues/6#issuecomment-373768538",
+          "pluginName": "sourcecred/github-beta",
+          "type": "COMMENT",
+        },
+        "payload": Object {
+          "body": "And the maintainer said, \\"Let there be comments!\\"",
+          "url": "https://github.com/sourcecred/example-github/issues/6#issuecomment-373768538",
+        },
+      },
+      Object {
+        "address": Object {
+          "id": "https://github.com/sourcecred/example-github/issues/6#issuecomment-385223316",
+          "pluginName": "sourcecred/github-beta",
+          "type": "COMMENT",
+        },
+        "payload": Object {
+          "body": "This comment references an #2, which itself references an issue. This comment is thus allows us to test that in-references are not included when requesting a Post's references.",
+          "url": "https://github.com/sourcecred/example-github/issues/6#issuecomment-385223316",
         },
       },
     ],
@@ -1165,7 +857,7 @@ exports[`GithubParser reference detection handles dangling references gracefully
 Array [
   Object {
     "type": "sourcecred/sourcecred/Graph",
-    "version": "0.1.0",
+    "version": "0.2.0",
   },
   Object {
     "edges": Array [
@@ -1175,322 +867,215 @@ Array [
       },
       Object {
         "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/decentralion\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"AUTHOR\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/issues/2#issuecomment-373768703\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"COMMENT\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"AUTHORS\\"}": Object {
-          "dst": Object {
-            "id": "https://github.com/decentralion",
-            "pluginName": "sourcecred/github-beta",
-            "type": "AUTHOR",
-          },
+          "dstIndex": 0,
           "payload": Object {},
-          "src": Object {
-            "id": "https://github.com/sourcecred/example-github/issues/2#issuecomment-373768703",
-            "pluginName": "sourcecred/github-beta",
-            "type": "COMMENT",
-          },
+          "srcIndex": 3,
         },
         "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/decentralion\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"AUTHOR\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/issues/2#issuecomment-373768850\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"COMMENT\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"AUTHORS\\"}": Object {
-          "dst": Object {
-            "id": "https://github.com/decentralion",
-            "pluginName": "sourcecred/github-beta",
-            "type": "AUTHOR",
-          },
+          "dstIndex": 0,
           "payload": Object {},
-          "src": Object {
-            "id": "https://github.com/sourcecred/example-github/issues/2#issuecomment-373768850",
-            "pluginName": "sourcecred/github-beta",
-            "type": "COMMENT",
-          },
+          "srcIndex": 4,
         },
         "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/decentralion\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"AUTHOR\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/issues/2#issuecomment-385576185\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"COMMENT\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"AUTHORS\\"}": Object {
-          "dst": Object {
-            "id": "https://github.com/decentralion",
-            "pluginName": "sourcecred/github-beta",
-            "type": "AUTHOR",
-          },
+          "dstIndex": 0,
           "payload": Object {},
-          "src": Object {
-            "id": "https://github.com/sourcecred/example-github/issues/2#issuecomment-385576185",
-            "pluginName": "sourcecred/github-beta",
-            "type": "COMMENT",
-          },
+          "srcIndex": 5,
         },
         "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/decentralion\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"AUTHOR\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/issues/2#issuecomment-385576220\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"COMMENT\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"AUTHORS\\"}": Object {
-          "dst": Object {
-            "id": "https://github.com/decentralion",
-            "pluginName": "sourcecred/github-beta",
-            "type": "AUTHOR",
-          },
+          "dstIndex": 0,
           "payload": Object {},
-          "src": Object {
-            "id": "https://github.com/sourcecred/example-github/issues/2#issuecomment-385576220",
-            "pluginName": "sourcecred/github-beta",
-            "type": "COMMENT",
-          },
+          "srcIndex": 6,
         },
         "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/decentralion\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"AUTHOR\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/issues/2#issuecomment-385576248\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"COMMENT\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"AUTHORS\\"}": Object {
-          "dst": Object {
-            "id": "https://github.com/decentralion",
-            "pluginName": "sourcecred/github-beta",
-            "type": "AUTHOR",
-          },
+          "dstIndex": 0,
           "payload": Object {},
-          "src": Object {
-            "id": "https://github.com/sourcecred/example-github/issues/2#issuecomment-385576248",
-            "pluginName": "sourcecred/github-beta",
-            "type": "COMMENT",
-          },
+          "srcIndex": 7,
         },
         "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/decentralion\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"AUTHOR\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/issues/2#issuecomment-385576273\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"COMMENT\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"AUTHORS\\"}": Object {
-          "dst": Object {
-            "id": "https://github.com/decentralion",
-            "pluginName": "sourcecred/github-beta",
-            "type": "AUTHOR",
-          },
+          "dstIndex": 0,
           "payload": Object {},
-          "src": Object {
-            "id": "https://github.com/sourcecred/example-github/issues/2#issuecomment-385576273",
-            "pluginName": "sourcecred/github-beta",
-            "type": "COMMENT",
-          },
+          "srcIndex": 8,
         },
         "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/decentralion\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"AUTHOR\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/issues/2#issuecomment-385576920\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"COMMENT\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"AUTHORS\\"}": Object {
-          "dst": Object {
-            "id": "https://github.com/decentralion",
-            "pluginName": "sourcecred/github-beta",
-            "type": "AUTHOR",
-          },
+          "dstIndex": 0,
           "payload": Object {},
-          "src": Object {
-            "id": "https://github.com/sourcecred/example-github/issues/2#issuecomment-385576920",
-            "pluginName": "sourcecred/github-beta",
-            "type": "COMMENT",
-          },
+          "srcIndex": 9,
         },
         "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/decentralion\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"AUTHOR\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/issues/2#issuecomment-385576936\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"COMMENT\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"AUTHORS\\"}": Object {
-          "dst": Object {
-            "id": "https://github.com/decentralion",
-            "pluginName": "sourcecred/github-beta",
-            "type": "AUTHOR",
-          },
+          "dstIndex": 0,
           "payload": Object {},
-          "src": Object {
-            "id": "https://github.com/sourcecred/example-github/issues/2#issuecomment-385576936",
-            "pluginName": "sourcecred/github-beta",
-            "type": "COMMENT",
-          },
+          "srcIndex": 10,
         },
         "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/decentralion\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"AUTHOR\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/issues/2\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"ISSUE\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"AUTHORS\\"}": Object {
-          "dst": Object {
-            "id": "https://github.com/decentralion",
-            "pluginName": "sourcecred/github-beta",
-            "type": "AUTHOR",
-          },
+          "dstIndex": 0,
           "payload": Object {},
-          "src": Object {
-            "id": "https://github.com/sourcecred/example-github/issues/2",
-            "pluginName": "sourcecred/github-beta",
-            "type": "ISSUE",
-          },
+          "srcIndex": 2,
         },
         "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/issues/2#issuecomment-385576920\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"COMMENT\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/issues/2\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"ISSUE\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"REFERENCES\\"}": Object {
-          "dst": Object {
-            "id": "https://github.com/sourcecred/example-github/issues/2",
-            "pluginName": "sourcecred/github-beta",
-            "type": "ISSUE",
-          },
+          "dstIndex": 2,
           "payload": Object {},
-          "src": Object {
-            "id": "https://github.com/sourcecred/example-github/issues/2#issuecomment-385576920",
-            "pluginName": "sourcecred/github-beta",
-            "type": "COMMENT",
-          },
+          "srcIndex": 9,
         },
         "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/issues/2\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"ISSUE\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/issues/2#issuecomment-373768703\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"COMMENT\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"CONTAINS\\"}": Object {
-          "dst": Object {
-            "id": "https://github.com/sourcecred/example-github/issues/2#issuecomment-373768703",
-            "pluginName": "sourcecred/github-beta",
-            "type": "COMMENT",
-          },
+          "dstIndex": 3,
           "payload": Object {},
-          "src": Object {
-            "id": "https://github.com/sourcecred/example-github/issues/2",
-            "pluginName": "sourcecred/github-beta",
-            "type": "ISSUE",
-          },
+          "srcIndex": 2,
         },
         "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/issues/2\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"ISSUE\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/issues/2#issuecomment-373768850\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"COMMENT\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"CONTAINS\\"}": Object {
-          "dst": Object {
-            "id": "https://github.com/sourcecred/example-github/issues/2#issuecomment-373768850",
-            "pluginName": "sourcecred/github-beta",
-            "type": "COMMENT",
-          },
+          "dstIndex": 4,
           "payload": Object {},
-          "src": Object {
-            "id": "https://github.com/sourcecred/example-github/issues/2",
-            "pluginName": "sourcecred/github-beta",
-            "type": "ISSUE",
-          },
+          "srcIndex": 2,
         },
         "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/issues/2\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"ISSUE\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/issues/2#issuecomment-385576185\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"COMMENT\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"CONTAINS\\"}": Object {
-          "dst": Object {
-            "id": "https://github.com/sourcecred/example-github/issues/2#issuecomment-385576185",
-            "pluginName": "sourcecred/github-beta",
-            "type": "COMMENT",
-          },
+          "dstIndex": 5,
           "payload": Object {},
-          "src": Object {
-            "id": "https://github.com/sourcecred/example-github/issues/2",
-            "pluginName": "sourcecred/github-beta",
-            "type": "ISSUE",
-          },
+          "srcIndex": 2,
         },
         "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/issues/2\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"ISSUE\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/issues/2#issuecomment-385576220\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"COMMENT\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"CONTAINS\\"}": Object {
-          "dst": Object {
-            "id": "https://github.com/sourcecred/example-github/issues/2#issuecomment-385576220",
-            "pluginName": "sourcecred/github-beta",
-            "type": "COMMENT",
-          },
+          "dstIndex": 6,
           "payload": Object {},
-          "src": Object {
-            "id": "https://github.com/sourcecred/example-github/issues/2",
-            "pluginName": "sourcecred/github-beta",
-            "type": "ISSUE",
-          },
+          "srcIndex": 2,
         },
         "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/issues/2\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"ISSUE\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/issues/2#issuecomment-385576248\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"COMMENT\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"CONTAINS\\"}": Object {
-          "dst": Object {
-            "id": "https://github.com/sourcecred/example-github/issues/2#issuecomment-385576248",
-            "pluginName": "sourcecred/github-beta",
-            "type": "COMMENT",
-          },
+          "dstIndex": 7,
           "payload": Object {},
-          "src": Object {
-            "id": "https://github.com/sourcecred/example-github/issues/2",
-            "pluginName": "sourcecred/github-beta",
-            "type": "ISSUE",
-          },
+          "srcIndex": 2,
         },
         "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/issues/2\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"ISSUE\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/issues/2#issuecomment-385576273\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"COMMENT\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"CONTAINS\\"}": Object {
-          "dst": Object {
-            "id": "https://github.com/sourcecred/example-github/issues/2#issuecomment-385576273",
-            "pluginName": "sourcecred/github-beta",
-            "type": "COMMENT",
-          },
+          "dstIndex": 8,
           "payload": Object {},
-          "src": Object {
-            "id": "https://github.com/sourcecred/example-github/issues/2",
-            "pluginName": "sourcecred/github-beta",
-            "type": "ISSUE",
-          },
+          "srcIndex": 2,
         },
         "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/issues/2\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"ISSUE\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/issues/2#issuecomment-385576920\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"COMMENT\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"CONTAINS\\"}": Object {
-          "dst": Object {
-            "id": "https://github.com/sourcecred/example-github/issues/2#issuecomment-385576920",
-            "pluginName": "sourcecred/github-beta",
-            "type": "COMMENT",
-          },
+          "dstIndex": 9,
           "payload": Object {},
-          "src": Object {
-            "id": "https://github.com/sourcecred/example-github/issues/2",
-            "pluginName": "sourcecred/github-beta",
-            "type": "ISSUE",
-          },
+          "srcIndex": 2,
         },
         "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/issues/2\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"ISSUE\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/issues/2#issuecomment-385576936\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"COMMENT\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"CONTAINS\\"}": Object {
-          "dst": Object {
-            "id": "https://github.com/sourcecred/example-github/issues/2#issuecomment-385576936",
-            "pluginName": "sourcecred/github-beta",
-            "type": "COMMENT",
-          },
+          "dstIndex": 10,
           "payload": Object {},
-          "src": Object {
-            "id": "https://github.com/sourcecred/example-github/issues/2",
-            "pluginName": "sourcecred/github-beta",
-            "type": "ISSUE",
-          },
+          "srcIndex": 2,
         },
         "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"REPOSITORY\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/issues/2\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"ISSUE\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"CONTAINS\\"}": Object {
-          "dst": Object {
-            "id": "https://github.com/sourcecred/example-github/issues/2",
-            "pluginName": "sourcecred/github-beta",
-            "type": "ISSUE",
-          },
+          "dstIndex": 2,
           "payload": Object {},
-          "src": Object {
-            "id": "https://github.com/sourcecred/example-github",
-            "pluginName": "sourcecred/github-beta",
-            "type": "REPOSITORY",
-          },
+          "srcIndex": 1,
         },
       },
     ],
     "nodes": Array [
       Object {
-        "type": "sourcecred/sourcecred/AddressMap",
-        "version": "0.1.0",
+        "address": Object {
+          "id": "https://github.com/decentralion",
+          "pluginName": "sourcecred/github-beta",
+          "type": "AUTHOR",
+        },
+        "payload": Object {
+          "login": "decentralion",
+          "subtype": "USER",
+          "url": "https://github.com/decentralion",
+        },
       },
       Object {
-        "{\\"id\\":\\"https://github.com/decentralion\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"AUTHOR\\"}": Object {
-          "payload": Object {
-            "login": "decentralion",
-            "subtype": "USER",
-            "url": "https://github.com/decentralion",
-          },
+        "address": Object {
+          "id": "https://github.com/sourcecred/example-github",
+          "pluginName": "sourcecred/github-beta",
+          "type": "REPOSITORY",
         },
-        "{\\"id\\":\\"https://github.com/sourcecred/example-github\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"REPOSITORY\\"}": Object {
-          "payload": Object {
-            "name": "example-github",
-            "owner": "sourcecred",
-            "url": "https://github.com/sourcecred/example-github",
-          },
+        "payload": Object {
+          "name": "example-github",
+          "owner": "sourcecred",
+          "url": "https://github.com/sourcecred/example-github",
         },
-        "{\\"id\\":\\"https://github.com/sourcecred/example-github/issues/2\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"ISSUE\\"}": Object {
-          "payload": Object {
-            "body": "This issue references another issue, namely #1",
-            "number": 2,
-            "title": "A referencing issue.",
-            "url": "https://github.com/sourcecred/example-github/issues/2",
-          },
+      },
+      Object {
+        "address": Object {
+          "id": "https://github.com/sourcecred/example-github/issues/2",
+          "pluginName": "sourcecred/github-beta",
+          "type": "ISSUE",
         },
-        "{\\"id\\":\\"https://github.com/sourcecred/example-github/issues/2#issuecomment-373768703\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"COMMENT\\"}": Object {
-          "payload": Object {
-            "body": "It should also be possible to reference by exact url: https://github.com/sourcecred/example-github/issues/6",
-            "url": "https://github.com/sourcecred/example-github/issues/2#issuecomment-373768703",
-          },
+        "payload": Object {
+          "body": "This issue references another issue, namely #1",
+          "number": 2,
+          "title": "A referencing issue.",
+          "url": "https://github.com/sourcecred/example-github/issues/2",
         },
-        "{\\"id\\":\\"https://github.com/sourcecred/example-github/issues/2#issuecomment-373768850\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"COMMENT\\"}": Object {
-          "payload": Object {
-            "body": "We might also reference individual comments directly.
+      },
+      Object {
+        "address": Object {
+          "id": "https://github.com/sourcecred/example-github/issues/2#issuecomment-373768703",
+          "pluginName": "sourcecred/github-beta",
+          "type": "COMMENT",
+        },
+        "payload": Object {
+          "body": "It should also be possible to reference by exact url: https://github.com/sourcecred/example-github/issues/6",
+          "url": "https://github.com/sourcecred/example-github/issues/2#issuecomment-373768703",
+        },
+      },
+      Object {
+        "address": Object {
+          "id": "https://github.com/sourcecred/example-github/issues/2#issuecomment-373768850",
+          "pluginName": "sourcecred/github-beta",
+          "type": "COMMENT",
+        },
+        "payload": Object {
+          "body": "We might also reference individual comments directly.
 https://github.com/sourcecred/example-github/issues/6#issuecomment-373768538",
-            "url": "https://github.com/sourcecred/example-github/issues/2#issuecomment-373768850",
-          },
+          "url": "https://github.com/sourcecred/example-github/issues/2#issuecomment-373768850",
         },
-        "{\\"id\\":\\"https://github.com/sourcecred/example-github/issues/2#issuecomment-385576185\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"COMMENT\\"}": Object {
-          "payload": Object {
-            "body": "Here's a PR by direct url: https://github.com/sourcecred/example-github/pull/5",
-            "url": "https://github.com/sourcecred/example-github/issues/2#issuecomment-385576185",
-          },
+      },
+      Object {
+        "address": Object {
+          "id": "https://github.com/sourcecred/example-github/issues/2#issuecomment-385576185",
+          "pluginName": "sourcecred/github-beta",
+          "type": "COMMENT",
         },
-        "{\\"id\\":\\"https://github.com/sourcecred/example-github/issues/2#issuecomment-385576220\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"COMMENT\\"}": Object {
-          "payload": Object {
-            "body": "a PR review by url: https://github.com/sourcecred/example-github/pull/5#pullrequestreview-100313899",
-            "url": "https://github.com/sourcecred/example-github/issues/2#issuecomment-385576220",
-          },
+        "payload": Object {
+          "body": "Here's a PR by direct url: https://github.com/sourcecred/example-github/pull/5",
+          "url": "https://github.com/sourcecred/example-github/issues/2#issuecomment-385576185",
         },
-        "{\\"id\\":\\"https://github.com/sourcecred/example-github/issues/2#issuecomment-385576248\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"COMMENT\\"}": Object {
-          "payload": Object {
-            "body": "a PR Review Comment by url: https://github.com/sourcecred/example-github/pull/5#discussion_r171460198",
-            "url": "https://github.com/sourcecred/example-github/issues/2#issuecomment-385576248",
-          },
+      },
+      Object {
+        "address": Object {
+          "id": "https://github.com/sourcecred/example-github/issues/2#issuecomment-385576220",
+          "pluginName": "sourcecred/github-beta",
+          "type": "COMMENT",
         },
-        "{\\"id\\":\\"https://github.com/sourcecred/example-github/issues/2#issuecomment-385576273\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"COMMENT\\"}": Object {
-          "payload": Object {
-            "body": "a user by url: https://github.com/wchargin",
-            "url": "https://github.com/sourcecred/example-github/issues/2#issuecomment-385576273",
-          },
+        "payload": Object {
+          "body": "a PR review by url: https://github.com/sourcecred/example-github/pull/5#pullrequestreview-100313899",
+          "url": "https://github.com/sourcecred/example-github/issues/2#issuecomment-385576220",
         },
-        "{\\"id\\":\\"https://github.com/sourcecred/example-github/issues/2#issuecomment-385576920\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"COMMENT\\"}": Object {
-          "payload": Object {
-            "body": "Here are several references:
+      },
+      Object {
+        "address": Object {
+          "id": "https://github.com/sourcecred/example-github/issues/2#issuecomment-385576248",
+          "pluginName": "sourcecred/github-beta",
+          "type": "COMMENT",
+        },
+        "payload": Object {
+          "body": "a PR Review Comment by url: https://github.com/sourcecred/example-github/pull/5#discussion_r171460198",
+          "url": "https://github.com/sourcecred/example-github/issues/2#issuecomment-385576248",
+        },
+      },
+      Object {
+        "address": Object {
+          "id": "https://github.com/sourcecred/example-github/issues/2#issuecomment-385576273",
+          "pluginName": "sourcecred/github-beta",
+          "type": "COMMENT",
+        },
+        "payload": Object {
+          "body": "a user by url: https://github.com/wchargin",
+          "url": "https://github.com/sourcecred/example-github/issues/2#issuecomment-385576273",
+        },
+      },
+      Object {
+        "address": Object {
+          "id": "https://github.com/sourcecred/example-github/issues/2#issuecomment-385576920",
+          "pluginName": "sourcecred/github-beta",
+          "type": "COMMENT",
+        },
+        "payload": Object {
+          "body": "Here are several references:
 #1 
 #2
 #3 
@@ -1498,14 +1083,18 @@ https://github.com/sourcecred/example-github/issues/6#issuecomment-373768538",
 https://github.com/sourcecred/example-github/pull/5#discussion_r171460198
 https://github.com/sourcecred/example-github/pull/5#pullrequestreview-100313899
 ",
-            "url": "https://github.com/sourcecred/example-github/issues/2#issuecomment-385576920",
-          },
+          "url": "https://github.com/sourcecred/example-github/issues/2#issuecomment-385576920",
         },
-        "{\\"id\\":\\"https://github.com/sourcecred/example-github/issues/2#issuecomment-385576936\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"COMMENT\\"}": Object {
-          "payload": Object {
-            "body": "This comment has no references.",
-            "url": "https://github.com/sourcecred/example-github/issues/2#issuecomment-385576936",
-          },
+      },
+      Object {
+        "address": Object {
+          "id": "https://github.com/sourcecred/example-github/issues/2#issuecomment-385576936",
+          "pluginName": "sourcecred/github-beta",
+          "type": "COMMENT",
+        },
+        "payload": Object {
+          "body": "This comment has no references.",
+          "url": "https://github.com/sourcecred/example-github/issues/2#issuecomment-385576936",
         },
       },
     ],
@@ -1517,7 +1106,7 @@ exports[`GithubParser whole repo parsing parses the entire example-github as exp
 Array [
   Object {
     "type": "sourcecred/sourcecred/Graph",
-    "version": "0.1.0",
+    "version": "0.2.0",
   },
   Object {
     "edges": Array [
@@ -1527,945 +1116,481 @@ Array [
       },
       Object {
         "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/decentralion\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"AUTHOR\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/issues/1\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"ISSUE\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"AUTHORS\\"}": Object {
-          "dst": Object {
-            "id": "https://github.com/decentralion",
-            "pluginName": "sourcecred/github-beta",
-            "type": "AUTHOR",
-          },
+          "dstIndex": 2,
           "payload": Object {},
-          "src": Object {
-            "id": "https://github.com/sourcecred/example-github/issues/1",
-            "pluginName": "sourcecred/github-beta",
-            "type": "ISSUE",
-          },
+          "srcIndex": 4,
         },
         "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/decentralion\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"AUTHOR\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/issues/2#issuecomment-373768703\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"COMMENT\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"AUTHORS\\"}": Object {
-          "dst": Object {
-            "id": "https://github.com/decentralion",
-            "pluginName": "sourcecred/github-beta",
-            "type": "AUTHOR",
-          },
+          "dstIndex": 2,
           "payload": Object {},
-          "src": Object {
-            "id": "https://github.com/sourcecred/example-github/issues/2#issuecomment-373768703",
-            "pluginName": "sourcecred/github-beta",
-            "type": "COMMENT",
-          },
+          "srcIndex": 6,
         },
         "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/decentralion\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"AUTHOR\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/issues/2#issuecomment-373768850\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"COMMENT\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"AUTHORS\\"}": Object {
-          "dst": Object {
-            "id": "https://github.com/decentralion",
-            "pluginName": "sourcecred/github-beta",
-            "type": "AUTHOR",
-          },
+          "dstIndex": 2,
           "payload": Object {},
-          "src": Object {
-            "id": "https://github.com/sourcecred/example-github/issues/2#issuecomment-373768850",
-            "pluginName": "sourcecred/github-beta",
-            "type": "COMMENT",
-          },
+          "srcIndex": 7,
         },
         "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/decentralion\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"AUTHOR\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/issues/2#issuecomment-385576185\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"COMMENT\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"AUTHORS\\"}": Object {
-          "dst": Object {
-            "id": "https://github.com/decentralion",
-            "pluginName": "sourcecred/github-beta",
-            "type": "AUTHOR",
-          },
+          "dstIndex": 2,
           "payload": Object {},
-          "src": Object {
-            "id": "https://github.com/sourcecred/example-github/issues/2#issuecomment-385576185",
-            "pluginName": "sourcecred/github-beta",
-            "type": "COMMENT",
-          },
+          "srcIndex": 8,
         },
         "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/decentralion\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"AUTHOR\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/issues/2#issuecomment-385576220\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"COMMENT\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"AUTHORS\\"}": Object {
-          "dst": Object {
-            "id": "https://github.com/decentralion",
-            "pluginName": "sourcecred/github-beta",
-            "type": "AUTHOR",
-          },
+          "dstIndex": 2,
           "payload": Object {},
-          "src": Object {
-            "id": "https://github.com/sourcecred/example-github/issues/2#issuecomment-385576220",
-            "pluginName": "sourcecred/github-beta",
-            "type": "COMMENT",
-          },
+          "srcIndex": 9,
         },
         "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/decentralion\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"AUTHOR\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/issues/2#issuecomment-385576248\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"COMMENT\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"AUTHORS\\"}": Object {
-          "dst": Object {
-            "id": "https://github.com/decentralion",
-            "pluginName": "sourcecred/github-beta",
-            "type": "AUTHOR",
-          },
+          "dstIndex": 2,
           "payload": Object {},
-          "src": Object {
-            "id": "https://github.com/sourcecred/example-github/issues/2#issuecomment-385576248",
-            "pluginName": "sourcecred/github-beta",
-            "type": "COMMENT",
-          },
+          "srcIndex": 10,
         },
         "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/decentralion\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"AUTHOR\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/issues/2#issuecomment-385576273\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"COMMENT\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"AUTHORS\\"}": Object {
-          "dst": Object {
-            "id": "https://github.com/decentralion",
-            "pluginName": "sourcecred/github-beta",
-            "type": "AUTHOR",
-          },
+          "dstIndex": 2,
           "payload": Object {},
-          "src": Object {
-            "id": "https://github.com/sourcecred/example-github/issues/2#issuecomment-385576273",
-            "pluginName": "sourcecred/github-beta",
-            "type": "COMMENT",
-          },
+          "srcIndex": 11,
         },
         "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/decentralion\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"AUTHOR\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/issues/2#issuecomment-385576920\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"COMMENT\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"AUTHORS\\"}": Object {
-          "dst": Object {
-            "id": "https://github.com/decentralion",
-            "pluginName": "sourcecred/github-beta",
-            "type": "AUTHOR",
-          },
+          "dstIndex": 2,
           "payload": Object {},
-          "src": Object {
-            "id": "https://github.com/sourcecred/example-github/issues/2#issuecomment-385576920",
-            "pluginName": "sourcecred/github-beta",
-            "type": "COMMENT",
-          },
+          "srcIndex": 12,
         },
         "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/decentralion\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"AUTHOR\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/issues/2#issuecomment-385576936\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"COMMENT\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"AUTHORS\\"}": Object {
-          "dst": Object {
-            "id": "https://github.com/decentralion",
-            "pluginName": "sourcecred/github-beta",
-            "type": "AUTHOR",
-          },
+          "dstIndex": 2,
           "payload": Object {},
-          "src": Object {
-            "id": "https://github.com/sourcecred/example-github/issues/2#issuecomment-385576936",
-            "pluginName": "sourcecred/github-beta",
-            "type": "COMMENT",
-          },
+          "srcIndex": 13,
         },
         "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/decentralion\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"AUTHOR\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/issues/2\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"ISSUE\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"AUTHORS\\"}": Object {
-          "dst": Object {
-            "id": "https://github.com/decentralion",
-            "pluginName": "sourcecred/github-beta",
-            "type": "AUTHOR",
-          },
+          "dstIndex": 2,
           "payload": Object {},
-          "src": Object {
-            "id": "https://github.com/sourcecred/example-github/issues/2",
-            "pluginName": "sourcecred/github-beta",
-            "type": "ISSUE",
-          },
+          "srcIndex": 5,
         },
         "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/decentralion\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"AUTHOR\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/issues/4\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"ISSUE\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"AUTHORS\\"}": Object {
-          "dst": Object {
-            "id": "https://github.com/decentralion",
-            "pluginName": "sourcecred/github-beta",
-            "type": "AUTHOR",
-          },
+          "dstIndex": 2,
           "payload": Object {},
-          "src": Object {
-            "id": "https://github.com/sourcecred/example-github/issues/4",
-            "pluginName": "sourcecred/github-beta",
-            "type": "ISSUE",
-          },
+          "srcIndex": 14,
         },
         "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/decentralion\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"AUTHOR\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/issues/6#issuecomment-373768442\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"COMMENT\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"AUTHORS\\"}": Object {
-          "dst": Object {
-            "id": "https://github.com/decentralion",
-            "pluginName": "sourcecred/github-beta",
-            "type": "AUTHOR",
-          },
+          "dstIndex": 2,
           "payload": Object {},
-          "src": Object {
-            "id": "https://github.com/sourcecred/example-github/issues/6#issuecomment-373768442",
-            "pluginName": "sourcecred/github-beta",
-            "type": "COMMENT",
-          },
+          "srcIndex": 16,
         },
         "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/decentralion\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"AUTHOR\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/issues/6#issuecomment-373768538\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"COMMENT\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"AUTHORS\\"}": Object {
-          "dst": Object {
-            "id": "https://github.com/decentralion",
-            "pluginName": "sourcecred/github-beta",
-            "type": "AUTHOR",
-          },
+          "dstIndex": 2,
           "payload": Object {},
-          "src": Object {
-            "id": "https://github.com/sourcecred/example-github/issues/6#issuecomment-373768538",
-            "pluginName": "sourcecred/github-beta",
-            "type": "COMMENT",
-          },
+          "srcIndex": 17,
         },
         "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/decentralion\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"AUTHOR\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/issues/6#issuecomment-385223316\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"COMMENT\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"AUTHORS\\"}": Object {
-          "dst": Object {
-            "id": "https://github.com/decentralion",
-            "pluginName": "sourcecred/github-beta",
-            "type": "AUTHOR",
-          },
+          "dstIndex": 2,
           "payload": Object {},
-          "src": Object {
-            "id": "https://github.com/sourcecred/example-github/issues/6#issuecomment-385223316",
-            "pluginName": "sourcecred/github-beta",
-            "type": "COMMENT",
-          },
+          "srcIndex": 18,
         },
         "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/decentralion\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"AUTHOR\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/issues/6\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"ISSUE\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"AUTHORS\\"}": Object {
-          "dst": Object {
-            "id": "https://github.com/decentralion",
-            "pluginName": "sourcecred/github-beta",
-            "type": "AUTHOR",
-          },
+          "dstIndex": 2,
           "payload": Object {},
-          "src": Object {
-            "id": "https://github.com/sourcecred/example-github/issues/6",
-            "pluginName": "sourcecred/github-beta",
-            "type": "ISSUE",
-          },
+          "srcIndex": 15,
         },
         "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/decentralion\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"AUTHOR\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/issues/7\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"ISSUE\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"AUTHORS\\"}": Object {
-          "dst": Object {
-            "id": "https://github.com/decentralion",
-            "pluginName": "sourcecred/github-beta",
-            "type": "AUTHOR",
-          },
+          "dstIndex": 2,
           "payload": Object {},
-          "src": Object {
-            "id": "https://github.com/sourcecred/example-github/issues/7",
-            "pluginName": "sourcecred/github-beta",
-            "type": "ISSUE",
-          },
+          "srcIndex": 19,
         },
         "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/decentralion\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"AUTHOR\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/issues/8\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"ISSUE\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"AUTHORS\\"}": Object {
-          "dst": Object {
-            "id": "https://github.com/decentralion",
-            "pluginName": "sourcecred/github-beta",
-            "type": "AUTHOR",
-          },
+          "dstIndex": 2,
           "payload": Object {},
-          "src": Object {
-            "id": "https://github.com/sourcecred/example-github/issues/8",
-            "pluginName": "sourcecred/github-beta",
-            "type": "ISSUE",
-          },
+          "srcIndex": 20,
         },
         "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/decentralion\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"AUTHOR\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/pull/3#issuecomment-369162222\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"COMMENT\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"AUTHORS\\"}": Object {
-          "dst": Object {
-            "id": "https://github.com/decentralion",
-            "pluginName": "sourcecred/github-beta",
-            "type": "AUTHOR",
-          },
+          "dstIndex": 2,
           "payload": Object {},
-          "src": Object {
-            "id": "https://github.com/sourcecred/example-github/pull/3#issuecomment-369162222",
-            "pluginName": "sourcecred/github-beta",
-            "type": "COMMENT",
-          },
+          "srcIndex": 22,
         },
         "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/decentralion\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"AUTHOR\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/pull/3\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"PULL_REQUEST\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"AUTHORS\\"}": Object {
-          "dst": Object {
-            "id": "https://github.com/decentralion",
-            "pluginName": "sourcecred/github-beta",
-            "type": "AUTHOR",
-          },
+          "dstIndex": 2,
           "payload": Object {},
-          "src": Object {
-            "id": "https://github.com/sourcecred/example-github/pull/3",
-            "pluginName": "sourcecred/github-beta",
-            "type": "PULL_REQUEST",
-          },
+          "srcIndex": 21,
         },
         "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/decentralion\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"AUTHOR\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/pull/5\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"PULL_REQUEST\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"AUTHORS\\"}": Object {
-          "dst": Object {
-            "id": "https://github.com/decentralion",
-            "pluginName": "sourcecred/github-beta",
-            "type": "AUTHOR",
-          },
+          "dstIndex": 2,
           "payload": Object {},
-          "src": Object {
-            "id": "https://github.com/sourcecred/example-github/pull/5",
-            "pluginName": "sourcecred/github-beta",
-            "type": "PULL_REQUEST",
-          },
+          "srcIndex": 23,
         },
         "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/decentralion\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"AUTHOR\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/pull/9\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"PULL_REQUEST\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"AUTHORS\\"}": Object {
-          "dst": Object {
-            "id": "https://github.com/decentralion",
-            "pluginName": "sourcecred/github-beta",
-            "type": "AUTHOR",
-          },
+          "dstIndex": 2,
           "payload": Object {},
-          "src": Object {
-            "id": "https://github.com/sourcecred/example-github/pull/9",
-            "pluginName": "sourcecred/github-beta",
-            "type": "PULL_REQUEST",
-          },
+          "srcIndex": 27,
         },
         "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/issues/2#issuecomment-373768703\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"COMMENT\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/issues/6\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"ISSUE\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"REFERENCES\\"}": Object {
-          "dst": Object {
-            "id": "https://github.com/sourcecred/example-github/issues/6",
-            "pluginName": "sourcecred/github-beta",
-            "type": "ISSUE",
-          },
+          "dstIndex": 15,
           "payload": Object {},
-          "src": Object {
-            "id": "https://github.com/sourcecred/example-github/issues/2#issuecomment-373768703",
-            "pluginName": "sourcecred/github-beta",
-            "type": "COMMENT",
-          },
+          "srcIndex": 6,
         },
         "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/issues/2#issuecomment-373768850\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"COMMENT\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/issues/6#issuecomment-373768538\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"COMMENT\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"REFERENCES\\"}": Object {
-          "dst": Object {
-            "id": "https://github.com/sourcecred/example-github/issues/6#issuecomment-373768538",
-            "pluginName": "sourcecred/github-beta",
-            "type": "COMMENT",
-          },
+          "dstIndex": 17,
           "payload": Object {},
-          "src": Object {
-            "id": "https://github.com/sourcecred/example-github/issues/2#issuecomment-373768850",
-            "pluginName": "sourcecred/github-beta",
-            "type": "COMMENT",
-          },
+          "srcIndex": 7,
         },
         "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/issues/2#issuecomment-385576185\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"COMMENT\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/pull/5\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"PULL_REQUEST\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"REFERENCES\\"}": Object {
-          "dst": Object {
-            "id": "https://github.com/sourcecred/example-github/pull/5",
-            "pluginName": "sourcecred/github-beta",
-            "type": "PULL_REQUEST",
-          },
+          "dstIndex": 23,
           "payload": Object {},
-          "src": Object {
-            "id": "https://github.com/sourcecred/example-github/issues/2#issuecomment-385576185",
-            "pluginName": "sourcecred/github-beta",
-            "type": "COMMENT",
-          },
+          "srcIndex": 8,
         },
         "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/issues/2#issuecomment-385576220\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"COMMENT\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/pull/5#pullrequestreview-100313899\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"PULL_REQUEST_REVIEW\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"REFERENCES\\"}": Object {
-          "dst": Object {
-            "id": "https://github.com/sourcecred/example-github/pull/5#pullrequestreview-100313899",
-            "pluginName": "sourcecred/github-beta",
-            "type": "PULL_REQUEST_REVIEW",
-          },
+          "dstIndex": 25,
           "payload": Object {},
-          "src": Object {
-            "id": "https://github.com/sourcecred/example-github/issues/2#issuecomment-385576220",
-            "pluginName": "sourcecred/github-beta",
-            "type": "COMMENT",
-          },
+          "srcIndex": 9,
         },
         "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/issues/2#issuecomment-385576248\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"COMMENT\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/pull/5#discussion_r171460198\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"PULL_REQUEST_REVIEW_COMMENT\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"REFERENCES\\"}": Object {
-          "dst": Object {
-            "id": "https://github.com/sourcecred/example-github/pull/5#discussion_r171460198",
-            "pluginName": "sourcecred/github-beta",
-            "type": "PULL_REQUEST_REVIEW_COMMENT",
-          },
+          "dstIndex": 24,
           "payload": Object {},
-          "src": Object {
-            "id": "https://github.com/sourcecred/example-github/issues/2#issuecomment-385576248",
-            "pluginName": "sourcecred/github-beta",
-            "type": "COMMENT",
-          },
+          "srcIndex": 10,
         },
         "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/issues/2#issuecomment-385576273\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"COMMENT\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/wchargin\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"AUTHOR\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"REFERENCES\\"}": Object {
-          "dst": Object {
-            "id": "https://github.com/wchargin",
-            "pluginName": "sourcecred/github-beta",
-            "type": "AUTHOR",
-          },
+          "dstIndex": 28,
           "payload": Object {},
-          "src": Object {
-            "id": "https://github.com/sourcecred/example-github/issues/2#issuecomment-385576273",
-            "pluginName": "sourcecred/github-beta",
-            "type": "COMMENT",
-          },
+          "srcIndex": 11,
         },
         "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/issues/2#issuecomment-385576920\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"COMMENT\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/issues/1\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"ISSUE\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"REFERENCES\\"}": Object {
-          "dst": Object {
-            "id": "https://github.com/sourcecred/example-github/issues/1",
-            "pluginName": "sourcecred/github-beta",
-            "type": "ISSUE",
-          },
+          "dstIndex": 4,
           "payload": Object {},
-          "src": Object {
-            "id": "https://github.com/sourcecred/example-github/issues/2#issuecomment-385576920",
-            "pluginName": "sourcecred/github-beta",
-            "type": "COMMENT",
-          },
+          "srcIndex": 12,
         },
         "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/issues/2#issuecomment-385576920\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"COMMENT\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/issues/2\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"ISSUE\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"REFERENCES\\"}": Object {
-          "dst": Object {
-            "id": "https://github.com/sourcecred/example-github/issues/2",
-            "pluginName": "sourcecred/github-beta",
-            "type": "ISSUE",
-          },
+          "dstIndex": 5,
           "payload": Object {},
-          "src": Object {
-            "id": "https://github.com/sourcecred/example-github/issues/2#issuecomment-385576920",
-            "pluginName": "sourcecred/github-beta",
-            "type": "COMMENT",
-          },
+          "srcIndex": 12,
         },
         "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/issues/2#issuecomment-385576920\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"COMMENT\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/pull/3\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"PULL_REQUEST\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"REFERENCES\\"}": Object {
-          "dst": Object {
-            "id": "https://github.com/sourcecred/example-github/pull/3",
-            "pluginName": "sourcecred/github-beta",
-            "type": "PULL_REQUEST",
-          },
+          "dstIndex": 21,
           "payload": Object {},
-          "src": Object {
-            "id": "https://github.com/sourcecred/example-github/issues/2#issuecomment-385576920",
-            "pluginName": "sourcecred/github-beta",
-            "type": "COMMENT",
-          },
+          "srcIndex": 12,
         },
         "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/issues/2#issuecomment-385576920\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"COMMENT\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/pull/5#discussion_r171460198\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"PULL_REQUEST_REVIEW_COMMENT\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"REFERENCES\\"}": Object {
-          "dst": Object {
-            "id": "https://github.com/sourcecred/example-github/pull/5#discussion_r171460198",
-            "pluginName": "sourcecred/github-beta",
-            "type": "PULL_REQUEST_REVIEW_COMMENT",
-          },
+          "dstIndex": 24,
           "payload": Object {},
-          "src": Object {
-            "id": "https://github.com/sourcecred/example-github/issues/2#issuecomment-385576920",
-            "pluginName": "sourcecred/github-beta",
-            "type": "COMMENT",
-          },
+          "srcIndex": 12,
         },
         "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/issues/2#issuecomment-385576920\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"COMMENT\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/pull/5#pullrequestreview-100313899\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"PULL_REQUEST_REVIEW\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"REFERENCES\\"}": Object {
-          "dst": Object {
-            "id": "https://github.com/sourcecred/example-github/pull/5#pullrequestreview-100313899",
-            "pluginName": "sourcecred/github-beta",
-            "type": "PULL_REQUEST_REVIEW",
-          },
+          "dstIndex": 25,
           "payload": Object {},
-          "src": Object {
-            "id": "https://github.com/sourcecred/example-github/issues/2#issuecomment-385576920",
-            "pluginName": "sourcecred/github-beta",
-            "type": "COMMENT",
-          },
+          "srcIndex": 12,
         },
         "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/issues/2\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"ISSUE\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/issues/1\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"ISSUE\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"REFERENCES\\"}": Object {
-          "dst": Object {
-            "id": "https://github.com/sourcecred/example-github/issues/1",
-            "pluginName": "sourcecred/github-beta",
-            "type": "ISSUE",
-          },
+          "dstIndex": 4,
           "payload": Object {},
-          "src": Object {
-            "id": "https://github.com/sourcecred/example-github/issues/2",
-            "pluginName": "sourcecred/github-beta",
-            "type": "ISSUE",
-          },
+          "srcIndex": 5,
         },
         "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/issues/2\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"ISSUE\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/issues/2#issuecomment-373768703\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"COMMENT\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"CONTAINS\\"}": Object {
-          "dst": Object {
-            "id": "https://github.com/sourcecred/example-github/issues/2#issuecomment-373768703",
-            "pluginName": "sourcecred/github-beta",
-            "type": "COMMENT",
-          },
+          "dstIndex": 6,
           "payload": Object {},
-          "src": Object {
-            "id": "https://github.com/sourcecred/example-github/issues/2",
-            "pluginName": "sourcecred/github-beta",
-            "type": "ISSUE",
-          },
+          "srcIndex": 5,
         },
         "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/issues/2\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"ISSUE\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/issues/2#issuecomment-373768850\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"COMMENT\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"CONTAINS\\"}": Object {
-          "dst": Object {
-            "id": "https://github.com/sourcecred/example-github/issues/2#issuecomment-373768850",
-            "pluginName": "sourcecred/github-beta",
-            "type": "COMMENT",
-          },
+          "dstIndex": 7,
           "payload": Object {},
-          "src": Object {
-            "id": "https://github.com/sourcecred/example-github/issues/2",
-            "pluginName": "sourcecred/github-beta",
-            "type": "ISSUE",
-          },
+          "srcIndex": 5,
         },
         "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/issues/2\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"ISSUE\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/issues/2#issuecomment-385576185\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"COMMENT\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"CONTAINS\\"}": Object {
-          "dst": Object {
-            "id": "https://github.com/sourcecred/example-github/issues/2#issuecomment-385576185",
-            "pluginName": "sourcecred/github-beta",
-            "type": "COMMENT",
-          },
+          "dstIndex": 8,
           "payload": Object {},
-          "src": Object {
-            "id": "https://github.com/sourcecred/example-github/issues/2",
-            "pluginName": "sourcecred/github-beta",
-            "type": "ISSUE",
-          },
+          "srcIndex": 5,
         },
         "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/issues/2\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"ISSUE\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/issues/2#issuecomment-385576220\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"COMMENT\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"CONTAINS\\"}": Object {
-          "dst": Object {
-            "id": "https://github.com/sourcecred/example-github/issues/2#issuecomment-385576220",
-            "pluginName": "sourcecred/github-beta",
-            "type": "COMMENT",
-          },
+          "dstIndex": 9,
           "payload": Object {},
-          "src": Object {
-            "id": "https://github.com/sourcecred/example-github/issues/2",
-            "pluginName": "sourcecred/github-beta",
-            "type": "ISSUE",
-          },
+          "srcIndex": 5,
         },
         "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/issues/2\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"ISSUE\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/issues/2#issuecomment-385576248\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"COMMENT\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"CONTAINS\\"}": Object {
-          "dst": Object {
-            "id": "https://github.com/sourcecred/example-github/issues/2#issuecomment-385576248",
-            "pluginName": "sourcecred/github-beta",
-            "type": "COMMENT",
-          },
+          "dstIndex": 10,
           "payload": Object {},
-          "src": Object {
-            "id": "https://github.com/sourcecred/example-github/issues/2",
-            "pluginName": "sourcecred/github-beta",
-            "type": "ISSUE",
-          },
+          "srcIndex": 5,
         },
         "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/issues/2\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"ISSUE\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/issues/2#issuecomment-385576273\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"COMMENT\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"CONTAINS\\"}": Object {
-          "dst": Object {
-            "id": "https://github.com/sourcecred/example-github/issues/2#issuecomment-385576273",
-            "pluginName": "sourcecred/github-beta",
-            "type": "COMMENT",
-          },
+          "dstIndex": 11,
           "payload": Object {},
-          "src": Object {
-            "id": "https://github.com/sourcecred/example-github/issues/2",
-            "pluginName": "sourcecred/github-beta",
-            "type": "ISSUE",
-          },
+          "srcIndex": 5,
         },
         "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/issues/2\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"ISSUE\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/issues/2#issuecomment-385576920\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"COMMENT\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"CONTAINS\\"}": Object {
-          "dst": Object {
-            "id": "https://github.com/sourcecred/example-github/issues/2#issuecomment-385576920",
-            "pluginName": "sourcecred/github-beta",
-            "type": "COMMENT",
-          },
+          "dstIndex": 12,
           "payload": Object {},
-          "src": Object {
-            "id": "https://github.com/sourcecred/example-github/issues/2",
-            "pluginName": "sourcecred/github-beta",
-            "type": "ISSUE",
-          },
+          "srcIndex": 5,
         },
         "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/issues/2\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"ISSUE\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/issues/2#issuecomment-385576936\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"COMMENT\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"CONTAINS\\"}": Object {
-          "dst": Object {
-            "id": "https://github.com/sourcecred/example-github/issues/2#issuecomment-385576936",
-            "pluginName": "sourcecred/github-beta",
-            "type": "COMMENT",
-          },
+          "dstIndex": 13,
           "payload": Object {},
-          "src": Object {
-            "id": "https://github.com/sourcecred/example-github/issues/2",
-            "pluginName": "sourcecred/github-beta",
-            "type": "ISSUE",
-          },
+          "srcIndex": 5,
         },
         "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/issues/6#issuecomment-385223316\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"COMMENT\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/issues/2\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"ISSUE\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"REFERENCES\\"}": Object {
-          "dst": Object {
-            "id": "https://github.com/sourcecred/example-github/issues/2",
-            "pluginName": "sourcecred/github-beta",
-            "type": "ISSUE",
-          },
+          "dstIndex": 5,
           "payload": Object {},
-          "src": Object {
-            "id": "https://github.com/sourcecred/example-github/issues/6#issuecomment-385223316",
-            "pluginName": "sourcecred/github-beta",
-            "type": "COMMENT",
-          },
+          "srcIndex": 18,
         },
         "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/issues/6\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"ISSUE\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/issues/6#issuecomment-373768442\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"COMMENT\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"CONTAINS\\"}": Object {
-          "dst": Object {
-            "id": "https://github.com/sourcecred/example-github/issues/6#issuecomment-373768442",
-            "pluginName": "sourcecred/github-beta",
-            "type": "COMMENT",
-          },
+          "dstIndex": 16,
           "payload": Object {},
-          "src": Object {
-            "id": "https://github.com/sourcecred/example-github/issues/6",
-            "pluginName": "sourcecred/github-beta",
-            "type": "ISSUE",
-          },
+          "srcIndex": 15,
         },
         "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/issues/6\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"ISSUE\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/issues/6#issuecomment-373768538\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"COMMENT\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"CONTAINS\\"}": Object {
-          "dst": Object {
-            "id": "https://github.com/sourcecred/example-github/issues/6#issuecomment-373768538",
-            "pluginName": "sourcecred/github-beta",
-            "type": "COMMENT",
-          },
+          "dstIndex": 17,
           "payload": Object {},
-          "src": Object {
-            "id": "https://github.com/sourcecred/example-github/issues/6",
-            "pluginName": "sourcecred/github-beta",
-            "type": "ISSUE",
-          },
+          "srcIndex": 15,
         },
         "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/issues/6\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"ISSUE\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/issues/6#issuecomment-385223316\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"COMMENT\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"CONTAINS\\"}": Object {
-          "dst": Object {
-            "id": "https://github.com/sourcecred/example-github/issues/6#issuecomment-385223316",
-            "pluginName": "sourcecred/github-beta",
-            "type": "COMMENT",
-          },
+          "dstIndex": 18,
           "payload": Object {},
-          "src": Object {
-            "id": "https://github.com/sourcecred/example-github/issues/6",
-            "pluginName": "sourcecred/github-beta",
-            "type": "ISSUE",
-          },
+          "srcIndex": 15,
         },
         "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/pull/3#issuecomment-369162222\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"COMMENT\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/issues/2\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"ISSUE\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"REFERENCES\\"}": Object {
-          "dst": Object {
-            "id": "https://github.com/sourcecred/example-github/issues/2",
-            "pluginName": "sourcecred/github-beta",
-            "type": "ISSUE",
-          },
+          "dstIndex": 5,
           "payload": Object {},
-          "src": Object {
-            "id": "https://github.com/sourcecred/example-github/pull/3#issuecomment-369162222",
-            "pluginName": "sourcecred/github-beta",
-            "type": "COMMENT",
-          },
+          "srcIndex": 22,
         },
         "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/pull/3\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"PULL_REQUEST\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"0a223346b4e6dec0127b1e6aa892c4ee0424b66a\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/git-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"COMMIT\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"MERGED_AS\\"}": Object {
-          "dst": Object {
-            "id": "0a223346b4e6dec0127b1e6aa892c4ee0424b66a",
-            "pluginName": "sourcecred/git-beta",
-            "type": "COMMIT",
-          },
+          "dstIndex": 0,
           "payload": Object {
             "hash": "0a223346b4e6dec0127b1e6aa892c4ee0424b66a",
           },
-          "src": Object {
-            "id": "https://github.com/sourcecred/example-github/pull/3",
-            "pluginName": "sourcecred/github-beta",
-            "type": "PULL_REQUEST",
-          },
+          "srcIndex": 21,
         },
         "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/pull/3\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"PULL_REQUEST\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/pull/3#issuecomment-369162222\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"COMMENT\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"CONTAINS\\"}": Object {
-          "dst": Object {
-            "id": "https://github.com/sourcecred/example-github/pull/3#issuecomment-369162222",
-            "pluginName": "sourcecred/github-beta",
-            "type": "COMMENT",
-          },
+          "dstIndex": 22,
           "payload": Object {},
-          "src": Object {
-            "id": "https://github.com/sourcecred/example-github/pull/3",
-            "pluginName": "sourcecred/github-beta",
-            "type": "PULL_REQUEST",
-          },
+          "srcIndex": 21,
         },
         "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/pull/5#pullrequestreview-100313899\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"PULL_REQUEST_REVIEW\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/pull/5#discussion_r171460198\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"PULL_REQUEST_REVIEW_COMMENT\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"CONTAINS\\"}": Object {
-          "dst": Object {
-            "id": "https://github.com/sourcecred/example-github/pull/5#discussion_r171460198",
-            "pluginName": "sourcecred/github-beta",
-            "type": "PULL_REQUEST_REVIEW_COMMENT",
-          },
+          "dstIndex": 24,
           "payload": Object {},
-          "src": Object {
-            "id": "https://github.com/sourcecred/example-github/pull/5#pullrequestreview-100313899",
-            "pluginName": "sourcecred/github-beta",
-            "type": "PULL_REQUEST_REVIEW",
-          },
+          "srcIndex": 25,
         },
         "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/pull/5\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"PULL_REQUEST\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"6d5b3aa31ebb68a06ceb46bbd6cf49b6ccd6f5e6\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/git-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"COMMIT\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"MERGED_AS\\"}": Object {
-          "dst": Object {
-            "id": "6d5b3aa31ebb68a06ceb46bbd6cf49b6ccd6f5e6",
-            "pluginName": "sourcecred/git-beta",
-            "type": "COMMIT",
-          },
+          "dstIndex": 1,
           "payload": Object {
             "hash": "6d5b3aa31ebb68a06ceb46bbd6cf49b6ccd6f5e6",
           },
-          "src": Object {
-            "id": "https://github.com/sourcecred/example-github/pull/5",
-            "pluginName": "sourcecred/github-beta",
-            "type": "PULL_REQUEST",
-          },
+          "srcIndex": 23,
         },
         "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/pull/5\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"PULL_REQUEST\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/pull/5#pullrequestreview-100313899\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"PULL_REQUEST_REVIEW\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"CONTAINS\\"}": Object {
-          "dst": Object {
-            "id": "https://github.com/sourcecred/example-github/pull/5#pullrequestreview-100313899",
-            "pluginName": "sourcecred/github-beta",
-            "type": "PULL_REQUEST_REVIEW",
-          },
+          "dstIndex": 25,
           "payload": Object {},
-          "src": Object {
-            "id": "https://github.com/sourcecred/example-github/pull/5",
-            "pluginName": "sourcecred/github-beta",
-            "type": "PULL_REQUEST",
-          },
+          "srcIndex": 23,
         },
         "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/pull/5\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"PULL_REQUEST\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/pull/5#pullrequestreview-100314038\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"PULL_REQUEST_REVIEW\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"CONTAINS\\"}": Object {
-          "dst": Object {
-            "id": "https://github.com/sourcecred/example-github/pull/5#pullrequestreview-100314038",
-            "pluginName": "sourcecred/github-beta",
-            "type": "PULL_REQUEST_REVIEW",
-          },
+          "dstIndex": 26,
           "payload": Object {},
-          "src": Object {
-            "id": "https://github.com/sourcecred/example-github/pull/5",
-            "pluginName": "sourcecred/github-beta",
-            "type": "PULL_REQUEST",
-          },
+          "srcIndex": 23,
         },
         "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/pull/5\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"PULL_REQUEST\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/wchargin\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"AUTHOR\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"REFERENCES\\"}": Object {
-          "dst": Object {
-            "id": "https://github.com/wchargin",
-            "pluginName": "sourcecred/github-beta",
-            "type": "AUTHOR",
-          },
+          "dstIndex": 28,
           "payload": Object {},
-          "src": Object {
-            "id": "https://github.com/sourcecred/example-github/pull/5",
-            "pluginName": "sourcecred/github-beta",
-            "type": "PULL_REQUEST",
-          },
+          "srcIndex": 23,
         },
         "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/pull/9\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"PULL_REQUEST\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/wchargin\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"AUTHOR\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"REFERENCES\\"}": Object {
-          "dst": Object {
-            "id": "https://github.com/wchargin",
-            "pluginName": "sourcecred/github-beta",
-            "type": "AUTHOR",
-          },
+          "dstIndex": 28,
           "payload": Object {},
-          "src": Object {
-            "id": "https://github.com/sourcecred/example-github/pull/9",
-            "pluginName": "sourcecred/github-beta",
-            "type": "PULL_REQUEST",
-          },
+          "srcIndex": 27,
         },
         "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"REPOSITORY\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/issues/1\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"ISSUE\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"CONTAINS\\"}": Object {
-          "dst": Object {
-            "id": "https://github.com/sourcecred/example-github/issues/1",
-            "pluginName": "sourcecred/github-beta",
-            "type": "ISSUE",
-          },
+          "dstIndex": 4,
           "payload": Object {},
-          "src": Object {
-            "id": "https://github.com/sourcecred/example-github",
-            "pluginName": "sourcecred/github-beta",
-            "type": "REPOSITORY",
-          },
+          "srcIndex": 3,
         },
         "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"REPOSITORY\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/issues/2\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"ISSUE\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"CONTAINS\\"}": Object {
-          "dst": Object {
-            "id": "https://github.com/sourcecred/example-github/issues/2",
-            "pluginName": "sourcecred/github-beta",
-            "type": "ISSUE",
-          },
+          "dstIndex": 5,
           "payload": Object {},
-          "src": Object {
-            "id": "https://github.com/sourcecred/example-github",
-            "pluginName": "sourcecred/github-beta",
-            "type": "REPOSITORY",
-          },
+          "srcIndex": 3,
         },
         "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"REPOSITORY\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/issues/4\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"ISSUE\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"CONTAINS\\"}": Object {
-          "dst": Object {
-            "id": "https://github.com/sourcecred/example-github/issues/4",
-            "pluginName": "sourcecred/github-beta",
-            "type": "ISSUE",
-          },
+          "dstIndex": 14,
           "payload": Object {},
-          "src": Object {
-            "id": "https://github.com/sourcecred/example-github",
-            "pluginName": "sourcecred/github-beta",
-            "type": "REPOSITORY",
-          },
+          "srcIndex": 3,
         },
         "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"REPOSITORY\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/issues/6\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"ISSUE\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"CONTAINS\\"}": Object {
-          "dst": Object {
-            "id": "https://github.com/sourcecred/example-github/issues/6",
-            "pluginName": "sourcecred/github-beta",
-            "type": "ISSUE",
-          },
+          "dstIndex": 15,
           "payload": Object {},
-          "src": Object {
-            "id": "https://github.com/sourcecred/example-github",
-            "pluginName": "sourcecred/github-beta",
-            "type": "REPOSITORY",
-          },
+          "srcIndex": 3,
         },
         "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"REPOSITORY\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/issues/7\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"ISSUE\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"CONTAINS\\"}": Object {
-          "dst": Object {
-            "id": "https://github.com/sourcecred/example-github/issues/7",
-            "pluginName": "sourcecred/github-beta",
-            "type": "ISSUE",
-          },
+          "dstIndex": 19,
           "payload": Object {},
-          "src": Object {
-            "id": "https://github.com/sourcecred/example-github",
-            "pluginName": "sourcecred/github-beta",
-            "type": "REPOSITORY",
-          },
+          "srcIndex": 3,
         },
         "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"REPOSITORY\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/issues/8\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"ISSUE\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"CONTAINS\\"}": Object {
-          "dst": Object {
-            "id": "https://github.com/sourcecred/example-github/issues/8",
-            "pluginName": "sourcecred/github-beta",
-            "type": "ISSUE",
-          },
+          "dstIndex": 20,
           "payload": Object {},
-          "src": Object {
-            "id": "https://github.com/sourcecred/example-github",
-            "pluginName": "sourcecred/github-beta",
-            "type": "REPOSITORY",
-          },
+          "srcIndex": 3,
         },
         "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"REPOSITORY\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/pull/3\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"PULL_REQUEST\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"CONTAINS\\"}": Object {
-          "dst": Object {
-            "id": "https://github.com/sourcecred/example-github/pull/3",
-            "pluginName": "sourcecred/github-beta",
-            "type": "PULL_REQUEST",
-          },
+          "dstIndex": 21,
           "payload": Object {},
-          "src": Object {
-            "id": "https://github.com/sourcecred/example-github",
-            "pluginName": "sourcecred/github-beta",
-            "type": "REPOSITORY",
-          },
+          "srcIndex": 3,
         },
         "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"REPOSITORY\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/pull/5\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"PULL_REQUEST\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"CONTAINS\\"}": Object {
-          "dst": Object {
-            "id": "https://github.com/sourcecred/example-github/pull/5",
-            "pluginName": "sourcecred/github-beta",
-            "type": "PULL_REQUEST",
-          },
+          "dstIndex": 23,
           "payload": Object {},
-          "src": Object {
-            "id": "https://github.com/sourcecred/example-github",
-            "pluginName": "sourcecred/github-beta",
-            "type": "REPOSITORY",
-          },
+          "srcIndex": 3,
         },
         "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"REPOSITORY\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/pull/9\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"PULL_REQUEST\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"CONTAINS\\"}": Object {
-          "dst": Object {
-            "id": "https://github.com/sourcecred/example-github/pull/9",
-            "pluginName": "sourcecred/github-beta",
-            "type": "PULL_REQUEST",
-          },
+          "dstIndex": 27,
           "payload": Object {},
-          "src": Object {
-            "id": "https://github.com/sourcecred/example-github",
-            "pluginName": "sourcecred/github-beta",
-            "type": "REPOSITORY",
-          },
+          "srcIndex": 3,
         },
         "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/wchargin\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"AUTHOR\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/pull/5#discussion_r171460198\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"PULL_REQUEST_REVIEW_COMMENT\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"AUTHORS\\"}": Object {
-          "dst": Object {
-            "id": "https://github.com/wchargin",
-            "pluginName": "sourcecred/github-beta",
-            "type": "AUTHOR",
-          },
+          "dstIndex": 28,
           "payload": Object {},
-          "src": Object {
-            "id": "https://github.com/sourcecred/example-github/pull/5#discussion_r171460198",
-            "pluginName": "sourcecred/github-beta",
-            "type": "PULL_REQUEST_REVIEW_COMMENT",
-          },
+          "srcIndex": 24,
         },
         "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/wchargin\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"AUTHOR\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/pull/5#pullrequestreview-100313899\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"PULL_REQUEST_REVIEW\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"AUTHORS\\"}": Object {
-          "dst": Object {
-            "id": "https://github.com/wchargin",
-            "pluginName": "sourcecred/github-beta",
-            "type": "AUTHOR",
-          },
+          "dstIndex": 28,
           "payload": Object {},
-          "src": Object {
-            "id": "https://github.com/sourcecred/example-github/pull/5#pullrequestreview-100313899",
-            "pluginName": "sourcecred/github-beta",
-            "type": "PULL_REQUEST_REVIEW",
-          },
+          "srcIndex": 25,
         },
         "{\\"id\\":\\"[{\\\\\\"id\\\\\\":\\\\\\"https://github.com/wchargin\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"AUTHOR\\\\\\"},{\\\\\\"id\\\\\\":\\\\\\"https://github.com/sourcecred/example-github/pull/5#pullrequestreview-100314038\\\\\\",\\\\\\"pluginName\\\\\\":\\\\\\"sourcecred/github-beta\\\\\\",\\\\\\"type\\\\\\":\\\\\\"PULL_REQUEST_REVIEW\\\\\\"}]\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"AUTHORS\\"}": Object {
-          "dst": Object {
-            "id": "https://github.com/wchargin",
-            "pluginName": "sourcecred/github-beta",
-            "type": "AUTHOR",
-          },
+          "dstIndex": 28,
           "payload": Object {},
-          "src": Object {
-            "id": "https://github.com/sourcecred/example-github/pull/5#pullrequestreview-100314038",
-            "pluginName": "sourcecred/github-beta",
-            "type": "PULL_REQUEST_REVIEW",
-          },
+          "srcIndex": 26,
         },
       },
     ],
     "nodes": Array [
       Object {
-        "type": "sourcecred/sourcecred/AddressMap",
-        "version": "0.1.0",
+        "address": Object {
+          "id": "0a223346b4e6dec0127b1e6aa892c4ee0424b66a",
+          "pluginName": "sourcecred/git-beta",
+          "type": "COMMIT",
+        },
       },
       Object {
-        "{\\"id\\":\\"https://github.com/decentralion\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"AUTHOR\\"}": Object {
-          "payload": Object {
-            "login": "decentralion",
-            "subtype": "USER",
-            "url": "https://github.com/decentralion",
-          },
+        "address": Object {
+          "id": "6d5b3aa31ebb68a06ceb46bbd6cf49b6ccd6f5e6",
+          "pluginName": "sourcecred/git-beta",
+          "type": "COMMIT",
         },
-        "{\\"id\\":\\"https://github.com/sourcecred/example-github\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"REPOSITORY\\"}": Object {
-          "payload": Object {
-            "name": "example-github",
-            "owner": "sourcecred",
-            "url": "https://github.com/sourcecred/example-github",
-          },
+      },
+      Object {
+        "address": Object {
+          "id": "https://github.com/decentralion",
+          "pluginName": "sourcecred/github-beta",
+          "type": "AUTHOR",
         },
-        "{\\"id\\":\\"https://github.com/sourcecred/example-github/issues/1\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"ISSUE\\"}": Object {
-          "payload": Object {
-            "body": "This is just an example issue.",
-            "number": 1,
-            "title": "An example issue.",
-            "url": "https://github.com/sourcecred/example-github/issues/1",
-          },
+        "payload": Object {
+          "login": "decentralion",
+          "subtype": "USER",
+          "url": "https://github.com/decentralion",
         },
-        "{\\"id\\":\\"https://github.com/sourcecred/example-github/issues/2\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"ISSUE\\"}": Object {
-          "payload": Object {
-            "body": "This issue references another issue, namely #1",
-            "number": 2,
-            "title": "A referencing issue.",
-            "url": "https://github.com/sourcecred/example-github/issues/2",
-          },
+      },
+      Object {
+        "address": Object {
+          "id": "https://github.com/sourcecred/example-github",
+          "pluginName": "sourcecred/github-beta",
+          "type": "REPOSITORY",
         },
-        "{\\"id\\":\\"https://github.com/sourcecred/example-github/issues/2#issuecomment-373768703\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"COMMENT\\"}": Object {
-          "payload": Object {
-            "body": "It should also be possible to reference by exact url: https://github.com/sourcecred/example-github/issues/6",
-            "url": "https://github.com/sourcecred/example-github/issues/2#issuecomment-373768703",
-          },
+        "payload": Object {
+          "name": "example-github",
+          "owner": "sourcecred",
+          "url": "https://github.com/sourcecred/example-github",
         },
-        "{\\"id\\":\\"https://github.com/sourcecred/example-github/issues/2#issuecomment-373768850\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"COMMENT\\"}": Object {
-          "payload": Object {
-            "body": "We might also reference individual comments directly.
+      },
+      Object {
+        "address": Object {
+          "id": "https://github.com/sourcecred/example-github/issues/1",
+          "pluginName": "sourcecred/github-beta",
+          "type": "ISSUE",
+        },
+        "payload": Object {
+          "body": "This is just an example issue.",
+          "number": 1,
+          "title": "An example issue.",
+          "url": "https://github.com/sourcecred/example-github/issues/1",
+        },
+      },
+      Object {
+        "address": Object {
+          "id": "https://github.com/sourcecred/example-github/issues/2",
+          "pluginName": "sourcecred/github-beta",
+          "type": "ISSUE",
+        },
+        "payload": Object {
+          "body": "This issue references another issue, namely #1",
+          "number": 2,
+          "title": "A referencing issue.",
+          "url": "https://github.com/sourcecred/example-github/issues/2",
+        },
+      },
+      Object {
+        "address": Object {
+          "id": "https://github.com/sourcecred/example-github/issues/2#issuecomment-373768703",
+          "pluginName": "sourcecred/github-beta",
+          "type": "COMMENT",
+        },
+        "payload": Object {
+          "body": "It should also be possible to reference by exact url: https://github.com/sourcecred/example-github/issues/6",
+          "url": "https://github.com/sourcecred/example-github/issues/2#issuecomment-373768703",
+        },
+      },
+      Object {
+        "address": Object {
+          "id": "https://github.com/sourcecred/example-github/issues/2#issuecomment-373768850",
+          "pluginName": "sourcecred/github-beta",
+          "type": "COMMENT",
+        },
+        "payload": Object {
+          "body": "We might also reference individual comments directly.
 https://github.com/sourcecred/example-github/issues/6#issuecomment-373768538",
-            "url": "https://github.com/sourcecred/example-github/issues/2#issuecomment-373768850",
-          },
+          "url": "https://github.com/sourcecred/example-github/issues/2#issuecomment-373768850",
         },
-        "{\\"id\\":\\"https://github.com/sourcecred/example-github/issues/2#issuecomment-385576185\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"COMMENT\\"}": Object {
-          "payload": Object {
-            "body": "Here's a PR by direct url: https://github.com/sourcecred/example-github/pull/5",
-            "url": "https://github.com/sourcecred/example-github/issues/2#issuecomment-385576185",
-          },
+      },
+      Object {
+        "address": Object {
+          "id": "https://github.com/sourcecred/example-github/issues/2#issuecomment-385576185",
+          "pluginName": "sourcecred/github-beta",
+          "type": "COMMENT",
         },
-        "{\\"id\\":\\"https://github.com/sourcecred/example-github/issues/2#issuecomment-385576220\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"COMMENT\\"}": Object {
-          "payload": Object {
-            "body": "a PR review by url: https://github.com/sourcecred/example-github/pull/5#pullrequestreview-100313899",
-            "url": "https://github.com/sourcecred/example-github/issues/2#issuecomment-385576220",
-          },
+        "payload": Object {
+          "body": "Here's a PR by direct url: https://github.com/sourcecred/example-github/pull/5",
+          "url": "https://github.com/sourcecred/example-github/issues/2#issuecomment-385576185",
         },
-        "{\\"id\\":\\"https://github.com/sourcecred/example-github/issues/2#issuecomment-385576248\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"COMMENT\\"}": Object {
-          "payload": Object {
-            "body": "a PR Review Comment by url: https://github.com/sourcecred/example-github/pull/5#discussion_r171460198",
-            "url": "https://github.com/sourcecred/example-github/issues/2#issuecomment-385576248",
-          },
+      },
+      Object {
+        "address": Object {
+          "id": "https://github.com/sourcecred/example-github/issues/2#issuecomment-385576220",
+          "pluginName": "sourcecred/github-beta",
+          "type": "COMMENT",
         },
-        "{\\"id\\":\\"https://github.com/sourcecred/example-github/issues/2#issuecomment-385576273\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"COMMENT\\"}": Object {
-          "payload": Object {
-            "body": "a user by url: https://github.com/wchargin",
-            "url": "https://github.com/sourcecred/example-github/issues/2#issuecomment-385576273",
-          },
+        "payload": Object {
+          "body": "a PR review by url: https://github.com/sourcecred/example-github/pull/5#pullrequestreview-100313899",
+          "url": "https://github.com/sourcecred/example-github/issues/2#issuecomment-385576220",
         },
-        "{\\"id\\":\\"https://github.com/sourcecred/example-github/issues/2#issuecomment-385576920\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"COMMENT\\"}": Object {
-          "payload": Object {
-            "body": "Here are several references:
+      },
+      Object {
+        "address": Object {
+          "id": "https://github.com/sourcecred/example-github/issues/2#issuecomment-385576248",
+          "pluginName": "sourcecred/github-beta",
+          "type": "COMMENT",
+        },
+        "payload": Object {
+          "body": "a PR Review Comment by url: https://github.com/sourcecred/example-github/pull/5#discussion_r171460198",
+          "url": "https://github.com/sourcecred/example-github/issues/2#issuecomment-385576248",
+        },
+      },
+      Object {
+        "address": Object {
+          "id": "https://github.com/sourcecred/example-github/issues/2#issuecomment-385576273",
+          "pluginName": "sourcecred/github-beta",
+          "type": "COMMENT",
+        },
+        "payload": Object {
+          "body": "a user by url: https://github.com/wchargin",
+          "url": "https://github.com/sourcecred/example-github/issues/2#issuecomment-385576273",
+        },
+      },
+      Object {
+        "address": Object {
+          "id": "https://github.com/sourcecred/example-github/issues/2#issuecomment-385576920",
+          "pluginName": "sourcecred/github-beta",
+          "type": "COMMENT",
+        },
+        "payload": Object {
+          "body": "Here are several references:
 #1 
 #2
 #3 
@@ -2473,126 +1598,205 @@ https://github.com/sourcecred/example-github/issues/6#issuecomment-373768538",
 https://github.com/sourcecred/example-github/pull/5#discussion_r171460198
 https://github.com/sourcecred/example-github/pull/5#pullrequestreview-100313899
 ",
-            "url": "https://github.com/sourcecred/example-github/issues/2#issuecomment-385576920",
-          },
+          "url": "https://github.com/sourcecred/example-github/issues/2#issuecomment-385576920",
         },
-        "{\\"id\\":\\"https://github.com/sourcecred/example-github/issues/2#issuecomment-385576936\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"COMMENT\\"}": Object {
-          "payload": Object {
-            "body": "This comment has no references.",
-            "url": "https://github.com/sourcecred/example-github/issues/2#issuecomment-385576936",
-          },
+      },
+      Object {
+        "address": Object {
+          "id": "https://github.com/sourcecred/example-github/issues/2#issuecomment-385576936",
+          "pluginName": "sourcecred/github-beta",
+          "type": "COMMENT",
         },
-        "{\\"id\\":\\"https://github.com/sourcecred/example-github/issues/4\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"ISSUE\\"}": Object {
-          "payload": Object {
-            "body": "Alas, its life as an open issue had only just begun.",
-            "number": 4,
-            "title": "A closed pull request",
-            "url": "https://github.com/sourcecred/example-github/issues/4",
-          },
+        "payload": Object {
+          "body": "This comment has no references.",
+          "url": "https://github.com/sourcecred/example-github/issues/2#issuecomment-385576936",
         },
-        "{\\"id\\":\\"https://github.com/sourcecred/example-github/issues/6\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"ISSUE\\"}": Object {
-          "payload": Object {
-            "body": "This issue shall shortly have a few comments.",
-            "number": 6,
-            "title": "An issue with comments",
-            "url": "https://github.com/sourcecred/example-github/issues/6",
-          },
+      },
+      Object {
+        "address": Object {
+          "id": "https://github.com/sourcecred/example-github/issues/4",
+          "pluginName": "sourcecred/github-beta",
+          "type": "ISSUE",
         },
-        "{\\"id\\":\\"https://github.com/sourcecred/example-github/issues/6#issuecomment-373768442\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"COMMENT\\"}": Object {
-          "payload": Object {
-            "body": "A wild COMMENT appeared!",
-            "url": "https://github.com/sourcecred/example-github/issues/6#issuecomment-373768442",
-          },
+        "payload": Object {
+          "body": "Alas, its life as an open issue had only just begun.",
+          "number": 4,
+          "title": "A closed pull request",
+          "url": "https://github.com/sourcecred/example-github/issues/4",
         },
-        "{\\"id\\":\\"https://github.com/sourcecred/example-github/issues/6#issuecomment-373768538\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"COMMENT\\"}": Object {
-          "payload": Object {
-            "body": "And the maintainer said, \\"Let there be comments!\\"",
-            "url": "https://github.com/sourcecred/example-github/issues/6#issuecomment-373768538",
-          },
+      },
+      Object {
+        "address": Object {
+          "id": "https://github.com/sourcecred/example-github/issues/6",
+          "pluginName": "sourcecred/github-beta",
+          "type": "ISSUE",
         },
-        "{\\"id\\":\\"https://github.com/sourcecred/example-github/issues/6#issuecomment-385223316\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"COMMENT\\"}": Object {
-          "payload": Object {
-            "body": "This comment references an #2, which itself references an issue. This comment is thus allows us to test that in-references are not included when requesting a Post's references.",
-            "url": "https://github.com/sourcecred/example-github/issues/6#issuecomment-385223316",
-          },
+        "payload": Object {
+          "body": "This issue shall shortly have a few comments.",
+          "number": 6,
+          "title": "An issue with comments",
+          "url": "https://github.com/sourcecred/example-github/issues/6",
         },
-        "{\\"id\\":\\"https://github.com/sourcecred/example-github/issues/7\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"ISSUE\\"}": Object {
-          "payload": Object {
-            "body": "Deal with this, naive string display algorithms!!!!!",
-            "number": 7,
-            "title": "An issue with an extremely long title, which even has a VerySuperFragicalisticialiManyCharacterUberLongTriplePlusGood word in it, and should really be truncated intelligently or something",
-            "url": "https://github.com/sourcecred/example-github/issues/7",
-          },
+      },
+      Object {
+        "address": Object {
+          "id": "https://github.com/sourcecred/example-github/issues/6#issuecomment-373768442",
+          "pluginName": "sourcecred/github-beta",
+          "type": "COMMENT",
         },
-        "{\\"id\\":\\"https://github.com/sourcecred/example-github/issues/8\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"ISSUE\\"}": Object {
-          "payload": Object {
-            "body": "Issue with Unicode: ȴሲ𣐳楢👍 :heart: 𐤔𐤁𐤀𐤑𐤍𐤉𐤔𐤌𐤄𐤍𐤍 ❤️
+        "payload": Object {
+          "body": "A wild COMMENT appeared!",
+          "url": "https://github.com/sourcecred/example-github/issues/6#issuecomment-373768442",
+        },
+      },
+      Object {
+        "address": Object {
+          "id": "https://github.com/sourcecred/example-github/issues/6#issuecomment-373768538",
+          "pluginName": "sourcecred/github-beta",
+          "type": "COMMENT",
+        },
+        "payload": Object {
+          "body": "And the maintainer said, \\"Let there be comments!\\"",
+          "url": "https://github.com/sourcecred/example-github/issues/6#issuecomment-373768538",
+        },
+      },
+      Object {
+        "address": Object {
+          "id": "https://github.com/sourcecred/example-github/issues/6#issuecomment-385223316",
+          "pluginName": "sourcecred/github-beta",
+          "type": "COMMENT",
+        },
+        "payload": Object {
+          "body": "This comment references an #2, which itself references an issue. This comment is thus allows us to test that in-references are not included when requesting a Post's references.",
+          "url": "https://github.com/sourcecred/example-github/issues/6#issuecomment-385223316",
+        },
+      },
+      Object {
+        "address": Object {
+          "id": "https://github.com/sourcecred/example-github/issues/7",
+          "pluginName": "sourcecred/github-beta",
+          "type": "ISSUE",
+        },
+        "payload": Object {
+          "body": "Deal with this, naive string display algorithms!!!!!",
+          "number": 7,
+          "title": "An issue with an extremely long title, which even has a VerySuperFragicalisticialiManyCharacterUberLongTriplePlusGood word in it, and should really be truncated intelligently or something",
+          "url": "https://github.com/sourcecred/example-github/issues/7",
+        },
+      },
+      Object {
+        "address": Object {
+          "id": "https://github.com/sourcecred/example-github/issues/8",
+          "pluginName": "sourcecred/github-beta",
+          "type": "ISSUE",
+        },
+        "payload": Object {
+          "body": "Issue with Unicode: ȴሲ𣐳楢👍 :heart: 𐤔𐤁𐤀𐤑𐤍𐤉𐤔𐤌𐤄𐤍𐤍 ❤️
 Issue with Unicode: ȴሲ𣐳楢👍 :heart: 𐤔𐤁𐤀𐤑𐤍𐤉𐤔𐤌𐤄𐤍𐤍 ❤️",
-            "number": 8,
-            "title": "Issue with Unicode: ȴሲ𣐳楢👍 :heart: 𐤔𐤁𐤀𐤑𐤍𐤉𐤔𐤌𐤄𐤍𐤍 ❤️",
-            "url": "https://github.com/sourcecred/example-github/issues/8",
-          },
+          "number": 8,
+          "title": "Issue with Unicode: ȴሲ𣐳楢👍 :heart: 𐤔𐤁𐤀𐤑𐤍𐤉𐤔𐤌𐤄𐤍𐤍 ❤️",
+          "url": "https://github.com/sourcecred/example-github/issues/8",
         },
-        "{\\"id\\":\\"https://github.com/sourcecred/example-github/pull/3\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"PULL_REQUEST\\"}": Object {
-          "payload": Object {
-            "body": "Oh look, it's a pull request.",
-            "number": 3,
-            "title": "Add README, merge via PR.",
-            "url": "https://github.com/sourcecred/example-github/pull/3",
-          },
+      },
+      Object {
+        "address": Object {
+          "id": "https://github.com/sourcecred/example-github/pull/3",
+          "pluginName": "sourcecred/github-beta",
+          "type": "PULL_REQUEST",
         },
-        "{\\"id\\":\\"https://github.com/sourcecred/example-github/pull/3#issuecomment-369162222\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"COMMENT\\"}": Object {
-          "payload": Object {
-            "body": "It seems apropos to reference something from a pull request comment... eg: #2 ",
-            "url": "https://github.com/sourcecred/example-github/pull/3#issuecomment-369162222",
-          },
+        "payload": Object {
+          "body": "Oh look, it's a pull request.",
+          "number": 3,
+          "title": "Add README, merge via PR.",
+          "url": "https://github.com/sourcecred/example-github/pull/3",
         },
-        "{\\"id\\":\\"https://github.com/sourcecred/example-github/pull/5\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"PULL_REQUEST\\"}": Object {
-          "payload": Object {
-            "body": "@wchargin could you please do the following:
+      },
+      Object {
+        "address": Object {
+          "id": "https://github.com/sourcecred/example-github/pull/3#issuecomment-369162222",
+          "pluginName": "sourcecred/github-beta",
+          "type": "COMMENT",
+        },
+        "payload": Object {
+          "body": "It seems apropos to reference something from a pull request comment... eg: #2 ",
+          "url": "https://github.com/sourcecred/example-github/pull/3#issuecomment-369162222",
+        },
+      },
+      Object {
+        "address": Object {
+          "id": "https://github.com/sourcecred/example-github/pull/5",
+          "pluginName": "sourcecred/github-beta",
+          "type": "PULL_REQUEST",
+        },
+        "payload": Object {
+          "body": "@wchargin could you please do the following:
 - add a commit comment
 - add a review comment requesting some trivial change
 - i'll change it
 - then approve the pr",
-            "number": 5,
-            "title": "This pull request will be more contentious. I can feel it...",
-            "url": "https://github.com/sourcecred/example-github/pull/5",
-          },
+          "number": 5,
+          "title": "This pull request will be more contentious. I can feel it...",
+          "url": "https://github.com/sourcecred/example-github/pull/5",
         },
-        "{\\"id\\":\\"https://github.com/sourcecred/example-github/pull/5#discussion_r171460198\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"PULL_REQUEST_REVIEW_COMMENT\\"}": Object {
-          "payload": Object {
-            "body": "seems a bit capricious",
-            "url": "https://github.com/sourcecred/example-github/pull/5#discussion_r171460198",
-          },
+      },
+      Object {
+        "address": Object {
+          "id": "https://github.com/sourcecred/example-github/pull/5#discussion_r171460198",
+          "pluginName": "sourcecred/github-beta",
+          "type": "PULL_REQUEST_REVIEW_COMMENT",
         },
-        "{\\"id\\":\\"https://github.com/sourcecred/example-github/pull/5#pullrequestreview-100313899\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"PULL_REQUEST_REVIEW\\"}": Object {
-          "payload": Object {
-            "body": "hmmm.jpg",
-            "state": "CHANGES_REQUESTED",
-            "url": "https://github.com/sourcecred/example-github/pull/5#pullrequestreview-100313899",
-          },
+        "payload": Object {
+          "body": "seems a bit capricious",
+          "url": "https://github.com/sourcecred/example-github/pull/5#discussion_r171460198",
         },
-        "{\\"id\\":\\"https://github.com/sourcecred/example-github/pull/5#pullrequestreview-100314038\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"PULL_REQUEST_REVIEW\\"}": Object {
-          "payload": Object {
-            "body": "I'm sold",
-            "state": "APPROVED",
-            "url": "https://github.com/sourcecred/example-github/pull/5#pullrequestreview-100314038",
-          },
+      },
+      Object {
+        "address": Object {
+          "id": "https://github.com/sourcecred/example-github/pull/5#pullrequestreview-100313899",
+          "pluginName": "sourcecred/github-beta",
+          "type": "PULL_REQUEST_REVIEW",
         },
-        "{\\"id\\":\\"https://github.com/sourcecred/example-github/pull/9\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"PULL_REQUEST\\"}": Object {
-          "payload": Object {
-            "body": "Nominally paired with @wchargin",
-            "number": 9,
-            "title": "An unmerged pull request",
-            "url": "https://github.com/sourcecred/example-github/pull/9",
-          },
+        "payload": Object {
+          "body": "hmmm.jpg",
+          "state": "CHANGES_REQUESTED",
+          "url": "https://github.com/sourcecred/example-github/pull/5#pullrequestreview-100313899",
         },
-        "{\\"id\\":\\"https://github.com/wchargin\\",\\"pluginName\\":\\"sourcecred/github-beta\\",\\"type\\":\\"AUTHOR\\"}": Object {
-          "payload": Object {
-            "login": "wchargin",
-            "subtype": "USER",
-            "url": "https://github.com/wchargin",
-          },
+      },
+      Object {
+        "address": Object {
+          "id": "https://github.com/sourcecred/example-github/pull/5#pullrequestreview-100314038",
+          "pluginName": "sourcecred/github-beta",
+          "type": "PULL_REQUEST_REVIEW",
+        },
+        "payload": Object {
+          "body": "I'm sold",
+          "state": "APPROVED",
+          "url": "https://github.com/sourcecred/example-github/pull/5#pullrequestreview-100314038",
+        },
+      },
+      Object {
+        "address": Object {
+          "id": "https://github.com/sourcecred/example-github/pull/9",
+          "pluginName": "sourcecred/github-beta",
+          "type": "PULL_REQUEST",
+        },
+        "payload": Object {
+          "body": "Nominally paired with @wchargin",
+          "number": 9,
+          "title": "An unmerged pull request",
+          "url": "https://github.com/sourcecred/example-github/pull/9",
+        },
+      },
+      Object {
+        "address": Object {
+          "id": "https://github.com/wchargin",
+          "pluginName": "sourcecred/github-beta",
+          "type": "AUTHOR",
+        },
+        "payload": Object {
+          "login": "wchargin",
+          "subtype": "USER",
+          "url": "https://github.com/wchargin",
         },
       },
     ],


### PR DESCRIPTION
Summary:
This is an implementation-only, API-preserving change to the `Graph`
class. Edges’ `src` and `dst` attributes are now internally represented
as integer indices into a fixed ordering of nodes, which may depend on
non-logical properties such as insertion order. The graph’s serialized
form also now stores edges with integer `src`/`dst` keys, but the node
ordering is canonicalized so that two graphs are logically equal if and
only if their serialized forms are equal. This change substantially
reduces the rest storage space for graphs: the `sourcecred/sourcecred`
graph drops from 39MB to 30MB.

Currently, the graph will have to translate between integer indices and
full addresses at each client operation. This is not actually a big
performance regression, because it is just one more integer-index
dereference over the previous behavior, but it does indicate that the
optimization is not living up to its full potential. In subsequent
changes, the `NodeReference` class will be outfitted with facilities to
take advantage of the internal indexing; a long-term goal is that
roughly all operations should be able to be performed within the indexed
layer, and that translating between integers and addresses should only
happen at non-hot-path API boundaries.

This diff is considerably smaller and easier to read with `-w`.

Paired with @decentralion.

Test Plan:
I inspected the snapshots for general form, and manually verified that
the indices for one edge were correct (the MERGED_AS edge for the head
commit of the example repo). Other than that, existing unit tests mostly
suffice; one new unit test added.

wchargin-branch: graph-indexed-edges