### PR TITLE
Ignore coverage output in Prettier

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,3 +1,4 @@
 /bin
 /build
+/coverage
 /flow-typed


### PR DESCRIPTION
Test Plan:
Run `yarn test --env=jsdom --coverage`, and note that files are
generated into `coverage/`. Then, run `yarn travis`, which fails before
this patch (on `check-pretty`) and passes after it.

wchargin-branch: prettier-ignore-coverage