### PR TITLE
Add unified address assertions, fromParts, toParts

### DIFF
--- a/src/v3/core/__snapshots__/address.test.js.snap
+++ b/src/v3/core/__snapshots__/address.test.js.snap
@@ -1,0 +1,3 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`core/address makeAddressModule has a stable internal representation 1`] = `"\\"F\\\\u0000\\\\u0000hello\\\\u0000\\\\u0000\\\\u0000sweet\\\\u0000world\\\\u0000\\\\u0000\\\\u0000\\\\u0000\\""`;


### PR DESCRIPTION
Summary:
This implements the following functions for the unified addresses:

  - assertions: `assertValid`, `assertValidParts`
  - injection: `fromParts`
  - projection: `toParts`

(These functions depend on each other for testing, so we implement them
together.)

Test Plan:
Unit tests included. Run `yarn travis`.

wchargin-branch: address-assertion-injection-projection