### PR TITLE
Add v3 `Graph` nodes methods

### DIFF
--- a/src/v3/core/graph.js
+++ b/src/v3/core/graph.js
@@ -43,22 +43,24 @@ export class Graph {
   }
 
   addNode(a: NodeAddress): this {
-    const _ = a;
-    throw new Error("addNode");
+    Address.assertNodeAddress(a);
+    this._nodes.add(a);
+    return this;
   }
 
   removeNode(a: NodeAddress): this {
-    const _ = a;
-    throw new Error("removeNode");
+    Address.assertNodeAddress(a);
+    this._nodes.delete(a);
+    return this;
   }
 
   hasNode(a: NodeAddress): boolean {
-    const _ = a;
-    throw new Error("hasNode");
+    Address.assertNodeAddress(a);
+    return this._nodes.has(a);
   }
 
-  nodes(): Iterator<NodeAddress> {
-    throw new Error("nodes");
+  *nodes(): Iterator<NodeAddress> {
+    yield* this._nodes;
   }
 
   addEdge({src, dst, address}: Edge): this {

--- a/src/v3/core/graph.test.js
+++ b/src/v3/core/graph.test.js
@@ -37,5 +37,72 @@ describe("core/graph", () => {
       // $ExpectFlowError
       expect(() => x.measureSpectacularity()).toThrow();
     });
+    function graphRejectsNulls(f) {
+      [null, undefined].forEach((bad) => {
+        it(`${f.name} errors on ${String(bad)}`, () => {
+          // $ExpectFlowError
+          expect(() => f.call(new Graph(), bad)).toThrow(String(bad));
+        });
+      });
+    }
+    describe("node methods", () => {
+      describe("error on", () => {
+        const p = Graph.prototype;
+        const nodeMethods = [p.addNode, p.removeNode, p.hasNode];
+        function rejectsEdge(f) {
+          it(`${f.name} rejects EdgeAddress`, () => {
+            const e = Address.edgeAddress(["foo"]);
+            // $ExpectFlowError
+            expect(() => f.call(new Graph(), e)).toThrow("got EdgeAddress");
+          });
+        }
+        nodeMethods.forEach(graphRejectsNulls);
+        nodeMethods.forEach(rejectsEdge);
+      });
+
+      describe("work on", () => {
+        const n1 = Address.nodeAddress(["foo"]);
+        it("a graph with no nodes", () => {
+          const graph = new Graph();
+          expect(graph.hasNode(n1)).toBe(false);
+          expect(Array.from(graph.nodes())).toHaveLength(0);
+        });
+        it("a graph with a node added", () => {
+          const graph = new Graph().addNode(n1);
+          expect(graph.hasNode(n1)).toBe(true);
+          expect(Array.from(graph.nodes())).toEqual([n1]);
+        });
+        it("a graph with the same node added twice", () => {
+          const graph = new Graph().addNode(n1).addNode(n1);
+          expect(graph.hasNode(n1)).toBe(true);
+          expect(Array.from(graph.nodes())).toEqual([n1]);
+        });
+        it("a graph with an absent node removed", () => {
+          const graph = new Graph().removeNode(n1);
+          expect(graph.hasNode(n1)).toBe(false);
+          expect(Array.from(graph.nodes())).toHaveLength(0);
+        });
+        it("a graph with an added node removed", () => {
+          const graph = new Graph().addNode(n1).removeNode(n1);
+          expect(graph.hasNode(n1)).toBe(false);
+          expect(Array.from(graph.nodes())).toHaveLength(0);
+        });
+        it("a graph with an added node removed twice", () => {
+          const graph = new Graph()
+            .addNode(n1)
+            .removeNode(n1)
+            .removeNode(n1);
+          expect(graph.hasNode(n1)).toBe(false);
+          expect(Array.from(graph.nodes())).toHaveLength(0);
+        });
+        it("a graph with two nodes", () => {
+          const n2 = Address.nodeAddress([""]);
+          const graph = new Graph().addNode(n1).addNode(n2);
+          expect(graph.hasNode(n1)).toBe(true);
+          expect(graph.hasNode(n2)).toBe(true);
+          expect(Array.from(graph.nodes()).sort()).toEqual([n2, n1]);
+        });
+      });
+    });
   });
 });


### PR DESCRIPTION
This commit implements and tests the following methods on the `Graph`:
- `addNode`
- `removeNode`
- `hasNode`
- `nodes`

Test plan: Unit tests are included.

Paired with @wchargin