### PR TITLE
Implement `copy` for GraphV2

### DIFF
--- a/src/core2/graph.js
+++ b/src/core2/graph.js
@@ -357,7 +357,7 @@ export class Graph {
   }
 
   copy(): Graph {
-    throw new Error("Graphv2 is not yet implemented");
+    return Graph.mergeConservative(this.plugins(), [this]);
   }
 
   plugins(): Plugins {

--- a/src/core2/graph.test.js
+++ b/src/core2/graph.test.js
@@ -779,6 +779,33 @@ describe("graph", () => {
       expect(g.equals(newGraph())).toBe(true);
     });
   });
+
+  describe("copy", () => {
+    it("yields a reference-distinct but logically-equal graph", () => {
+      const g = newGraph()
+        .addNode(new FooPayload())
+        .addEdge({
+          address: {
+            owner: {plugin: EXAMPLE_PLUGIN_NAME, type: "EDGE"},
+            id: "e",
+          },
+          src: new BarPayload(1, "hello").address(),
+          dst: new BarPayload(2, "there").address(),
+          payload: "stuff",
+        });
+      const h = g.copy();
+      expect(g).not.toBe(h);
+      expect(g.equals(h)).toBe(true);
+      expect(g.plugins()).toEqual(h.plugins());
+    });
+
+    it("allows independent mutation of the original and copied graphs", () => {
+      const g = newGraph();
+      const h = g.copy();
+      g.addNode(new FooPayload());
+      expect(g.equals(h)).toBe(false);
+    });
+  });
 });
 
 describe("DelegateNodeReference", () => {


### PR DESCRIPTION
Summary:
Both the implementation and the tests here are pretty straightforward.
The only change from GraphV1 is that we should explicitly check that the
plugins are copied correctly, because graph equality does not check
this.

Test Plan:
New unit tests suffice.

wchargin-branch: copy-v2