### PR TITLE
[change-base] Refactor GH `createGraph` to use `RelationalView`

### DIFF
--- a/src/v3/plugins/github/createGraph.js
+++ b/src/v3/plugins/github/createGraph.js
@@ -1,161 +1,85 @@
 // @flow
 
 import {Graph} from "../../core/graph";
-import type {
-  GithubResponseJSON,
-  RepositoryJSON,
-  ReviewJSON,
-  PullJSON,
-  IssueJSON,
-  CommentJSON,
-  ReviewCommentJSON,
-  NullableAuthorJSON,
-} from "./graphql";
-
-import type {
-  RepoAddress,
-  IssueAddress,
-  PullAddress,
-  ReviewAddress,
-  UserlikeAddress,
-  StructuredAddress,
-  AuthorableAddress,
-  ChildAddress,
-  ParentAddress,
-} from "./nodes";
-import {toRaw} from "./nodes";
-
+import * as GitNode from "../git/nodes";
+import * as N from "./nodes";
+import * as R from "./relationalView";
 import {createEdge} from "./edges";
 
-import {COMMIT_TYPE, toRaw as gitToRaw} from "../git/nodes";
-
-import {
-  reviewUrlToId,
-  issueCommentUrlToId,
-  pullCommentUrlToId,
-  reviewCommentUrlToId,
-} from "./urlIdParse";
-
-export function createGraph(data: GithubResponseJSON): Graph {
-  const creator = new GraphCreator();
-  creator.addData(data);
+export function createGraph(view: R.RelationalView): Graph {
+  const creator = new GraphCreator(view);
   return creator.graph;
 }
 
 class GraphCreator {
   graph: Graph;
+  view: R.RelationalView;
 
-  constructor() {
+  constructor(view: R.RelationalView) {
     this.graph = new Graph();
+    this.view = view;
+    for (const r of view.repos()) {
+      this.addRepo(r);
+    }
   }
 
-  addNode(addr: StructuredAddress) {
-    this.graph.addNode(toRaw(addr));
+  addNode(addr: N.StructuredAddress) {
+    this.graph.addNode(N.toRaw(addr));
   }
 
-  addData(data: GithubResponseJSON) {
-    this.addRepository(data.repository);
+  addRepo(entry: R.RepoEntry) {
+    this.addNode(entry.address);
+    entry.issues.forEach((e) => this.addIssue(e));
+    entry.pulls.forEach((e) => this.addPull(e));
   }
 
-  addRepository(repoJSON: RepositoryJSON) {
-    const repo: RepoAddress = {
-      type: "REPO",
-      owner: repoJSON.owner.login,
-      name: repoJSON.name,
-    };
-    this.addNode(repo);
-    repoJSON.issues.nodes.forEach((issue) => this.addIssue(repo, issue));
-    repoJSON.pulls.nodes.forEach((pull) => this.addPull(repo, pull));
+  addIssue(entry: R.IssueEntry) {
+    this.addNode(entry.address);
+    this.addAuthors(entry.address, entry.nominalAuthor);
+    this.addHasParent(entry.address, entry.address.repo);
+    entry.comments.forEach((e) => this.addComment(e));
   }
 
-  addIssue(repo: RepoAddress, issueJSON: IssueJSON) {
-    const issue: IssueAddress = {
-      type: "ISSUE",
-      repo,
-      number: String(issueJSON.number),
-    };
-    this.addNode(issue);
-    this.addAuthors(issue, issueJSON.author);
-    this.addHasParent(issue, repo);
-    issueJSON.comments.nodes.forEach((comment) =>
-      this.addComment(issue, comment)
+  addPull(entry: R.PullEntry) {
+    this.addNode(entry.address);
+    this.addAuthors(entry.address, entry.nominalAuthor);
+    this.addHasParent(entry.address, entry.address.repo);
+    entry.comments.forEach((e) => this.addComment(e));
+    entry.reviews.forEach((e) => this.addReview(e));
+    const commit = entry.mergedAs;
+    if (commit != null) {
+      this.graph.addNode(GitNode.toRaw(commit));
+      this.graph.addEdge(createEdge.mergedAs(entry.address, commit));
+    }
+  }
+
+  addReview(entry: R.ReviewEntry) {
+    this.addNode(entry.address);
+    this.addAuthors(entry.address, entry.nominalAuthor);
+    this.addHasParent(entry.address, entry.address.pull);
+    entry.comments.forEach((e) => this.addComment(e));
+  }
+
+  addComment(entry: R.CommentEntry) {
+    this.addNode(entry.address);
+    this.addAuthors(entry.address, entry.nominalAuthor);
+    this.addHasParent(entry.address, entry.address.parent);
+  }
+
+  addAuthors(
+    contentAddress: N.AuthorableAddress,
+    nominalAuthor: ?R.UserlikeEntry
+  ) {
+    if (nominalAuthor == null) {
+      return;
+    }
+    this.addNode(nominalAuthor.address);
+    this.graph.addEdge(
+      createEdge.authors(nominalAuthor.address, contentAddress)
     );
   }
 
-  addPull(repo: RepoAddress, pullJSON: PullJSON) {
-    const pull: PullAddress = {
-      type: "PULL",
-      repo,
-      number: String(pullJSON.number),
-    };
-    this.addNode(pull);
-    this.addAuthors(pull, pullJSON.author);
-    this.addHasParent(pull, repo);
-    pullJSON.comments.nodes.forEach((c) => this.addComment(pull, c));
-    pullJSON.reviews.nodes.forEach((review) => this.addReview(pull, review));
-    if (pullJSON.mergeCommit != null) {
-      const commitHash = pullJSON.mergeCommit.oid;
-      const commit = {type: COMMIT_TYPE, hash: commitHash};
-      this.graph.addNode(gitToRaw(commit));
-      this.graph.addEdge(createEdge.mergedAs(pull, commit));
-    }
-  }
-
-  addReview(pull: PullAddress, reviewJSON: ReviewJSON) {
-    const id = reviewUrlToId(reviewJSON.url);
-    const review = {
-      type: "REVIEW",
-      pull,
-      id,
-    };
-    this.addNode(review);
-    reviewJSON.comments.nodes.forEach((c) => this.addComment(review, c));
-    this.addAuthors(review, reviewJSON.author);
-    this.addHasParent(review, pull);
-  }
-
-  addComment(
-    parent: IssueAddress | PullAddress | ReviewAddress,
-    commentJSON: CommentJSON | ReviewCommentJSON
-  ) {
-    const id = (function() {
-      switch (parent.type) {
-        case "ISSUE":
-          return issueCommentUrlToId(commentJSON.url);
-        case "PULL":
-          return pullCommentUrlToId(commentJSON.url);
-        case "REVIEW":
-          return reviewCommentUrlToId(commentJSON.url);
-        default:
-          // eslint-disable-next-line no-unused-expressions
-          (parent.type: empty);
-          throw new Error(`Unexpected comment parent type: ${parent.type}`);
-      }
-    })();
-    const comment = {
-      type: "COMMENT",
-      parent,
-      id,
-    };
-    this.addNode(comment);
-    this.addAuthors(comment, commentJSON.author);
-    this.addHasParent(comment, parent);
-  }
-
-  addAuthors(content: AuthorableAddress, authorJSON: NullableAuthorJSON) {
-    // author may be null, as not all posts have authors
-    if (authorJSON == null) {
-      return;
-    }
-    const author: UserlikeAddress = {
-      type: "USERLIKE",
-      login: authorJSON.login,
-    };
-    this.addNode(author);
-    this.graph.addEdge(createEdge.authors(author, content));
-  }
-
-  addHasParent(child: ChildAddress, parent: ParentAddress) {
+  addHasParent(child: N.ChildAddress, parent: N.ParentAddress) {
     this.graph.addEdge(createEdge.hasParent(child, parent));
   }
 }

--- a/src/v3/plugins/github/createGraph.test.js
+++ b/src/v3/plugins/github/createGraph.test.js
@@ -2,11 +2,16 @@
 
 import {createGraph} from "./createGraph";
 import {GraphView} from "./graphView";
+import {RelationalView} from "./relationalView";
+import type {GithubResponseJSON} from "./graphql";
 import cloneDeep from "lodash.clonedeep";
 
 function exampleGraph() {
-  const data = cloneDeep(require("./demoData/example-github"));
-  return createGraph(data);
+  const data: GithubResponseJSON = cloneDeep(
+    require("./demoData/example-github")
+  );
+  const view = new RelationalView(data);
+  return createGraph(view);
 }
 
 describe("plugins/github/createGraph", () => {

--- a/src/v3/plugins/github/graphView.test.js
+++ b/src/v3/plugins/github/graphView.test.js
@@ -3,14 +3,19 @@
 import {Graph, type Edge, EdgeAddress} from "../../core/graph";
 import {createGraph} from "./createGraph";
 import {GraphView} from "./graphView";
+import {RelationalView} from "./relationalView";
 import * as GE from "./edges";
 import * as GN from "./nodes";
 import cloneDeep from "lodash.clonedeep";
 import {COMMIT_TYPE, toRaw as gitToRaw, TREE_TYPE} from "../git/nodes";
+import type {GithubResponseJSON} from "./graphql";
 
 function exampleView() {
-  const data = cloneDeep(require("./demoData/example-github"));
-  const graph = createGraph(data);
+  const data: GithubResponseJSON = cloneDeep(
+    require("./demoData/example-github")
+  );
+  const view = new RelationalView(data);
+  const graph = createGraph(view);
   return new GraphView(graph);
 }
 


### PR DESCRIPTION
This commit modifies `github/createGraph` to use the `RelationalView`
class created in #411 and #412. The code is now simpler and cleaner.

I also fixed some `any`s that were leaking in our test code (due to use
of runtime require for GitHub example data). These anys were discovered
by bumping into uncaught type errors. :)

Test plan:
Observe that the graph snapshot was not changed.