### PR TITLE
Add `toString` functions for addresses and edges

### DIFF
--- a/src/v3/core/_address.js
+++ b/src/v3/core/_address.js
@@ -130,3 +130,15 @@ export function edgeAppend(
   assertAddressArray(components);
   return base + nullDelimited(components);
 }
+
+export function nodeToString(a: NodeAddress): string {
+  assertNodeAddress(a);
+  const parts = toParts(a);
+  return `nodeAddress(${stringify(parts)})`;
+}
+
+export function edgeToString(a: EdgeAddress): string {
+  assertEdgeAddress(a);
+  const parts = toParts(a);
+  return `edgeAddress(${stringify(parts)})`;
+}

--- a/src/v3/core/graph.js
+++ b/src/v3/core/graph.js
@@ -110,3 +110,10 @@ export class Graph {
     throw new Error("merge");
   }
 }
+
+export function edgeToString(edge: Edge): string {
+  const address = Address.edgeToString(edge.address);
+  const src = Address.nodeToString(edge.src);
+  const dst = Address.nodeToString(edge.dst);
+  return `{address: ${address}, src: ${src}, dst: ${dst}}`;
+}

--- a/src/v3/core/graph.test.js
+++ b/src/v3/core/graph.test.js
@@ -1,6 +1,6 @@
 // @flow
 
-import {Address, Graph} from "./graph";
+import {Address, Graph, edgeToString} from "./graph";
 import type {NodeAddress, EdgeAddress} from "./graph";
 
 describe("core/graph", () => {
@@ -103,6 +103,23 @@ describe("core/graph", () => {
           expect(Array.from(graph.nodes()).sort()).toEqual([n2, n1]);
         });
       });
+    });
+  });
+
+  describe("edgeToString", () => {
+    it("works", () => {
+      const edge = {
+        address: Address.edgeAddress(["one", "two"]),
+        dst: Address.nodeAddress(["five", "six"]),
+        src: Address.nodeAddress(["three", "four"]),
+      };
+      const expected =
+        "{" +
+        'address: edgeAddress(["one","two"]), ' +
+        'src: nodeAddress(["three","four"]), ' +
+        'dst: nodeAddress(["five","six"])' +
+        "}";
+      expect(edgeToString(edge)).toEqual(expected);
     });
   });
 });


### PR DESCRIPTION
Summary:
If you just print out an address, depending on output context the NUL
separators may just disappear, which is really bad. Using `stringify` is
better, but causes these characters to appear as `\u0000`, which is not
very pretty.

This commit adds pretty-printing functions that clearly display the
addresses. A node address is printed as:

    nodeAddress(["array","of","parts"])

An edge address is printed as:

    edgeAddress(["array","of","parts"])

An edge in the graph is printed as:

    {address: edgeAddress(["one"]), src: nodeAddress(["two"]), dst: nodeAddress(["three"])}

Note that each of these is a valid JavaScript expression that evaluates
to the argument that was originally converted to string.

Paired with @decentralion.

Test Plan:
Unit tests added. Run `yarn travis`.

wchargin-branch: node-edge-tostring