### PR TITLE
Fix address `toString` test case structure

### DIFF
--- a/src/v3/core/_address.test.js
+++ b/src/v3/core/_address.test.js
@@ -171,11 +171,17 @@ describe("core/address", () => {
 
       describe("works on", () => {
         const camelKind = kind.charAt(0).toLowerCase() + kind.substring(1);
-        expect(f(goodConstructor([]))).toEqual(`${camelKind}([])`);
-        expect(f(goodConstructor([""]))).toEqual(`${camelKind}([""])`);
-        expect(f(goodConstructor(["one", "", "two"]))).toEqual(
-          `${camelKind}(["one","","two"])`
-        );
+        test("the empty address", () => {
+          expect(f(goodConstructor([]))).toEqual(`${camelKind}([])`);
+        });
+        test("the address with one empty component", () => {
+          expect(f(goodConstructor([""]))).toEqual(`${camelKind}([""])`);
+        });
+        test("a normal address", () => {
+          expect(f(goodConstructor(["one", "", "two"]))).toEqual(
+            `${camelKind}(["one","","two"])`
+          );
+        });
       });
     });
   }


### PR DESCRIPTION
Summary:
This fixes an organizational error on my part: the assertions were not
in `it`-blocks, so (a) no test cases were listed, and (b) assertion
failure would have been considered an error in the test suite itself.
(This wouldn’t have led to tests spuriously passing, though.)

Test Plan:
Note the new test case structure:

```
    nodeToString
      errors on
        ✓ null base input
        ✓ undefined base input
        ✓ wrong kind
      works on
        ✓ the empty address
        ✓ the address with one empty component
        ✓ a normal address
    edgeToString
      errors on
        ✓ null base input
        ✓ undefined base input
        ✓ wrong kind
      works on
        ✓ the empty address
        ✓ the address with one empty component
        ✓ a normal address
```

wchargin-branch: tostring-test-case-structure