### PR TITLE
Include context parameters for address assertions

### DIFF
--- a/src/v3/core/_address.js
+++ b/src/v3/core/_address.js
@@ -30,58 +30,65 @@ function addressType(x: string): ?AddressType {
   }
 }
 
-export function assertNodeAddress(x: NodeAddress) {
+export function assertNodeAddress(x: NodeAddress, what: string = "node") {
   const type = addressType(x);
   switch (type) {
     case "NODE":
       return;
     case "EDGE":
-      throw new Error(`Expected NodeAddress, got EdgeAddress: ${stringify(x)}`);
+      throw new Error(
+        `${what}: expected NodeAddress, got EdgeAddress: ${stringify(x)}`
+      );
     case null:
     case undefined:
-      throw new Error(`Bad address: ${stringify(x)}`);
+      throw new Error(`${what}: bad address: ${stringify(x)}`);
     default:
       // eslint-disable-next-line no-unused-expressions
       (type: empty);
-      throw new Error(`Invariant violation: ${stringify(x)}`);
+      throw new Error(`${what}: invariant violation: ${stringify(x)}`);
   }
 }
 
-export function assertEdgeAddress(x: EdgeAddress) {
+export function assertEdgeAddress(x: EdgeAddress, what: string = "edge") {
   const type = addressType(x);
   switch (type) {
     case "NODE":
-      throw new Error(`Expected EdgeAddress, got NodeAddress: ${stringify(x)}`);
+      throw new Error(
+        `${what}: expected EdgeAddress, got NodeAddress: ${stringify(x)}`
+      );
     case "EDGE":
       return;
     case null:
     case undefined:
-      throw new Error(`Bad address: ${stringify(x)}`);
+      throw new Error(`${what}: bad address: ${stringify(x)}`);
     default:
       // eslint-disable-next-line no-unused-expressions
       (type: empty);
-      throw new Error(`Invariant violation: ${stringify(x)}`);
+      throw new Error(`${what}: invariant violation: ${stringify(x)}`);
   }
 }
 
-export function assertAddress(x: GenericAddress) {
+export function assertAddress(x: GenericAddress, what: string = "address") {
   if (addressType(x) == null) {
     throw new Error(
-      `Expected NodeAddress or EdgeAddress, got: ${stringify(x)}`
+      `${what}: expected NodeAddress or EdgeAddress, got: ${stringify(x)}`
     );
   }
 }
 
-export function assertAddressArray(arr: $ReadOnlyArray<string>) {
+export function assertAddressArray(
+  arr: $ReadOnlyArray<string>,
+  what: string = "address array"
+) {
   if (arr == null) {
     throw new Error(String(arr));
   }
   arr.forEach((s: string) => {
     if (s == null) {
-      throw new Error(`${String(s)} in ${stringify(arr)}`);
+      throw new Error(`${what}: ${String(s)} in ${stringify(arr)}`);
     }
     if (s.indexOf(SEPARATOR) !== -1) {
-      throw new Error(`NUL char: ${stringify(arr)}`);
+      throw new Error(`${what}: NUL char: ${stringify(arr)}`);
     }
   });
 }

--- a/src/v3/core/_address.test.js
+++ b/src/v3/core/_address.test.js
@@ -53,7 +53,7 @@ describe("core/address", () => {
     throwOnNullOrUndefined(toParts);
     it("throws on malformed address", () => {
       // $ExpectFlowError
-      expect(() => toParts("zookomoobo")).toThrow(/Expected .*Address/);
+      expect(() => toParts("zookomoobo")).toThrow(/expected .*Address/);
     });
     it("throws on fake (slash-separated) node address", () => {
       // $ExpectFlowError
@@ -104,12 +104,12 @@ describe("core/address", () => {
         });
         it("malformed base", () => {
           // $ExpectFlowError
-          expect(() => f("foo", "foo")).toThrow("Bad address");
+          expect(() => f("foo", "foo")).toThrow("bad address");
         });
         it("base of wrong kind", () => {
           // $ExpectFlowError
           expect(() => f(badConstructor(["foo"]), "foo")).toThrow(
-            /Expected.*Address/
+            /expected.*Address/
           );
         });
         it("invalid component", () => {
@@ -159,8 +159,14 @@ describe("core/address", () => {
           expect(() => f(bad)).toThrow(badMsg);
         });
         it("errors on non-address", () => {
+          it("errors on the wrong type of address with a custom message", () => {
+            // $ExpectFlowError
+            expect(() => f(bad, "widget")).toThrow(
+              new RegExp("widget:.*" + badMsg)
+            );
+          });
           // $ExpectFlowError
-          expect(() => f("foomulous")).toThrow("Bad address:");
+          expect(() => f("foomulous")).toThrow("bad address:");
         });
       });
     }


### PR DESCRIPTION
Summary:
Now, a client calling `assertNodeAddress` can indicate the context to
clients, like `assertNodeAddress(foo.bar.node, "foo.bar.node")`.

Paired with @decentralion.

Test Plan:
Unit tests updated. Existing graph code does not need to be updated,
because the default values work fine.

wchargin-branch: assertion-context-parameters