### PR TITLE
Add snapshot test for GitHub GraphQL query

### DIFF
--- a/src/v3/plugins/github/__snapshots__/graphql.test.js.snap
+++ b/src/v3/plugins/github/__snapshots__/graphql.test.js.snap
@@ -200,3 +200,128 @@ Object {
   },
 }
 `;
+
+exports[`graphql creates a query 1`] = `
+"query FetchData($repoOwner: String! $repoName: String!) {
+  repository(owner: $repoOwner name: $repoName) {
+    url
+    name
+    owner {
+      ...whoami
+    }
+    id
+    issues(first: 50) {
+      ...issues
+    }
+    pullRequests(first: 50) {
+      ...prs
+    }
+  }
+}
+fragment whoami on Actor {
+  __typename
+  login
+  url
+  ... on User {
+    id
+  }
+  ... on Organization {
+    id
+  }
+  ... on Bot {
+    id
+  }
+}
+fragment issues on IssueConnection {
+  pageInfo {
+    hasNextPage
+    endCursor
+  }
+  nodes {
+    id
+    url
+    title
+    body
+    number
+    author {
+      ...whoami
+    }
+    comments(first: 20) {
+      ...comments
+    }
+  }
+}
+fragment prs on PullRequestConnection {
+  pageInfo {
+    hasNextPage
+    endCursor
+  }
+  nodes {
+    id
+    url
+    title
+    body
+    number
+    mergeCommit {
+      oid
+    }
+    additions
+    deletions
+    author {
+      ...whoami
+    }
+    comments(first: 20) {
+      ...comments
+    }
+    reviews(first: 10) {
+      ...reviews
+    }
+  }
+}
+fragment comments on IssueCommentConnection {
+  pageInfo {
+    hasNextPage
+    endCursor
+  }
+  nodes {
+    id
+    url
+    author {
+      ...whoami
+    }
+    body
+  }
+}
+fragment reviews on PullRequestReviewConnection {
+  pageInfo {
+    hasNextPage
+    endCursor
+  }
+  nodes {
+    id
+    url
+    body
+    author {
+      ...whoami
+    }
+    state
+    comments(first: 10) {
+      ...reviewComments
+    }
+  }
+}
+fragment reviewComments on PullRequestReviewCommentConnection {
+  pageInfo {
+    hasNextPage
+    endCursor
+  }
+  nodes {
+    id
+    url
+    body
+    author {
+      ...whoami
+    }
+  }
+}"
+`;

--- a/src/v3/plugins/github/graphql.test.js
+++ b/src/v3/plugins/github/graphql.test.js
@@ -1,7 +1,7 @@
 // @flow
 
 import type {Continuation} from "./graphql";
-import {build} from "../../graphql/queries";
+import {build, stringify, multilineLayout} from "../../graphql/queries";
 import {
   PAGE_LIMIT,
   createQuery,
@@ -949,5 +949,11 @@ describe("graphql", () => {
       // shouldn't be any nodes in the snapshot that have more pages.
       expect(result).toMatchSnapshot();
     });
+  });
+
+  it("creates a query", () => {
+    expect(
+      stringify.body(createQuery(), multilineLayout("  "))
+    ).toMatchSnapshot();
   });
 });


### PR DESCRIPTION
Summary:
This has two primary benefits:
  - Humans can look at this snapshot file to see what’s being queried,
    or to manually issue a query.
  - When we change the programmatically generated query, we can easily
    see what the results are in the GraphQL output. This makes it easy
    to verify that a change is correct.

Test Plan:
None.

wchargin-branch: snapshot-query