### PR TITLE
Rename various aspects of GitHub `nodes` module

### DIFF
--- a/src/v3/plugins/github/__snapshots__/nodes.test.js.snap
+++ b/src/v3/plugins/github/__snapshots__/nodes.test.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`plugins/github/address snapshots as expected: issue 1`] = `
+exports[`plugins/github/nodes snapshots as expected: issue 1`] = `
 Object {
   "address": Array [
     "sourcecred",
@@ -22,7 +22,7 @@ Object {
 }
 `;
 
-exports[`plugins/github/address snapshots as expected: issueComment 1`] = `
+exports[`plugins/github/nodes snapshots as expected: issueComment 1`] = `
 Object {
   "address": Array [
     "sourcecred",
@@ -50,7 +50,7 @@ Object {
 }
 `;
 
-exports[`plugins/github/address snapshots as expected: pull 1`] = `
+exports[`plugins/github/nodes snapshots as expected: pull 1`] = `
 Object {
   "address": Array [
     "sourcecred",
@@ -72,7 +72,7 @@ Object {
 }
 `;
 
-exports[`plugins/github/address snapshots as expected: pullComment 1`] = `
+exports[`plugins/github/nodes snapshots as expected: pullComment 1`] = `
 Object {
   "address": Array [
     "sourcecred",
@@ -100,7 +100,7 @@ Object {
 }
 `;
 
-exports[`plugins/github/address snapshots as expected: repo 1`] = `
+exports[`plugins/github/nodes snapshots as expected: repo 1`] = `
 Object {
   "address": Array [
     "sourcecred",
@@ -117,7 +117,7 @@ Object {
 }
 `;
 
-exports[`plugins/github/address snapshots as expected: review 1`] = `
+exports[`plugins/github/nodes snapshots as expected: review 1`] = `
 Object {
   "address": Array [
     "sourcecred",
@@ -144,7 +144,7 @@ Object {
 }
 `;
 
-exports[`plugins/github/address snapshots as expected: reviewComment 1`] = `
+exports[`plugins/github/nodes snapshots as expected: reviewComment 1`] = `
 Object {
   "address": Array [
     "sourcecred",
@@ -177,7 +177,7 @@ Object {
 }
 `;
 
-exports[`plugins/github/address snapshots as expected: user 1`] = `
+exports[`plugins/github/nodes snapshots as expected: user 1`] = `
 Object {
   "address": Array [
     "sourcecred",

--- a/src/v3/plugins/github/nodes.js
+++ b/src/v3/plugins/github/nodes.js
@@ -2,10 +2,10 @@
 
 import {NodeAddress, type NodeAddressT} from "../../core/graph";
 
-export opaque type GithubAddressT: NodeAddressT = NodeAddressT;
+export opaque type RawAddress: NodeAddressT = NodeAddressT;
 
 const GITHUB_PREFIX = NodeAddress.fromParts(["sourcecred", "github"]);
-function githubAddress(...parts: string[]): GithubAddressT {
+function githubAddress(...parts: string[]): RawAddress {
   return NodeAddress.append(GITHUB_PREFIX, ...parts);
 }
 
@@ -47,7 +47,7 @@ export type StructuredAddress =
   | CommentAddress
   | UserlikeAddress;
 
-export function structure(x: GithubAddressT): StructuredAddress {
+export function fromRaw(x: RawAddress): StructuredAddress {
   function fail() {
     return new Error(`Bad address: ${NodeAddress.toString(x)}`);
   }
@@ -138,7 +138,7 @@ export function structure(x: GithubAddressT): StructuredAddress {
   }
 }
 
-export function destructure(x: StructuredAddress): GithubAddressT {
+export function toRaw(x: StructuredAddress): RawAddress {
   switch (x.type) {
     case "REPO":
       return githubAddress("repo", x.owner, x.name);

--- a/src/v3/plugins/github/nodes.test.js
+++ b/src/v3/plugins/github/nodes.test.js
@@ -1,9 +1,9 @@
 // @flow
 
-import {structure, destructure} from "./address";
 import {NodeAddress} from "../../core/graph";
+import {fromRaw, toRaw} from "./nodes";
 
-describe("plugins/github/address", () => {
+describe("plugins/github/nodes", () => {
   const repo = () => ({
     type: "REPO",
     owner: "sourcecred",
@@ -39,21 +39,21 @@ describe("plugins/github/address", () => {
     user,
   };
 
-  describe("Structured -> Raw -> Structured is identity", () => {
+  describe("`fromRaw` after `toRaw` is identity", () => {
     Object.keys(examples).forEach((example) => {
       it(example, () => {
         const instance = examples[example]();
-        expect(structure(destructure(instance))).toEqual(instance);
+        expect(fromRaw(toRaw(instance))).toEqual(instance);
       });
     });
   });
 
-  describe("Raw -> Structured -> Raw is identity", () => {
+  describe("`toRaw` after `fromRaw` is identity", () => {
     Object.keys(examples).forEach((example) => {
       it(example, () => {
         const instance = examples[example]();
-        const raw = destructure(instance);
-        expect(destructure(structure(raw))).toEqual(raw);
+        const raw = toRaw(instance);
+        expect(toRaw(fromRaw(raw))).toEqual(raw);
       });
     });
   });
@@ -62,14 +62,14 @@ describe("plugins/github/address", () => {
     Object.keys(examples).forEach((example) => {
       it(example, () => {
         const instance = examples[example]();
-        const raw = NodeAddress.toParts(destructure(instance));
+        const raw = NodeAddress.toParts(toRaw(instance));
         expect({address: raw, structured: instance}).toMatchSnapshot();
       });
     });
   });
 
   describe("errors on", () => {
-    describe("structure(...) with", () => {
+    describe("fromRaw(...) with", () => {
       function expectBadAddress(name: string, parts: $ReadOnlyArray<string>) {
         it(name, () => {
           const address = NodeAddress.fromParts([
@@ -78,7 +78,7 @@ describe("plugins/github/address", () => {
             ...parts,
           ]);
           // $ExpectFlowError
-          expect(() => structure(address)).toThrow("Bad address");
+          expect(() => fromRaw(address)).toThrow("Bad address");
         });
       }
       function checkBadCases(
@@ -96,15 +96,15 @@ describe("plugins/github/address", () => {
       }
       it("undefined", () => {
         // $ExpectFlowError
-        expect(() => structure(undefined)).toThrow("undefined");
+        expect(() => fromRaw(undefined)).toThrow("undefined");
       });
       it("null", () => {
         // $ExpectFlowError
-        expect(() => structure(null)).toThrow("null");
+        expect(() => fromRaw(null)).toThrow("null");
       });
       it("with bad prefix", () => {
         // $ExpectFlowError
-        expect(() => structure(NodeAddress.fromParts(["foo"]))).toThrow(
+        expect(() => fromRaw(NodeAddress.fromParts(["foo"]))).toThrow(
           "Bad address"
         );
       });
@@ -181,25 +181,23 @@ describe("plugins/github/address", () => {
       });
     });
 
-    describe("destructure(...) with", () => {
+    describe("toRaw(...) with", () => {
       it("null", () => {
         // $ExpectFlowError
-        expect(() => destructure(null)).toThrow("null");
+        expect(() => toRaw(null)).toThrow("null");
       });
       it("undefined", () => {
         // $ExpectFlowError
-        expect(() => destructure(undefined)).toThrow("undefined");
+        expect(() => toRaw(undefined)).toThrow("undefined");
       });
       it("bad type", () => {
         // $ExpectFlowError
-        expect(() => destructure({type: "ICE_CREAM"})).toThrow(
-          "Unexpected type"
-        );
+        expect(() => toRaw({type: "ICE_CREAM"})).toThrow("Unexpected type");
       });
       it("bad comment type", () => {
         expect(() => {
           // $ExpectFlowError
-          destructure({type: "COMMENT", parent: {type: "ICE_CREAM"}});
+          toRaw({type: "COMMENT", parent: {type: "ICE_CREAM"}});
         }).toThrow("Bad comment parent type");
       });
     });


### PR DESCRIPTION
Summary:
First, we rename the module itself from `address` to `nodes`: we’d like
to put the edge functions in a parallel `edges` module instead of
cramping it into this one, so it stands to reason that this one should
be called `nodes`.

We also rename the `GithubAddressT` type to `RawAddress`, so that the
module exports `RawAddress` and `StructuredAddress`. The functions then
have much better natural names of `toRaw` and `fromRaw`.

Test Plan:
Existing unit tests suffice.

wchargin-branch: rename-nodes