### PR TITLE
Disable the `no-useless-constructor` lint rule

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -11,5 +11,6 @@ module.exports = {
       },
     ],
     "no-use-before-define": ["off"],
+    "no-useless-constructor": ["off"],
   },
 };


### PR DESCRIPTION
Summary:
In fact, a constructor that only calls `super` is useful: it specifies
the API for constructing an object of a given class without needing to
traverse its prototype chain. (That constructors are inherited at all is
arguably a design flaw.)

Test Plan:
None.

wchargin-branch: yes-useful-constructor