### PR TITLE
Add `addressAppend`

### DIFF
--- a/src/v3/core/_address.js
+++ b/src/v3/core/_address.js
@@ -86,18 +86,40 @@ export function assertAddressArray(arr: $ReadOnlyArray<string>) {
   });
 }
 
+function nullDelimited(components: $ReadOnlyArray<string>): string {
+  return [...components, ""].join(SEPARATOR);
+}
+
 export function nodeAddress(arr: $ReadOnlyArray<string>): NodeAddress {
   assertAddressArray(arr);
-  return [NODE_PREFIX, ...arr, ""].join(SEPARATOR);
+  return NODE_PREFIX + SEPARATOR + nullDelimited(arr);
 }
 
 export function edgeAddress(arr: $ReadOnlyArray<string>): EdgeAddress {
   assertAddressArray(arr);
-  return [EDGE_PREFIX, ...arr, ""].join(SEPARATOR);
+  return EDGE_PREFIX + SEPARATOR + nullDelimited(arr);
 }
 
 export function toParts(a: GenericAddress): string[] {
   assertAddress(a);
   const parts = a.split(SEPARATOR);
   return parts.slice(1, parts.length - 1);
+}
+
+export function nodeAppend(
+  base: NodeAddress,
+  ...components: string[]
+): NodeAddress {
+  assertNodeAddress(base);
+  assertAddressArray(components);
+  return base + nullDelimited(components);
+}
+
+export function edgeAppend(
+  base: EdgeAddress,
+  ...components: string[]
+): EdgeAddress {
+  assertEdgeAddress(base);
+  assertAddressArray(components);
+  return base + nullDelimited(components);
 }


### PR DESCRIPTION
Consider a case where a user wants to construct many addresses sharing a
common prefix. For example, every GitHub entity may have an address
starting with the component sequence `["sourcecred", "github"]`.

Currently, users can implement this with `toParts`:

```js
const GITHUB_ADDRESS = Address.nodeAddress(["sourcecred", "github"]);
function createGithubAddress(ids: $ReadOnlyArray<string>): NodeAddress {
  return nodeAddress([...Address.toParts(GITHUB_ADDRESS), ...ids]);
}
```

This is unfortunate from a performance standpoint, as we needlessly
perform string and array operations, when under the hood this is
basically a string concatenation.

This commit fixes this by adding functions `nodeAppend` and
`edgeAppend`, which take a node (resp. edge) and some components to
append, returning a new address. Consider how straightforward our
example case becomes:

```js
const GITHUB_NODE_PREFIX = Address.nodeAddress(["sourcecred", "github"]);
const ISSUE_NODE_PREFIX = Address.nodeAppend(GITHUB_NODE_PREFIX, "issue");

// There is no longer any need for an explicit creation function
const anIssueAddress = Address.nodeAppend(ISSUE_NODE_PREFIX, someIssueID);
```

Paired with @wchargin.

Test Plan:
Unit tests added; run `yarn travis`.
