### PR TITLE
Copy graph-independent V1 Git plugin code to V3

### DIFF
--- a/config/paths.js
+++ b/config/paths.js
@@ -68,8 +68,14 @@ module.exports = {
     createExampleRepo: resolveApp(
       "src/v1/plugins/git/bin/createExampleRepo.js"
     ),
+    createExampleRepoV3: resolveApp(
+      "src/v3/plugins/git/bin/createExampleRepo.js"
+    ),
     loadAndPrintGitRepository: resolveApp(
       "src/v1/plugins/git/bin/loadAndPrintRepository.js"
+    ),
+    loadAndPrintGitRepositoryV3: resolveApp(
+      "src/v3/plugins/git/bin/loadAndPrintRepository.js"
     ),
   },
 };

--- a/config/travis.js
+++ b/config/travis.js
@@ -87,6 +87,11 @@ function makeTasks(mode /*: "BASIC" | "FULL" */) {
       cmd: ["./src/v1/plugins/git/loadRepositoryTest.sh", "--no-build"],
       deps: ["backend-in-place"],
     },
+    {
+      id: "loadRepositoryTestV3",
+      cmd: ["./src/v3/plugins/git/loadRepositoryTest.sh", "--no-build"],
+      deps: ["backend-in-place"],
+    },
   ];
   switch (mode) {
     case "BASIC":

--- a/src/v3/plugins/git/__snapshots__/loadRepository.test.js.snap
+++ b/src/v3/plugins/git/__snapshots__/loadRepository.test.js.snap
@@ -1,0 +1,14 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`loadRepository processes an old commit 1`] = `
+Object {
+  "commits": Set {
+    "c08ee3a4edea384d5291ffcbf06724a13ed72325",
+    "c2b51945e7457546912a8ce158ed9d294558d294",
+  },
+  "trees": Set {
+    "2f7155e359fd0ecb96ffdca66fa45b6ed5792809",
+    "bdff5d94193170015d6cbb549b7b630649428b1f",
+  },
+}
+`;

--- a/src/v3/plugins/git/bin/createExampleRepo.js
+++ b/src/v3/plugins/git/bin/createExampleRepo.js
@@ -1,0 +1,74 @@
+// @flow
+
+import fs from "fs";
+
+import {
+  createExampleRepo,
+  createExampleSubmoduleRepo,
+} from "../demoData/exampleRepo";
+
+function parseArgs() {
+  const argv = process.argv.slice(2);
+  const fail = () => {
+    const invocation = process.argv.slice(0, 2).join(" ");
+    throw new Error(`Usage: ${invocation} [--[no-]submodule] TARGET_DIRECTORY`);
+  };
+
+  let submodule: boolean = false;
+  let target: ?string = null;
+
+  for (const arg of argv) {
+    if (arg === "--submodule") {
+      submodule = true;
+    } else if (arg === "--no-submodule") {
+      submodule = false;
+    } else {
+      if (target == null) {
+        target = arg;
+      } else {
+        fail();
+      }
+    }
+  }
+
+  if (target == null) {
+    fail();
+    throw new Error("Unreachable"); // for Flow
+  }
+  return {
+    submodule,
+    target: (target: string),
+  };
+}
+
+function ensureEmptyDirectoryOrNonexistent(target: string) {
+  const files = (() => {
+    try {
+      return fs.readdirSync(target);
+    } catch (e) {
+      if (e.code === "ENOTDIR") {
+        throw new Error("Target exists, but is not a directory.");
+      } else if (e.code === "ENOENT") {
+        // No problem. We'll create it.
+        return [];
+      } else {
+        throw e;
+      }
+    }
+  })();
+  if (files.length > 0) {
+    throw new Error("Target directory exists, but is nonempty.");
+  }
+}
+
+function main() {
+  const args = parseArgs();
+  ensureEmptyDirectoryOrNonexistent(args.target);
+  if (args.submodule) {
+    createExampleSubmoduleRepo(args.target);
+  } else {
+    createExampleRepo(args.target);
+  }
+}
+
+main();

--- a/src/v3/plugins/git/bin/loadAndPrintRepository.js
+++ b/src/v3/plugins/git/bin/loadAndPrintRepository.js
@@ -1,0 +1,36 @@
+/*
+ * Command-line utility to load a Git repository into memory and then
+ * print the resulting JSON representation.
+ *
+ * Usage:
+ *
+ *   node bin/loadAndPrintGitRepository.js PATH [ROOT_REF]
+ *
+ * where PATH is the path on disk to a Git repository, and ROOT_REF is
+ * the revision to load (defaults to HEAD).
+ */
+// @flow
+
+import stringify from "json-stable-stringify";
+
+import {loadRepository} from "../loadRepository";
+
+function parseArgs() {
+  const argv = process.argv.slice(2);
+  if (argv.length !== 1 && argv.length !== 2) {
+    const invocation = process.argv.slice(0, 2).join(" ");
+    throw new Error(`Usage: ${invocation} PATH`);
+  }
+  return {
+    repositoryPath: argv[0],
+    rootRef: argv.length > 1 ? argv[1] : "HEAD",
+  };
+}
+
+function main() {
+  const args = parseArgs();
+  const result = loadRepository(args.repositoryPath, args.rootRef);
+  console.log(stringify(result, {space: 4}));
+}
+
+main();

--- a/src/v3/plugins/git/cloneAndLoadRepository.js
+++ b/src/v3/plugins/git/cloneAndLoadRepository.js
@@ -1,0 +1,29 @@
+// @flow
+
+import tmp from "tmp";
+import {localGit} from "./gitUtils";
+import type {Repository} from "./types";
+import {loadRepository} from "./loadRepository";
+
+/**
+ * Load Git Repository data from a fresh clone of a GitHub repo.
+ *
+ * @param {String} repoOwner
+ *   the GitHub username of the owner of the repository to be cloned
+ * @param {String} repoName
+ *   the name of the repository to be cloned
+ * @return {Repository}
+ *   the parsed Repository from the cloned repo
+ */
+export default function cloneAndLoadRepository(
+  repoOwner: string,
+  repoName: string
+): Repository {
+  const cloneUrl = `https://github.com/${repoOwner}/${repoName}.git`;
+  const tmpdir = tmp.dirSync({unsafeCleanup: true});
+  const git = localGit(tmpdir.name);
+  git(["clone", cloneUrl, ".", "--quiet"]);
+  const result = loadRepository(tmpdir.name, "HEAD");
+  tmpdir.removeCallback();
+  return result;
+}

