### PR TITLE
Add `edgeToParts` convenience export from `Graph`

### DIFF
--- a/src/v3/core/graph.js
+++ b/src/v3/core/graph.js
@@ -588,3 +588,12 @@ export function edgeToString(edge: Edge): string {
   const dst = NodeAddress.toString(edge.dst);
   return `{address: ${address}, src: ${src}, dst: ${dst}}`;
 }
+
+export function edgeToParts(
+  edge: Edge
+): {|+addressParts: string[], +srcParts: string[], +dstParts: string[]|} {
+  const addressParts = EdgeAddress.toParts(edge.address);
+  const srcParts = NodeAddress.toParts(edge.src);
+  const dstParts = NodeAddress.toParts(edge.dst);
+  return {addressParts, srcParts, dstParts};
+}

--- a/src/v3/core/graph.test.js
+++ b/src/v3/core/graph.test.js
@@ -14,6 +14,7 @@ import {
   Graph,
   NodeAddress,
   edgeToString,
+  edgeToParts,
 } from "./graph";
 
 describe("core/graph", () => {
@@ -1465,6 +1466,22 @@ describe("core/graph", () => {
         'dst: NodeAddress["five","six"]' +
         "}";
       expect(edgeToString(edge)).toEqual(expected);
+    });
+  });
+
+  describe("edgeToParts", () => {
+    it("works", () => {
+      const edge = {
+        address: EdgeAddress.fromParts(["one", "two"]),
+        dst: NodeAddress.fromParts(["five", "six"]),
+        src: NodeAddress.fromParts(["three", "four"]),
+      };
+      const expected = {
+        addressParts: ["one", "two"],
+        srcParts: ["three", "four"],
+        dstParts: ["five", "six"],
+      };
+      expect(edgeToParts(edge)).toEqual(expected);
     });
   });
 });


### PR DESCRIPTION
Summary:
We have `edgeToString`, which formats edges as nicely human-readable
strings. However, these strings have some quotes in them, and so when
they are themselves stringified (e.g., as part of a Jest snapshot), they
become much harder to read. We thus introduce `edgeToParts` to make our
snapshots more readable.

Test Plan:
Unit tests added; run `yarn travis`.

wchargin-branch: add-edgeToParts