### PR TITLE
Fix `ensure-flow.sh` running under Node

### DIFF
--- a/scripts/ensure-flow.sh
+++ b/scripts/ensure-flow.sh
@@ -1,7 +1,7 @@
-#!/bin/sh
+#!/bin/bash
 set -eu
 git grep -Fz --files-without-match -e '@flow' -e '@no-flow' -- '*.js' \
     | grep -zv '^flow-typed/' \
     | tr '\0' '\n' \
-    | tee /dev/stderr \
+    | tee >(cat >&2) \
     | diff -q /dev/null - >/dev/null


### PR DESCRIPTION
Summary:
The use of `tee /dev/stderr` failed when running as a child process
under Node for some reason. (I haven’t been able to figure out why—it
works fine when run as a standalone script or when run as a child
process under Python.) This is also technically Linux-specific, so I’ve
changed it to use a process substitution. After looking around for a
bit, there doesn’t seem to be a way to do this in a way that is
portable, uses only POSIX shell features, and doesn’t create temporary
files all at the same time, so the script is now run under `bash`.

Test Plan:
Run `yarn travis` and note that the `ensure-flow.sh` output no longer
contains the line `tee: /dev/stderr: No such device or address`.

wchargin-branch: no-tee-devstderr