### PR TITLE
Fetch PR additions and deletions from GitHub

### DIFF
--- a/src/v1/plugins/github/__snapshots__/parser.test.js.snap
+++ b/src/v1/plugins/github/__snapshots__/parser.test.js.snap
@@ -305,11 +305,13 @@ Array [
           "type": "PULL_REQUEST",
         },
         "payload": Object {
+          "additions": 1,
           "body": "@wchargin could you please do the following:
 - add a commit comment
 - add a review comment requesting some trivial change
 - i'll change it
 - then approve the pr",
+          "deletions": 0,
           "number": 5,
           "title": "This pull request will be more contentious. I can feel it...",
           "url": "https://github.com/sourcecred/example-github/pull/5",
@@ -448,7 +450,9 @@ Array [
           "type": "PULL_REQUEST",
         },
         "payload": Object {
+          "additions": 1,
           "body": "Oh look, it's a pull request.",
+          "deletions": 0,
           "number": 3,
           "title": "Add README, merge via PR.",
           "url": "https://github.com/sourcecred/example-github/pull/3",
@@ -1705,7 +1709,9 @@ Issue with Unicode: ȴሲ𣐳楢👍 :heart: 𐤔𐤁𐤀𐤑𐤍𐤉𐤔𐤌�
           "type": "PULL_REQUEST",
         },
         "payload": Object {
+          "additions": 1,
           "body": "Oh look, it's a pull request.",
+          "deletions": 0,
           "number": 3,
           "title": "Add README, merge via PR.",
           "url": "https://github.com/sourcecred/example-github/pull/3",
@@ -1729,11 +1735,13 @@ Issue with Unicode: ȴሲ𣐳楢👍 :heart: 𐤔𐤁𐤀𐤑𐤍𐤉𐤔𐤌�
           "type": "PULL_REQUEST",
         },
         "payload": Object {
+          "additions": 1,
           "body": "@wchargin could you please do the following:
 - add a commit comment
 - add a review comment requesting some trivial change
 - i'll change it
 - then approve the pr",
+          "deletions": 0,
           "number": 5,
           "title": "This pull request will be more contentious. I can feel it...",
           "url": "https://github.com/sourcecred/example-github/pull/5",
@@ -1781,7 +1789,9 @@ Issue with Unicode: ȴሲ𣐳楢👍 :heart: 𐤔𐤁𐤀𐤑𐤍𐤉𐤔𐤌�
           "type": "PULL_REQUEST",
         },
         "payload": Object {
+          "additions": 3,
           "body": "Nominally paired with @wchargin",
+          "deletions": 0,
           "number": 9,
           "title": "An unmerged pull request",
           "url": "https://github.com/sourcecred/example-github/pull/9",

--- a/src/v1/plugins/github/__snapshots__/porcelain.test.js.snap
+++ b/src/v1/plugins/github/__snapshots__/porcelain.test.js.snap
@@ -84,7 +84,7 @@ Object {
   "https://github.com/decentralion": "@decentralion",
   "https://github.com/sourcecred/example-github/issues/2": "#2: A referencing issue.",
   "https://github.com/sourcecred/example-github/issues/2#issuecomment-373768703": "comment by @decentralion on #2",
-  "https://github.com/sourcecred/example-github/pull/5": "#5: This pull request will be more contentious. I can feel it...",
+  "https://github.com/sourcecred/example-github/pull/5": "#5 (+1/−0): This pull request will be more contentious. I can feel it...",
   "https://github.com/sourcecred/example-github/pull/5#discussion_r171460198": "review comment by @wchargin on #5",
   "https://github.com/sourcecred/example-github/pull/5#pullrequestreview-100313899": "review by @wchargin on #5",
 }

--- a/src/v1/plugins/github/demoData/example-github.json
+++ b/src/v1/plugins/github/demoData/example-github.json
@@ -266,6 +266,7 @@
         "pullRequests": {
             "nodes": [
                 {
+                    "additions": 1,
                     "author": {
                         "__typename": "User",
                         "id": "MDQ6VXNlcjE0MDAwMjM=",
@@ -292,6 +293,7 @@
                             "hasNextPage": false
                         }
                     },
+                    "deletions": 0,
                     "id": "MDExOlB1bGxSZXF1ZXN0MTcxODg3NzQx",
                     "mergeCommit": {
                         "oid": "0a223346b4e6dec0127b1e6aa892c4ee0424b66a"
@@ -309,6 +311,7 @@
                     "url": "https://github.com/sourcecred/example-github/pull/3"
                 },
                 {
+                    "additions": 1,
                     "author": {
                         "__typename": "User",
                         "id": "MDQ6VXNlcjE0MDAwMjM=",
@@ -324,6 +327,7 @@
                             "hasNextPage": false
                         }
                     },
+                    "deletions": 0,
                     "id": "MDExOlB1bGxSZXF1ZXN0MTcxODg4NTIy",
                     "mergeCommit": {
                         "oid": "6d5b3aa31ebb68a06ceb46bbd6cf49b6ccd6f5e6"
@@ -392,6 +396,7 @@
                     "url": "https://github.com/sourcecred/example-github/pull/5"
                 },
                 {
+                    "additions": 3,
                     "author": {
                         "__typename": "User",
                         "id": "MDQ6VXNlcjE0MDAwMjM=",
@@ -407,6 +412,7 @@
                             "hasNextPage": false
                         }
                     },
+                    "deletions": 0,
                     "id": "MDExOlB1bGxSZXF1ZXN0MTg1ODA2MTU3",
                     "mergeCommit": null,
                     "number": 9,

--- a/src/v1/plugins/github/graphql.js
+++ b/src/v1/plugins/github/graphql.js
@@ -700,6 +700,8 @@ export type PullRequestJSON = {|
   +title: string,
   +body: string,
   +number: number,
+  +additions: number,
+  +deletions: number,
   +author: NullableAuthorJSON,
   +comments: ConnectionJSON<CommentJSON>,
   +reviews: ConnectionJSON<PullRequestReviewJSON>,
@@ -717,6 +719,8 @@ function pullRequestsFragment(): FragmentDefinition {
       b.field("body"),
       b.field("number"),
       b.field("mergeCommit", {}, [b.field("oid")]),
+      b.field("additions"),
+      b.field("deletions"),
       makeAuthor(),
       b.field("comments", {first: b.literal(PAGE_SIZE_COMMENTS)}, [
         b.fragmentSpread("comments"),

--- a/src/v1/plugins/github/parser.js
+++ b/src/v1/plugins/github/parser.js
@@ -216,6 +216,8 @@ class GithubParser {
       number: prJson.number,
       title: prJson.title,
       body: prJson.body,
+      additions: prJson.additions,
+      deletions: prJson.deletions,
     };
     const pullRequestNode: Node<PullRequestNodePayload> = {
       address: this.makeNodeAddress("PULL_REQUEST", prJson.url),

--- a/src/v1/plugins/github/porcelain.js
+++ b/src/v1/plugins/github/porcelain.js
@@ -392,6 +392,14 @@ export class PullRequestPorcelain extends PostPorcelain<
     return this.payload().title;
   }
 
+  additions(): number {
+    return this.payload().additions;
+  }
+
+  deletions(): number {
+    return this.payload().deletions;
+  }
+
   ref(): PullRequestReference {
     return new PullRequestReference(super.ref());
   }

--- a/src/v1/plugins/github/render.js
+++ b/src/v1/plugins/github/render.js
@@ -40,7 +40,8 @@ export function nodeDescription(ref: NodeReference<NodePayload>) {
     }
     case "PULL_REQUEST": {
       const pr = new PullRequestPorcelain(porcelain);
-      return `#${pr.number()}: ${pr.title()}`;
+      const diff = `+${pr.additions()}/\u2212${pr.deletions()}`;
+      return `#${pr.number()} (${diff}): ${pr.title()}`;
     }
     case "COMMENT": {
       const comment = new CommentReference(ref);

--- a/src/v1/plugins/github/types.js
+++ b/src/v1/plugins/github/types.js
@@ -22,6 +22,8 @@ export type PullRequestNodePayload = {|
   +title: string,
   +number: number,
   +body: string,
+  +additions: number,
+  +deletions: number,
 |};
 
 export type PullRequestReviewState =


### PR DESCRIPTION
Summary:
Closes #336.

Test Plan:
Snapshots updated; changes are easily readable. Existing tests pass.
Running the cred explorer on the `sourcecred/sourcecred` graph shows
pull requests like `#124 (+73/−3): Update the README`, which is good.

wchargin-branch: pr-addition-deletion