--- a/src/v3/plugins/git/demoData/__snapshots__/exampleRepo.test.js.snap
+++ b/src/v3/plugins/git/demoData/__snapshots__/exampleRepo.test.js.snap
@@ -1,0 +1,20 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`createExampleRepo is deterministic 1`] = `
+Array [
+  "c2b51945e7457546912a8ce158ed9d294558d294",
+  "c08ee3a4edea384d5291ffcbf06724a13ed72325",
+  "8d287c3bfbf8455ef30187bf5153ffc1b6eef268",
+  "d160cca97611e9dfed642522ad44408d0292e8ea",
+  "e8b7a8f19701cd5a25e4a097d513ead60e5f8bcc",
+  "69c5aad50eec8f2a0a07c988c3b283a6490eb45b",
+  "3715ddfb8d4c4fd2a6f6af75488c82f84c92ec2f",
+]
+`;
+
+exports[`createExampleSubmoduleRepo is deterministic 1`] = `
+Array [
+  "762c062fbdc7ec198cd693e95d55b374a08ff3e3",
+  "29ef158bc982733e2ba429fcf73e2f7562244188",
+]
+`;

--- a/src/v3/plugins/git/demoData/example-git.json
+++ b/src/v3/plugins/git/demoData/example-git.json
@@ -1,0 +1,288 @@
+{
+    "commits": {
+        "3715ddfb8d4c4fd2a6f6af75488c82f84c92ec2f": {
+            "hash": "3715ddfb8d4c4fd2a6f6af75488c82f84c92ec2f",
+            "parentHashes": [
+                "69c5aad50eec8f2a0a07c988c3b283a6490eb45b"
+            ],
+            "submoduleUrls": {
+                "pygravitydefier": "https://github.com/sourcecred/example-git-submodule.git"
+            },
+            "treeHash": "7be3ecfee5314ffa9b2d93fc4377792b2d6d70ed"
+        },
+        "69c5aad50eec8f2a0a07c988c3b283a6490eb45b": {
+            "hash": "69c5aad50eec8f2a0a07c988c3b283a6490eb45b",
+            "parentHashes": [
+                "e8b7a8f19701cd5a25e4a097d513ead60e5f8bcc"
+            ],
+            "submoduleUrls": {
+                "pygravitydefier": "https://github.com/sourcecred/example-git-submodule.git"
+            },
+            "treeHash": "bbf3b8b3d26a4f884b5c022d46851f593d329192"
+        },
+        "8d287c3bfbf8455ef30187bf5153ffc1b6eef268": {
+            "hash": "8d287c3bfbf8455ef30187bf5153ffc1b6eef268",
+            "parentHashes": [
+                "c08ee3a4edea384d5291ffcbf06724a13ed72325"
+            ],
+            "submoduleUrls": {
+                "pygravitydefier": "https://github.com/sourcecred/example-git-submodule.git"
+            },
+            "treeHash": "3dfb84795e07341b05fad3a0d5a55f8304b2d7d8"
+        },
+        "c08ee3a4edea384d5291ffcbf06724a13ed72325": {
+            "hash": "c08ee3a4edea384d5291ffcbf06724a13ed72325",
+            "parentHashes": [
+                "c2b51945e7457546912a8ce158ed9d294558d294"
+            ],
+            "submoduleUrls": {
+            },
+            "treeHash": "2f7155e359fd0ecb96ffdca66fa45b6ed5792809"
+        },
+        "c2b51945e7457546912a8ce158ed9d294558d294": {
+            "hash": "c2b51945e7457546912a8ce158ed9d294558d294",
+            "parentHashes": [
+            ],
+            "submoduleUrls": {
+            },
+            "treeHash": "bdff5d94193170015d6cbb549b7b630649428b1f"
+        },
+        "d160cca97611e9dfed642522ad44408d0292e8ea": {
+            "hash": "d160cca97611e9dfed642522ad44408d0292e8ea",
+            "parentHashes": [
+                "8d287c3bfbf8455ef30187bf5153ffc1b6eef268"
+            ],
+            "submoduleUrls": {
+                "pygravitydefier": "https://github.com/sourcecred/example-git-submodule.git"
+            },
+            "treeHash": "569e1d383759903134df75230d63c0090196d4cb"
+        },
+        "e8b7a8f19701cd5a25e4a097d513ead60e5f8bcc": {
+            "hash": "e8b7a8f19701cd5a25e4a097d513ead60e5f8bcc",
+            "parentHashes": [
+                "d160cca97611e9dfed642522ad44408d0292e8ea"
+            ],
+            "submoduleUrls": {
+                "pygravitydefier": "https://github.com/sourcecred/example-git-submodule.git"
+            },
+            "treeHash": "819fc546cea489476ce8dc90785e9ba7753d0a8f"
+        }
+    },
+    "trees": {
+        "2f7155e359fd0ecb96ffdca66fa45b6ed5792809": {
+            "entries": {
+                "README.txt": {
+                    "hash": "0fb31858c8e3710be77e1dbb8880acf8a5543d82",
+                    "name": "README.txt",
+                    "type": "blob"
+                },
+                "science.txt": {
+                    "hash": "f1f2514ca6d7a6a1a0511957021b1995bf9ace1c",
+                    "name": "science.txt",
+                    "type": "blob"
+                }
+            },
+            "hash": "2f7155e359fd0ecb96ffdca66fa45b6ed5792809"
+        },
+        "3dfb84795e07341b05fad3a0d5a55f8304b2d7d8": {
+            "entries": {
+                ".gitmodules": {
+                    "hash": "8c6cac301e763aa6d36466e0a775eb804be2c311",
+                    "name": ".gitmodules",
+                    "type": "blob"
+                },
+                "README.txt": {
+                    "hash": "0fb31858c8e3710be77e1dbb8880acf8a5543d82",
+                    "name": "README.txt",
+                    "type": "blob"
+                },
+                "pygravitydefier": {
+                    "hash": "762c062fbdc7ec198cd693e95d55b374a08ff3e3",
+                    "name": "pygravitydefier",
+                    "type": "commit"
+                },
+                "science.txt": {
+                    "hash": "f1f2514ca6d7a6a1a0511957021b1995bf9ace1c",
+                    "name": "science.txt",
+                    "type": "blob"
+                }
+            },
+            "hash": "3dfb84795e07341b05fad3a0d5a55f8304b2d7d8"
+        },
+        "569e1d383759903134df75230d63c0090196d4cb": {
+            "entries": {
+                ".gitmodules": {
+                    "hash": "8c6cac301e763aa6d36466e0a775eb804be2c311",
+                    "name": ".gitmodules",
+                    "type": "blob"
+                },
+                "README.txt": {
+                    "hash": "0fb31858c8e3710be77e1dbb8880acf8a5543d82",
+                    "name": "README.txt",
+                    "type": "blob"
+                },
+                "TODOS.txt": {
+                    "hash": "ddec7477206c30c31b81482e56b877a0b3c2638b",
+                    "name": "TODOS.txt",
+                    "type": "blob"
+                },
+                "pygravitydefier": {
+                    "hash": "762c062fbdc7ec198cd693e95d55b374a08ff3e3",
+                    "name": "pygravitydefier",
+                    "type": "commit"
+                },
+                "science.txt": {
+                    "hash": "f1f2514ca6d7a6a1a0511957021b1995bf9ace1c",
+                    "name": "science.txt",
+                    "type": "blob"
+                },
+                "src": {
+                    "hash": "7b79d579b62994faba3b69fdf8aa442586c32681",
+                    "name": "src",
+                    "type": "tree"
+                }
+            },
+            "hash": "569e1d383759903134df75230d63c0090196d4cb"
+        },
+        "78fc9c83023386854c6bfdc5761c0e58f68e226f": {
+            "entries": {
+                "index.py": {
+                    "hash": "674b0b476989384510304846248b3acd16206782",
+                    "name": "index.py",
+                    "type": "blob"
+                },
+                "quantum_gravity.py": {
+                    "hash": "aea4f28abb23abde151b0ead4063227f8bf6c0b0",
+                    "name": "quantum_gravity.py",
+                    "type": "blob"
+                }
+            },
+            "hash": "78fc9c83023386854c6bfdc5761c0e58f68e226f"
+        },
+        "7b79d579b62994faba3b69fdf8aa442586c32681": {
+            "entries": {
+                "index.py": {
+                    "hash": "674b0b476989384510304846248b3acd16206782",
+                    "name": "index.py",
+                    "type": "blob"
+                },
+                "quantum_gravity.py": {
+                    "hash": "887ad856bbc1373da146106c86cb581ad78cdafe",
+                    "name": "quantum_gravity.py",
+                    "type": "blob"
+                }
+            },
+            "hash": "7b79d579b62994faba3b69fdf8aa442586c32681"
+        },
+        "7be3ecfee5314ffa9b2d93fc4377792b2d6d70ed": {
+            "entries": {
+                ".gitmodules": {
+                    "hash": "8c6cac301e763aa6d36466e0a775eb804be2c311",
+                    "name": ".gitmodules",
+                    "type": "blob"
+                },
+                "README.txt": {
+                    "hash": "0fb31858c8e3710be77e1dbb8880acf8a5543d82",
+                    "name": "README.txt",
+                    "type": "blob"
+                },
+                "pygravitydefier": {
+                    "hash": "29ef158bc982733e2ba429fcf73e2f7562244188",
+                    "name": "pygravitydefier",
+                    "type": "commit"
+                },
+                "science.txt": {
+                    "hash": "f1f2514ca6d7a6a1a0511957021b1995bf9ace1c",
+                    "name": "science.txt",
+                    "type": "blob"
+                },
+                "src": {
+                    "hash": "78fc9c83023386854c6bfdc5761c0e58f68e226f",
+                    "name": "src",
+                    "type": "tree"
+                }
+            },
+            "hash": "7be3ecfee5314ffa9b2d93fc4377792b2d6d70ed"
+        },
+        "819fc546cea489476ce8dc90785e9ba7753d0a8f": {
+            "entries": {
+                ".gitmodules": {
+                    "hash": "8c6cac301e763aa6d36466e0a775eb804be2c311",
+                    "name": ".gitmodules",
+                    "type": "blob"
+                },
+                "README.txt": {
+                    "hash": "0fb31858c8e3710be77e1dbb8880acf8a5543d82",
+                    "name": "README.txt",
+                    "type": "blob"
+                },
+                "TODOS.txt": {
+                    "hash": "ddec7477206c30c31b81482e56b877a0b3c2638b",
+                    "name": "TODOS.txt",
+                    "type": "blob"
+                },
+                "pygravitydefier": {
+                    "hash": "29ef158bc982733e2ba429fcf73e2f7562244188",
+                    "name": "pygravitydefier",
+                    "type": "commit"
+                },
+                "science.txt": {
+                    "hash": "f1f2514ca6d7a6a1a0511957021b1995bf9ace1c",
+                    "name": "science.txt",
+                    "type": "blob"
+                },
+                "src": {
+                    "hash": "7b79d579b62994faba3b69fdf8aa442586c32681",
+                    "name": "src",
+                    "type": "tree"
+                }
+            },
+            "hash": "819fc546cea489476ce8dc90785e9ba7753d0a8f"
+        },
+        "bbf3b8b3d26a4f884b5c022d46851f593d329192": {
+            "entries": {
+                ".gitmodules": {
+                    "hash": "8c6cac301e763aa6d36466e0a775eb804be2c311",
+                    "name": ".gitmodules",
+                    "type": "blob"
+                },
+                "README.txt": {
+                    "hash": "0fb31858c8e3710be77e1dbb8880acf8a5543d82",
+                    "name": "README.txt",
+                    "type": "blob"
+                },
+                "TODOS.txt": {
+                    "hash": "ddec7477206c30c31b81482e56b877a0b3c2638b",
+                    "name": "TODOS.txt",
+                    "type": "blob"
+                },
+                "pygravitydefier": {
+                    "hash": "29ef158bc982733e2ba429fcf73e2f7562244188",
+                    "name": "pygravitydefier",
+                    "type": "commit"
+                },
+                "science.txt": {
+                    "hash": "f1f2514ca6d7a6a1a0511957021b1995bf9ace1c",
+                    "name": "science.txt",
+                    "type": "blob"
+                },
+                "src": {
+                    "hash": "78fc9c83023386854c6bfdc5761c0e58f68e226f",
+                    "name": "src",
+                    "type": "tree"
+                }
+            },
+            "hash": "bbf3b8b3d26a4f884b5c022d46851f593d329192"
+        },
+        "bdff5d94193170015d6cbb549b7b630649428b1f": {
+            "entries": {
+                "README.txt": {
+                    "hash": "0fb31858c8e3710be77e1dbb8880acf8a5543d82",
+                    "name": "README.txt",
+                    "type": "blob"
+                }
+            },
+            "hash": "bdff5d94193170015d6cbb549b7b630649428b1f"
+        }
+    }
+}

