### PR TITLE
Greatly simplify GitHub edge tests

### DIFF
--- a/src/v3/plugins/github/__snapshots__/edges.test.js.snap
+++ b/src/v3/plugins/github/__snapshots__/edges.test.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`plugins/github/edges createEdge works for authors edges 1`] = `
+exports[`plugins/github/edges createEdge works for "authors" 1`] = `
 Object {
   "addressParts": Array [
     "sourcecred",
@@ -32,7 +32,7 @@ Object {
 }
 `;
 
-exports[`plugins/github/edges createEdge works for has-parent edges 1`] = `
+exports[`plugins/github/edges createEdge works for "hasParent" 1`] = `
 Object {
   "addressParts": Array [
     "sourcecred",
@@ -70,7 +70,7 @@ Object {
 }
 `;
 
-exports[`plugins/github/edges createEdge works for merged-as edges 1`] = `
+exports[`plugins/github/edges createEdge works for "mergedAs" 1`] = `
 Object {
   "addressParts": Array [
     "sourcecred",
@@ -98,7 +98,7 @@ Object {
 }
 `;
 
-exports[`plugins/github/edges createEdge works for reference edges 1`] = `
+exports[`plugins/github/edges createEdge works for "references" 1`] = `
 Object {
   "addressParts": Array [
     "sourcecred",
@@ -131,145 +131,5 @@ Object {
     "example-github",
     "2",
   ],
-}
-`;
-
-exports[`plugins/github/edges snapshots as expected: authors 1`] = `
-Object {
-  "address": Array [
-    "sourcecred",
-    "github",
-    "AUTHORS",
-    "2",
-    "USERLIKE",
-    "decentralion",
-    "4",
-    "PULL",
-    "sourcecred",
-    "example-github",
-    "5",
-  ],
-  "structured": Object {
-    "author": Object {
-      "login": "decentralion",
-      "type": "USERLIKE",
-    },
-    "content": Object {
-      "number": "5",
-      "repo": Object {
-        "name": "example-github",
-        "owner": "sourcecred",
-        "type": "REPO",
-      },
-      "type": "PULL",
-    },
-    "type": "AUTHORS",
-  },
-}
-`;
-
-exports[`plugins/github/edges snapshots as expected: hasParent 1`] = `
-Object {
-  "address": Array [
-    "sourcecred",
-    "github",
-    "HAS_PARENT",
-    "7",
-    "COMMENT",
-    "REVIEW",
-    "sourcecred",
-    "example-github",
-    "5",
-    "100313899",
-    "171460198",
-  ],
-  "structured": Object {
-    "child": Object {
-      "id": "171460198",
-      "parent": Object {
-        "id": "100313899",
-        "pull": Object {
-          "number": "5",
-          "repo": Object {
-            "name": "example-github",
-            "owner": "sourcecred",
-            "type": "REPO",
-          },
-          "type": "PULL",
-        },
-        "type": "REVIEW",
-      },
-      "type": "COMMENT",
-    },
-    "type": "HAS_PARENT",
-  },
-}
-`;
-
-exports[`plugins/github/edges snapshots as expected: mergedAs 1`] = `
-Object {
-  "address": Array [
-    "sourcecred",
-    "github",
-    "MERGED_AS",
-    "4",
-    "PULL",
-    "sourcecred",
-    "example-github",
-    "5",
-  ],
-  "structured": Object {
-    "pull": Object {
-      "number": "5",
-      "repo": Object {
-        "name": "example-github",
-        "owner": "sourcecred",
-        "type": "REPO",
-      },
-      "type": "PULL",
-    },
-    "type": "MERGED_AS",
-  },
-}
-`;
-
-exports[`plugins/github/edges snapshots as expected: references 1`] = `
-Object {
-  "address": Array [
-    "sourcecred",
-    "github",
-    "REFERENCES",
-    "4",
-    "ISSUE",
-    "sourcecred",
-    "example-github",
-    "2",
-    "4",
-    "ISSUE",
-    "sourcecred",
-    "example-github",
-    "1",
-  ],
-  "structured": Object {
-    "referent": Object {
-      "number": "1",
-      "repo": Object {
-        "name": "example-github",
-        "owner": "sourcecred",
-        "type": "REPO",
-      },
-      "type": "ISSUE",
-    },
-    "referrer": Object {
-      "number": "2",
-      "repo": Object {
-        "name": "example-github",
-        "owner": "sourcecred",
-        "type": "REPO",
-      },
-      "type": "ISSUE",
-    },
-    "type": "REFERENCES",
-  },
 }
 `;

--- a/src/v3/plugins/github/edges.test.js
+++ b/src/v3/plugins/github/edges.test.js
@@ -1,6 +1,6 @@
 // @flow
 
-import {NodeAddress, EdgeAddress, edgeToParts} from "../../core/graph";
+import {type EdgeAddressT, NodeAddress, edgeToParts} from "../../core/graph";
 import {createEdge, fromRaw, toRaw} from "./edges";
 import * as GE from "./edges";
 import * as GN from "./nodes";
@@ -42,64 +42,23 @@ describe("plugins/github/edges", () => {
   };
 
   const edgeExamples = {
-    authors: () => ({
-      type: GE.AUTHORS_TYPE,
-      author: nodeExamples.user(),
-      content: nodeExamples.pull(),
-    }),
-    mergedAs: () => ({
-      type: GE.MERGED_AS_TYPE,
-      pull: nodeExamples.pull(),
-    }),
-    hasParent: () => ({
-      type: GE.HAS_PARENT_TYPE,
-      child: nodeExamples.reviewComment(),
-    }),
-    references: () => ({
-      type: GE.REFERENCES_TYPE,
-      referrer: nodeExamples.issue(),
-      referent: {type: GN.ISSUE_TYPE, repo: nodeExamples.repo(), number: "1"},
-    }),
+    authors: () =>
+      createEdge.authors(nodeExamples.user(), nodeExamples.issue()),
+    mergedAs: () => {
+      const commitAddress = NodeAddress.fromParts(["git", "commit", "123"]);
+      return createEdge.mergedAs(nodeExamples.pull(), commitAddress);
+    },
+    hasParent: () =>
+      createEdge.hasParent(nodeExamples.reviewComment(), nodeExamples.review()),
+    references: () =>
+      createEdge.references(nodeExamples.issue(), nodeExamples.pull()),
   };
 
   describe("createEdge", () => {
-    it("works for authors edges", () => {
-      expect(
-        edgeToParts(
-          createEdge.authors(nodeExamples.user(), nodeExamples.issue())
-        )
-      ).toMatchSnapshot();
-    });
-    it("works for merged-as edges", () => {
-      const commitAddress = NodeAddress.fromParts(["git", "commit", "123"]);
-      expect(
-        edgeToParts(createEdge.mergedAs(nodeExamples.pull(), commitAddress))
-      ).toMatchSnapshot();
-    });
-    it("works for has-parent edges", () => {
-      expect(
-        edgeToParts(
-          createEdge.hasParent(
-            nodeExamples.reviewComment(),
-            nodeExamples.review()
-          )
-        )
-      ).toMatchSnapshot();
-    });
-    it("works for reference edges", () => {
-      expect(
-        edgeToParts(
-          createEdge.references(nodeExamples.issue(), nodeExamples.pull())
-        )
-      ).toMatchSnapshot();
-    });
-  });
-
-  describe("`fromRaw` after `toRaw` is identity", () => {
     Object.keys(edgeExamples).forEach((example) => {
-      it(example, () => {
+      it(`works for ${JSON.stringify(example)}`, () => {
         const instance = edgeExamples[example]();
-        expect(fromRaw(toRaw(instance))).toEqual(instance);
+        expect(edgeToParts(instance)).toMatchSnapshot();
       });
     });
   });
@@ -107,19 +66,20 @@ describe("plugins/github/edges", () => {
   describe("`toRaw` after `fromRaw` is identity", () => {
     Object.keys(edgeExamples).forEach((example) => {
       it(example, () => {
-        const instance = edgeExamples[example]();
-        const raw = toRaw(instance);
-        expect(toRaw(fromRaw(raw))).toEqual(raw);
+        const baseAddress: EdgeAddressT = edgeExamples[example]().address;
+        const instance: GE.RawAddress = (baseAddress: any);
+        expect(toRaw(fromRaw(instance))).toEqual(instance);
       });
     });
   });
 
-  describe("snapshots as expected:", () => {
+  describe("`fromRaw` after `toRaw` is identity", () => {
     Object.keys(edgeExamples).forEach((example) => {
       it(example, () => {
-        const instance = edgeExamples[example]();
-        const raw = EdgeAddress.toParts(toRaw(instance));
-        expect({address: raw, structured: instance}).toMatchSnapshot();
+        const baseAddress: EdgeAddressT = edgeExamples[example]().address;
+        const instance: GE.RawAddress = (baseAddress: any);
+        const structured: GE.StructuredAddress = fromRaw(instance);
+        expect(fromRaw(toRaw(structured))).toEqual(structured);
       });
     });
   });


### PR DESCRIPTION
Summary:
We had `edgeExamples`, wherein we constructed examples of edge addresses
(not actual edges) by manual instantiation. We checked that these
matched snapshots, and then we also called `createEdge` a bunch to
create actual edges, and checked that those matched snapshots, too.
Consequently, we had twice as many snapshots as we needed, and also
defined twice as many edge addresses as we needed.

Test Plan:
Note that snapshot contents are either deleted or unchanged.

wchargin-branch: simplify-github-edge-tests