### PR TITLE
Update `src/v1/` paths for CI cron

### DIFF
--- a/config/travis.js
+++ b/config/travis.js
@@ -74,12 +74,12 @@ function makeTasks(mode /*: "BASIC" | "FULL" */) {
     },
     {
       id: "fetchGithubRepoTest",
-      cmd: ["./src/plugins/github/fetchGithubRepoTest.sh", "--no-build"],
+      cmd: ["./src/v1/plugins/github/fetchGithubRepoTest.sh", "--no-build"],
       deps: ["backend-in-place"],
     },
     {
       id: "loadRepositoryTest",
-      cmd: ["./src/plugins/git/loadRepositoryTest.sh", "--no-build"],
+      cmd: ["./src/v1/plugins/git/loadRepositoryTest.sh", "--no-build"],
       deps: ["backend-in-place"],
     },
   ];

--- a/src/v1/plugins/git/loadRepositoryTest.sh
+++ b/src/v1/plugins/git/loadRepositoryTest.sh
@@ -2,7 +2,7 @@
 
 set -eu
 
-data_file=src/plugins/git/demoData/example-git.json
+data_file=src/v1/plugins/git/demoData/example-git.json
 
 usage() {
   printf 'usage: %s [-u|--updateSnapshot] [--help]\n' "$0"

--- a/src/v1/plugins/github/fetchGithubRepoTest.sh
+++ b/src/v1/plugins/github/fetchGithubRepoTest.sh
@@ -2,7 +2,7 @@
 
 set -eu
 
-data_file=src/plugins/github/demoData/example-github.json
+data_file=src/v1/plugins/github/demoData/example-github.json
 
 usage() {
   printf 'usage: %s [-u|--updateSnapshot] [--[no-]build] [--help]\n' "$0"


### PR DESCRIPTION
Summary:
Fixes breakage due to https://github.com/sourcecred/sourcecred/pull/327.

Test Plan:
`yarn travis --full` now passes.

wchargin-branch: src-v1-cron