### PR TITLE
Add load CLI command

### DIFF
--- a/config/paths.js
+++ b/config/paths.js
@@ -61,7 +61,7 @@ module.exports = {
     apiApp: resolveApp("src/v1/app/apiApp.js"),
     //
     sourcecredV3: resolveApp("src/v3/cli/sourcecred.js"),
-    "commands/load-plugin-v3": resolveApp("src/v3/cli/commands/loadPlugin.js"),
+    "commands/load": resolveApp("src/v3/cli/commands/load.js"),
     //
     fetchAndPrintGithubRepo: resolveApp(
       "src/v1/plugins/github/bin/fetchAndPrintGithubRepo.js"


### PR DESCRIPTION
The `load` command replaces `plugin-load`. By default, it loads data for
all plugins, and does so in parallel using execDependencyGraph. If
passed the optional `--plugin` flag, then it will load data just for
that plugin.

As an implementation detail, when loading all plugins, load calls itself
with the plugin flag set.

Usage:
`node bin/sourcecred.js load repoOwner repoName`

Test plan:
Tested by hand; I blew away my SourceCred directory and then loaded the
example-github repository.