### PR TITLE
[cr] Find all references in `EntityStore`

### DIFF
--- a/src/v3/plugins/github/__snapshots__/findReferences.test.js.snap
+++ b/src/v3/plugins/github/__snapshots__/findReferences.test.js.snap
@@ -1,0 +1,391 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`plugins/github/findReferences matches snapshot on exmaple-github data 1`] = `
+Array [
+  Object {
+    "dst": Object {
+      "number": "1",
+      "repo": Object {
+        "name": "example-github",
+        "owner": "sourcecred",
+        "type": "REPO",
+      },
+      "type": "ISSUE",
+    },
+    "src": Object {
+      "number": "2",
+      "repo": Object {
+        "name": "example-github",
+        "owner": "sourcecred",
+        "type": "REPO",
+      },
+      "type": "ISSUE",
+    },
+  },
+  Object {
+    "dst": Object {
+      "login": "wchargin",
+      "type": "USERLIKE",
+    },
+    "src": Object {
+      "number": "5",
+      "repo": Object {
+        "name": "example-github",
+        "owner": "sourcecred",
+        "type": "REPO",
+      },
+      "type": "PULL",
+    },
+  },
+  Object {
+    "dst": Object {
+      "login": "wchargin",
+      "type": "USERLIKE",
+    },
+    "src": Object {
+      "number": "9",
+      "repo": Object {
+        "name": "example-github",
+        "owner": "sourcecred",
+        "type": "REPO",
+      },
+      "type": "PULL",
+    },
+  },
+  Object {
+    "dst": Object {
+      "number": "6",
+      "repo": Object {
+        "name": "example-github",
+        "owner": "sourcecred",
+        "type": "REPO",
+      },
+      "type": "ISSUE",
+    },
+    "src": Object {
+      "id": "373768703",
+      "parent": Object {
+        "number": "2",
+        "repo": Object {
+          "name": "example-github",
+          "owner": "sourcecred",
+          "type": "REPO",
+        },
+        "type": "ISSUE",
+      },
+      "type": "COMMENT",
+    },
+  },
+  Object {
+    "dst": Object {
+      "id": "373768538",
+      "parent": Object {
+        "number": "6",
+        "repo": Object {
+          "name": "example-github",
+          "owner": "sourcecred",
+          "type": "REPO",
+        },
+        "type": "ISSUE",
+      },
+      "type": "COMMENT",
+    },
+    "src": Object {
+      "id": "373768850",
+      "parent": Object {
+        "number": "2",
+        "repo": Object {
+          "name": "example-github",
+          "owner": "sourcecred",
+          "type": "REPO",
+        },
+        "type": "ISSUE",
+      },
+      "type": "COMMENT",
+    },
+  },
+  Object {
+    "dst": Object {
+      "number": "5",
+      "repo": Object {
+        "name": "example-github",
+        "owner": "sourcecred",
+        "type": "REPO",
+      },
+      "type": "PULL",
+    },
+    "src": Object {
+      "id": "385576185",
+      "parent": Object {
+        "number": "2",
+        "repo": Object {
+          "name": "example-github",
+          "owner": "sourcecred",
+          "type": "REPO",
+        },
+        "type": "ISSUE",
+      },
+      "type": "COMMENT",
+    },
+  },
+  Object {
+    "dst": Object {
+      "id": "100313899",
+      "pull": Object {
+        "number": "5",
+        "repo": Object {
+          "name": "example-github",
+          "owner": "sourcecred",
+          "type": "REPO",
+        },
+        "type": "PULL",
+      },
+      "type": "REVIEW",
+    },
+    "src": Object {
+      "id": "385576220",
+      "parent": Object {
+        "number": "2",
+        "repo": Object {
+          "name": "example-github",
+          "owner": "sourcecred",
+          "type": "REPO",
+        },
+        "type": "ISSUE",
+      },
+      "type": "COMMENT",
+    },
+  },
+  Object {
+    "dst": Object {
+      "id": "171460198",
+      "parent": Object {
+        "id": "100313899",
+        "pull": Object {
+          "number": "5",
+          "repo": Object {
+            "name": "example-github",
+            "owner": "sourcecred",
+            "type": "REPO",
+          },
+          "type": "PULL",
+        },
+        "type": "REVIEW",
+      },
+      "type": "COMMENT",
+    },
+    "src": Object {
+      "id": "385576248",
+      "parent": Object {
+        "number": "2",
+        "repo": Object {
+          "name": "example-github",
+          "owner": "sourcecred",
+          "type": "REPO",
+        },
+        "type": "ISSUE",
+      },
+      "type": "COMMENT",
+    },
+  },
+  Object {
+    "dst": Object {
+      "login": "wchargin",
+      "type": "USERLIKE",
+    },
+    "src": Object {
+      "id": "385576273",
+      "parent": Object {
+        "number": "2",
+        "repo": Object {
+          "name": "example-github",
+          "owner": "sourcecred",
+          "type": "REPO",
+        },
+        "type": "ISSUE",
+      },
+      "type": "COMMENT",
+    },
+  },
+  Object {
+    "dst": Object {
+      "number": "1",
+      "repo": Object {
+        "name": "example-github",
+        "owner": "sourcecred",
+        "type": "REPO",
+      },
+      "type": "ISSUE",
+    },
+    "src": Object {
+      "id": "385576920",
+      "parent": Object {
+        "number": "2",
+        "repo": Object {
+          "name": "example-github",
+          "owner": "sourcecred",
+          "type": "REPO",
+        },
+        "type": "ISSUE",
+      },
+      "type": "COMMENT",
+    },
+  },
+  Object {
+    "dst": Object {
+      "number": "2",
+      "repo": Object {
+        "name": "example-github",
+        "owner": "sourcecred",
+        "type": "REPO",
+      },
+      "type": "ISSUE",
+    },
+    "src": Object {
+      "id": "385576920",
+      "parent": Object {
+        "number": "2",
+        "repo": Object {
+          "name": "example-github",
+          "owner": "sourcecred",
+          "type": "REPO",
+        },
+        "type": "ISSUE",
+      },
+      "type": "COMMENT",
+    },
+  },
+  Object {
+    "dst": Object {
+      "number": "3",
+      "repo": Object {
+        "name": "example-github",
+        "owner": "sourcecred",
+        "type": "REPO",
+      },
+      "type": "PULL",
+    },
+    "src": Object {
+      "id": "385576920",
+      "parent": Object {
+        "number": "2",
+        "repo": Object {
+          "name": "example-github",
+          "owner": "sourcecred",
+          "type": "REPO",
+        },
+        "type": "ISSUE",
+      },
+      "type": "COMMENT",
+    },
+  },
+  Object {
+    "dst": Object {
+      "id": "171460198",
+      "parent": Object {
+        "id": "100313899",
+        "pull": Object {
+          "number": "5",
+          "repo": Object {
+            "name": "example-github",
+            "owner": "sourcecred",
+            "type": "REPO",
+          },
+          "type": "PULL",
+        },
+        "type": "REVIEW",
+      },
+      "type": "COMMENT",
+    },
+    "src": Object {
+      "id": "385576920",
+      "parent": Object {
+        "number": "2",
+        "repo": Object {
+          "name": "example-github",
+          "owner": "sourcecred",
+          "type": "REPO",
+        },
+        "type": "ISSUE",
+      },
+      "type": "COMMENT",
+    },
+  },
+  Object {
+    "dst": Object {
+      "id": "100313899",
+      "pull": Object {
+        "number": "5",
+        "repo": Object {
+          "name": "example-github",
+          "owner": "sourcecred",
+          "type": "REPO",
+        },
+        "type": "PULL",
+      },
+      "type": "REVIEW",
+    },
+    "src": Object {
+      "id": "385576920",
+      "parent": Object {
+        "number": "2",
+        "repo": Object {
+          "name": "example-github",
+          "owner": "sourcecred",
+          "type": "REPO",
+        },
+        "type": "ISSUE",
+      },
+      "type": "COMMENT",
+    },
+  },
+  Object {
+    "dst": Object {
+      "number": "2",
+      "repo": Object {
+        "name": "example-github",
+        "owner": "sourcecred",
+        "type": "REPO",
+      },
+      "type": "ISSUE",
+    },
+    "src": Object {
+      "id": "385223316",
+      "parent": Object {
+        "number": "6",
+        "repo": Object {
+          "name": "example-github",
+          "owner": "sourcecred",
+          "type": "REPO",
+        },
+        "type": "ISSUE",
+      },
+      "type": "COMMENT",
+    },
+  },
+  Object {
+    "dst": Object {
+      "number": "2",
+      "repo": Object {
+        "name": "example-github",
+        "owner": "sourcecred",
+        "type": "REPO",
+      },
+      "type": "ISSUE",
+    },
+    "src": Object {
+      "id": "369162222",
+      "parent": Object {
+        "number": "3",
+        "repo": Object {
+          "name": "example-github",
+          "owner": "sourcecred",
+          "type": "REPO",
+        },
+        "type": "PULL",
+      },
+      "type": "COMMENT",
+    },
+  },
+]
+`;