--- a/src/v3/plugins/git/demoData/exampleRepo.js
+++ b/src/v3/plugins/git/demoData/exampleRepo.js
@@ -1,0 +1,137 @@
+// @flow
+
+import mkdirp from "mkdirp";
+import tmp from "tmp";
+
+import {makeUtils} from "../gitUtils";
+import type {Hash} from "../types";
+
+type RepositoryInfo = {|
+  +path: string,
+  +commits: $ReadOnlyArray<Hash>, // in oldest-to-newest order
+|};
+
+// For determinism, the example repository's submodule URL must be set
+// to a fixed value. We choose the URL of the GitHub mirror (it's as
+// good as any other, and makes sense).
+export const SUBMODULE_REMOTE_URL =
+  "https://github.com/sourcecred/example-git-submodule.git";
+
+// The example repository checks out two different versions of the
+// submodule, as given by the following two hashes. These must exist
+// within the submodule; this property is checked by the test file for
+// this module.
+export const SUBMODULE_COMMIT_1: Hash =
+  "762c062fbdc7ec198cd693e95d55b374a08ff3e3";
+export const SUBMODULE_COMMIT_2: Hash =
+  "29ef158bc982733e2ba429fcf73e2f7562244188";
+
+/**
+ * Create the main example repository.
+ */
+export function createExampleRepo(intoDirectory: string): RepositoryInfo {
+  const repositoryPath = intoDirectory;
+  mkdirp(repositoryPath);
+  const git = makeUtils(repositoryPath);
+  const commits = [];
+  function commit(message) {
+    git.deterministicCommit(message);
+    commits.push(git.head());
+  }
+
+  git.exec(["init"]);
+
+  git.writeAndStage(
+    "README.txt",
+    [
+      "example-git\n",
+      "-----------\n\n",
+      "This repository provides example data for the SourceCred Git plugin.\n",
+      "Pay no attention to the contents behind the curtain.\n",
+    ].join("")
+  );
+  commit("Initial commit");
+
+  git.writeAndStage("science.txt", "Amazing physics going on...\n");
+  commit("Add repository description");
+
+  const tmpdir = tmp.dirSync({unsafeCleanup: true});
+  const submoduleName = "pygravitydefier";
+  createExampleSubmoduleRepo(tmpdir.name);
+  git.exec(["submodule", "add", "--quiet", tmpdir.name, submoduleName]);
+  // After cloning the submodule, we don't need it anymore.
+  tmpdir.removeCallback();
+  // We need all our commits to be deterministic, which means that the
+  // submodule URL needs to be independent of the actual location on
+  // disk (which may be, e.g., a temporary directory).
+  git.exec([
+    "config",
+    "--file=.gitmodules",
+    `submodule.${submoduleName}.url`,
+    SUBMODULE_REMOTE_URL,
+  ]);
+  git.exec(["submodule", "sync", "--quiet"]);
+  git.exec(["add", ".gitmodules"]);
+  git.exec(["-C", submoduleName, "checkout", SUBMODULE_COMMIT_1, "--quiet"]);
+  git.exec(["add", submoduleName]);
+  commit("Add gravity defiance module");
+
+  git.writeAndStage("src/index.py", "import antigravity\n");
+  git.writeAndStage(
+    "src/quantum_gravity.py",
+    'raise NotImplementedError("TODO(physicists)")\n'
+  );
+  git.writeAndStage("TODOS.txt", "1. Resolve quantum gravity\n");
+  commit("Discover gravity");
+
+  git.exec(["-C", submoduleName, "checkout", SUBMODULE_COMMIT_2, "--quiet"]);
+  git.exec(["add", submoduleName]);
+  commit("Pull quantum gravity defiance from upstream");
+
+  git.writeAndStage(
+    "src/quantum_gravity.py",
+    "import random\nif random.random() < 0.5:\n  import antigravity\n"
+  );
+  commit("Solve quantum gravity");
+
+  git.exec(["rm", "TODOS.txt"]);
+  commit("Clean up TODOS");
+
+  return {path: repositoryPath, commits};
+}
+
+/**
+ * Create the example repository that should be included as a submodule
+ * in a larger repository. (This repository does not itself have
+ * submodules.)
+ */
+export function createExampleSubmoduleRepo(
+  intoDirectory: string
+): RepositoryInfo {
+  const repositoryPath = intoDirectory;
+  mkdirp(repositoryPath);
+  const git = makeUtils(repositoryPath);
+  const commits = [];
+  function commit(message) {
+    git.deterministicCommit(message);
+    commits.push(git.head());
+  }
+
+  git.exec(["init"]);
+
+  git.writeAndStage(
+    "README.txt",
+    [
+      "example-git-submodule\n",
+      "---------------------\n\n",
+      "This simple repository serves no purpose other than to be included as\n",
+      "a submodule in a larger repository.\n",
+    ].join("")
+  );
+  commit("Initial commit");
+
+  git.writeAndStage("useless.txt", "Nothing to see here; move along.\n");
+  commit("Add a file, so that we have multiple commits");
+
+  return {path: repositoryPath, commits};
+}

