### PR TITLE
Create a V3 command-line entry point

### DIFF
--- a/config/paths.js
+++ b/config/paths.js
@@ -59,6 +59,7 @@ module.exports = {
     "commands/start": resolveApp("src/v1/cli/commands/start.js"),
     apiApp: resolveApp("src/v1/app/apiApp.js"),
     sourcecred: resolveApp("src/v1/cli/sourcecred.js"),
+    sourcecredV3: resolveApp("src/v3/cli/sourcecred.js"),
     fetchAndPrintGithubRepo: resolveApp(
       "src/v1/plugins/github/bin/fetchAndPrintGithubRepo.js"
     ),

--- a/src/v3/cli/sourcecred.js
+++ b/src/v3/cli/sourcecred.js
@@ -1,0 +1,5 @@
+// @flow
+require("../../tools/entry");
+require("@oclif/command")
+  .run()
+  .catch(require("@oclif/errors/handle"));


### PR DESCRIPTION
Summary:
Due to oclif’s structure, this entry point shares its `commands`
directory with that of the V1 entry point. We’ll therefore add commands
like `start-v3` as we go.

Paired with @decentralion.

Test Plan:
`yarn backend` works, and `node bin/sourcecredV3.js start` launches the
V1 server.

wchargin-branch: v3-cli