### PR TITLE
Pull `Direction` values into an enum

### DIFF
--- a/src/v3/core/graph.js
+++ b/src/v3/core/graph.js
@@ -14,11 +14,15 @@ export type Edge = {|
 |};
 
 export type Neighbor = {|+node: NodeAddress, +edge: Edge|};
-export opaque type Direction = Symbol;
-export const IN: Direction = Symbol("IN");
-export const OUT: Direction = Symbol("OUT");
+
+export opaque type DirectionT = Symbol;
+export const Direction: {|+IN: DirectionT, +OUT: DirectionT|} = Object.freeze({
+  IN: Symbol("IN"),
+  OUT: Symbol("OUT"),
+});
+
 export type NeighborsOptions = {|
-  +direction: ?Direction,
+  +direction: ?DirectionT,
   +nodePrefix: ?NodeAddress,
   +edgePrefix: ?EdgeAddress,
 |};

--- a/src/v3/core/graph.test.js
+++ b/src/v3/core/graph.test.js
@@ -1,6 +1,6 @@
 // @flow
 
-import {Address, Graph, edgeToString} from "./graph";
+import {Address, Direction, Graph, edgeToString} from "./graph";
 import type {NodeAddress, EdgeAddress} from "./graph";
 
 describe("core/graph", () => {
@@ -26,6 +26,15 @@ describe("core/graph", () => {
       expect(() => {
         // $ExpectFlowError
         Address.toParts = wonkyToParts;
+      }).toThrow(/read.only property/);
+    });
+  });
+
+  describe("Direction values", () => {
+    it("are read-only", () => {
+      expect(() => {
+        // $ExpectFlowError
+        Direction.IN = Direction.OUT;
       }).toThrow(/read.only property/);
     });
   });


### PR DESCRIPTION
Summary:
This saves clients from having to pollute their global namespace with
`IN` and `OUT` (and, soon, `ANY`). Calls now look like:
```js
myNode.neighbors({direction: Direction.OUT});
```
Callers who prefer to pollute their namespaces are of course still
welcome to do so, at the cost of one `const {IN, OUT} = Direction`.

Test Plan:
New unit tests for frozenness included.

wchargin-branch: direction-enum