--- a/src/v3/plugins/git/demoData/exampleRepo.test.js
+++ b/src/v3/plugins/git/demoData/exampleRepo.test.js
@@ -1,0 +1,42 @@
+// @flow
+
+import tmp from "tmp";
+
+import {
+  createExampleRepo,
+  createExampleSubmoduleRepo,
+  SUBMODULE_COMMIT_1,
+  SUBMODULE_COMMIT_2,
+} from "./exampleRepo";
+
+const cleanups: (() => void)[] = [];
+afterAll(() => {
+  cleanups.forEach((f) => {
+    f();
+  });
+});
+
+function mkdtemp() {
+  const result = tmp.dirSync({unsafeCleanup: true});
+  cleanups.push(() => result.removeCallback());
+  return result.name;
+}
+
+describe("createExampleRepo", () => {
+  it("is deterministic", () => {
+    expect(createExampleRepo(mkdtemp()).commits).toMatchSnapshot();
+  });
+});
+
+describe("createExampleSubmoduleRepo", () => {
+  it("is deterministic", () => {
+    expect(createExampleSubmoduleRepo(mkdtemp()).commits).toMatchSnapshot();
+  });
+
+  it("includes all the SHAs that it should", () => {
+    const commits = createExampleSubmoduleRepo(mkdtemp()).commits;
+    expect(commits).toEqual(
+      expect.arrayContaining([SUBMODULE_COMMIT_1, SUBMODULE_COMMIT_2])
+    );
+  });
+});

