### PR TITLE
Refactor `addressFilterer` for using PluginFilter

### DIFF
--- a/src/core2/graph.test.js
+++ b/src/core2/graph.test.js
@@ -136,6 +136,12 @@ describe("graph", () => {
       expect(fooNodes).toEqual([fooNode()]);
       expect(barNodes).toEqual([barNode()]);
     });
+    it("complains if you filter by only type", () => {
+      // $ExpectFlowError
+      expect(() => Array.from(newGraph().nodes({type: "foo"}))).toThrowError(
+        "must filter by plugin"
+      );
+    });
     it("does not return removed nodes", () => {
       const g = newGraph()
         .addNode(barPayload())


### PR DESCRIPTION
Given that we have reified the type `PluginFilter` as a consistent way
to filter nodes and edges by plugin and type, we should also have
re-usable logic for that end.

This commit adds `addressFilterer`, which takes a `PluginFilter` and
returns a function that checks whether a given address matches the
filter. Right now, only the `nodes` function uses it.

For added safety, `addressFilterer` does runtime validation that the
required `plugin` property was set.

Test plan: See included unit tests.