### PR TITLE
Use uppercase enum constants in GitHub addresses

### DIFF
--- a/src/v3/plugins/github/__snapshots__/edges.test.js.snap
+++ b/src/v3/plugins/github/__snapshots__/edges.test.js.snap
@@ -1,24 +1,24 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`plugins/github/edges createEdge works for authors edges 1`] = `"{address: EdgeAddress[\\"sourcecred\\",\\"github\\",\\"authors\\",\\"2\\",\\"userlike\\",\\"decentralion\\",\\"4\\",\\"issue\\",\\"sourcecred\\",\\"example-github\\",\\"2\\"], src: NodeAddress[\\"sourcecred\\",\\"github\\",\\"userlike\\",\\"decentralion\\"], dst: NodeAddress[\\"sourcecred\\",\\"github\\",\\"issue\\",\\"sourcecred\\",\\"example-github\\",\\"2\\"]}"`;
+exports[`plugins/github/edges createEdge works for authors edges 1`] = `"{address: EdgeAddress[\\"sourcecred\\",\\"github\\",\\"AUTHORS\\",\\"2\\",\\"USERLIKE\\",\\"decentralion\\",\\"4\\",\\"ISSUE\\",\\"sourcecred\\",\\"example-github\\",\\"2\\"], src: NodeAddress[\\"sourcecred\\",\\"github\\",\\"USERLIKE\\",\\"decentralion\\"], dst: NodeAddress[\\"sourcecred\\",\\"github\\",\\"ISSUE\\",\\"sourcecred\\",\\"example-github\\",\\"2\\"]}"`;
 
-exports[`plugins/github/edges createEdge works for has-parent edges 1`] = `"{address: EdgeAddress[\\"sourcecred\\",\\"github\\",\\"has_parent\\",\\"7\\",\\"comment\\",\\"review\\",\\"sourcecred\\",\\"example-github\\",\\"5\\",\\"100313899\\",\\"171460198\\"], src: NodeAddress[\\"sourcecred\\",\\"github\\",\\"comment\\",\\"review\\",\\"sourcecred\\",\\"example-github\\",\\"5\\",\\"100313899\\",\\"171460198\\"], dst: NodeAddress[\\"sourcecred\\",\\"github\\",\\"review\\",\\"sourcecred\\",\\"example-github\\",\\"5\\",\\"100313899\\"]}"`;
+exports[`plugins/github/edges createEdge works for has-parent edges 1`] = `"{address: EdgeAddress[\\"sourcecred\\",\\"github\\",\\"HAS_PARENT\\",\\"7\\",\\"COMMENT\\",\\"REVIEW\\",\\"sourcecred\\",\\"example-github\\",\\"5\\",\\"100313899\\",\\"171460198\\"], src: NodeAddress[\\"sourcecred\\",\\"github\\",\\"COMMENT\\",\\"REVIEW\\",\\"sourcecred\\",\\"example-github\\",\\"5\\",\\"100313899\\",\\"171460198\\"], dst: NodeAddress[\\"sourcecred\\",\\"github\\",\\"REVIEW\\",\\"sourcecred\\",\\"example-github\\",\\"5\\",\\"100313899\\"]}"`;
 
-exports[`plugins/github/edges createEdge works for merged-as edges 1`] = `"{address: EdgeAddress[\\"sourcecred\\",\\"github\\",\\"merged_as\\",\\"4\\",\\"pull\\",\\"sourcecred\\",\\"example-github\\",\\"5\\"], src: NodeAddress[\\"sourcecred\\",\\"github\\",\\"pull\\",\\"sourcecred\\",\\"example-github\\",\\"5\\"], dst: NodeAddress[\\"git\\",\\"commit\\",\\"123\\"]}"`;
+exports[`plugins/github/edges createEdge works for merged-as edges 1`] = `"{address: EdgeAddress[\\"sourcecred\\",\\"github\\",\\"MERGED_AS\\",\\"4\\",\\"PULL\\",\\"sourcecred\\",\\"example-github\\",\\"5\\"], src: NodeAddress[\\"sourcecred\\",\\"github\\",\\"PULL\\",\\"sourcecred\\",\\"example-github\\",\\"5\\"], dst: NodeAddress[\\"git\\",\\"commit\\",\\"123\\"]}"`;
 
