### PR TITLE
Limit Cred Explorer to display 100 entries

### DIFF
--- a/src/v1/app/credExplorer/pagerankTable.js
+++ b/src/v1/app/credExplorer/pagerankTable.js
@@ -13,6 +13,8 @@ import {nodeDescription as githubNodeDescription} from "../../plugins/github/ren
 import {nodeDescription as gitNodeDescription} from "../../plugins/git/render";
 import type {PagerankResult} from "./basicPagerank";
 
+const MAX_TABLE_ENTRIES = 100;
+
 type Props = {
   pagerankResult: ?PagerankResult,
   graph: ?Graph,
@@ -220,6 +222,7 @@ class RecursiveTables extends React.Component<RecursiveTablesProps> {
         const y = pagerankResult.get(b).probability;
         return y - x;
       })
+      .slice(0, MAX_TABLE_ENTRIES)
       .map((address) => (
         <RecursiveTable
           depth={depth}


### PR DESCRIPTION
Right now, the cred explorer attempts to display every node in the
graph. As graphs easily grow to O(100k) nodes, this is not kind to the
browser.

This commit limits display to the first 100 entries. Since they are
sorted by percieved importance, and it's easy to filter by type (e.g. to
find all users), this limitation is fine in practice.

Test plan:
Run the cred explorer on a larger repo and observe that the performance
is enormously improved. No unit tests added, as the cred explorer is a
prototype which is basically untested (#269)