### PR TITLE
Display edges in Cred Explorer

### DIFF
--- a/src/app/credExplorer/__snapshots__/PagerankTable.test.js.snap
+++ b/src/app/credExplorer/__snapshots__/PagerankTable.test.js.snap
@@ -53,7 +53,16 @@ Array [
 ]
 `;
 
-exports[`app/credExplorer/PagerankTable full rendering tables  subtables have depth-based styling 1`] = `
+exports[`app/credExplorer/PagerankTable full rendering tables sub-tables display extra information about edges 1`] = `
+Array [
+  "bars and is barred by bar: NodeAddress[\\"bar\\",\\"a\\",\\"1\\"]",
+  "bars xox node!",
+  "bars xox node!",
+  "is fooed by foo: NodeAddress[\\"foo\\",\\"a\\",\\"1\\"]",
+]
+`;
+
+exports[`app/credExplorer/PagerankTable full rendering tables sub-tables have depth-based styling 1`] = `
 Array [
   Object {
     "button": Object {

--- a/src/app/pluginAdapter.js
+++ b/src/app/pluginAdapter.js
@@ -1,9 +1,10 @@
 // @flow
 
-import type {Graph, NodeAddressT} from "../core/graph";
+import type {Graph, NodeAddressT, EdgeAddressT} from "../core/graph";
 
 export interface Renderer {
   nodeDescription(NodeAddressT): string;
+  edgeVerb(EdgeAddressT, "FORWARD" | "BACKWARD"): string;
 }
 
 export interface PluginAdapter {
@@ -11,6 +12,7 @@ export interface PluginAdapter {
   graph(): Graph;
   renderer(): Renderer;
   nodePrefix(): NodeAddressT;
+  edgePrefix(): EdgeAddressT;
   nodeTypes(): Array<{|
     +name: string,
     +prefix: NodeAddressT,

--- a/src/plugins/git/pluginAdapter.js
+++ b/src/plugins/git/pluginAdapter.js
@@ -5,7 +5,8 @@ import type {
 } from "../../app/pluginAdapter";
 import {Graph} from "../../core/graph";
 import * as N from "./nodes";
-import {description} from "./render";
+import * as E from "./edges";
+import {description, edgeVerb} from "./render";
 
 export async function createPluginAdapter(
   repoOwner: string,
@@ -38,6 +39,9 @@ class PluginAdapter implements IPluginAdapter {
   nodePrefix() {
     return N._Prefix.base;
   }
+  edgePrefix() {
+    return E._Prefix.base;
+  }
   nodeTypes() {
     return [
       {name: "Blob", prefix: N._Prefix.blob},
@@ -54,5 +58,8 @@ class Renderer implements IRenderer {
     // silent failures or cause problems down the road.
     const address = N.fromRaw((node: any));
     return description(address);
+  }
+  edgeVerb(edgeAddress, direction) {
+    return edgeVerb(E.fromRaw((edgeAddress: any)), direction);
   }
 }

--- a/src/plugins/git/render.js
+++ b/src/plugins/git/render.js
@@ -1,6 +1,7 @@
 // @flow
 
 import * as N from "./nodes";
+import * as E from "./edges";
 
 export function description(address: N.StructuredAddress) {
   switch (address.type) {
@@ -14,6 +15,27 @@ export function description(address: N.StructuredAddress) {
       return `entry ${JSON.stringify(address.name)} in tree ${
         address.treeHash
       }`;
+    default:
+      throw new Error(`unknown type: ${(address.type: empty)}`);
+  }
+}
+
+export function edgeVerb(
+  address: E.StructuredAddress,
+  direction: "FORWARD" | "BACKWARD"
+) {
+  const forward = direction === "FORWARD";
+  switch (address.type) {
+    case "HAS_TREE":
+      return forward ? "has tree" : "owned by";
+    case "HAS_PARENT":
+      return forward ? "has parent" : "is parent of";
+    case "INCLUDES":
+      return forward ? "includes" : "is included by";
+    case "BECOMES":
+      return forward ? "evolves to" : "evolves from";
+    case "HAS_CONTENTS":
+      return forward ? "has contents" : "is contents of";
     default:
       throw new Error(`unknown type: ${(address.type: empty)}`);
   }

--- a/src/plugins/github/pluginAdapter.js
+++ b/src/plugins/github/pluginAdapter.js
@@ -6,8 +6,9 @@ import type {
 import {type Graph, NodeAddress} from "../../core/graph";
 import {createGraph} from "./createGraph";
 import * as N from "./nodes";
+import * as E from "./edges";
 import {RelationalView} from "./relationalView";
-import {description} from "./render";
+import {description, edgeVerb} from "./render";
 
 export async function createPluginAdapter(
   repoOwner: string,
@@ -43,6 +44,9 @@ class PluginAdapter implements IPluginAdapter {
   nodePrefix() {
     return N._Prefix.base;
   }
+  edgePrefix() {
+    return E._Prefix.base;
+  }
   nodeTypes() {
     return [
       {name: "Repository", prefix: N._Prefix.repo},
@@ -69,5 +73,8 @@ class Renderer implements IRenderer {
       throw new Error(`unknown entity: ${NodeAddress.toString(node)}`);
     }
     return description(entity);
+  }
+  edgeVerb(edgeAddress, direction) {
+    return edgeVerb(E.fromRaw((edgeAddress: any)), direction);
   }
 }

--- a/src/plugins/github/render.js
+++ b/src/plugins/github/render.js
@@ -1,6 +1,7 @@
 // @flow
 
 import * as R from "./relationalView";
+import * as E from "./edges";
 
 export function description(e: R.Entity) {
   const withAuthors = (x: R.AuthoredEntity) => {
@@ -23,4 +24,23 @@ export function description(e: R.Entity) {
     userlike: (x) => `@${x.login()}`,
   };
   return R.match(handlers, e);
+}
+
+export function edgeVerb(
+  e: E.StructuredAddress,
+  direction: "FORWARD" | "BACKWARD"
+) {
+  const forward = direction === "FORWARD";
+  switch (e.type) {
+    case "AUTHORS":
+      return forward ? "authors" : "is authored by";
+    case "MERGED_AS":
+      return forward ? "merges" : "is merged by";
+    case "HAS_PARENT":
+      return forward ? "has parent" : "has child";
+    case "REFERENCES":
+      return forward ? "references" : "is referenced by";
+    default:
+      throw new Error(`Unexpected type ${(e.type: empty)}`);
+  }
 }


### PR DESCRIPTION
Previously, when expanding a node in the cred explorer, it would display
the neighboring nodes, but not any information about the edges linking
to that node. If the same node was reached by multiple edges, this
information was not communicated to the user.

As of this commit, it now concisely communicates what kind of edge was
connecting the chosen node to its adjacencies. There's a new `edgeVerb`
method that plugin adapters must implement, which gives a
direction-based verb descriptiong of the edge, e.g. "authors" or "is
authored by".

Test plan:
Unit tests added to the PagerankTable tests, and hand inspection.

Paired with @wchargin