### PR TITLE
Fix off-by-1 error in PageRank iteration limit

### DIFF
--- a/src/v3/core/attribution/markovChain.js
+++ b/src/v3/core/attribution/markovChain.js
@@ -117,6 +117,12 @@ export function findStationaryDistribution(
   }
   let iteration = 0;
   while (true) {
+    if (iteration >= fullOptions.maxIterations) {
+      if (fullOptions.verbose) {
+        console.log(`[${iteration}] FAILED to converge`);
+      }
+      return r0;
+    }
     iteration++;
     const r1 = sparseMarkovChainAction(chain, r0);
     const delta = computeDelta(r0, r1);
@@ -127,12 +133,6 @@ export function findStationaryDistribution(
     if (delta < fullOptions.convergenceThreshold) {
       if (fullOptions.verbose) {
         console.log(`[${iteration}] CONVERGED`);
-      }
-      return r0;
-    }
-    if (iteration >= fullOptions.maxIterations) {
-      if (fullOptions.verbose) {
-        console.log(`[${iteration}] FAILED to converge`);
       }
       return r0;
     }

--- a/src/v3/core/attribution/markovChain.test.js
+++ b/src/v3/core/attribution/markovChain.test.js
@@ -182,5 +182,12 @@ describe("core/attribution/markovChain", () => {
       const expected = new Float64Array([0.5, 0.5]);
       expectAllClose(pi, expected);
     });
+
+    it("returns initial distribution if maxIterations===0", () => {
+      const chain = sparseMarkovChainFromTransitionMatrix([[0, 1], [0, 1]]);
+      const pi = findStationaryDistribution(chain, {maxIterations: 0});
+      const expected = new Float64Array([0.5, 0.5]);
+      expect(pi).toEqual(expected);
+    });
   });
 });


### PR DESCRIPTION
If `findStationaryDistribution` is passed `0` as `maxIterations`, then
it should return the initial distribution.

Test plan: see new unit test

Paired with @wchargin