### PR TITLE
Check for STOPSHIPs in CI

### DIFF
--- a/config/travis.js
+++ b/config/travis.js
@@ -23,6 +23,13 @@ function makeTasks(mode /*: "BASIC" | "FULL" */) {
       deps: [],
     },
     {
+      // eslint-disable-next-line no-useless-concat
+      id: "check-stop" + "ships",
+      // eslint-disable-next-line no-useless-concat
+      cmd: ["./scripts/check-stop" + "ships.sh"],
+      deps: [],
+    },
+    {
       id: "check-pretty",
       cmd: ["npm", "run", "--silent", "check-pretty"],
       deps: [],

--- a/scripts/check-stopships.sh
+++ b/scripts/check-stopships.sh
@@ -1,0 +1,2 @@
+#!/bin/sh
+! git grep -n -i "STOP""SHIP" -- :/


### PR DESCRIPTION
Summary:
Placing `STOPSHIP` or `stopship` (or any case variant) in any file
tracked by Git will now cause a `yarn travis` failure. If you need to
use this string, you can concatenate it as `"stop" + "ship"` or
equivalent.

Test Plan:
In `travis.js`, change `"check-stop" + "ships"` to `"check-stopships"`,
and note that this causes the build to fail with a nice message. Note
that this also causes `check-stopships.sh` to fail even when invoked
from an unrelated directory, like `src`.

wchargin-branch: check-stopships