### PR TITLE
Implement `Graph.toJSON` and `Graph.fromJSON`

### DIFF
--- a/src/v3/core/__snapshots__/graph.test.js.snap
+++ b/src/v3/core/__snapshots__/graph.test.js.snap
@@ -1,0 +1,37 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`core/graph toJSON / fromJSON toJSON matches snapshot 1`] = `
+Array [
+  Object {
+    "type": "sourcecred/graph",
+    "version": "0.4.0",
+  },
+  Object {
+    "edges": Array [
+      Object {
+        "address": Array [
+          "edge",
+        ],
+        "dstIndex": 0,
+        "srcIndex": 1,
+      },
+      Object {
+        "address": Array [
+          "edge",
+          "2",
+        ],
+        "dstIndex": 1,
+        "srcIndex": 0,
+      },
+    ],
+    "nodes": Array [
+      Array [
+        "dst",
+      ],
+      Array [
+        "src",
+      ],
+    ],
+  },
+]
+`;


### PR DESCRIPTION
The serialization scheme uses `IndexedEdge`s:

```js
type Integer = number;
type IndexedEdge = {|
  Address: EdgeAddressT,
  srcIndex: Integer,
  dstIndex: Integer,
|}
```

The nodes are first sorted. Then, we generate indexed edges from the
regular edges by replacing each node address with its index in the
sorted order. This encoding reduces the number of addresses serialized
from `n + 3e` to `n + e` (where `n` is the number of nodes and `e` is
the number of edges).

This is based on work in #295, but in contrast to that PR, we do not
index the in-memory representations of graphs. Only the JSON
representation is indexed.

Test plan:
Unit tests added. A snapshot test is also included, both to make it easy
to inspect an example of a JSON-serialized graph, and to ensure
backwards-compatibility. (The snapshot likely should not change
independent of the VERSION string.)