### PR TITLE
Generate `bin/` in-place for cron CI

### DIFF
--- a/config/travis.js
+++ b/config/travis.js
@@ -65,14 +65,22 @@ function makeTasks(mode /*: "BASIC" | "FULL" */) {
   ];
   const extraTasks = [
     {
+      id: "backend-in-place",
+      cmd: ["npm", "run", "--silent", "backend"],
+      // This task depends on `check-pretty` in order to work around a
+      // race condition in Prettier:
+      // https://github.com/prettier/prettier/issues/4468
+      deps: ["check-pretty"],
+    },
+    {
       id: "fetchGithubRepoTest",
       cmd: ["./src/plugins/github/fetchGithubRepoTest.sh", "--no-build"],
-      deps: ["backend"],
+      deps: ["backend-in-place"],
     },
     {
       id: "loadRepositoryTest",
       cmd: ["./src/plugins/git/loadRepositoryTest.sh", "--no-build"],
-      deps: ["backend"],
+      deps: ["backend-in-place"],
     },
   ];
   switch (mode) {


### PR DESCRIPTION
Summary:
This fixes a bug introduced in #317, which only occurred in the cron job
variant of the CI script (`yarn travis --full`): the two scripts run in
the cron job depend on `yarn backend` having previously written to the
`bin/` directory, but this is precisely what we wanted to prevent. To
fix this, we simply add an additional target for `yarn backend` during
the cron job. This is a little bit wasteful in that we compile the
backend applications twice, but it’s not a big deal because (a) it only
runs in cron jobs, so it won’t slow down normal builds, and (b) it only
takes about 5 seconds, anyway.

Test Plan:
Export a `GITHUB_TOKEN` and run `yarn travis --full`, which fails before
this change and passes after it.

wchargin-branch: cron-ci-overwrite-bin