### PR TITLE
Add `name` function to plugin adapter

### DIFF
--- a/src/v3/app/pluginAdapter.js
+++ b/src/v3/app/pluginAdapter.js
@@ -7,6 +7,7 @@ export interface Renderer {
 }
 
 export interface PluginAdapter {
+  name(): string;
   graph(): Graph;
   renderer(): Renderer;
   nodePrefix(): NodeAddressT;

--- a/src/v3/plugins/git/pluginAdapter.js
+++ b/src/v3/plugins/git/pluginAdapter.js
@@ -26,6 +26,9 @@ class PluginAdapter implements IPluginAdapter {
   constructor(graph: Graph) {
     this._graph = graph;
   }
+  name() {
+    return "Git";
+  }
   graph() {
     return this._graph;
   }

--- a/src/v3/plugins/github/pluginAdapter.js
+++ b/src/v3/plugins/github/pluginAdapter.js
@@ -31,6 +31,9 @@ class PluginAdapter implements IPluginAdapter {
     this._view = view;
     this._graph = graph;
   }
+  name() {
+    return "GitHub";
+  }
   graph() {
     return this._graph;
   }


### PR DESCRIPTION
Summary:
This presents a human-readable name for a plugin. It’s not yet used
anywhere.

Paired with @decentralion.

Test Plan:
Flow passes.

wchargin-branch: plugin-name