### PR TITLE
Add `view.entity`

### DIFF
--- a/src/v3/plugins/github/relationalView.js
+++ b/src/v3/plugins/github/relationalView.js
@@ -124,6 +124,25 @@ export class RelationalView {
     return entry == null ? entry : new Userlike(this, entry);
   }
 
+  entity(address: N.StructuredAddress): ?Entity {
+    switch (address.type) {
+      case "REPO":
+        return this.repo(address);
+      case "ISSUE":
+        return this.issue(address);
+      case "PULL":
+        return this.pull(address);
+      case "REVIEW":
+        return this.review(address);
+      case "COMMENT":
+        return this.comment(address);
+      case "USERLIKE":
+        return this.userlike(address);
+      default:
+        throw new Error(`Unexpected address type: ${(address.type: empty)}`);
+    }
+  }
+
   *referentEntities(): Iterator<ReferentEntity> {
     yield* this.repos();
     yield* this.issues();

--- a/src/v3/plugins/github/relationalView.test.js
+++ b/src/v3/plugins/github/relationalView.test.js
@@ -140,6 +140,36 @@ describe("plugins/github/relationalView", () => {
     has("url", () => entity.url());
   });
 
+  describe("entity", () => {
+    it("works for repo", () => {
+      expect(view.entity(repo.address())).toEqual(repo);
+    });
+    it("works for issue", () => {
+      expect(view.entity(issue.address())).toEqual(issue);
+    });
+    it("works for pull", () => {
+      expect(view.entity(pull.address())).toEqual(pull);
+    });
+    it("works for review", () => {
+      expect(view.entity(review.address())).toEqual(review);
+    });
+    it("works for comment", () => {
+      expect(view.entity(comment.address())).toEqual(comment);
+    });
+    it("works for userlike", () => {
+      expect(view.entity(userlike.address())).toEqual(userlike);
+    });
+    it("returns undefined on nonexistent address", () => {
+      expect(
+        view.entity({type: "REPO", owner: "foo", name: "bar"})
+      ).not.toEqual(expect.anything());
+    });
+    it("errors for bad address type", () => {
+      // $ExpectFlowError
+      expect(() => view.entity({type: "BAD"})).toThrow("address type");
+    });
+  });
+
   describe("match", () => {
     const handlers = {
       // Return the address so we know it was actually called on the entity,


### PR DESCRIPTION
This method takes an arbitrary structured address and returns an entity
for it (if a matching entity exists).

Test plan: travis