### PR TITLE
Add “node types” listing to plugin adapter

### DIFF
--- a/src/v3/app/pluginAdapter.js
+++ b/src/v3/app/pluginAdapter.js
@@ -11,4 +11,8 @@ export interface PluginAdapter {
   graph(): Graph;
   renderer(): Renderer;
   nodePrefix(): NodeAddressT;
+  nodeTypes(): Array<{|
+    +name: string,
+    +prefix: NodeAddressT,
+  |}>;
 }

--- a/src/v3/plugins/git/pluginAdapter.js
+++ b/src/v3/plugins/git/pluginAdapter.js
@@ -38,6 +38,14 @@ class PluginAdapter implements IPluginAdapter {
   nodePrefix() {
     return N._Prefix.base;
   }
+  nodeTypes() {
+    return [
+      {name: "Blob", prefix: N._Prefix.blob},
+      {name: "Commit", prefix: N._Prefix.commit},
+      {name: "Tree", prefix: N._Prefix.tree},
+      {name: "Tree entry", prefix: N._Prefix.treeEntry},
+    ];
+  }
 }
 
 class Renderer implements IRenderer {

--- a/src/v3/plugins/github/pluginAdapter.js
+++ b/src/v3/plugins/github/pluginAdapter.js
@@ -43,6 +43,16 @@ class PluginAdapter implements IPluginAdapter {
   nodePrefix() {
     return N._Prefix.base;
   }
+  nodeTypes() {
+    return [
+      {name: "Repository", prefix: N._Prefix.repo},
+      {name: "Issue", prefix: N._Prefix.issue},
+      {name: "Pull request", prefix: N._Prefix.pull},
+      {name: "Pull request review", prefix: N._Prefix.review},
+      {name: "Comment", prefix: N._Prefix.comment},
+      {name: "User", prefix: N._Prefix.userlike},
+    ];
+  }
 }
 
 class Renderer implements IRenderer {


### PR DESCRIPTION
Summary:
This enables plugins to specify different semantic types of nodes, along
with human-readable names. This will be used, for instance, in the cred
explorer, where users may filter to one of these node types.

Paired with @decentralion.

Test Plan:
Flow passes.

wchargin-branch: plugin-node-types