### PR TITLE
Add support for detecting cross-repo references

### DIFF
--- a/src/v3/plugins/github/parseReferences.js
+++ b/src/v3/plugins/github/parseReferences.js
@@ -12,9 +12,20 @@ export function parseReferences(body: string): ParsedReference[] {
   // https://github.com/sourcecred/sourcecred/pull/130#pullrequestreview-113849998
   return [
     ...findNumericReferences(body),
+    ...findRepoNumericReferences(body),
     ...findGithubUrlReferences(body),
     ...findUsernameReferences(body),
   ];
+}
+
+function findRepoNumericReferences(body: string): ParsedReference[] {
+  return findAllMatches(
+    /(?:\W|^)([a-zA-Z0-9-]+\/[a-zA-Z0-9-]+#\d+)(?:\W|$)/g,
+    body
+  ).map((x) => ({
+    refType: "BASIC",
+    ref: x[1],
+  }));
 }
 
 function findNumericReferences(body: string): ParsedReference[] {

--- a/src/v3/plugins/github/parseReferences.test.js
+++ b/src/v3/plugins/github/parseReferences.test.js
@@ -32,10 +32,18 @@ describe("parseReferences", () => {
     expect(parseReferences("foo#123 #124bar")).toHaveLength(0);
   });
 
-  it("does not yet find concise cross-repo links", () => {
-    // The link below is valid, when we add cross-repo support we
-    // should fix this test case
-    expect(parseReferences("sourcecred/sourcecred#12")).toHaveLength(0);
+  describe("cross-repo links", () => {
+    const repoRef = "sourcecred/sourcecred#12";
+    it("a bare link", () => {
+      expect(parseReferences(repoRef)).toEqual([
+        {refType: "BASIC", ref: repoRef},
+      ]);
+    });
+    it("a link with surrounding context", () => {
+      expect(parseReferences("please see sourcecred/sourcecred#12")).toEqual([
+        {refType: "BASIC", ref: repoRef},
+      ]);
+    });
   });
 
   it("finds a trivial url reference", () => {

--- a/src/v3/plugins/github/relationalView.js
+++ b/src/v3/plugins/github/relationalView.js
@@ -361,6 +361,10 @@ export class RelationalView {
       }
       if (e instanceof Issue || e instanceof Pull) {
         refToAddress.set(`#${e.number()}`, a);
+        refToAddress.set(
+          `${e.parent().owner()}/${e.parent().name()}#${e.number()}`,
+          a
+        );
       }
     }
     for (const e of this.textContentEntities()) {


### PR DESCRIPTION
In GitHub, you can make cross repo references. For example,
sourcecred/sourcecred#459 is one such reference. This commit adds
support for detecting those references and adding them to the GitHub
graph.

Test plan:
See attached unit tests.