### PR TITLE
Add GitPluginAdapter and Git render module

### DIFF
--- a/src/v3/plugins/git/__snapshots__/render.test.js.snap
+++ b/src/v3/plugins/git/__snapshots__/render.test.js.snap
@@ -1,0 +1,9 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`plugins/git/render blob snapshots as expected 1`] = `"blob f1f2514ca6d7a6a1a0511957021b1995bf9ace1c"`;
+
+exports[`plugins/git/render commit snapshots as expected 1`] = `"commit 3715ddfb8d4c4fd2a6f6af75488c82f84c92ec2f"`;
+
+exports[`plugins/git/render tree snapshots as expected 1`] = `"tree 7be3ecfee5314ffa9b2d93fc4377792b2d6d70ed"`;
+
+exports[`plugins/git/render treeEntry snapshots as expected 1`] = `"entry \\"science.txt\\" in tree 7be3ecfee5314ffa9b2d93fc4377792b2d6d70ed"`;

--- a/src/v3/plugins/git/pluginAdapter.js
+++ b/src/v3/plugins/git/pluginAdapter.js
@@ -1,0 +1,47 @@
+// @flow
+import type {
+  PluginAdapter as IPluginAdapter,
+  Renderer as IRenderer,
+} from "../../app/pluginAdapter";
+import {Graph} from "../../core/graph";
+import * as N from "./nodes";
+import {description} from "./render";
+
+export async function createPluginAdapter(
+  repoOwner: string,
+  repoName: string
+): Promise<IPluginAdapter> {
+  const url = `/api/v1/data/data/${repoOwner}/${repoName}/git/graph.json`;
+  const response = await fetch(url);
+  if (!response.ok) {
+    return Promise.reject(response);
+  }
+  const json = await response.json();
+  const graph = Graph.fromJSON(json);
+  return new PluginAdapter(graph);
+}
+
+class PluginAdapter implements IPluginAdapter {
+  +_graph: Graph;
+  constructor(graph: Graph) {
+    this._graph = graph;
+  }
+  graph() {
+    return this._graph;
+  }
+  renderer() {
+    return new Renderer();
+  }
+  nodePrefix() {
+    return N._Prefix.base;
+  }
+}
+
+class Renderer implements IRenderer {
+  nodeDescription(node) {
+    // This cast is unsound, and might throw at runtime, but won't have
+    // silent failures or cause problems down the road.
+    const address = N.fromRaw((node: any));
+    return description(address);
+  }
+}

--- a/src/v3/plugins/git/render.js
+++ b/src/v3/plugins/git/render.js
@@ -1,0 +1,20 @@
+// @flow
+
+import * as N from "./nodes";
+
+export function description(address: N.StructuredAddress) {
+  switch (address.type) {
+    case "COMMIT":
+      return `commit ${address.hash}`;
+    case "TREE":
+      return `tree ${address.hash}`;
+    case "BLOB":
+      return `blob ${address.hash}`;
+    case "TREE_ENTRY":
+      return `entry ${JSON.stringify(address.name)} in tree ${
+        address.treeHash
+      }`;
+    default:
+      throw new Error(`unknown type: ${(address.type: empty)}`);
+  }
+}

--- a/src/v3/plugins/git/render.test.js
+++ b/src/v3/plugins/git/render.test.js
@@ -1,0 +1,38 @@
+// @flow
+
+import * as GN from "./nodes";
+import {description} from "./render";
+
+describe("plugins/git/render", () => {
+  const examples = {
+    blob: (): GN.BlobAddress => ({
+      type: GN.BLOB_TYPE,
+      hash: "f1f2514ca6d7a6a1a0511957021b1995bf9ace1c",
+    }),
+    commit: (): GN.CommitAddress => ({
+      type: GN.COMMIT_TYPE,
+      hash: "3715ddfb8d4c4fd2a6f6af75488c82f84c92ec2f",
+    }),
+    tree: (): GN.TreeAddress => ({
+      type: GN.TREE_TYPE,
+      hash: "7be3ecfee5314ffa9b2d93fc4377792b2d6d70ed",
+    }),
+    treeEntry: (): GN.TreeEntryAddress => ({
+      type: GN.TREE_ENTRY_TYPE,
+      treeHash: "7be3ecfee5314ffa9b2d93fc4377792b2d6d70ed",
+      name: "science.txt",
+    }),
+  };
+  it("blob snapshots as expected", () => {
+    expect(description(examples.blob())).toMatchSnapshot();
+  });
+  it("commit snapshots as expected", () => {
+    expect(description(examples.commit())).toMatchSnapshot();
+  });
+  it("tree snapshots as expected", () => {
+    expect(description(examples.tree())).toMatchSnapshot();
+  });
+  it("treeEntry snapshots as expected", () => {
+    expect(description(examples.treeEntry())).toMatchSnapshot();
+  });
+});


### PR DESCRIPTION
Test plan:
Run the following commands:

```
node bin/sourcecredV3.js load-plugin-v3 sourcecred example-github --plugin=git
node bin/sourcecredV3.js load-plugin-v3 sourcecred example-github --plugin=github
yarn start
```

Then, navigate in-browser to the v3 cred explorer and load data for
`sourcecred/example-github`. The following messages are printed to
console:

```
GitHub: Loaded graph: 31 nodes, 73 edges.
Git: Loaded graph: 15 nodes, 19 edges.
Combined: Loaded graph: 44 nodes, 92 edges.
```

Paired with @wchargin