### PR TITLE
Add a GitHub `example` module

### DIFF
--- a/src/v3/plugins/github/createGraph.test.js
+++ b/src/v3/plugins/github/createGraph.test.js
@@ -1,18 +1,7 @@
 // @flow
 
-import {createGraph} from "./createGraph";
 import {GraphView} from "./graphView";
-import {RelationalView} from "./relationalView";
-import type {GithubResponseJSON} from "./graphql";
-import cloneDeep from "lodash.clonedeep";
-
-function exampleGraph() {
-  const data: GithubResponseJSON = cloneDeep(
-    require("./example/example-github")
-  );
-  const view = new RelationalView(data);
-  return createGraph(view);
-}
+import {exampleGraph} from "./example/example";
 
 describe("plugins/github/createGraph", () => {
   it("example graph matches snapshot", () => {
@@ -20,8 +9,7 @@ describe("plugins/github/createGraph", () => {
   });
 
   it("passes all GraphView invariants", () => {
-    const graph = exampleGraph();
-    const view = new GraphView(graph);
+    const view = new GraphView(exampleGraph());
     // This test is high leverage. It checks:
     // - that every node starting with a GitHub prefix
     //   - can be structured using fromRaw

--- a/src/v3/plugins/github/example/example.js
+++ b/src/v3/plugins/github/example/example.js
@@ -1,0 +1,19 @@
+// @flow
+
+import {RelationalView} from "../relationalView";
+import type {GithubResponseJSON} from "../graphql";
+import {Graph} from "../../../core/graph";
+import cloneDeep from "lodash.clonedeep";
+import {createGraph} from "../createGraph";
+
+export function exampleData(): GithubResponseJSON {
+  return cloneDeep(require("./example-github"));
+}
+
+export function exampleRelationalView(): RelationalView {
+  return new RelationalView(exampleData());
+}
+
+export function exampleGraph(): Graph {
+  return createGraph(exampleRelationalView());
+}

--- a/src/v3/plugins/github/graphView.test.js
+++ b/src/v3/plugins/github/graphView.test.js
@@ -1,22 +1,14 @@
 // @flow
 
 import {Graph, type Edge, EdgeAddress} from "../../core/graph";
-import {createGraph} from "./createGraph";
 import {GraphView} from "./graphView";
-import {RelationalView} from "./relationalView";
 import * as GE from "./edges";
 import * as GN from "./nodes";
-import cloneDeep from "lodash.clonedeep";
 import {COMMIT_TYPE, toRaw as gitToRaw, TREE_TYPE} from "../git/nodes";
-import type {GithubResponseJSON} from "./graphql";
+import {exampleGraph} from "./example/example";
 
 function exampleView() {
-  const data: GithubResponseJSON = cloneDeep(
-    require("./example/example-github")
-  );
-  const view = new RelationalView(data);
-  const graph = createGraph(view);
-  return new GraphView(graph);
+  return new GraphView(exampleGraph());
 }
 
 const decentralion = {type: "USERLIKE", login: "decentralion"};

--- a/src/v3/plugins/github/relationalView.test.js
+++ b/src/v3/plugins/github/relationalView.test.js
@@ -2,11 +2,11 @@
 
 import * as R from "./relationalView";
 import * as N from "./nodes";
+import {exampleRelationalView} from "./example/example";
 
 describe("plugins/github/relationalView", () => {
-  const data = require("./example/example-github");
   // Sharing this state is OK because it's just a view - no mutation allowed!
-  const view = new R.RelationalView(data);
+  const view = exampleRelationalView();
 
   function hasEntities(name, method) {
     describe(name, () => {


### PR DESCRIPTION
Currently, GitHub tests load example data with ad-hoc methods. It makes
it easy for the author of a new test file to forget to clone the test
data (and risk cross-test-file state pollution), or to forget to apply
the correct typing.

This commit factors a shared `example` module which provides a safe way
to access the example data, along with some convenient helpers for
constructing a graph or relational view.

Test plan:
`yarn travis`

Fixes #430.