--- a/src/v3/plugins/git/demoData/synchronizeToGithub.sh
+++ b/src/v3/plugins/git/demoData/synchronizeToGithub.sh
@@ -1,0 +1,41 @@
+#!/bin/bash
+
+set -eu
+
+main() {
+    if [ "${1:-}" = "-n" ] || [ "${1:-}" = "--dry-run" ]; then
+        DRY_RUN=1
+    fi
+    cd "$(git rev-parse --show-toplevel)"
+    yarn backend
+    printf '\n'
+    printf 'Synchronizing: example-git\n'
+    synchronize \
+        --no-submodule 'git@github.com:sourcecred/example-git.git'
+    printf '\n'
+    printf 'Synchronizing: example-git-submodule\n'
+    synchronize \
+        --submodule 'git@github.com:sourcecred/example-git-submodule.git'
+    printf '\n'
+    printf 'Done.\n'
+}
+
+synchronize() (
+    submodule_flag="$1"  # --submodule | --no-submodule
+    remote_url="$2"
+    tmpdir="$(mktemp -d)"
+    node bin/createExampleRepoV3.js "${submodule_flag}" "${tmpdir}"
+    (
+        cd "${tmpdir}"
+        git remote add upstream "${remote_url}"
+        git fetch upstream --quiet
+        args=( git push --force-with-lease upstream HEAD:master )
+        if [ -n "${DRY_RUN:-}" ]; then
+            args+=( --dry-run )
+        fi
+        "${args[@]}"
+    )
+    rm -rf "${tmpdir}"
+)
+
+main "$@"

--- a/src/v3/plugins/git/gitUtils.js
+++ b/src/v3/plugins/git/gitUtils.js
@@ -1,0 +1,84 @@
+// @flow
+
+import {execFileSync} from "child_process";
+import fs from "fs";
+import mkdirp from "mkdirp";
+import path from "path";
+
+export interface Utils {
+  exec: GitDriver;
+  head(): string;
+  writeAndStage(filename: string, contents: string): void;
+  deterministicCommit(message: string): void;
+}
+
+export type GitDriver = (args: string[], env?: {[string]: string}) => string;
+
+export function localGit(repositoryPath: string): GitDriver {
+  return function git(args: string[], env?: {[string]: string}): string {
+    // We standardize the environment variables shown to Git, using
+    // Git's test suite [1] as inspiration. It is particularly important
+    // that `GIT_DIR` be unset from the parent process environment.
+    // Otherwise, these tests have the wrong behavior when running in an
+    // `exec` step of a Git rebase.
+    //
+    // [1]: https://github.com/git/git/blob/1f1cddd558b54bb0ce19c8ace353fd07b758510d/t/test-lib.sh#L90
+    const fullEnv = {
+      // Standardize output.
+      LANG: "C",
+      LC_ALL: "C",
+      PAGER: "cat",
+      TZ: "UTC",
+      // Short-circuit editing.
+      EDITOR: "true", // (this is `true` the command-line program)
+      GIT_MERGE_AUTOEDIT: "no",
+      // Ignore global Git settings, for test isolation.
+      GIT_CONFIG_NOSYSTEM: "1",
+      GIT_ATTR_NOSYSTEM: "1",
+      ...(env || {}),
+    };
+    const options = {env: fullEnv};
+    return execFileSync(
+      "git",
+      ["-C", repositoryPath, ...args],
+      options
+    ).toString();
+  };
+}
+
+export function makeUtils(repositoryPath: string): Utils {
+  const git = localGit(repositoryPath);
+  return {
+    exec: git,
+
+    head() {
+      return git(["rev-parse", "HEAD"]).trim();
+    },
+
+    writeAndStage(filename: string, contents: string) {
+      const filepath = path.join(repositoryPath, filename);
+      const dirpath = path.join(repositoryPath, path.dirname(filename));
+      mkdirp.sync(dirpath);
+      fs.writeFileSync(filepath, contents);
+      git(["add", filename]);
+    },
+
+    deterministicCommit(message: string): void {
+      git(
+        [
+          "-c",
+          "user.name=Test Runner",
+          "-c",
+          "user.email=nobody@example.com",
+          "commit",
+          "-m",
+          message,
+        ],
+        {
+          GIT_AUTHOR_DATE: "2001-02-03T04:05:06",
+          GIT_COMMITTER_DATE: "2002-03-04T05:06:07",
+        }
+      );
+    },
+  };
+}

