### PR TITLE
Flow: enable `//$ExpectError`

### DIFF
--- a/.flowconfig
+++ b/.flowconfig
@@ -8,5 +8,7 @@ flow-typed
 [lints]
 
 [options]
+suppress_comment=\\(.\\|\n\\)*\\$ExpectFlowError
+include_warnings=true
 
 [strict]

--- a/config/travis.js
+++ b/config/travis.js
@@ -41,7 +41,15 @@ function makeTasks(mode /*: "BASIC" | "FULL" */) {
     },
     {
       id: "flow",
-      cmd: ["npm", "run", "--silent", "flow", "--", "--quiet"],
+      cmd: [
+        "npm",
+        "run",
+        "--silent",
+        "flow",
+        "--",
+        "--quiet",
+        "--max-warnings=0",
+      ],
       deps: [],
     },
     {


### PR DESCRIPTION
As of this commit, adding the comment `//$ExpectError` in flow-typed
code asserts that the next line must cause a flow error. If it does, no
error or warning is generated. If it does not, then this produces a flow
warning, which is visible to developers running `yarn flow` and
additionally causes travis to fail.

Test plan:

- As committed, `yarn travis` passes.
- I added `//$ExpectError` above some line of flow-checked code which does
not currently throw an error. Afterwards, `yarn travis` failed (and a
helpful message was displayed in console on running `yarn flow`)
- I added the following bad code into one of our files:
```javascript
//$ExpectError
const foo: string = 3;
```
As expected, `yarn flow` and `yarn travis` both passed.