### PR TITLE
Fix GitHub node `fromRaw` error-path test cases

### DIFF
--- a/src/v3/plugins/github/nodes.test.js
+++ b/src/v3/plugins/github/nodes.test.js
@@ -141,14 +141,14 @@ describe("plugins/github/nodes", () => {
       expectBadAddress("no kind", []);
       describe("repository with", () => {
         checkBadCases([
-          {name: "no owner", parts: ["repo"]},
+          {name: "no owner", parts: [GN.REPO_TYPE]},
           {name: "no name", parts: ["owner"]},
           {name: "extra parts", parts: ["name", "foo"]},
         ]);
       });
       describe("issue with", () => {
         checkBadCases([
-          {name: "no owner", parts: ["issue"]},
+          {name: "no owner", parts: [GN.ISSUE_TYPE]},
           {name: "no name", parts: ["owner"]},
           {name: "no number", parts: ["name"]},
           {name: "extra parts", parts: ["123", "foo"]},
@@ -156,7 +156,7 @@ describe("plugins/github/nodes", () => {
       });
       describe("pull request with", () => {
         checkBadCases([
-          {name: "no owner", parts: ["pull"]},
+          {name: "no owner", parts: [GN.PULL_TYPE]},
           {name: "no name", parts: ["owner"]},
           {name: "no number", parts: ["name"]},
           {name: "extra parts", parts: ["123", "foo"]},
@@ -164,7 +164,7 @@ describe("plugins/github/nodes", () => {
       });
       describe("pull request review with", () => {
         checkBadCases([
-          {name: "no owner", parts: ["review"]},
+          {name: "no owner", parts: [GN.REVIEW_TYPE]},
           {name: "no name", parts: ["owner"]},
           {name: "no number", parts: ["name"]},
           {name: "no id", parts: ["123"]},
@@ -172,11 +172,11 @@ describe("plugins/github/nodes", () => {
         ]);
       });
       describe("comment", () => {
-        expectBadAddress("with no subkind", ["comment"]);
-        expectBadAddress("with bad subkind", ["comment", "icecream"]);
+        expectBadAddress("with no subkind", [GN.COMMENT_TYPE]);
+        expectBadAddress("with bad subkind", [GN.COMMENT_TYPE, "ICE_CREAM"]);
         describe("on issue with", () => {
           checkBadCases([
-            {name: "no owner", parts: ["comment", "issue"]},
+            {name: "no owner", parts: [GN.COMMENT_TYPE, GN.ISSUE_TYPE]},
             {name: "no name", parts: ["owner"]},
             {name: "no number", parts: ["name"]},
             {name: "no id", parts: ["123"]},
@@ -185,7 +185,7 @@ describe("plugins/github/nodes", () => {
         });
         describe("on pull request with", () => {
           checkBadCases([
-            {name: "no owner", parts: ["comment", "pull"]},
+            {name: "no owner", parts: [GN.COMMENT_TYPE, GN.PULL_TYPE]},
             {name: "no name", parts: ["owner"]},
             {name: "no number", parts: ["name"]},
             {name: "no id", parts: ["123"]},
@@ -194,7 +194,7 @@ describe("plugins/github/nodes", () => {
         });
         describe("on pull request review with", () => {
           checkBadCases([
-            {name: "no owner", parts: ["comment", "review"]},
+            {name: "no owner", parts: [GN.COMMENT_TYPE, GN.REVIEW_TYPE]},
             {name: "no name", parts: ["owner"]},
             {name: "no number", parts: ["name"]},
             {name: "no review id", parts: ["123"]},
@@ -205,7 +205,7 @@ describe("plugins/github/nodes", () => {
       });
       describe("userlike", () => {
         checkBadCases([
-          {name: "no login", parts: ["userlike"]},
+          {name: "no login", parts: [GN.USERLIKE_TYPE]},
           {name: "extra parts", parts: ["decentra", "lion"]},
         ]);
       });


### PR DESCRIPTION
Summary:
In #394, we uppercased the constants for GitHub node types. However, we
were using string literals instead of constants in the test cases. These
test cases were supposed to cover every error path, but instead ended up
just covering the “bad type” error path many times.

Any one of the following would have prevented this regression:

 1. using string constants instead of literals in the test case;
 2. throwing and checking more precise error messages; or
 3. being alerted that coverage decreased as a result of the change.

In this commit, we enact the first of these options. I’m open to adding
a coverage bot, but don’t feel strongly about it at this time.

Test Plan:
Running `yarn coverage` now shows 100% coverage for the `nodes.js`
module, whereas previously almost all `throw fail();` lines were
uncovered (and the branch coverage was just 76%).

wchargin-branch: fix-github-node-error-tests