### PR TITLE
Add address prefix testing functions

### DIFF
--- a/src/v3/core/_address.js
+++ b/src/v3/core/_address.js
@@ -142,3 +142,31 @@ export function edgeToString(a: EdgeAddress): string {
   const parts = toParts(a);
   return `edgeAddress(${stringify(parts)})`;
 }
+
+/**
+ * Determine whether the parts of `prefix` form a prefix of the parts of
+ * `address`. That is, determine whether there exists an `i` such that
+ * `toParts(prefix)` equals `toParts(address).slice(0, i)`.
+ */
+export function nodeHasPrefix(
+  address: NodeAddress,
+  prefix: NodeAddress
+): boolean {
+  assertNodeAddress(address);
+  assertNodeAddress(prefix);
+  return address.startsWith(prefix);
+}
+
+/**
+ * Determine whether the parts of `prefix` form a prefix of the parts of
+ * `address`. That is, determine whether there exists an `i` such that
+ * `toParts(prefix)` equals `toParts(address).slice(0, i)`.
+ */
+export function edgeHasPrefix(
+  address: EdgeAddress,
+  prefix: EdgeAddress
+): boolean {
+  assertEdgeAddress(address);
+  assertEdgeAddress(prefix);
+  return address.startsWith(prefix);
+}


### PR DESCRIPTION
Summary:
These functions can be used for address filtering: finding all nodes
owned by a plugin, or all edges of a certain plugin-type, or similar.
Clients can implement this in terms of `toParts`, but when the
underlying type of the opaque type is known there exists a simpler and
more efficient implementation.

Test Plan:
Unit tests added. Run `yarn travis`.

wchargin-branch: address-prefix