### PR TITLE
Don’t erase the `bin/` folder in CI

### DIFF
--- a/config/travis.js
+++ b/config/travis.js
@@ -59,7 +59,7 @@ function makeTasks(mode /*: "BASIC" | "FULL" */) {
     },
     {
       id: "backend",
-      cmd: ["npm", "run", "--silent", "backend"],
+      cmd: ["npm", "run", "--silent", "backend", "--", "--dry-run"],
       deps: [],
     },
   ];

--- a/config/webpack.config.backend.js
+++ b/config/webpack.config.backend.js
@@ -7,7 +7,7 @@ const nodeExternals = require("webpack-node-externals");
 
 // This is the backend configuration. It builds applications that target
 // Node and will not run in a browser.
-module.exports = {
+module.exports = (outputPath) => ({
   // Don't attempt to continue if there are any errors.
   bail: true,
   // Target Node instead of the browser.
@@ -15,7 +15,7 @@ module.exports = {
   entry: paths.backendEntryPoints,
   externals: [nodeExternals()],
   output: {
-    path: paths.backendBuild,
+    path: outputPath,
     // Generated JS file names (with nested folders).
     // There will be one main bundle, and one file per asynchronous chunk.
     // We don't currently advertise code splitting but Webpack supports it.
@@ -77,4 +77,4 @@ module.exports = {
       ),
     }),
   ],
-};
+});


### PR DESCRIPTION
Summary:
Previously, our CI script would run `yarn backend`, which has the
side-effect of erasing the `bin/` directory. By itself, this is not
great, but not awful. However, this frequently triggers a race condition
in Prettier, causing the `check-pretty` step of the build to fail. (More
details: https://github.com/prettier/prettier/issues/4468.)

This patch changes the CI script to build the backend scripts into a
temporary directory.

Test Plan:
Before applying this patch: `yarn backend` and then `yarn travis`. If
this consistently causes a Travis failure due to `check-pretty`, then
your machine can reproduce the race condition that we‛re trying to
eliminate. (Otherwise, you can try creating a bunch more Git history…
I’m not really sure what to say. It is a race condition, after all.)
Then, apply this patch, and repeat the above steps; note that the error
no longer occurs, and that the build output is to a temporary directory.

wchargin-branch: ci-preserve-bin