### PR TITLE
Trim Flow’s server startup build output

### DIFF
--- a/config/travis.js
+++ b/config/travis.js
@@ -41,7 +41,7 @@ function makeTasks(mode /*: "BASIC" | "FULL" */) {
     },
     {
       id: "flow",
-      cmd: ["npm", "run", "--silent", "flow"],
+      cmd: ["npm", "run", "--silent", "flow", "--", "--quiet"],
       deps: [],
     },
     {


### PR DESCRIPTION
Test Plan:
Run `yarn flow stop; yarn travis | cat` and note the absence of the
really long line that has ~2500 bytes of “Server is initializing”.

wchargin-branch: quiet-flow-server