### PR TITLE
Tune GitHub graphql page limit

### DIFF
--- a/src/v1/plugins/github/graphql.js
+++ b/src/v1/plugins/github/graphql.js
@@ -44,9 +44,9 @@ import {build} from "../../graphql/queries";
  *
  * [1]: https://developer.github.com/v4/guides/resource-limitations/#node-limit
  */
-export const PAGE_LIMIT = 100;
-const PAGE_SIZE_ISSUES = 100;
-const PAGE_SIZE_PRS = 100;
+export const PAGE_LIMIT = 50;
+const PAGE_SIZE_ISSUES = 50;
+const PAGE_SIZE_PRS = 50;
 const PAGE_SIZE_COMMENTS = 20;
 const PAGE_SIZE_REVIEWS = 10;
 const PAGE_SIZE_REVIEW_COMMENTS = 10;


### PR DESCRIPTION
On larger repos (e.g. `ipfs/js-ipfs` and `ipfs/go-ipfs`) our GitHub
query tends to fail with an opaque (possibly timeout) error message.

Based on a discussion with @mikeal, it sounds like this is probably
GitHub killing queries that "take too long". This commit reduces our
default page sizes so that we make more smaller queries. Empirically, it
seems to help, and it's very unlikely to  break anything.

Test plan:

Run

```
yarn backend
node bin/sourcecred.js plugin-graph --plugin=github ipfs js-ipfs \
  > graph.json
```

before and after this change. Before, it fails; after, it succeeds.