### PR TITLE
Log error contents on promise rejection

### DIFF
--- a/src/tools/entry.js
+++ b/src/tools/entry.js
@@ -3,9 +3,13 @@
 // Common entry point module. This module should be required by every
 // module that is intended to be run as a standalone application.
 
+const util = require("util");
+
 // Makes the script crash on unhandled rejections instead of silently
 // ignoring them. In the future, promise rejections that are not handled will
 // terminate the Node.js process with a non-zero exit code.
 process.on("unhandledRejection", (err) => {
+  const details = util.inspect(err, {showHidden: true, depth: null});
+  console.error(details);
   throw err;
 });


### PR DESCRIPTION
Summary:
Using `throw err;` was not useful when the error’s message was an
object: `[object Object]` would be printed to the console, in lieu of
any useful information. We now additionally use `console.error` to print
the full object contents.

Test Plan:
Apply the following patch:

```diff
diff --git a/src/v1/cli/commands/combine.js b/src/v1/cli/commands/combine.js
index b60f91e..2fc4061 100644
--- a/src/v1/cli/commands/combine.js
+++ b/src/v1/cli/commands/combine.js
@@ -24,6 +24,7 @@ export default class CombineCommand extends Command {
     "  where each GRAPH is a JSON file generated by plugin-graph";

   async run() {
+    Promise.reject({a: {b: {c: {d: {e: {f: "gee"}}}}}});
     const {argv} = this.parse(CombineCommand);
     combine(argv);
   }
```

Then, run `yarn backend && node bin/sourcecred.js combine`, and note
that the full contents of the object are printed. (If the `util.inspect`
is replaced with a simple `console.error`, then the object’s
representation will be truncated, so the `util.inspect` is important.)

wchargin-branch: rejection-error-full-contents