### PR TITLE
Add basic Graph data structures

### DIFF
--- a/src/v3/core/graph.js
+++ b/src/v3/core/graph.js
@@ -92,8 +92,20 @@ export function fromEdgeAddress(n: EdgeAddress): string[] {
 }
 
 export class Graph {
+  _nodes: Set<NodeAddress>;
+  // If `e` is an Edge in the graph, then:
+  // * _edges.get(e.address) `deepEquals` e
+  // * _inEdges.get(e.dst) `contains` e
+  // * _outEdges.get(e.src) `contains` e
+  _edges: Map<EdgeAddress, Edge>;
+  _inEdges: Map<NodeAddress, Edge[]>;
+  _outEdges: Map<NodeAddress, Edge[]>;
+
   constructor(): void {
-    throw new Error("constructor");
+    this._nodes = new Set();
+    this._edges = new Map();
+    this._inEdges = new Map();
+    this._outEdges = new Map();
   }
 
   addNode(a: NodeAddress): this {

--- a/src/v3/core/graph.test.js
+++ b/src/v3/core/graph.test.js
@@ -5,6 +5,7 @@ import {
   fromNodeAddress,
   toEdgeAddress,
   fromEdgeAddress,
+  Graph,
 } from "./graph";
 
 describe("core/graph", () => {
@@ -105,6 +106,15 @@ describe("core/graph", () => {
     it("edge and node addresses are distinct", () => {
       expect(toEdgeAddress([""])).not.toEqual(toNodeAddress([""]));
       expect(toEdgeAddress(["foo"])).not.toEqual(toNodeAddress(["foo"]));
+    });
+  });
+
+  describe("Graph class", () => {
+    it("can be constructed", () => {
+      const x = new Graph();
+      // Verify that `x` is not of type `any`
+      // $ExpectFlowError
+      expect(() => x.measureSpectacularity()).toThrow();
     });
   });
 });


### PR DESCRIPTION
This very minor commit adds the basic data structures to the `Graph`
that will act as underlying storage for nodes and edges. This is similar
to how nodes and edges are stored in `Graph` v1 and v2, except much
simpler, because we now have string keys, no data stored with nodes, and
minimal data stored with edges.

Test plan: The only observable change is that the graph can now be
constructed without error. I added a unit test to verify this behavior
:) as well as that the Graph constructor properly returns an object of 
type `Graph` and not an `any`.
(Context: https://github.com/facebook/flow/issues/6400)

Paired with @wchargin