### PR TITLE
Reimplement `Graph.copy` using `Graph.merge`

### DIFF
--- a/src/v3/core/graph.js
+++ b/src/v3/core/graph.js
@@ -312,14 +312,7 @@ export class Graph {
   }
 
   copy(): Graph {
-    const result = new Graph();
-    for (const node of this.nodes()) {
-      result.addNode(node);
-    }
-    for (const edge of this.edges()) {
-      result.addEdge(edge);
-    }
-    return result;
+    return Graph.merge([this]);
   }
 
   toJSON(): GraphJSON {

--- a/src/v3/core/graph.js
+++ b/src/v3/core/graph.js
@@ -332,8 +332,16 @@ export class Graph {
   }
 
   static merge(graphs: Iterable<Graph>): Graph {
-    const _ = graphs;
-    throw new Error("merge");
+    const result = new Graph();
+    for (const graph of graphs) {
+      for (const node of graph.nodes()) {
+        result.addNode(node);
+      }
+      for (const edge of graph.edges()) {
+        result.addEdge(edge);
+      }
+    }
+    return result;
   }
 }
 


### PR DESCRIPTION
Test plan:
Existing unit tests suffice

Suggested by @wchargin