--- a/src/v3/plugins/git/loadRepository.js
+++ b/src/v3/plugins/git/loadRepository.js
@@ -1,0 +1,168 @@
+/*
+ * Load a git repository into memory. This dumps the commit and tree
+ * data into a structured form. Contents of blobs are not loaded.
+ *
+ * If the repository contains file names that are not valid UTF-8
+ * strings, the result is undefined.
+ *
+ * Note: git(1) is a runtime dependency of this module.
+ */
+// @flow
+
+import type {GitDriver} from "./gitUtils";
+import type {Repository, Hash, Commit, Tree, TreeEntry} from "./types";
+import {localGit} from "./gitUtils";
+
+/**
+ * Load a Git repository from disk into memory. The `rootRef` should be
+ * a revision reference as accepted by `git rev-parse`: "HEAD" and
+ * "origin/master" will be common, while a specific SHA or tag might be
+ * used to fix a particular state of a repository.
+ */
+export function loadRepository(
+  repositoryPath: string,
+  rootRef: string
+): Repository {
+  const git = localGit(repositoryPath);
+  const commits = findCommits(git, rootRef);
+  const trees = findTrees(git, new Set(commits.map((x) => x.treeHash)));
+  return {commits: objectMap(commits), trees: objectMap(trees)};
+}
+
+function objectMap<T: {+hash: Hash}>(ts: $ReadOnlyArray<T>): {[Hash]: T} {
+  const result = {};
+  ts.forEach((t) => {
+    result[t.hash] = t;
+  });
+  return result;
+}
+
+function findCommits(git: GitDriver, rootRef: string): Commit[] {
+  return git(["log", "--oneline", "--pretty=%H %T %P", rootRef])
+    .split("\n")
+    .filter((line) => line.length > 0)
+    .map((line) => {
+      const [hash, treeHash, ...parentHashes] = line.trim().split(" ");
+      const submoduleUrls = loadSubmoduleUrls(git, hash);
+      return {hash, parentHashes, treeHash, submoduleUrls};
+    });
+}
+
+const GITMODULES_SUBMODULES_KEY_RE = /^submodule\.(.*)\.(path|url)$/;
+
+function loadSubmoduleUrls(
+  git: GitDriver,
+  commitHash: Hash
+): {[path: string]: string} {
+  const gitmodulesRef = `${commitHash}:.gitmodules`;
+  const gitmodulesBlob: string | null = (() => {
+    try {
+      return git(["rev-parse", "--quiet", "--verify", gitmodulesRef]).trim();
+    } catch (e) {
+      if (e.status === 1) {
+        // No .gitmodules file here.
+        return null;
+      } else {
+        throw e;
+      }
+    }
+  })();
+  if (gitmodulesBlob == null) {
+    // No problem; there just weren't any submodules at this commit.
+    return {};
+  }
+
+  // The output format of the following is `${key}\n${value}\0...`, as
+  // specified in `git help config`'s section about the `-z` option.
+  // The format is safe because keys are strictly validated; see the
+  // function `git_config_parse_key` in `git/git:config.c`.
+  const rawConfig = git(["config", "--blob", gitmodulesBlob, "--list", "-z"]);
+  const configKeyValuePairs = rawConfig
+    .split("\0")
+    .filter((line) => line.length > 0)
+    .map((line) => {
+      const separator = line.indexOf("\n");
+      if (separator < 0) {
+        // Shouldn't happen, according to Git docs. Guard anyway.
+        throw new Error(`Bad .gitmodules line at ${commitHash}: ${line}`);
+      }
+      return {
+        key: line.substring(0, separator),
+        value: line.substring(separator + 1),
+      };
+    });
+
+  const submoduleInfoByKey: {
+    [submoduleKey: string]: {path: string | null, url: string | null},
+  } = {};
+  configKeyValuePairs.forEach(({key, value}) => {
+    const match = key.match(GITMODULES_SUBMODULES_KEY_RE);
+    if (!match) {
+      return;
+    }
+    const [_, submoduleKey, kind] = match;
+    if (submoduleInfoByKey[submoduleKey] == null) {
+      submoduleInfoByKey[submoduleKey] = {path: null, url: null};
+    }
+    if (kind !== "path" && kind !== "url") {
+      throw new Error(`Invariant violation: bad kind: ${kind}`);
+    }
+    submoduleInfoByKey[submoduleKey][kind] = value;
+  });
+
+  const result = {};
+  Object.keys(submoduleInfoByKey).forEach((submoduleKey) => {
+    const {path, url} = submoduleInfoByKey[submoduleKey];
+    if (path != null && url != null) {
+      result[path] = url;
+    } else {
+      console.warn(`Partial submodule at ${commitHash}: ${submoduleKey}`);
+    }
+  });
+  return result;
+}
+
+function findTrees(git: GitDriver, rootTrees: Set<Hash>): Tree[] {
+  const result: Tree[] = [];
+  const visited: Set<Hash> = new Set();
+  const frontier: Set<Hash> = new Set(rootTrees);
+  while (frontier.size > 0) {
+    const next = frontier.values().next();
+    if (next.done) {
+      // Flow doesn't know that this is impossible, but it is.
+      throw new Error("Impossible! `frontier` had positive size.");
+    }
+    const treeHash: Hash = next.value;
+    visited.add(treeHash);
+    frontier.delete(treeHash);
+    const tree = loadTree(git, treeHash);
+    result.push(tree);
+    Object.keys(tree.entries).forEach((key) => {
+      const entry = tree.entries[key];
+      if (entry.type === "tree" && !visited.has(entry.hash)) {
+        frontier.add(entry.hash);
+      }
+    });
+  }
+  return result;
+}
+
+function loadTree(git: GitDriver, treeHash: Hash): Tree {
+  const entries: {[name: string]: TreeEntry} = {};
+  git(["ls-tree", "--full-tree", "-z", treeHash])
+    .split("\0")
+    .filter((line) => line.length > 0)
+    .forEach((line) => {
+      // See `git help ls-tree`, section OUTPUT FORMAT, for details.
+      const [metadata, name] = line.split("\t");
+      const [_unused_mode, type, hash] = metadata.split(" ");
+      if (type !== "blob" && type !== "commit" && type !== "tree") {
+        throw new Error(
+          `entry ${treeHash}[${JSON.stringify(name)}] ` +
+            `has unexpected type "${type}"`
+        );
+      }
+      entries[name] = {name, type, hash};
+    });
+  return {hash: treeHash, entries: entries};
+}

