### PR TITLE
Add `loadGitData` and wire it into CLI

### DIFF
--- a/src/v3/cli/commands/loadPlugin.js
+++ b/src/v3/cli/commands/loadPlugin.js
@@ -5,6 +5,7 @@ import mkdirp from "mkdirp";
 import path from "path";
 
 import {loadGithubData} from "../../plugins/github/loadGithubData";
+import {loadGitData} from "../../plugins/git/loadGitData";
 import {pluginNames, sourcecredDirectoryFlag} from "../common";
 
 export default class PluginGraphCommand extends Command {
@@ -78,6 +79,9 @@ function loadPlugin({basedir, plugin, repoOwner, repoName, githubToken}) {
           outputDirectory,
         });
       }
+      break;
+    case "git":
+      loadGitData({repoOwner, repoName, outputDirectory});
       break;
     default:
       console.error("fatal: Unknown plugin: " + (plugin: empty));

--- a/src/v3/cli/common.js
+++ b/src/v3/cli/common.js
@@ -4,9 +4,9 @@ import {flags} from "@oclif/command";
 import os from "os";
 import path from "path";
 
-export type PluginName = "github";
+export type PluginName = "github" | "git";
 export function pluginNames(): PluginName[] {
-  return ["github"];
+  return ["github", "git"];
 }
 
 function defaultStorageDirectory() {

--- a/src/v3/plugins/git/loadGitData.js
+++ b/src/v3/plugins/git/loadGitData.js
@@ -1,0 +1,24 @@
+// @flow
+
+import fs from "fs-extra";
+import path from "path";
+
+import cloneAndLoadRepository from "./cloneAndLoadRepository";
+import {createGraph} from "./createGraph";
+
+export type Options = {|
+  +repoOwner: string,
+  +repoName: string,
+  +outputDirectory: string,
+|};
+
+export function loadGitData(options: Options): Promise<void> {
+  const repository = cloneAndLoadRepository(
+    options.repoOwner,
+    options.repoName
+  );
+  const graph = createGraph(repository);
+  const blob = JSON.stringify(graph);
+  const outputFilename = path.join(options.outputDirectory, "graph.json");
+  return fs.writeFile(outputFilename, blob);
+}


### PR DESCRIPTION
Add `loadGitData` and wire it into CLI

This commit adds `loadGitData`, which clones the git repository for a
given repo and saves the corresponding git graph. It also adds that
method to the `loadPlugin` command, so that the following command now
works:

```
$ node bin/sourcecredV3.js load-plugin-v3  sourcecred example-git --plugin=git
```

After running that command, the correct file is present:

```
$ du -sh tmp/sourcecred/data/sourcecred/example-git/git/graph.json
28K     /home/dandelion/tmp/sourcecred/data/sourcecred/example-git/git/graph.json
```

The command takes:

| repository               | time (s)  |
:------------------------- | ----------:
| `sourcecred/example-git` | 1         |
| `sourcecred/sourcecred`  | 5         |
| `ipfs/js-ipfs`           | 18        |
| `ipfs/go-ipfs`           | ∞ (OOM)   |