-exports[`plugins/github/edges createEdge works for reference edges 1`] = `"{address: EdgeAddress[\\"sourcecred\\",\\"github\\",\\"references\\",\\"4\\",\\"issue\\",\\"sourcecred\\",\\"example-github\\",\\"2\\",\\"4\\",\\"pull\\",\\"sourcecred\\",\\"example-github\\",\\"5\\"], src: NodeAddress[\\"sourcecred\\",\\"github\\",\\"issue\\",\\"sourcecred\\",\\"example-github\\",\\"2\\"], dst: NodeAddress[\\"sourcecred\\",\\"github\\",\\"pull\\",\\"sourcecred\\",\\"example-github\\",\\"5\\"]}"`;
+exports[`plugins/github/edges createEdge works for reference edges 1`] = `"{address: EdgeAddress[\\"sourcecred\\",\\"github\\",\\"REFERENCES\\",\\"4\\",\\"ISSUE\\",\\"sourcecred\\",\\"example-github\\",\\"2\\",\\"4\\",\\"PULL\\",\\"sourcecred\\",\\"example-github\\",\\"5\\"], src: NodeAddress[\\"sourcecred\\",\\"github\\",\\"ISSUE\\",\\"sourcecred\\",\\"example-github\\",\\"2\\"], dst: NodeAddress[\\"sourcecred\\",\\"github\\",\\"PULL\\",\\"sourcecred\\",\\"example-github\\",\\"5\\"]}"`;
 
 exports[`plugins/github/edges snapshots as expected: authors 1`] = `
 Object {
   "address": Array [
     "sourcecred",
     "github",
-    "authors",
+    "AUTHORS",
     "2",
-    "userlike",
+    "USERLIKE",
     "decentralion",
     "4",
-    "pull",
+    "PULL",
     "sourcecred",
     "example-github",
     "5",
@@ -47,10 +47,10 @@ Object {
   "address": Array [
     "sourcecred",
     "github",
-    "has_parent",
+    "HAS_PARENT",
     "7",
-    "comment",
-    "review",
+    "COMMENT",
+    "REVIEW",
     "sourcecred",
     "example-github",
     "5",
@@ -85,9 +85,9 @@ Object {
   "address": Array [
     "sourcecred",
     "github",
-    "merged_as",
+    "MERGED_AS",
     "4",
-    "pull",
+    "PULL",
     "sourcecred",
     "example-github",
     "5",
@@ -112,14 +112,14 @@ Object {
   "address": Array [
     "sourcecred",
     "github",
-    "references",
+    "REFERENCES",
     "4",
-    "issue",
+    "ISSUE",
     "sourcecred",
     "example-github",
     "2",
     "4",
-    "issue",
+    "ISSUE",
     "sourcecred",
     "example-github",
     "1",

--- a/src/v3/plugins/github/__snapshots__/nodes.test.js.snap
+++ b/src/v3/plugins/github/__snapshots__/nodes.test.js.snap
@@ -5,7 +5,7 @@ Object {
   "address": Array [
     "sourcecred",
     "github",
-    "issue",
+    "ISSUE",
     "sourcecred",
     "example-github",
     "2",
@@ -27,8 +27,8 @@ Object {
   "address": Array [
     "sourcecred",
     "github",
-    "comment",
-    "issue",
+    "COMMENT",
+    "ISSUE",
     "sourcecred",
     "example-github",
     "2",
@@ -55,7 +55,7 @@ Object {
   "address": Array [
     "sourcecred",
     "github",
-    "pull",
+    "PULL",
     "sourcecred",
     "example-github",
     "5",
@@ -77,8 +77,8 @@ Object {
   "address": Array [
     "sourcecred",
     "github",
-    "comment",
-    "pull",
+    "COMMENT",
+    "PULL",
     "sourcecred",
     "example-github",
     "5",
@@ -105,7 +105,7 @@ Object {
   "address": Array [
     "sourcecred",
     "github",
-    "repo",
+    "REPO",
     "sourcecred",
     "example-github",
   ],
@@ -122,7 +122,7 @@ Object {
   "address": Array [
     "sourcecred",
     "github",
-    "review",
+    "REVIEW",
     "sourcecred",
     "example-github",
     "5",
@@ -149,8 +149,8 @@ Object {
   "address": Array [
     "sourcecred",
     "github",
-    "comment",
-    "review",
+    "COMMENT",
+    "REVIEW",
     "sourcecred",
     "example-github",
     "5",
@@ -182,7 +182,7 @@ Object {
   "address": Array [
     "sourcecred",
     "github",
-    "userlike",
+    "USERLIKE",
     "decentralion",
   ],
   "structured": Object {

--- a/src/v3/plugins/github/edges.js
+++ b/src/v3/plugins/github/edges.js
@@ -121,7 +121,7 @@ export function fromRaw(x: RawAddress): StructuredAddress {
   }
   const [_unused_sc, _unused_gh, kind, ...rest] = EdgeAddress.toParts(x);
   switch (kind) {
-    case "authors": {
+    case "AUTHORS": {
       const parts = multiLengthDecode(rest, fail);
       if (parts.length !== 2) {
         throw fail();
@@ -135,7 +135,7 @@ export function fromRaw(x: RawAddress): StructuredAddress {
       ): any);
       return ({type: "AUTHORS", author, content}: AuthorsAddress);
     }
-    case "merged_as": {
+    case "MERGED_AS": {
       const parts = multiLengthDecode(rest, fail);
       if (parts.length !== 1) {
         throw fail();
@@ -146,7 +146,7 @@ export function fromRaw(x: RawAddress): StructuredAddress {
       ): any);
       return ({type: "MERGED_AS", pull}: MergedAsAddress);
     }
-    case "has_parent": {
+    case "HAS_PARENT": {
       const parts = multiLengthDecode(rest, fail);
       if (parts.length !== 1) {
         throw fail();
@@ -157,7 +157,7 @@ export function fromRaw(x: RawAddress): StructuredAddress {
       ): any);
       return ({type: "HAS_PARENT", child}: HasParentAddress);
     }
-    case "references": {
+    case "REFERENCES": {
       const parts = multiLengthDecode(rest, fail);
       if (parts.length !== 2) {
         throw fail();
@@ -180,23 +180,23 @@ export function toRaw(x: StructuredAddress): RawAddress {
   switch (x.type) {
     case "AUTHORS":
       return githubEdgeAddress(
-        "authors",
+        "AUTHORS",
         ...lengthEncode(GithubNode.toRaw(x.author)),
         ...lengthEncode(GithubNode.toRaw(x.content))
       );
     case "MERGED_AS":
       return githubEdgeAddress(
-        "merged_as",
+        "MERGED_AS",
         ...lengthEncode(GithubNode.toRaw(x.pull))
       );
     case "HAS_PARENT":
       return githubEdgeAddress(
-        "has_parent",
+        "HAS_PARENT",
         ...lengthEncode(GithubNode.toRaw(x.child))
       );
     case "REFERENCES":
       return githubEdgeAddress(
-        "references",
+        "REFERENCES",
         ...lengthEncode(GithubNode.toRaw(x.referrer)),
         ...lengthEncode(GithubNode.toRaw(x.referent))
       );

--- a/src/v3/plugins/github/nodes.js
+++ b/src/v3/plugins/github/nodes.js
@@ -99,14 +99,14 @@ export function fromRaw(x: RawAddress): StructuredAddress {
   }
   const [_unused_sc, _unused_gh, kind, ...rest] = NodeAddress.toParts(x);
   switch (kind) {
-    case "repo": {
+    case "REPO": {
       if (rest.length !== 2) {
         throw fail();
       }
       const [owner, name] = rest;
       return {type: "REPO", owner, name};
     }
-    case "issue": {
+    case "ISSUE": {
       if (rest.length !== 3) {
         throw fail();
       }
@@ -114,7 +114,7 @@ export function fromRaw(x: RawAddress): StructuredAddress {
       const repo = {type: "REPO", owner, name};
       return {type: "ISSUE", repo, number};
     }
-    case "pull": {
+    case "PULL": {
       if (rest.length !== 3) {
         throw fail();
       }
@@ -122,7 +122,7 @@ export function fromRaw(x: RawAddress): StructuredAddress {
       const repo = {type: "REPO", owner, name};
       return {type: "PULL", repo, number};
     }
-    case "review": {
+    case "REVIEW": {
       if (rest.length !== 4) {
         throw fail();
       }
@@ -131,13 +131,13 @@ export function fromRaw(x: RawAddress): StructuredAddress {
       const pull = {type: "PULL", repo, number: pullNumber};
       return {type: "REVIEW", pull, id};
     }
-    case "comment": {
+    case "COMMENT": {
       if (rest.length < 1) {
         throw fail();
       }
       const [subkind, ...subrest] = rest;
       switch (subkind) {
-        case "issue": {
+        case "ISSUE": {
           if (subrest.length !== 4) {
             throw fail();
           }
@@ -146,7 +146,7 @@ export function fromRaw(x: RawAddress): StructuredAddress {
           const issue = {type: "ISSUE", repo, number: issueNumber};
           return {type: "COMMENT", parent: issue, id};
         }
-        case "pull": {
+        case "PULL": {
           if (subrest.length !== 4) {
             throw fail();
           }
@@ -155,7 +155,7 @@ export function fromRaw(x: RawAddress): StructuredAddress {
           const pull = {type: "PULL", repo, number: pullNumber};
           return {type: "COMMENT", parent: pull, id};
         }
-        case "review": {
+        case "REVIEW": {
           if (subrest.length !== 5) {
             throw fail();
           }
@@ -169,7 +169,7 @@ export function fromRaw(x: RawAddress): StructuredAddress {
           throw fail();
       }
     }
-    case "userlike": {
+    case "USERLIKE": {
       if (rest.length !== 1) {
         throw fail();
       }
@@ -184,14 +184,14 @@ export function fromRaw(x: RawAddress): StructuredAddress {
 export function toRaw(x: StructuredAddress): RawAddress {
   switch (x.type) {
     case "REPO":
-      return _githubAddress("repo", x.owner, x.name);
+      return _githubAddress("REPO", x.owner, x.name);
     case "ISSUE":
-      return _githubAddress("issue", x.repo.owner, x.repo.name, x.number);
+      return _githubAddress("ISSUE", x.repo.owner, x.repo.name, x.number);
     case "PULL":
-      return _githubAddress("pull", x.repo.owner, x.repo.name, x.number);
+      return _githubAddress("PULL", x.repo.owner, x.repo.name, x.number);
     case "REVIEW":
       return _githubAddress(
-        "review",
+        "REVIEW",
         x.pull.repo.owner,
         x.pull.repo.name,
         x.pull.number,
@@ -201,8 +201,8 @@ export function toRaw(x: StructuredAddress): RawAddress {
       switch (x.parent.type) {
         case "ISSUE":
           return _githubAddress(
-            "comment",
-            "issue",
+            "COMMENT",
+            "ISSUE",
             x.parent.repo.owner,
             x.parent.repo.name,
             x.parent.number,
@@ -210,8 +210,8 @@ export function toRaw(x: StructuredAddress): RawAddress {
           );
         case "PULL":
           return _githubAddress(
-            "comment",
-            "pull",
+            "COMMENT",
+            "PULL",
             x.parent.repo.owner,
             x.parent.repo.name,
             x.parent.number,
@@ -219,8 +219,8 @@ export function toRaw(x: StructuredAddress): RawAddress {
           );
         case "REVIEW":
           return _githubAddress(
-            "comment",
-            "review",
+            "COMMENT",
+            "REVIEW",
             x.parent.pull.repo.owner,
             x.parent.pull.repo.name,
             x.parent.pull.number,
@@ -233,7 +233,7 @@ export function toRaw(x: StructuredAddress): RawAddress {
           throw new Error(`Bad comment parent type: ${x.parent.type}`);
       }
     case "USERLIKE":
-      return _githubAddress("userlike", x.login);
+      return _githubAddress("USERLIKE", x.login);
     default:
       // eslint-disable-next-line no-unused-expressions
       (x.type: empty);


### PR DESCRIPTION
Summary:
@decentralion wants this! :-)

Test Plan:
Verify that the case-insensitive diff is empty:
```
$ git config --global difftool.idiff.cmd 'diff -ui "$LOCAL" "$REMOTE"'
$ git difftool -y --tool idiff HEAD~1..HEAD
```

wchargin-branch: uppercase-enum