### PR TITLE
Expose contributions structure of Markov chains

### DIFF
--- a/src/core/attribution/__snapshots__/pagerank.test.js.snap
+++ b/src/core/attribution/__snapshots__/pagerank.test.js.snap
@@ -47,7 +47,7 @@ Array [
     "parts": Array [
       "loop",
     ],
-    "probability": 0.25,
+    "probability": 0.25000000000000017,
   },
   Object {
     "parts": Array [

--- a/src/core/attribution/pagerank.js
+++ b/src/core/attribution/pagerank.js
@@ -4,7 +4,8 @@ import {type Edge, Graph} from "../graph";
 import {
   type PagerankResult,
   distributionToPagerankResult,
-  graphToOrderedSparseMarkovChain,
+  createContributions,
+  createOrderedSparseMarkovChain,
   type EdgeWeight,
 } from "./graphToMarkovChain";
 
@@ -39,11 +40,12 @@ export function pagerank(
     ...defaultOptions(),
     ...(options || {}),
   };
-  const osmc = graphToOrderedSparseMarkovChain(
+  const contributions = createContributions(
     graph,
     edgeWeight,
     fullOptions.selfLoopWeight
   );
+  const osmc = createOrderedSparseMarkovChain(contributions);
   const distribution = findStationaryDistribution(osmc.chain, {
     verbose: fullOptions.verbose,
     convergenceThreshold: fullOptions.convergenceThreshold,

--- a/src/core/attribution/pagerank.test.js
+++ b/src/core/attribution/pagerank.test.js
@@ -5,6 +5,8 @@ import {NodeAddress} from "../graph";
 import {advancedGraph} from "../graphTestUtil";
 
 function snapshotPagerankResult(result) {
+  const prTotal = Array.from(result.values()).reduce((a, b) => a + b, 0);
+  expect(prTotal).toBeCloseTo(1.0, 1e-9);
   const partsToProbability = [];
   const sortedKeys = Array.from(result.keys()).sort();
   for (const key of sortedKeys) {


### PR DESCRIPTION
Summary:
When we convert a graph to a Markov chain, each cell in the transition
matrix is a sum of edge weights from the given `src` to the given `dst`,
plus the synthetic self-loop needed for stability. Performing this sum
loses information: given the transition matrix, a client cannot
determine how much a particular edge contributed to the score of a node
without redoing the relevant computations. In this commit, we expose the
structure of these contributions (i.e., edges and synthetic loops).

This changes the API of `graphToMarkovChain.js`, but it does not change
the resulting Markov chains. It also does not change the API of
`pagerank.js`. In particular, clients of `pagerank.js` will not have
access to the contributions structure that we have just created.

Test Plan:
Existing unit tests have been updated to use the new API, and pass
without change. An additional test is added for a newly exposed
function, even though this function is also tested extensively as part
of later downstream tests.

In one snapshot, one value changes from `0.25` to `0.25 + 1.7e-16`. The
other values in the enclosing distribution do not change, so I think
that it is more likely that this is due to floating-point instability
than an actual bug. (I’m not sure where exactly I commuted or associated
an operation, but it’s quite possible that I may have done so). To
compensate, I added an additional check that the values in the
stationary distribution sum to `1.0` within `1e-9` tolerance; this check
passes.

wchargin-branch: expose-contributions