### PR TITLE
Allow Git commits to have zero or one tree

### DIFF
--- a/src/v3/plugins/git/graphView.js
+++ b/src/v3/plugins/git/graphView.js
@@ -205,32 +205,27 @@ export class GraphView {
       }
     }
 
-    // Each commits must have a unique and properly named HAS_TREE edge.
+    // Any HAS_TREE edge to a commit must be properly named. This
+    // implies that a commit has at most one such edge. (Normal commits
+    // should have trees, but submodule commits might not.)
     for (const rawNode of this._graph.nodes({prefix: GN._Prefix.commit})) {
-      const treeNeighbors = Array.from(
-        this._graph.neighbors(rawNode, {
-          direction: Direction.OUT,
-          nodePrefix: NodeAddress.empty,
-          edgePrefix: GE._Prefix.hasTree,
-        })
-      );
-      if (treeNeighbors.length !== 1) {
-        throw new Error(
-          "invariant violation: commit should have 1 tree, " +
-            `but has ${treeNeighbors.length}: ${NodeAddress.toString(rawNode)}`
-        );
-      }
-      const rawEdge = treeNeighbors[0].edge;
-      const edge: GE.HasTreeAddress = (GE.fromRaw(
-        (((rawEdge.address: EdgeAddressT): any): GE.RawAddress)
-      ): any);
-      const node: GN.CommitAddress = ((GN.fromRaw(
-        (((rawNode: NodeAddressT): any): GN.RawAddress)
-      ): GN.StructuredAddress): any);
-      if (node.hash !== edge.commit.hash) {
-        throw new Error(
-          `invariant violation: bad HAS_TREE edge: ${edgeToString(rawEdge)}`
-        );
+      for (const neighbor of this._graph.neighbors(rawNode, {
+        direction: Direction.OUT,
+        nodePrefix: NodeAddress.empty,
+        edgePrefix: GE._Prefix.hasTree,
+      })) {
+        const rawEdge = neighbor.edge;
+        const edge: GE.HasTreeAddress = (GE.fromRaw(
+          (((rawEdge.address: EdgeAddressT): any): GE.RawAddress)
+        ): any);
+        const node: GN.CommitAddress = ((GN.fromRaw(
+          (((rawNode: NodeAddressT): any): GN.RawAddress)
+        ): GN.StructuredAddress): any);
+        if (node.hash !== edge.commit.hash) {
+          throw new Error(
+            `invariant violation: bad HAS_TREE edge: ${edgeToString(rawEdge)}`
+          );
+        }
       }
     }
 

--- a/src/v3/plugins/git/graphView.test.js
+++ b/src/v3/plugins/git/graphView.test.js
@@ -198,13 +198,6 @@ describe("plugins/git/graphView", () => {
             "invariant violation: bad hom: " + edgeToString(badEdge)
           );
         });
-        it("for existence", () => {
-          const g = baseGraph();
-          expect(() => new GraphView(g)).toThrow(
-            "invariant violation: commit should have 1 tree, but has 0: " +
-              NodeAddress.toString(GN.toRaw(commit))
-          );
-        });
         it("for correctness", () => {
           const badEdge = {...otherEdge, src: edge.src};
           const g = baseGraph().addEdge(badEdge);


### PR DESCRIPTION
Summary:
Submodule commits need not have associated tree objects, in case the
repository to which they belong does not exist in our graph. We’d like
to represent submodule commits as actual commits, which necessitates
this change. See #417 for context.

Test Plan:
Existing unit tests suffice.

wchargin-branch: git-affine-trees