### PR TITLE
Add RelationalView.{to,from}JSON

### DIFF
--- a/src/v3/plugins/github/relationalView.test.js
+++ b/src/v3/plugins/github/relationalView.test.js
@@ -223,4 +223,13 @@ describe("plugins/github/relationalView", () => {
     // may be fragile
     expect(rv1).toEqual(rv2);
   });
+
+  describe("to/fromJSON", () => {
+    it("to->from->to is identity", () => {
+      const json1 = view.toJSON();
+      const view1 = R.RelationalView.fromJSON(json1);
+      const json2 = view1.toJSON();
+      expect(json1).toEqual(json2);
+    });
+  });
 });


### PR DESCRIPTION
This adds methods for serializing the GitHub RelationalView.

We have not put in the work to ensure that these methods generate
canonical data. Getting the issues in a different order, or finding
references in a different order, can change the JSON output even if the
resulting repositories are equivalent.

@decentralion think it's not worth putting in the effort, since we may
switch to a SQL database soon anyway.

Test plan: travis

Paired with @wchargin