--- a/src/v3/plugins/github/findReferences.js
+++ b/src/v3/plugins/github/findReferences.js
@@ -1,0 +1,73 @@
+// @flow
+
+import * as N from "./nodes";
+import * as E from "./entityStore";
+import {parseReferences} from "./parseReferences";
+
+export type GithubReference = {|
+  src: N.TextContentAddress,
+  dst: N.ReferentAddress,
+|};
+
+type TextContentEntry = E.Issue | E.Pull | E.Comment | E.Review;
+export function* findReferences(
+  entityStore: E.EntityStore
+): Iterator<GithubReference> {
+  function* allGithubEntities(): Iterator<E.Entity> {
+    yield* entityStore.repos();
+    yield* entityStore.issues();
+    yield* entityStore.pulls();
+    yield* entityStore.reviews();
+    yield* entityStore.comments();
+    yield* entityStore.userlikes();
+  }
+
+  // refToAddress maps a "referencing string" to the address that string refers to.
+  // There are 3 kinds of valid referencing strings:
+  // - A canonical URL pointing to a GitHub entity, e.g.
+  //   https://github.com/sourcecred/sourcecred/pull/416
+  // - A # followed by a number, such as #416
+  // - An @ followed by a login name, such as @decentralion
+  const refToAddress: Map<string, N.StructuredAddress> = new Map();
+  for (const e of allGithubEntities()) {
+    const a = e.address;
+    refToAddress.set(e.url, a);
+    switch (e.type) {
+      case "USERLIKE":
+        refToAddress.set(`@${e.address.login}`, a);
+        break;
+      case "ISSUE":
+        refToAddress.set(`#${e.address.number}`, a);
+        break;
+      case "PULL":
+        refToAddress.set(`#${e.address.number}`, a);
+        break;
+      case "REPO":
+        break;
+      case "COMMENT":
+        break;
+      case "REVIEW":
+        break;
+      default:
+        // eslint-disable-next-line no-unused-expressions
+        (e.type: empty);
+        break;
+    }
+  }
+
+  function* allTextContentEntries(): Iterator<TextContentEntry> {
+    yield* entityStore.issues();
+    yield* entityStore.pulls();
+    yield* entityStore.reviews();
+    yield* entityStore.comments();
+  }
+
+  for (const e of allTextContentEntries()) {
+    for (const ref of parseReferences(e.body)) {
+      const refAddress = refToAddress.get(ref);
+      if (refAddress != null) {
+        yield {src: e.address, dst: refAddress};
+      }
+    }
+  }
+}

