### PR TITLE
Fix GitHub rendering for posts without authors

### DIFF
--- a/src/v1/plugins/github/render.js
+++ b/src/v1/plugins/github/render.js
@@ -81,6 +81,13 @@ function num(x: IssueReference | PullRequestReference) {
 function authors(authorable: {+authors: () => AuthorReference[]}) {
   // TODO: modify to accomodate multi-authorship
   const authorRefs = authorable.authors();
-  const firstAuthor = authorRefs[0].get();
-  return firstAuthor != null ? firstAuthor.login() : "[unknown]";
+  const firstAuthorRef = authorRefs[0];
+  if (firstAuthorRef == null) {
+    return "[unknown]";
+  }
+  const firstAuthorNode = firstAuthorRef.get();
+  if (firstAuthorNode == null) {
+    return "[unknown]";
+  }
+  return firstAuthorNode.login();
 }


### PR DESCRIPTION
Our GitHub renderer tries to display the author name for a comments or
pull request reviews. However, as we've already discovered (#228), not
every GitHub post has an author available. This breaks attempts to demo
the v1 cred explorer on some interesting repos, e.g. ipfs/js-ipfs.

Since the v1 code is all deprecated, it's effectively a demo branch
pending a rewrite of the cred explorer to use the v3 graph. As such, I
didn't include unit tests.

Test plan:
Attempt to run the cred explorer on `ipfs/js-ipfs` prior to this PR.
Observe that it loudly fails. Attempt to run it after this PR, and
that it succeeds.