--- a/src/v3/plugins/git/loadRepository.test.js
+++ b/src/v3/plugins/git/loadRepository.test.js
@@ -1,0 +1,51 @@
+// @flow
+
+import tmp from "tmp";
+
+import {createExampleRepo} from "./demoData/exampleRepo";
+import {loadRepository} from "./loadRepository";
+
+const cleanups: (() => void)[] = [];
+afterAll(() => {
+  cleanups.forEach((f) => {
+    f();
+  });
+});
+
+function mkdtemp() {
+  const result = tmp.dirSync({unsafeCleanup: true});
+  cleanups.push(() => result.removeCallback());
+  return result.name;
+}
+
+describe("loadRepository", () => {
+  it("loads from HEAD", () => {
+    const repository = createExampleRepo(mkdtemp());
+    // In case of failure, run
+    //     src/plugins/git/loadRepositoryTest.sh --updateSnapshot
+    // to update the snapshot, then inspect the resulting changes.
+    expect(loadRepository(repository.path, "HEAD")).toEqual(
+      require("./demoData/example-git.json")
+    );
+  });
+
+  it("processes an old commit", () => {
+    const repository = createExampleRepo(mkdtemp());
+    const whole = loadRepository(repository.path, "HEAD");
+    const part = loadRepository(repository.path, repository.commits[1]);
+
+    // Check that `part` is a subset of `whole`...
+    Object.keys(part.commits).forEach((hash) => {
+      expect(part.commits[hash]).toEqual(whole.commits[hash]);
+    });
+    Object.keys(part.trees).forEach((hash) => {
+      expect(part.trees[hash]).toEqual(whole.trees[hash]);
+    });
+
+    // ...and that it's the right subset.
+    expect({
+      commits: new Set(Object.keys(part.commits)),
+      trees: new Set(Object.keys(part.trees)),
+    }).toMatchSnapshot();
+  });
+});

