### PR TITLE
Add `empty` (monoid identity) to address modules

### DIFF
--- a/src/v3/core/address.js
+++ b/src/v3/core/address.js
@@ -19,6 +19,12 @@ export interface AddressModule<Address> {
   assertValidParts(parts: $ReadOnlyArray<string>, what?: string): void;
 
   /**
+   * The empty address (the identity for `append`). Equivalent to
+   * `fromParts([])`.
+   */
+  empty: Address;
+
+  /**
    * Convert an array of address parts to an address. The input must be
    * a non-null array of non-null strings, none of which contains the
    * NUL character. This is the inverse of `toParts`.
@@ -184,6 +190,8 @@ export function makeAddressModule(options: Options): AddressModule<string> {
     return nonce + separator + nullDelimited(parts);
   }
 
+  const empty = fromParts([]);
+
   function toParts(address: Address): string[] {
     assertValid(address);
     const parts = address.split(separator);
@@ -210,6 +218,7 @@ export function makeAddressModule(options: Options): AddressModule<string> {
   const result = {
     assertValid,
     assertValidParts,
+    empty,
     fromParts,
     toParts,
     toString,

--- a/src/v3/core/address.test.js
+++ b/src/v3/core/address.test.js
@@ -154,6 +154,16 @@ describe("core/address", () => {
       });
     });
 
+    describe("empty", () => {
+      const {FooAddress} = makeModules();
+      it("is a valid address", () => {
+        FooAddress.assertValid(FooAddress.empty);
+      });
+      it("has empty parts", () => {
+        expect(FooAddress.toParts(FooAddress.empty)).toEqual([]);
+      });
+    });
+
     describe("fromParts", () => {
       const {FooAddress, BarAddress} = makeModules();
 


### PR DESCRIPTION
Summary:
This can make invocations of `FooAddress.fromParts([])` a bit more
succinct.

Paired with @decentralion.

Test Plan:
Unit tests added. Run `yarn travis`.

wchargin-branch: address-empty