### PR TITLE
Add tests for adding a conflicting edge

### DIFF
--- a/src/v3/core/graph.test.js
+++ b/src/v3/core/graph.test.js
@@ -165,6 +165,21 @@ describe("core/graph", () => {
             });
           });
 
+          it("throws on conflicting edge", () => {
+            const src = NodeAddress.fromParts(["src"]);
+            const dst = NodeAddress.fromParts(["dst"]);
+            const address = EdgeAddress.fromParts(["hi"]);
+            const e1 = {src, dst, address};
+            const e2 = {src, dst: src, address};
+            const graph = new Graph()
+              .addNode(src)
+              .addNode(dst)
+              .addEdge(e1);
+            expect(() => graph.addEdge(e2)).toThrow(
+              "conflict between new edge"
+            );
+          });
+
           describe("throws on edge with", () => {
             const n = NodeAddress.fromParts(["foo"]);
             const e = EdgeAddress.fromParts(["bar"]);


### PR DESCRIPTION
Adding a conflicting edge (i.e. one with the same address, but different
`src` or `dst`) is an error. However, our coverage has determined that
the behavior isn't tested. This commit adds that test.

Test plan:
Only change is adding a new test. Verify `yarn travis` passes.