### PR TITLE
Represent submodule commits as normal commits

### DIFF
--- a/src/v3/plugins/git/__snapshots__/createGraph.test.js.snap
+++ b/src/v3/plugins/git/__snapshots__/createGraph.test.js.snap
@@ -121,7 +121,7 @@ Array [
           "3dfb84795e07341b05fad3a0d5a55f8304b2d7d8",
           "pygravitydefier",
         ],
-        "dstIndex": 15,
+        "dstIndex": 10,
         "srcIndex": 29,
       },
       Object {
@@ -186,7 +186,7 @@ Array [
           "569e1d383759903134df75230d63c0090196d4cb",
           "pygravitydefier",
         ],
-        "dstIndex": 15,
+        "dstIndex": 10,
         "srcIndex": 34,
       },
       Object {
@@ -303,7 +303,7 @@ Array [
           "7be3ecfee5314ffa9b2d93fc4377792b2d6d70ed",
           "pygravitydefier",
         ],
-        "dstIndex": 14,
+        "dstIndex": 7,
         "srcIndex": 43,
       },
       Object {
@@ -381,7 +381,7 @@ Array [
           "819fc546cea489476ce8dc90785e9ba7753d0a8f",
           "pygravitydefier",
         ],
-        "dstIndex": 14,
+        "dstIndex": 7,
         "srcIndex": 49,
       },
       Object {
@@ -459,7 +459,7 @@ Array [
           "bbf3b8b3d26a4f884b5c022d46851f593d329192",
           "pygravitydefier",
         ],
-        "dstIndex": 14,
+        "dstIndex": 7,
         "srcIndex": 55,
       },
       Object {
@@ -513,8 +513,8 @@ Array [
           "COMMIT",
           "69c5aad50eec8f2a0a07c988c3b283a6490eb45b",
         ],
-        "dstIndex": 8,
-        "srcIndex": 7,
+        "dstIndex": 9,
+        "srcIndex": 8,
       },
       Object {
         "address": Array [
@@ -528,8 +528,8 @@ Array [
           "COMMIT",
           "e8b7a8f19701cd5a25e4a097d513ead60e5f8bcc",
         ],
-        "dstIndex": 13,
-        "srcIndex": 8,
+        "dstIndex": 15,
+        "srcIndex": 9,
       },
       Object {
         "address": Array [
@@ -543,8 +543,8 @@ Array [
           "COMMIT",
           "c08ee3a4edea384d5291ffcbf06724a13ed72325",
         ],
-        "dstIndex": 10,
-        "srcIndex": 9,
+        "dstIndex": 12,
+        "srcIndex": 11,
       },
       Object {
         "address": Array [
@@ -558,8 +558,8 @@ Array [
           "COMMIT",
           "c2b51945e7457546912a8ce158ed9d294558d294",
         ],
-        "dstIndex": 11,
-        "srcIndex": 10,
+        "dstIndex": 13,
+        "srcIndex": 12,
       },
       Object {
         "address": Array [
@@ -573,8 +573,8 @@ Array [
           "COMMIT",
           "8d287c3bfbf8455ef30187bf5153ffc1b6eef268",
         ],
-        "dstIndex": 9,
-        "srcIndex": 12,
+        "dstIndex": 11,
+        "srcIndex": 14,
       },
       Object {
         "address": Array [
@@ -588,8 +588,8 @@ Array [
           "COMMIT",
           "d160cca97611e9dfed642522ad44408d0292e8ea",
         ],
-        "dstIndex": 12,
-        "srcIndex": 13,
+        "dstIndex": 14,
+        "srcIndex": 15,
       },
       Object {
         "address": Array [
@@ -601,7 +601,7 @@ Array [
           "3715ddfb8d4c4fd2a6f6af75488c82f84c92ec2f",
         ],
         "dstIndex": 21,
-        "srcIndex": 7,
+        "srcIndex": 8,
       },
       Object {
         "address": Array [
@@ -613,7 +613,7 @@ Array [
           "69c5aad50eec8f2a0a07c988c3b283a6490eb45b",
         ],
         "dstIndex": 23,
-        "srcIndex": 8,
+        "srcIndex": 9,
       },
       Object {
         "address": Array [
@@ -625,7 +625,7 @@ Array [
           "8d287c3bfbf8455ef30187bf5153ffc1b6eef268",
         ],
         "dstIndex": 17,
-        "srcIndex": 9,
+        "srcIndex": 11,
       },
       Object {
         "address": Array [
@@ -637,7 +637,7 @@ Array [
           "c08ee3a4edea384d5291ffcbf06724a13ed72325",
         ],
         "dstIndex": 16,
-        "srcIndex": 10,
+        "srcIndex": 12,
       },
       Object {
         "address": Array [
@@ -649,7 +649,7 @@ Array [
           "c2b51945e7457546912a8ce158ed9d294558d294",
         ],
         "dstIndex": 24,
-        "srcIndex": 11,
+        "srcIndex": 13,
       },
       Object {
         "address": Array [
@@ -661,7 +661,7 @@ Array [
           "d160cca97611e9dfed642522ad44408d0292e8ea",
         ],
         "dstIndex": 18,
-        "srcIndex": 12,
+        "srcIndex": 14,
       },
       Object {
         "address": Array [
@@ -673,7 +673,7 @@ Array [
           "e8b7a8f19701cd5a25e4a097d513ead60e5f8bcc",
         ],
         "dstIndex": 22,
-        "srcIndex": 13,
+        "srcIndex": 15,
       },
       Object {
         "address": Array [
@@ -1165,6 +1165,12 @@ Array [
         "sourcecred",
         "git",
         "COMMIT",
+        "29ef158bc982733e2ba429fcf73e2f7562244188",
+      ],
+      Array [
+        "sourcecred",
+        "git",
+        "COMMIT",
         "3715ddfb8d4c4fd2a6f6af75488c82f84c92ec2f",
       ],
       Array [
@@ -1172,6 +1178,12 @@ Array [
         "git",
         "COMMIT",
         "69c5aad50eec8f2a0a07c988c3b283a6490eb45b",
+      ],
+      Array [
+        "sourcecred",
+        "git",
+        "COMMIT",
+        "762c062fbdc7ec198cd693e95d55b374a08ff3e3",
       ],
       Array [
         "sourcecred",
@@ -1202,20 +1214,6 @@ Array [
         "git",
         "COMMIT",
         "e8b7a8f19701cd5a25e4a097d513ead60e5f8bcc",
-      ],
-      Array [
-        "sourcecred",
-        "git",
-        "SUBMODULE_COMMIT",
-        "https://github.com/sourcecred/example-git-submodule.git",
-        "29ef158bc982733e2ba429fcf73e2f7562244188",
-      ],
-      Array [
-        "sourcecred",
-        "git",
-        "SUBMODULE_COMMIT",
-        "https://github.com/sourcecred/example-git-submodule.git",
-        "762c062fbdc7ec198cd693e95d55b374a08ff3e3",
       ],
       Array [
         "sourcecred",

--- a/src/v3/plugins/git/__snapshots__/nodes.test.js.snap
+++ b/src/v3/plugins/git/__snapshots__/nodes.test.js.snap
@@ -30,23 +30,6 @@ Object {
 }
 `;
 
-exports[`plugins/git/nodes snapshots as expected: submoduleCommit 1`] = `
-Object {
-  "address": Array [
-    "sourcecred",
-    "git",
-    "SUBMODULE_COMMIT",
-    "https://github.com/sourcecred/example-git-submodule.git",
-    "29ef158bc982733e2ba429fcf73e2f7562244188",
-  ],
-  "structured": Object {
-    "commitHash": "29ef158bc982733e2ba429fcf73e2f7562244188",
-    "submoduleUrl": "https://github.com/sourcecred/example-git-submodule.git",
-    "type": "SUBMODULE_COMMIT",
-  },
-}
-`;
-
 exports[`plugins/git/nodes snapshots as expected: tree 1`] = `
 Object {
   "address": Array [

--- a/src/v3/plugins/git/createGraph.test.js
+++ b/src/v3/plugins/git/createGraph.test.js
@@ -37,13 +37,11 @@ describe("plugins/git/createGraph", () => {
             hash: "commit1",
             parentHashes: [],
             treeHash: beforeTree,
-            submoduleUrls: {},
           },
           commit2: {
             hash: "commit2",
             parentHashes: ["commit1"],
             treeHash: afterTree,
-            submoduleUrls: {},
           },
         },
         trees,

--- a/src/v3/plugins/git/demoData/example-git.json
+++ b/src/v3/plugins/git/demoData/example-git.json
@@ -5,9 +5,6 @@
             "parentHashes": [
                 "69c5aad50eec8f2a0a07c988c3b283a6490eb45b"
             ],
-            "submoduleUrls": {
-                "pygravitydefier": "https://github.com/sourcecred/example-git-submodule.git"
-            },
             "treeHash": "7be3ecfee5314ffa9b2d93fc4377792b2d6d70ed"
         },
         "69c5aad50eec8f2a0a07c988c3b283a6490eb45b": {
@@ -15,9 +12,6 @@
             "parentHashes": [
                 "e8b7a8f19701cd5a25e4a097d513ead60e5f8bcc"
             ],
-            "submoduleUrls": {
-                "pygravitydefier": "https://github.com/sourcecred/example-git-submodule.git"
-            },
             "treeHash": "bbf3b8b3d26a4f884b5c022d46851f593d329192"
         },
         "8d287c3bfbf8455ef30187bf5153ffc1b6eef268": {
@@ -25,9 +19,6 @@
             "parentHashes": [
                 "c08ee3a4edea384d5291ffcbf06724a13ed72325"
             ],
-            "submoduleUrls": {
-                "pygravitydefier": "https://github.com/sourcecred/example-git-submodule.git"
-            },
             "treeHash": "3dfb84795e07341b05fad3a0d5a55f8304b2d7d8"
         },
         "c08ee3a4edea384d5291ffcbf06724a13ed72325": {
@@ -35,16 +26,12 @@
             "parentHashes": [
                 "c2b51945e7457546912a8ce158ed9d294558d294"
             ],
-            "submoduleUrls": {
-            },
             "treeHash": "2f7155e359fd0ecb96ffdca66fa45b6ed5792809"
         },
         "c2b51945e7457546912a8ce158ed9d294558d294": {
             "hash": "c2b51945e7457546912a8ce158ed9d294558d294",
             "parentHashes": [
             ],
-            "submoduleUrls": {
-            },
             "treeHash": "bdff5d94193170015d6cbb549b7b630649428b1f"
         },
         "d160cca97611e9dfed642522ad44408d0292e8ea": {
@@ -52,9 +39,6 @@
             "parentHashes": [
                 "8d287c3bfbf8455ef30187bf5153ffc1b6eef268"
             ],
-            "submoduleUrls": {
-                "pygravitydefier": "https://github.com/sourcecred/example-git-submodule.git"
-            },
             "treeHash": "569e1d383759903134df75230d63c0090196d4cb"
         },
         "e8b7a8f19701cd5a25e4a097d513ead60e5f8bcc": {
@@ -62,9 +46,6 @@
             "parentHashes": [
                 "d160cca97611e9dfed642522ad44408d0292e8ea"
             ],
-            "submoduleUrls": {
-                "pygravitydefier": "https://github.com/sourcecred/example-git-submodule.git"
-            },
             "treeHash": "819fc546cea489476ce8dc90785e9ba7753d0a8f"
         }
     },

--- a/src/v3/plugins/git/edges.test.js
+++ b/src/v3/plugins/git/edges.test.js
@@ -19,11 +19,6 @@ describe("plugins/git/edges", () => {
       type: GN.COMMIT_TYPE,
       hash: "69c5aad50eec8f2a0a07c988c3b283a6490eb45b",
     }),
-    submoduleCommit: (): GN.SubmoduleCommitAddress => ({
-      type: GN.SUBMODULE_COMMIT_TYPE,
-      submoduleUrl: "https://github.com/sourcecred/example-git-submodule.git",
-      commitHash: "29ef158bc982733e2ba429fcf73e2f7562244188",
-    }),
     tree: (): GN.TreeAddress => ({
       type: GN.TREE_TYPE,
       hash: "7be3ecfee5314ffa9b2d93fc4377792b2d6d70ed",

--- a/src/v3/plugins/git/graphView.js
+++ b/src/v3/plugins/git/graphView.js
@@ -172,10 +172,7 @@ export class GraphView {
         homs: [
           {srcPrefix: GN._Prefix.treeEntry, dstPrefix: GN._Prefix.blob},
           {srcPrefix: GN._Prefix.treeEntry, dstPrefix: GN._Prefix.tree},
-          {
-            srcPrefix: GN._Prefix.treeEntry,
-            dstPrefix: GN._Prefix.submoduleCommit,
-          },
+          {srcPrefix: GN._Prefix.treeEntry, dstPrefix: GN._Prefix.commit},
         ],
       },
     };

--- a/src/v3/plugins/git/graphView.test.js
+++ b/src/v3/plugins/git/graphView.test.js
@@ -4,6 +4,7 @@ import cloneDeep from "lodash.clonedeep";
 
 import {EdgeAddress, Graph, NodeAddress, edgeToString} from "../../core/graph";
 import {createGraph} from "./createGraph";
+import * as exampleRepo from "./demoData/exampleRepo";
 import {GraphView} from "./graphView";
 import type {Repository} from "./types";
 
@@ -32,7 +33,13 @@ describe("plugins/git/graphView", () => {
     });
 
     it("#commits yields all commits", () => {
-      const expectedHashes = Object.keys(makeData().commits);
+      const extraSubmoduleCommits = [
+        exampleRepo.SUBMODULE_COMMIT_1,
+        exampleRepo.SUBMODULE_COMMIT_2,
+      ];
+      const expectedHashes = Object.keys(makeData().commits).concat(
+        extraSubmoduleCommits
+      );
       const actualHashes = Array.from(view.commits()).map((a) => a.hash);
       expectEqualMultisets(actualHashes, expectedHashes);
     });
@@ -104,12 +111,10 @@ describe("plugins/git/graphView", () => {
         const actual = Array.from(
           view.contents(entryByName("pygravitydefier"))
         );
-        const expected: $ReadOnlyArray<GN.SubmoduleCommitAddress> = [
+        const expected: $ReadOnlyArray<GN.CommitAddress> = [
           {
-            type: GN.SUBMODULE_COMMIT_TYPE,
-            submoduleUrl:
-              "https://github.com/sourcecred/example-git-submodule.git",
-            commitHash: "29ef158bc982733e2ba429fcf73e2f7562244188",
+            type: GN.COMMIT_TYPE,
+            hash: "29ef158bc982733e2ba429fcf73e2f7562244188",
           },
         ];
         expect(actual).toEqual(expected);

--- a/src/v3/plugins/git/nodes.js
+++ b/src/v3/plugins/git/nodes.js
@@ -12,7 +12,6 @@ export function _gitAddress(...parts: string[]): RawAddress {
 
 export const BLOB_TYPE: "BLOB" = "BLOB";
 export const COMMIT_TYPE: "COMMIT" = "COMMIT";
-export const SUBMODULE_COMMIT_TYPE: "SUBMODULE_COMMIT" = "SUBMODULE_COMMIT";
 export const TREE_TYPE: "TREE" = "TREE";
 export const TREE_ENTRY_TYPE: "TREE_ENTRY" = "TREE_ENTRY";
 
@@ -20,7 +19,6 @@ export const _Prefix = Object.freeze({
   base: GIT_PREFIX,
   blob: _gitAddress(BLOB_TYPE),
   commit: _gitAddress(COMMIT_TYPE),
-  submoduleCommit: _gitAddress(SUBMODULE_COMMIT_TYPE),
   tree: _gitAddress(TREE_TYPE),
   treeEntry: _gitAddress(TREE_ENTRY_TYPE),
 });
@@ -32,11 +30,6 @@ export type BlobAddress = {|
 export type CommitAddress = {|
   +type: typeof COMMIT_TYPE,
   +hash: Hash,
-|};
-export type SubmoduleCommitAddress = {|
-  +type: typeof SUBMODULE_COMMIT_TYPE,
-  +submoduleUrl: string,
-  +commitHash: Hash,
 |};
 export type TreeAddress = {|
   +type: typeof TREE_TYPE,
@@ -52,13 +45,12 @@ export type TreeEntryAddress = {|
 // addresses.
 export type TreeEntryContentsAddress =
   | BlobAddress
-  | TreeAddress
-  | SubmoduleCommitAddress;
+  | CommitAddress
+  | TreeAddress;
 
 export type StructuredAddress =
   | BlobAddress
   | CommitAddress
-  | SubmoduleCommitAddress
   | TreeAddress
   | TreeEntryAddress;
 
@@ -81,11 +73,6 @@ export function fromRaw(x: RawAddress): StructuredAddress {
       if (rest.length !== 1) throw fail();
       const [hash] = rest;
       return {type: COMMIT_TYPE, hash};
-    }
-    case "SUBMODULE_COMMIT": {
-      if (rest.length !== 2) throw fail();
-      const [submoduleUrl, commitHash] = rest;
-      return {type: SUBMODULE_COMMIT_TYPE, submoduleUrl, commitHash};
     }
     case "TREE": {
       if (rest.length !== 1) throw fail();
@@ -110,12 +97,6 @@ export function toRaw(x: StructuredAddress): RawAddress {
       return NodeAddress.append(_Prefix.blob, x.hash);
     case COMMIT_TYPE:
       return NodeAddress.append(_Prefix.commit, x.hash);
-    case SUBMODULE_COMMIT_TYPE:
-      return NodeAddress.append(
-        _Prefix.submoduleCommit,
-        x.submoduleUrl,
-        x.commitHash
-      );
     case TREE_TYPE:
       return NodeAddress.append(_Prefix.tree, x.hash);
     case TREE_ENTRY_TYPE:

--- a/src/v3/plugins/git/nodes.test.js
+++ b/src/v3/plugins/git/nodes.test.js
@@ -14,11 +14,6 @@ describe("plugins/git/nodes", () => {
       type: GN.COMMIT_TYPE,
       hash: "3715ddfb8d4c4fd2a6f6af75488c82f84c92ec2f",
     }),
-    submoduleCommit: (): GN.SubmoduleCommitAddress => ({
-      type: GN.SUBMODULE_COMMIT_TYPE,
-      submoduleUrl: "https://github.com/sourcecred/example-git-submodule.git",
-      commitHash: "29ef158bc982733e2ba429fcf73e2f7562244188",
-    }),
     tree: (): GN.TreeAddress => ({
       type: GN.TREE_TYPE,
       hash: "7be3ecfee5314ffa9b2d93fc4377792b2d6d70ed",
@@ -127,20 +122,6 @@ describe("plugins/git/nodes", () => {
         GN.TREE_ENTRY_TYPE,
         examples.treeEntry().treeHash,
         examples.treeEntry().name,
-        "wat",
-      ]);
-
-      expectBadAddress("submodule commit with no fields", [
-        GN.SUBMODULE_COMMIT_TYPE,
-      ]);
-      expectBadAddress("submodule commit with only URL", [
-        GN.SUBMODULE_COMMIT_TYPE,
-        examples.submoduleCommit().submoduleUrl,
-      ]);
-      expectBadAddress("submodule commit with extra field", [
-        GN.SUBMODULE_COMMIT_TYPE,
-        examples.submoduleCommit().submoduleUrl,
-        examples.submoduleCommit().commitHash,
         "wat",
       ]);
     });

--- a/src/v3/plugins/git/types.js
+++ b/src/v3/plugins/git/types.js
@@ -9,7 +9,6 @@ export type Commit = {|
   +hash: Hash,
   +parentHashes: $ReadOnlyArray<Hash>,
   +treeHash: Hash,
-  +submoduleUrls: {[path: string]: string},
 |};
 export type Tree = {|
   +hash: Hash,


### PR DESCRIPTION
Summary:
Closes #417. Submodule commits are dead; long live commits. The ontology
is now:

  - A tree includes tree entries.
  - A tree entry may have a blob as contents.
  - A tree entry may have a tree as contents.
  - A tree entry may have a commit as contents.

Test Plan:
Existing unit tests suffice, especially `#commits yields all commits`.

wchargin-branch: git-remove-submodule-commits