### PR TITLE
Implement `Graph.merge`

### DIFF
--- a/src/v3/core/graph.js
+++ b/src/v3/core/graph.js
@@ -332,8 +332,16 @@ export class Graph {
   }
 
   static merge(graphs: Iterable<Graph>): Graph {
-    const _ = graphs;
-    throw new Error("merge");
+    const result = new Graph();
+    for (const graph of graphs) {
+      for (const node of graph.nodes()) {
+        result.addNode(node);
+      }
+      for (const edge of graph.edges()) {
+        result.addEdge(edge);
+      }
+    }
+    return result;
   }
 }
 


### PR DESCRIPTION
Tests are mostly copied over from the v2, as implemented in #320.
Some new tests were added, e.g. checking that Merge correctly handles
10 small graphs combined.

Test plan:
See unit tests.