### PR TITLE
Extract contiguous blocks of text from Markdown

### DIFF
--- a/src/plugins/github/parseMarkdown.test.js
+++ b/src/plugins/github/parseMarkdown.test.js
@@ -2,7 +2,7 @@
 
 import {Node, Parser, XmlRenderer} from "commonmark";
 
-import {deformat, coalesceText} from "./parseMarkdown";
+import {coalesceText, deformat, textBlocks} from "./parseMarkdown";
 
 describe("plugins/github/parseMarkdown", () => {
   function astContents(ast) {
@@ -12,6 +12,45 @@ describe("plugins/github/parseMarkdown", () => {
     // that the Jest diffs are much more readable.
     return new XmlRenderer().render(ast);
   }
+
+  describe("textBlocks", () => {
+    it("works on a full example", () => {
+      const input = [
+        "Hello *dear **world** of* friends",
+        "and everyone else, too.",
+        "",
+        "Some `code` for [you][1]:",
+        "",
+        "```markdown",
+        "# such *meta*",
+        "much wow",
+        "```",
+        "",
+        "[1]: https://example.com/",
+        "",
+        "Here's a list: <!-- it's a secret -->",
+        "  - **important** things",
+        "  - *also **important*** stuff",
+        "  - a*b*c versus `a*b*c`",
+        "",
+        "> idea: ![lightbulb icon] never mind I forgot",
+        "",
+        "[lightbulb icon]: https://example.com/lightbulb.png",
+        "",
+      ].join("\n");
+      const expected = [
+        "Hello dear world of friends and everyone else, too.",
+        "Some ",
+        " for you:",
+        "Here's a list: ",
+        "important things",
+        "also important stuff",
+        "abc versus ",
+        "idea: lightbulb icon never mind I forgot",
+      ];
+      expect(textBlocks(input)).toEqual(expected);
+    });
+  });
 
   describe("coalesceText", () => {
     it("coalesces adjacent text blocks", () => {


### PR DESCRIPTION
Summary:
This commit exposes a function of type `(string): string[]` to
encapsulate the whole Markdown pipeline, from parsing to AST
transformation to text node extraction. Clients of this module do not
need to know about `commonmark`.

Test Plan:
A single comprehensive test case has been added.

wchargin-branch: text-blocks