### PR TITLE
Add Github prefixes and const types

### DIFF
--- a/src/v3/plugins/github/edges.test.js
+++ b/src/v3/plugins/github/edges.test.js
@@ -2,57 +2,63 @@
 
 import {NodeAddress, EdgeAddress, edgeToString} from "../../core/graph";
 import {createEdge, fromRaw, toRaw} from "./edges";
+import * as GE from "./edges";
+import * as GN from "./nodes";
 
 describe("plugins/github/edges", () => {
   const nodeExamples = {
     repo: () => ({
-      type: "REPO",
+      type: GN.REPO_TYPE,
       owner: "sourcecred",
       name: "example-github",
     }),
-    issue: () => ({type: "ISSUE", repo: nodeExamples.repo(), number: "2"}),
-    pull: () => ({type: "PULL", repo: nodeExamples.repo(), number: "5"}),
+    issue: () => ({
+      type: GN.ISSUE_TYPE,
+      repo: nodeExamples.repo(),
+      number: "2",
+    }),
+    pull: () => ({type: GN.PULL_TYPE, repo: nodeExamples.repo(), number: "5"}),
     review: () => ({
-      type: "REVIEW",
+      type: GN.REVIEW_TYPE,
       pull: nodeExamples.pull(),
       id: "100313899",
     }),
     issueComment: () => ({
-      type: "COMMENT",
+      type: GN.COMMENT_TYPE,
       parent: nodeExamples.issue(),
       id: "373768703",
     }),
     pullComment: () => ({
-      type: "COMMENT",
+      type: GN.COMMENT_TYPE,
       parent: nodeExamples.pull(),
       id: "396430464",
     }),
     reviewComment: () => ({
-      type: "COMMENT",
+      type: GN.COMMENT_TYPE,
       parent: nodeExamples.review(),
       id: "171460198",
     }),
-    user: () => ({type: "USERLIKE", login: "decentralion"}),
+    user: () => ({type: GN.USERLIKE_TYPE, login: "decentralion"}),
   };
 
   const edgeExamples = {
     authors: () => ({
-      type: "AUTHORS",
+      type: GE.AUTHORS_TYPE,
       author: nodeExamples.user(),
       content: nodeExamples.pull(),
     }),
     mergedAs: () => ({
-      type: "MERGED_AS",
+      type: GE.MERGED_AS_TYPE,
       pull: nodeExamples.pull(),
     }),
     hasParent: () => ({
-      type: "HAS_PARENT",
+      type: GE.HAS_PARENT_TYPE,
       child: nodeExamples.reviewComment(),
     }),
     references: () => ({
-      type: "REFERENCES",
+      type: GE.REFERENCES_TYPE,
       referrer: nodeExamples.issue(),
-      referent: {type: "ISSUE", repo: nodeExamples.repo(), number: "1"},
+      referent: {type: GN.ISSUE_TYPE, repo: nodeExamples.repo(), number: "1"},
     }),
   };
 

--- a/src/v3/plugins/github/nodes.test.js
+++ b/src/v3/plugins/github/nodes.test.js
@@ -1,33 +1,50 @@
 // @flow
 
 import {NodeAddress} from "../../core/graph";
+import * as GN from "./nodes";
 import {fromRaw, toRaw} from "./nodes";
 
 describe("plugins/github/nodes", () => {
-  const repo = () => ({
-    type: "REPO",
+  const repo = (): GN.RepoAddress => ({
+    type: GN.REPO_TYPE,
     owner: "sourcecred",
     name: "example-github",
   });
-  const issue = () => ({type: "ISSUE", repo: repo(), number: "2"});
-  const pull = () => ({type: "PULL", repo: repo(), number: "5"});
-  const review = () => ({type: "REVIEW", pull: pull(), id: "100313899"});
-  const issueComment = () => ({
-    type: "COMMENT",
+  const issue = (): GN.IssueAddress => ({
+    type: GN.ISSUE_TYPE,
+    repo: repo(),
+    number: "2",
+  });
+  const pull = (): GN.PullAddress => ({
+    type: GN.PULL_TYPE,
+    repo: repo(),
+    number: "5",
+  });
+  const review = (): GN.ReviewAddress => ({
+    type: GN.REVIEW_TYPE,
+    pull: pull(),
+    id: "100313899",
+  });
+  const issueComment = (): GN.CommentAddress => ({
+    type: GN.COMMENT_TYPE,
     parent: issue(),
     id: "373768703",
   });
-  const pullComment = () => ({
-    type: "COMMENT",
+  const pullComment = (): GN.CommentAddress => ({
+    type: GN.COMMENT_TYPE,
     parent: pull(),
     id: "396430464",
   });
-  const reviewComment = () => ({
-    type: "COMMENT",
+  const reviewComment = (): GN.CommentAddress => ({
+    type: GN.COMMENT_TYPE,
     parent: review(),
     id: "171460198",
   });
-  const user = () => ({type: "USERLIKE", login: "decentralion"});
+  const user = (): GN.UserlikeAddress => ({
+    type: GN.USERLIKE_TYPE,
+    login: "decentralion",
+  });
+
   const examples = {
     repo,
     issue,
@@ -38,6 +55,19 @@ describe("plugins/github/nodes", () => {
     reviewComment,
     user,
   };
+
+  // Incorrect types should be caught statically, either due to being
+  // totally invalid...
+  // $ExpectFlowError
+  const _unused_badRepo: GN.RepoAddress = {
+    type: "REPOSITORY",
+    owner: "foo",
+    name: "bar",
+  };
+  // ...or due to being annotated with the type of a distinct structured
+  // address:
+  // $ExpectFlowError
+  const _unused_badIssue: GN.IssueAddress = {...pull()};
 
   describe("`fromRaw` after `toRaw` is identity", () => {
     Object.keys(examples).forEach((example) => {


### PR DESCRIPTION
- Switch string constant node and edge types (e.g. "REPO") to exported
consts (eg `export const REPO_TYPE`).
- Add (and internally use) a `_Prefix` psuedomodule which contains
per-type address prefixes
- Test that constructing a StructuredAddress with the wrong type is an
error.

Test plan:
Unit tests pass, snapshots unchanged.

Paired with @wchargin