--- a/src/v3/plugins/git/loadRepositoryTest.sh
+++ b/src/v3/plugins/git/loadRepositoryTest.sh
@@ -1,0 +1,66 @@
+#!/bin/bash
+
+set -eu
+
+data_file=src/v3/plugins/git/demoData/example-git.json
+
+usage() {
+  printf 'usage: %s [-u|--updateSnapshot] [--help]\n' "$0"
+  printf 'Flags:\n'
+  printf '  -u|--updateSnapshot\n'
+  printf '      Update the stored file instead of checking its contents\n'
+  printf ' --[no-]build\n'
+  printf '      Whether to run "yarn backend" before the test.\n'
+  printf '      Default is --build.\n'
+  printf '  --help\n'
+  printf '      Show this message\n'
+}
+
+fetch() {
+  tmpdir="$(mktemp -d)"
+  node bin/createExampleRepoV3.js "${tmpdir}"
+  node bin/loadAndPrintGitRepositoryV3.js "${tmpdir}"
+  rm -rf "${tmpdir}"
+}
+
+check() {
+  output="$(mktemp)"
+  fetch >"${output}"
+  diff -uw "${data_file}" "${output}"
+  rm "${output}"
+}
+
+update() {
+  fetch >"${data_file}"
+}
+
+main() {
+  UPDATE=
+  BUILD=1
+  while [ $# -gt 0 ]; do
+    if [ "$1" = "--help" ]; then
+      usage
+      return 0
+    elif [ "$1" = "-u" ] || [ "$1" = "--updateSnapshot" ]; then
+      UPDATE=1
+    elif [ "$1" = "--build" ]; then
+      BUILD=1
+    elif [ "$1" = "--no-build" ]; then
+      BUILD=
+    else
+      usage >&2
+      return 1
+    fi
+    shift
+  done
+  if [ -n "${BUILD}" ]; then
+    yarn backend
+  fi
+  if [ -n "${UPDATE}" ]; then
+    update
+  else
+    check
+  fi
+}
+
+main "$@"

--- a/src/v3/plugins/git/types.js
+++ b/src/v3/plugins/git/types.js
@@ -1,0 +1,151 @@
+// @flow
+
+import stringify from "json-stable-stringify";
+
+export const GIT_PLUGIN_NAME = "sourcecred/git-beta";
+
+// Logical types
+export type Repository = {|
+  +commits: {[Hash]: Commit},
+  +trees: {[Hash]: Tree},
+|};
+export type Hash = string;
+export type Commit = {|
+  +hash: Hash,
+  +parentHashes: $ReadOnlyArray<Hash>,
+  +treeHash: Hash,
+  +submoduleUrls: {[path: string]: string},
+|};
+export type Tree = {|
+  +hash: Hash,
+  +entries: {[name: string]: TreeEntry},
+|};
+export type TreeEntry = {|
+  +type: "blob" | "commit" | "tree",
+  +name: string,
+  +hash: Hash,
+|};
+
+// Graph types
+
+// Nodes
+export const COMMIT_NODE_TYPE: "COMMIT" = "COMMIT";
+export type CommitNodePayload = {||};
+
+export const TREE_NODE_TYPE: "TREE" = "TREE";
+export type TreeNodePayload = {||};
+
+export const BLOB_NODE_TYPE: "BLOB" = "BLOB";
+export type BlobNodePayload = {||}; // we do not store the content
+
+// In Git, a tree may point to a commit directly; in our graph, we have
+// an explicit notion of "submodule commit", because, a priori, we do
+// not know the repository to which the commit belongs. A submodule
+// commit node stores the hash of the referent commit, as well as the
+// URL to the subproject as listed in the .gitmodules file.
+export const SUBMODULE_COMMIT_NODE_TYPE: "SUBMODULE_COMMIT" =
+  "SUBMODULE_COMMIT";
+export function submoduleCommitId(hash: Hash, submoduleUrl: string) {
+  return `${submoduleUrl}@${hash}`;
+}
+export type SubmoduleCommitPayload = {|
+  +hash: Hash,
+  +url: string, // from .gitmodules file
+|};
+
+export const TREE_ENTRY_NODE_TYPE: "TREE_ENTRY" = "TREE_ENTRY";
+export type TreeEntryNodePayload = {|
+  +name: string,
+|};
+export function treeEntryId(tree: Hash, name: string): string {
+  return `${tree}:${name}`;
+}
+
+export type NodePayload =
+  | BlobNodePayload
+  | CommitNodePayload
+  | SubmoduleCommitPayload
+  | TreeEntryNodePayload
+  | TreeNodePayload;
+
+export type NodeType =
+  | typeof BLOB_NODE_TYPE
+  | typeof COMMIT_NODE_TYPE
+  | typeof SUBMODULE_COMMIT_NODE_TYPE
+  | typeof TREE_ENTRY_NODE_TYPE
+  | typeof TREE_NODE_TYPE;
+
+// Edges
+
+// CommitNode -> CommitNode
+export const HAS_PARENT_EDGE_TYPE: "HAS_PARENT" = "HAS_PARENT";
+export type HasParentEdgePayload = {|
+  +parentIndex: number, // one-based
+|};
+export function hasParentEdgeId(
+  childCommitHash: Hash,
+  oneBasedParentIndex: number
+) {
+  if (
+    !isFinite(oneBasedParentIndex) ||
+    oneBasedParentIndex !== Math.floor(oneBasedParentIndex) ||
+    oneBasedParentIndex < 1
+  ) {
+    throw new Error(
+      "Expected positive integer parent index, " +
+        `but got: ${String(oneBasedParentIndex)}`
+    );
+  }
+  return `${childCommitHash}^${String(oneBasedParentIndex)}`;
+}
+
+// CommitNode -> TreeNode
+export const HAS_TREE_EDGE_TYPE: "HAS_TREE" = "HAS_TREE";
+export type HasTreeEdgePayload = {||};
+
+// TreeNode -> TreeEntryNode
+export const INCLUDES_EDGE_TYPE: "INCLUDES" = "INCLUDES";
+export type IncludesEdgePayload = {|
+  +name: string,
+|};
+export function includesEdgeId(treeSha: string, name: string): string {
+  return `${treeSha}:${name}`;
+}
+
+// TreeEntryNode -> TreeEntryNode
+// TODO: Rename the BECOMES edges to EVOLVES, as then we can cleanly express
+// the bidrectional relationship: EvolvesTo and EvolvesFrom.  Note that doing
+// so is a breaking change, and thus this change should be made after we have a
+// versioning system that can either maintain backcompat or invalidate old
+// serializations. See #280
+export const BECOMES_EDGE_TYPE: "BECOMES" = "BECOMES";
+export type BecomesEdgePayload = {|
+  +childCommit: Hash,
+  +parentCommit: Hash,
+  +path: $ReadOnlyArray<string>,
+|};
+export function becomesEdgeId(
+  childCommit: Hash,
+  parentCommit: Hash,
+  path: $ReadOnlyArray<string>
+) {
+  return stringify({childCommit, parentCommit, path});
+}
+
+// TreeEntryNode -> BlobNode | TreeNode
+export const HAS_CONTENTS_EDGE_TYPE: "HAS_CONTENTS" = "HAS_CONTENTS";
+export type HasContentsEdgePayload = {||};
+
+export type EdgeType =
+  | typeof HAS_TREE_EDGE_TYPE
+  | typeof HAS_PARENT_EDGE_TYPE
+  | typeof INCLUDES_EDGE_TYPE
+  | typeof BECOMES_EDGE_TYPE
+  | typeof HAS_CONTENTS_EDGE_TYPE;
+
+export type EdgePayload =
+  | HasTreeEdgePayload
+  | HasParentEdgePayload
+  | IncludesEdgePayload
+  | BecomesEdgePayload
+  | HasContentsEdgePayload;


### PR DESCRIPTION
Summary:
Many files are unchanged. Some files have had paths updated, or new
build/test targets added.

The `types.js` file includes payload type definitions. These are
technically independent of the graph abstraction (i.e., nothing from V1
is imported and the code all still works), but it of course implicitly
depends on the V1 model. For now, we include the entirety of this file,
just so that we have a clean copy operation. Subsequent commits will
strip out this extraneous code.

Suggest reviewing with the `--find-copies-harder` argument to Git’s
diffing functions.

Test Plan:
Running `yarn travis --full` passes. Running

    ./src/v3/plugins/git/demoData/synchronizeToGithub.sh --dry-run

yields “Everything up-to-date”.

wchargin-branch: git-v3-copy