### PR TITLE
Ensure build failure emails

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,3 +2,9 @@ language: node_js
 node_js:
   - "node"
 script: yarn travis
+notifications:
+  email:
+    recipients:
+      wchargin+travis-sourcecred@gmail.com
+      decentralion+travis-sourcecred@dandelion.io
+    on_failure: always


### PR DESCRIPTION
When the cron build fails, we want to make sure that we know about it.
This commit ensures that Travis emails @wchargin and @decentralion on
any build failure; our email filters will ensure that cron job failures
get noticed.

Based on documentation at: https://docs.travis-ci.com/user/notifications