### PR TITLE
Refactor GH `createGraph` to use `RelationalView`

### DIFF
--- a/src/v3/plugins/github/createGraph.js
+++ b/src/v3/plugins/github/createGraph.js
@@ -1,44 +1,14 @@
 // @flow
 
 import {Graph} from "../../core/graph";
-import type {
-  GithubResponseJSON,
-  RepositoryJSON,
-  ReviewJSON,
-  PullJSON,
-  IssueJSON,
-  CommentJSON,
-  ReviewCommentJSON,
-  NullableAuthorJSON,
-} from "./graphql";
-
-import type {
-  RepoAddress,
-  IssueAddress,
-  PullAddress,
-  ReviewAddress,
-  UserlikeAddress,
-  StructuredAddress,
-  AuthorableAddress,
-  ChildAddress,
-  ParentAddress,
-} from "./nodes";
-import {toRaw} from "./nodes";
-
+import * as GitNode from "../git/nodes";
+import * as N from "./nodes";
+import * as R from "./relationalView";
 import {createEdge} from "./edges";
 
-import {COMMIT_TYPE, toRaw as gitToRaw} from "../git/nodes";
-
-import {
-  reviewUrlToId,
-  issueCommentUrlToId,
-  pullCommentUrlToId,
-  reviewCommentUrlToId,
-} from "./urlIdParse";
-
-export function createGraph(data: GithubResponseJSON): Graph {
+export function createGraph(view: R.RelationalView): Graph {
   const creator = new GraphCreator();
-  creator.addData(data);
+  creator.addData(view);
   return creator.graph;
 }
 
@@ -49,113 +19,43 @@ class GraphCreator {
     this.graph = new Graph();
   }
 
-  addNode(addr: StructuredAddress) {
-    this.graph.addNode(toRaw(addr));
-  }
-
-  addData(data: GithubResponseJSON) {
-    this.addRepository(data.repository);
-  }
-
-  addRepository(repoJSON: RepositoryJSON) {
-    const repo: RepoAddress = {
-      type: "REPO",
-      owner: repoJSON.owner.login,
-      name: repoJSON.name,
-    };
-    this.addNode(repo);
-    repoJSON.issues.nodes.forEach((issue) => this.addIssue(repo, issue));
-    repoJSON.pulls.nodes.forEach((pull) => this.addPull(repo, pull));
-  }
-
-  addIssue(repo: RepoAddress, issueJSON: IssueJSON) {
-    const issue: IssueAddress = {
-      type: "ISSUE",
-      repo,
-      number: String(issueJSON.number),
-    };
-    this.addNode(issue);
-    this.addAuthors(issue, issueJSON.author);
-    this.addHasParent(issue, repo);
-    issueJSON.comments.nodes.forEach((comment) =>
-      this.addComment(issue, comment)
-    );
-  }
-
-  addPull(repo: RepoAddress, pullJSON: PullJSON) {
-    const pull: PullAddress = {
-      type: "PULL",
-      repo,
-      number: String(pullJSON.number),
-    };
-    this.addNode(pull);
-    this.addAuthors(pull, pullJSON.author);
-    this.addHasParent(pull, repo);
-    pullJSON.comments.nodes.forEach((c) => this.addComment(pull, c));
-    pullJSON.reviews.nodes.forEach((review) => this.addReview(pull, review));
-    if (pullJSON.mergeCommit != null) {
-      const commitHash = pullJSON.mergeCommit.oid;
-      const commit = {type: COMMIT_TYPE, hash: commitHash};
-      this.graph.addNode(gitToRaw(commit));
-      this.graph.addEdge(createEdge.mergedAs(pull, commit));
+  addData(view: R.RelationalView) {
+    for (const entity of view.entities()) {
+      this.addNode(entity.address());
     }
-  }
 
-  addReview(pull: PullAddress, reviewJSON: ReviewJSON) {
-    const id = reviewUrlToId(reviewJSON.url);
-    const review = {
-      type: "REVIEW",
-      pull,
-      id,
-    };
-    this.addNode(review);
-    reviewJSON.comments.nodes.forEach((c) => this.addComment(review, c));
-    this.addAuthors(review, reviewJSON.author);
-    this.addHasParent(review, pull);
-  }
+    for (const child of view.childEntities()) {
+      this.addHasParent(child);
+    }
 
-  addComment(
-    parent: IssueAddress | PullAddress | ReviewAddress,
-    commentJSON: CommentJSON | ReviewCommentJSON
-  ) {
-    const id = (function() {
-      switch (parent.type) {
-        case "ISSUE":
-          return issueCommentUrlToId(commentJSON.url);
-        case "PULL":
-          return pullCommentUrlToId(commentJSON.url);
-        case "REVIEW":
-          return reviewCommentUrlToId(commentJSON.url);
-        default:
-          // eslint-disable-next-line no-unused-expressions
-          (parent.type: empty);
-          throw new Error(`Unexpected comment parent type: ${parent.type}`);
+    for (const authored of view.authoredEntities()) {
+      this.addAuthors(authored);
+    }
+
+    for (const pull of view.pulls()) {
+      const commit = pull.mergedAs();
+      if (commit != null) {
+        this.graph.addNode(GitNode.toRaw(commit));
+        this.graph.addEdge(createEdge.mergedAs(pull.address(), commit));
       }
-    })();
-    const comment = {
-      type: "COMMENT",
-      parent,
-      id,
-    };
-    this.addNode(comment);
-    this.addAuthors(comment, commentJSON.author);
-    this.addHasParent(comment, parent);
-  }
-
-  addAuthors(content: AuthorableAddress, authorJSON: NullableAuthorJSON) {
-    // author may be null, as not all posts have authors
-    if (authorJSON == null) {
-      return;
     }
-    const author: UserlikeAddress = {
-      type: "USERLIKE",
-      login: authorJSON.login,
-    };
-    this.addNode(author);
-    this.graph.addEdge(createEdge.authors(author, content));
   }
 
-  addHasParent(child: ChildAddress, parent: ParentAddress) {
-    this.graph.addEdge(createEdge.hasParent(child, parent));
+  addNode(addr: N.StructuredAddress) {
+    this.graph.addNode(N.toRaw(addr));
+  }
+
+  addAuthors(entity: R.Issue | R.Pull | R.Comment | R.Review) {
+    for (const author of entity.authors()) {
+      this.graph.addEdge(
+        createEdge.authors(author.address(), entity.address())
+      );
+    }
+  }
+
+  addHasParent(child: R.Issue | R.Pull | R.Comment | R.Review) {
+    this.graph.addEdge(
+      createEdge.hasParent(child.address(), child.parent().address())
+    );
   }
 }

--- a/src/v3/plugins/github/createGraph.test.js
+++ b/src/v3/plugins/github/createGraph.test.js
@@ -2,11 +2,16 @@
 
 import {createGraph} from "./createGraph";
 import {GraphView} from "./graphView";
+import {RelationalView} from "./relationalView";
+import type {GithubResponseJSON} from "./graphql";
 import cloneDeep from "lodash.clonedeep";
 
 function exampleGraph() {
-  const data = cloneDeep(require("./demoData/example-github"));
-  return createGraph(data);
+  const data: GithubResponseJSON = cloneDeep(
+    require("./demoData/example-github")
+  );
+  const view = new RelationalView(data);
+  return createGraph(view);
 }
 
 describe("plugins/github/createGraph", () => {

--- a/src/v3/plugins/github/graphView.test.js
+++ b/src/v3/plugins/github/graphView.test.js
@@ -3,14 +3,19 @@
 import {Graph, type Edge, EdgeAddress} from "../../core/graph";
 import {createGraph} from "./createGraph";
 import {GraphView} from "./graphView";
+import {RelationalView} from "./relationalView";
 import * as GE from "./edges";
 import * as GN from "./nodes";
 import cloneDeep from "lodash.clonedeep";
 import {COMMIT_TYPE, toRaw as gitToRaw, TREE_TYPE} from "../git/nodes";
+import type {GithubResponseJSON} from "./graphql";
 
 function exampleView() {
-  const data = cloneDeep(require("./demoData/example-github"));
-  const graph = createGraph(data);
+  const data: GithubResponseJSON = cloneDeep(
+    require("./demoData/example-github")
+  );
+  const view = new RelationalView(data);
+  const graph = createGraph(view);
   return new GraphView(graph);
 }
 

--- a/src/v3/plugins/github/relationalView.js
+++ b/src/v3/plugins/github/relationalView.js
@@ -127,6 +127,36 @@ export class RelationalView {
     yield* this.comments();
   }
 
+  *parentEntities(): Iterator<ParentEntity> {
+    yield* this.repos();
+    yield* this.issues();
+    yield* this.pulls();
+    yield* this.reviews();
+  }
+
+  *childEntities(): Iterator<ChildEntity> {
+    yield* this.issues();
+    yield* this.pulls();
+    yield* this.reviews();
+    yield* this.comments();
+  }
+
+  *authoredEntities(): Iterator<AuthoredEntity> {
+    yield* this.issues();
+    yield* this.pulls();
+    yield* this.reviews();
+    yield* this.comments();
+  }
+
+  *entities(): Iterator<Entity<Entry>> {
+    yield* this.repos();
+    yield* this.issues();
+    yield* this.pulls();
+    yield* this.reviews();
+    yield* this.comments();
+    yield* this.userlikes();
+  }
+
   _addRepo(json: Q.RepositoryJSON) {
     const address: RepoAddress = {
       type: N.REPO_TYPE,
@@ -660,5 +690,8 @@ function* getAuthors(
   }
 }
 
+export type AuthoredEntity = Issue | Pull | Review | Comment;
 export type TextContentEntity = Issue | Pull | Review | Comment;
+export type ParentEntity = Repo | Issue | Pull | Review;
+export type ChildEntity = Issue | Pull | Review | Comment;
 export type ReferentEntity = Repo | Issue | Pull | Review | Comment | Userlike;


### PR DESCRIPTION
This commit modifies `github/createGraph` to use the `RelationalView`
class created in #424. The code is now much cleaner.

I also fixed some `any`s that were leaking in our test code (due to use
of runtime require for GitHub example data). These anys were discovered
by bumping into uncaught type errors. :)

This commit supercedes #413 and #419.

Test plan:
Observe that the graph snapshot was not changed.