### PR TITLE
Add a `coverage` package script

### DIFF
--- a/package.json
+++ b/package.json
@@ -66,6 +66,7 @@
     "backend": "node scripts/backend.js",
     "test": "node scripts/test.js --env=jsdom",
     "ci-test": "CI=1 npm run test",
+    "coverage": "npm run test -- --coverage",
     "flow": "flow",
     "lint": "eslint src config --max-warnings 0",
     "travis": "node ./config/travis.js"


### PR DESCRIPTION
Summary:
We’re not mandating anything about coverage right now, but by making it
easier to track coverage perhaps people will organically become more
motivated to write good tests.

Test Plan:
Run `yarn coverage`, and then open `coverage/lcov-report/index.html`.

wchargin-branch: coverage