### PR TITLE
Graph: implement edge methods

### DIFF
--- a/src/v3/core/graph.js
+++ b/src/v3/core/graph.js
@@ -26,11 +26,14 @@ export type NeighborsOptions = {|
 export opaque type GraphJSON = any; // TODO
 
 export class Graph {
+  // A node `n` is in the graph if `_nodes.has(n)`.
+  //
+  // An edge `e` is in the graph if `_edges.get(e.address)`
+  // is deep-equal to `e`.
+  //
+  // Invariant: If an edge `e` is in the graph, then `e.src` and `e.dst`
+  // are both in the graph.
   _nodes: Set<NodeAddress>;
-  // If `e` is an Edge in the graph, then:
-  // * _edges.get(e.address) `deepEquals` e
-  // * _inEdges.get(e.dst) `contains` e
-  // * _outEdges.get(e.src) `contains` e
   _edges: Map<EdgeAddress, Edge>;
   _inEdges: Map<NodeAddress, Edge[]>;
   _outEdges: Map<NodeAddress, Edge[]>;
@@ -50,6 +53,14 @@ export class Graph {
 
   removeNode(a: NodeAddress): this {
     Address.assertNodeAddress(a);
+    for (const e of this.edges()) {
+      if (e.src === a || e.dst === a) {
+        const srcOrDst = e.src === a ? "src" : "dst";
+        throw new Error(
+          `Attempted to remove ${srcOrDst} of ${edgeToString(e)}`
+        );
+      }
+    }
     this._nodes.delete(a);
     return this;
   }
@@ -63,28 +74,53 @@ export class Graph {
     yield* this._nodes;
   }
 
-  addEdge({src, dst, address}: Edge): this {
-    const _ = {src, dst, address};
-    throw new Error("addEdge");
+  addEdge(edge: Edge): this {
+    Address.assertNodeAddress(edge.src, "edge.src");
+    Address.assertNodeAddress(edge.dst, "edge.dst");
+    Address.assertEdgeAddress(edge.address, "edge.address");
+
+    const srcMissing = !this._nodes.has(edge.src);
+    const dstMissing = !this._nodes.has(edge.dst);
+    if (srcMissing || dstMissing) {
+      const missingThing = srcMissing ? "src" : "dst";
+      throw new Error(`Missing ${missingThing} on edge: ${edgeToString(edge)}`);
+    }
+    const existingEdge = this._edges.get(edge.address);
+    if (existingEdge != null) {
+      if (
+        existingEdge.src !== edge.src ||
+        existingEdge.dst !== edge.dst ||
+        existingEdge.address !== edge.address
+      ) {
+        const strEdge = edgeToString(edge);
+        const strExisting = edgeToString(existingEdge);
+        throw new Error(
+          `conflict between new edge ${strEdge} and existing ${strExisting}`
+        );
+      }
+    }
+    this._edges.set(edge.address, edge);
+    return this;
   }
 
-  removeEdge(a: EdgeAddress): this {
-    const _ = a;
-    throw new Error("removeEdge");
+  removeEdge(address: EdgeAddress): this {
+    Address.assertEdgeAddress(address);
+    this._edges.delete(address);
+    return this;
   }
 
   hasEdge(address: EdgeAddress): boolean {
-    const _ = address;
-    throw new Error("hasEdge");
+    Address.assertEdgeAddress(address);
+    return this._edges.has(address);
   }
 
   edge(address: EdgeAddress): ?Edge {
-    const _ = address;
-    throw new Error("edge");
+    Address.assertEdgeAddress(address);
+    return this._edges.get(address);
   }
 
-  edges(): Iterator<Edge> {
-    throw new Error("edges");
+  *edges(): Iterator<Edge> {
+    yield* this._edges.values();
   }
 
   neighbors(node: NodeAddress, options?: NeighborsOptions): Iterator<Neighbor> {


### PR DESCRIPTION
This commit implements the following edge related methods on graph:

- `Graph.addEdge(edge)`
- `Graph.hasEdge(address)`
- `Graph.edge(address)`
- `Graph.edges()`

We've decided to enforce an invariant that for every edge, its `src` and
`dst` nodes must be present in the graph. As such, `Graph.addEdge` may
error if this condition is not true for the proposed edge, and
`Graph.removeNode` may error if any edges depend on the node being
removed. This invariant is documented via comments, and checked by the
test code.

Test plan:
Extensive unit tests have been added. Run `yarn travis`.

Paired with @wchargin