### PR TITLE
Unify a command-line entry point module

### DIFF
--- a/scripts/backend.js
+++ b/scripts/backend.js
@@ -6,12 +6,7 @@ process.env.NODE_ENV = process.env.NODE_ENV || "development";
 process.env.BABEL_ENV = process.env.NODE_ENV;
 process.env.SOURCECRED_BACKEND = "true";
 
-// Makes the script crash on unhandled rejections instead of silently
-// ignoring them. In the future, promise rejections that are not handled will
-// terminate the Node.js process with a non-zero exit code.
-process.on("unhandledRejection", (err) => {
-  throw err;
-});
+require("../src/tools/entry");
 
 // Ensure environment variables are read.
 require("../config/env");

--- a/scripts/build.js
+++ b/scripts/build.js
@@ -5,12 +5,7 @@
 process.env.BABEL_ENV = "production";
 process.env.NODE_ENV = "production";
 
-// Makes the script crash on unhandled rejections instead of silently
-// ignoring them. In the future, promise rejections that are not handled will
-// terminate the Node.js process with a non-zero exit code.
-process.on("unhandledRejection", (err) => {
-  throw err;
-});
+require("../src/tools/entry");
 
 // Ensure environment variables are read.
 require("../config/env");

--- a/scripts/start.js
+++ b/scripts/start.js
@@ -5,12 +5,7 @@
 process.env.BABEL_ENV = "development";
 process.env.NODE_ENV = "development";
 
-// Makes the script crash on unhandled rejections instead of silently
-// ignoring them. In the future, promise rejections that are not handled will
-// terminate the Node.js process with a non-zero exit code.
-process.on("unhandledRejection", (err) => {
-  throw err;
-});
+require("../src/tools/entry");
 
 // Ensure environment variables are read.
 require("../config/env");

--- a/scripts/test.js
+++ b/scripts/test.js
@@ -6,12 +6,7 @@ process.env.BABEL_ENV = "test";
 process.env.NODE_ENV = "test";
 process.env.PUBLIC_URL = "";
 
-// Makes the script crash on unhandled rejections instead of silently
-// ignoring them. In the future, promise rejections that are not handled will
-// terminate the Node.js process with a non-zero exit code.
-process.on("unhandledRejection", (err) => {
-  throw err;
-});
+require("../src/tools/entry");
 
 // Ensure environment variables are read.
 require("../config/env");

--- a/src/tools/entry.js
+++ b/src/tools/entry.js
@@ -1,0 +1,11 @@
+// @flow
+//
+// Common entry point module. This module should be required by every
+// module that is intended to be run as a standalone application.
+
+// Makes the script crash on unhandled rejections instead of silently
+// ignoring them. In the future, promise rejections that are not handled will
+// terminate the Node.js process with a non-zero exit code.
+process.on("unhandledRejection", (err) => {
+  throw err;
+});

--- a/src/v1/cli/commands/combine.js
+++ b/src/v1/cli/commands/combine.js
@@ -7,13 +7,6 @@ import {promisify} from "util";
 
 import {Graph} from "../../core/graph";
 
-// Makes the script crash on unhandled rejections instead of silently
-// ignoring them. In the future, promise rejections that are not handled will
-// terminate the Node.js process with a non-zero exit code.
-process.on("unhandledRejection", (err) => {
-  throw err;
-});
-
 export default class CombineCommand extends Command {
   static description =
     "combine multiple contribution graphs into one big graph";

--- a/src/v1/cli/commands/graph.js
+++ b/src/v1/cli/commands/graph.js
@@ -13,13 +13,6 @@ import {
 const execDependencyGraph = require("../../../tools/execDependencyGraph")
   .default;
 
-// Makes the script crash on unhandled rejections instead of silently
-// ignoring them. In the future, promise rejections that are not handled will
-// terminate the Node.js process with a non-zero exit code.
-process.on("unhandledRejection", (err) => {
-  throw err;
-});
-
 export default class GraphCommand extends Command {
   static description = `\
 create the contribution graph for a repository

--- a/src/v1/cli/commands/pluginGraph.js
+++ b/src/v1/cli/commands/pluginGraph.js
@@ -9,13 +9,6 @@ import createGitGraph from "../../plugins/git/cloneGitGraph";
 import createGithubGraph from "../../plugins/github/fetchGithubGraph";
 import {pluginNames} from "../common";
 
-// Makes the script crash on unhandled rejections instead of silently
-// ignoring them. In the future, promise rejections that are not handled will
-// terminate the Node.js process with a non-zero exit code.
-process.on("unhandledRejection", (err) => {
-  throw err;
-});
-
 export default class PluginGraphCommand extends Command {
   static description = "create the contribution graph for a single plugin";
 

--- a/src/v1/cli/commands/start.js
+++ b/src/v1/cli/commands/start.js
@@ -8,13 +8,6 @@ import {choosePort} from "react-dev-utils/WebpackDevServerUtils";
 import apiApp from "../../app/apiApp";
 import {sourcecredDirectoryFlag} from "../common";
 
-// Makes the script crash on unhandled rejections instead of silently
-// ignoring them. In the future, promise rejections that are not handled will
-// terminate the Node.js process with a non-zero exit code.
-process.on("unhandledRejection", (err) => {
-  throw err;
-});
-
 const DEFAULT_PORT = parseInt(process.env.PORT, 10) || 4000;
 const HOST = process.env.HOST || "0.0.0.0";
 

--- a/src/v1/cli/sourcecred.js
+++ b/src/v1/cli/sourcecred.js
@@ -1,4 +1,5 @@
 // @flow
+require("../../tools/entry");
 require("@oclif/command")
   .run()
   .catch(require("@oclif/errors/handle"));


### PR DESCRIPTION
Summary:
For now, this contains the logic to register an `unhandledRejection`
error. I’ve removed all instances of those handlers, and `require`d this
module at every top-level entry point. (The individual CLI commands had
the handler before, but didn’t need it; conversely, the top-level CLI
entry point did not have the handler, but should have.)

Test Plan:
To test that the CLI commands still error on unhandled rejections, apply
the following patch:

```diff
diff --git a/src/v1/cli/commands/combine.js b/src/v1/cli/commands/combine.js
index b60f91e..d55b965 100644
--- a/src/v1/cli/commands/combine.js
+++ b/src/v1/cli/commands/combine.js
@@ -24,6 +24,7 @@ export default class CombineCommand extends Command {
     "  where each GRAPH is a JSON file generated by plugin-graph";

   async run() {
+    Promise.reject("wat");
     const {argv} = this.parse(CombineCommand);
     combine(argv);
   }
```

Then run `yarn backend` and `node bin/sourcecred.js combine`, and note
that the rejection handler is triggered.

wchargin-branch: unify-entry