### PR TITLE
Make Edges into Payload-esque objects

### DIFF
--- a/src/core2/__snapshots__/graph.test.js.snap
+++ b/src/core2/__snapshots__/graph.test.js.snap
@@ -9,25 +9,34 @@ Array [
   Object {
     "edges": Array [
       Object {
-        "type": "sourcecred/sourcecred/AddressMap",
-        "version": "0.2.0",
+        "dstIndex": 2,
+        "payload": Object {
+          "name": "a_absent",
+          "strangeness": 11,
+          "type": "STRANGE",
+        },
+        "plugin": "sourcecred/graph-demo-plugin",
+        "srcIndex": 0,
       },
       Object {
-        "{\\"id\\":\\"a_absent\\",\\"owner\\":{\\"plugin\\":\\"sourcecred/graph-demo-plugin\\",\\"type\\":\\"EDGE\\"}}": Object {
-          "dstIndex": 2,
-          "payload": "not much",
-          "srcIndex": 0,
+        "dstIndex": 1,
+        "payload": Object {
+          "name": "a_b",
+          "strangeness": 11,
+          "type": "STRANGE",
         },
-        "{\\"id\\":\\"a_b\\",\\"owner\\":{\\"plugin\\":\\"sourcecred/graph-demo-plugin\\",\\"type\\":\\"EDGE\\"}}": Object {
-          "dstIndex": 1,
-          "payload": "not much",
-          "srcIndex": 0,
+        "plugin": "sourcecred/graph-demo-plugin",
+        "srcIndex": 0,
+      },
+      Object {
+        "dstIndex": 1,
+        "payload": Object {
+          "name": "absent_b",
+          "strangeness": 11,
+          "type": "STRANGE",
         },
-        "{\\"id\\":\\"absent_b\\",\\"owner\\":{\\"plugin\\":\\"sourcecred/graph-demo-plugin\\",\\"type\\":\\"EDGE\\"}}": Object {
-          "dstIndex": 1,
-          "payload": "not much",
-          "srcIndex": 2,
-        },
+        "plugin": "sourcecred/graph-demo-plugin",
+        "srcIndex": 2,
       },
     ],
     "nodes": Array [


### PR DESCRIPTION
This commit changes `Edges` from being plain JS objects into
plugin-constructed class instances, like with NodePayload and
NodeReference. The interface is as follows:

```js
export interface Edge {
  /**
   * Convert this object to its serialized form. This must be a plain
   * old JSON value: i.e., a value `v` such that
   * `JSON.parse(JSON.stringify(v))` is deep-equal to `v`.
   * The `src` and `dst` should not be included in the JSON representation;
   * rather, the PluginHandler.createEdge method will be offered the src
   * and dst when regenerating the edge from JSON.
   */
  toJSON(): any;
  address(): Address;
  src(): NodeReference;
  dst(): NodeReference;
}
```

Plugin handlers must now provide a `createEdge` function:
```js
  /**
   * Deserialize a JSON edge payload, which is guaranteed to be the
   * seriaization of a previous `EP`.
   */
  createEdge(src: NodeReference, dst: NodeReference, json: any): E;
```

This has some nice consequences:
- We no longer need to serialize edge addresses, which are often very
long concatenations of two other addresses. Instead, we can serialize
the following `EdgeJSON`:

```js
type EdgeJSON = {|
  payload: any,
  plugin: string,
  srcIndex: Integer,
  dstIndex: Integer,
|};
type EdgesSortedByStringifiedAddress = EdgeJSON[];
export type GraphJSON = {|
  +nodes: NodesSortedByStringifiedAddress,
  +edges: EdgesSortedByStringifiedAddress,
|};
```

- Plugins can now provide Edge classes with refined type signatures, as
in the following example:
```js
export class MergedAsEdge {
  static TYPE: "MERGED_AS" = "MERGED_AS";
  _src: PullRequestReference;
  _dst: CommitReference;

  constructor(src: PullRequestReference, dst: CommitReference) {
    // ...
  }

  src(): PullRequestReference {
    return this._src;
  }
  // and so forth
}
```

- It makes the API overall feel more consistent. In the pre-refactor
world, all nodes and edges were stored as plain JS objects. Presently,
nodes are plugin-provided classes with accessor methods, but edges are
still plain JS objects. This commit unifies them.

However, it's a bit weird in this design that `Edges` (which are
nominally graph-agnostic) give `NodeReferences`, which are tied to
specific graphs. As implemented, graphs are permissive in that they will
accept edges from other graphs, but careful in what they return, in that
the edges they return always contain references to their own nodes.

Thus, it is not the case in general that adding an edge to a graph and
requesting it back gives a reference-identical edge; if the initial edge
contained references to a different graph, a new one is returned.

Also, the performance of this commit is not great, since internally the
edges go through address translation a lot: in `neighbors`, `addEdge`,
`removeEdge`, `toJSON`, `fromJSON`, etc. Most of these address
translations are unnecessary; if we refactor to expose an module-private
way to retrieve the index from an indexed `NodeReference`, we can solve
all of these performance issues without breaking the API.

Test plan: Many unit tests were added.