### PR TITLE
Add top-level address module error handling

### DIFF
--- a/src/v3/core/address.test.js
+++ b/src/v3/core/address.test.js
@@ -28,6 +28,29 @@ describe("core/address", () => {
     it("makes address modules using all the options", () => {
       makeModules();
     });
+    it("rejects a module whose nonce contains NUL", () => {
+      expect(() => {
+        makeAddressModule({name: "BadAddress", nonce: "n\0o"});
+      }).toThrow("invalid nonce (contains NUL):");
+    });
+    it("rejects a module with `otherNonces` containing NUL", () => {
+      expect(() => {
+        makeAddressModule({
+          name: "GoodAddress",
+          nonce: "G",
+          otherNonces: new Map().set("n\0o", "BadAddress"),
+        });
+      }).toThrow("invalid otherNonce (contains NUL):");
+    });
+    it("rejects a module with `nonce` in `otherNonces`", () => {
+      expect(() => {
+        makeAddressModule({
+          name: "GoodAddress",
+          nonce: "G",
+          otherNonces: new Map().set("G", "WatAddress"),
+        });
+      }).toThrow("primary nonce listed as otherNonce");
+    });
     it("returns an object with read-only properties", () => {
       const {FooAddress} = makeModules();
       expect(() => {


### PR DESCRIPTION
Summary:
This commit implements all the code needed for the top-level
`makeAddressModule` function, without implementing any of the address
functions. This mostly comprises handling of errors in the module
options.

Test Plan:
Unit tests added. Run `yarn travis`.

wchargin-branch: address-error-handling