--- a/src/v3/plugins/github/findReferences.test.js
+++ b/src/v3/plugins/github/findReferences.test.js
@@ -1,0 +1,16 @@
+// @flow
+
+import {findReferences} from "./findReferences.js";
+
+import {EntityStore} from "./entityStore";
+import type {GithubResponseJSON} from "./graphql";
+import {addressify} from "./addressify";
+
+describe("plugins/github/findReferences", () => {
+  it("matches snapshot on exmaple-github data", () => {
+    const data: GithubResponseJSON = require("./demoData/example-github");
+    const store = new EntityStore(addressify(data));
+    const references = Array.from(findReferences(store));
+    expect(references).toMatchSnapshot();
+  });
+});

--- a/src/v3/plugins/github/parseReferences.js
+++ b/src/v3/plugins/github/parseReferences.js
@@ -13,7 +13,7 @@ function findAllMatches(re: RegExp, s: string): any[] {
   return matches;
 }
 
-export function findReferences(body: string): string[] {
+export function parseReferences(body: string): string[] {
   // Note to maintainer: If it becomes necessary to encode references in a
   // richer format, consider implementing the type signature described in
   // https://github.com/sourcecred/sourcecred/pull/130#pullrequestreview-113849998

--- a/src/v3/plugins/github/parseReferences.test.js
+++ b/src/v3/plugins/github/parseReferences.test.js
@@ -1,15 +1,15 @@
 // @flow
 
-import {findReferences} from "./findReferences.js";
+import {parseReferences} from "./parseReferences.js";
 
-describe("findReferences", () => {
+describe("parseReferences", () => {
   it("finds no references when not present", () => {
-    expect(findReferences("foo bar bod boink")).toHaveLength(0);
-    expect(findReferences("")).toHaveLength(0);
+    expect(parseReferences("foo bar bod boink")).toHaveLength(0);
+    expect(parseReferences("")).toHaveLength(0);
   });
 
   it("finds trivial numeric references", () => {
-    expect(findReferences("#1, #2, and #3")).toEqual(["#1", "#2", "#3"]);
+    expect(parseReferences("#1, #2, and #3")).toEqual(["#1", "#2", "#3"]);
   });
 
   it("finds numeric references in a multiline string", () => {
@@ -17,22 +17,22 @@ describe("findReferences", () => {
     This is a multiline string.
     It refers to #1. Oh, and to #2 too.
     (#42 might be included too - who knows?)`;
-    expect(findReferences(example)).toEqual(["#1", "#2", "#42"]);
+    expect(parseReferences(example)).toEqual(["#1", "#2", "#42"]);
   });
 
   it("does not find bad references", () => {
-    expect(findReferences("foo#123 #124bar")).toHaveLength(0);
+    expect(parseReferences("foo#123 #124bar")).toHaveLength(0);
   });
 
   it("does not yet find concise cross-repo links", () => {
     // The link below is valid, when we add cross-repo support we
     // should fix this test case
-    expect(findReferences("sourcecred/sourcecred#12")).toHaveLength(0);
+    expect(parseReferences("sourcecred/sourcecred#12")).toHaveLength(0);
   });
 
   it("finds a trivial url reference", () => {
     expect(
-      findReferences("https://github.com/sourcecred/sourcecred/issues/86")
+      parseReferences("https://github.com/sourcecred/sourcecred/issues/86")
     ).toHaveLength(1);
   });
 
@@ -74,52 +74,52 @@ https://github.com/sourcecred/example-github/pull/3#issuecomment-369162222
       "https://github.com/sourcecred/example-github/pull/3#issuecomment-369162222",
     ];
 
-    expect(findReferences(example)).toEqual(expected);
+    expect(parseReferences(example)).toEqual(expected);
   });
 
   it("doesn't find urls mangled with word characters", () => {
     expect(
-      findReferences("foohttps://github.com/sourcecred/sourcecred/pull/94")
+      parseReferences("foohttps://github.com/sourcecred/sourcecred/pull/94")
     ).toHaveLength(0);
 
     expect(
-      findReferences("https://github.com/sourcecred/sourcecred/pull/94foo")
+      parseReferences("https://github.com/sourcecred/sourcecred/pull/94foo")
     ).toHaveLength(0);
 
     expect(
-      findReferences("(https://github.com/sourcecred/sourcecred/pull/94)")
+      parseReferences("(https://github.com/sourcecred/sourcecred/pull/94)")
     ).toHaveLength(1);
   });
 
   it("allows but excludes leading and trailing punctuation", () => {
     const base = "https://github.com/sourcecred/sourcecred/pull/94";
-    expect(findReferences(`!${base}`)).toEqual([base]);
-    expect(findReferences(`${base}!`)).toEqual([base]);
-    expect(findReferences(`!${base}!`)).toEqual([base]);
+    expect(parseReferences(`!${base}`)).toEqual([base]);
+    expect(parseReferences(`${base}!`)).toEqual([base]);
+    expect(parseReferences(`!${base}!`)).toEqual([base]);
   });
 
   it("finds username references", () => {
-    expect(findReferences("hello to @wchargin from @decentralion!")).toEqual([
+    expect(parseReferences("hello to @wchargin from @decentralion!")).toEqual([
       "@wchargin",
       "@decentralion",
     ]);
   });
 
   it("finds usernames with hypens and numbers", () => {
-    expect(findReferences("@paddy-hack and @0x00 are valid usernames")).toEqual(
-      ["@paddy-hack", "@0x00"]
-    );
+    expect(
+      parseReferences("@paddy-hack and @0x00 are valid usernames")
+    ).toEqual(["@paddy-hack", "@0x00"]);
   });
 
   it("finds username references by exact url", () => {
-    expect(findReferences("greetings https://github.com/wchargin")).toEqual([
+    expect(parseReferences("greetings https://github.com/wchargin")).toEqual([
       "https://github.com/wchargin",
     ]);
   });
 
   it("finds a mix of reference types", () => {
     expect(
-      findReferences(
+      parseReferences(
         "@wchargin commented on #125, eg https://github.com/sourcecred/sourcecred/pull/125#pullrequestreview-113402856"
       )
     ).toEqual([


### PR DESCRIPTION
This pull request renames findReferences to parseReferences, and then implements findReferences as a module that finds every reference in an `EntityStore`. This will make it very easy to add reference edges to the GitHub graph.

This replaces #416.

See individual commits for details.