### PR TITLE
[cb] Add type retrieval methods to `RelationalView`

### DIFF
--- a/src/v3/plugins/github/relationalView.js
+++ b/src/v3/plugins/github/relationalView.js
@@ -80,22 +80,40 @@ export class RelationalView {
   repos(): Iterator<RepoEntry> {
     return this._repos.values();
   }
-
   repo(address: N.RepoAddress): ?RepoEntry {
     return this._repos.get(N.toRaw(address));
   }
 
+  issues(): Iterator<IssueEntry> {
+    return this._issues.values();
+  }
   issue(address: N.IssueAddress): ?IssueEntry {
     return this._issues.get(N.toRaw(address));
+  }
+
+  pulls(): Iterator<PullEntry> {
+    return this._pulls.values();
   }
   pull(address: N.PullAddress): ?PullEntry {
     return this._pulls.get(N.toRaw(address));
   }
+
+  comments(): Iterator<CommentEntry> {
+    return this._comments.values();
+  }
   comment(address: N.CommentAddress): ?CommentEntry {
     return this._comments.get(N.toRaw(address));
   }
+
+  reviews(): Iterator<ReviewEntry> {
+    return this._reviews.values();
+  }
   review(address: N.ReviewAddress): ?ReviewEntry {
     return this._reviews.get(N.toRaw(address));
+  }
+
+  userlikes(): Iterator<UserlikeEntry> {
+    return this._userlikes.values();
   }
   userlike(address: N.UserlikeAddress): ?UserlikeEntry {
     return this._userlikes.get(N.toRaw(address));

--- a/src/v3/plugins/github/relationalView.test.js
+++ b/src/v3/plugins/github/relationalView.test.js
@@ -30,6 +30,11 @@ describe("plugins/github/relationalView", () => {
   });
 
   const issue = () => repo().issues[1];
+  it("issues are retrievable", () => {
+    expect(Array.from(view.issues())).toEqual(
+      expect.arrayContaining([issue()])
+    );
+  });
   it("issue matches snapshot", () => {
     expect(issue()).toMatchSnapshot();
   });
@@ -38,6 +43,9 @@ describe("plugins/github/relationalView", () => {
   });
 
   const pull = () => repo().pulls[1];
+  it("pulls are retrievable", () => {
+    expect(Array.from(view.pulls())).toEqual(expect.arrayContaining([pull()]));
+  });
   it("pull matches snapshot", () => {
     expect(pull()).toMatchSnapshot();
   });
@@ -46,6 +54,11 @@ describe("plugins/github/relationalView", () => {
   });
 
   const review = () => pull().reviews[0];
+  it("reviews are retrievable", () => {
+    expect(Array.from(view.reviews())).toEqual(
+      expect.arrayContaining([review()])
+    );
+  });
   it("review matches snapshot", () => {
     expect(review()).toMatchSnapshot();
   });
@@ -54,6 +67,11 @@ describe("plugins/github/relationalView", () => {
   });
 
   const comment = () => issue().comments[0];
+  it("comments are retrievable", () => {
+    expect(Array.from(view.comments())).toEqual(
+      expect.arrayContaining([comment()])
+    );
+  });
   it("comment matches snapshot", () => {
     expect(comment()).toMatchSnapshot();
   });
@@ -62,6 +80,11 @@ describe("plugins/github/relationalView", () => {
   });
 
   const userlike = () => issue().nominalAuthor;
+  it("userlikes are retrievable", () => {
+    expect(Array.from(view.userlikes())).toEqual(
+      expect.arrayContaining([userlike()])
+    );
+  });
   it("userlike matches snapshot", () => {
     expect(userlike()).toMatchSnapshot();
   });


### PR DESCRIPTION
Currently, the GitHub `RelationalView` enables iterating over every
`RepoEntry`, but has no corresponding methods for the other GitHub
types. This commit adds and tests those methods.

Test plan:
`yarn travis`