### PR TITLE
Use `MapUtil` functions where appropriate

### DIFF
--- a/src/core/address.js
+++ b/src/core/address.js
@@ -2,6 +2,8 @@
 
 import stringify from "json-stable-stringify";
 
+import * as MapUtil from "../util/map";
+
 export interface AddressModule<Address> {
   /**
    * Assert at runtime that the provided address is actually a valid
@@ -106,20 +108,22 @@ export function makeAddressModule(options: Options): AddressModule<string> {
   }
 
   const nonceWithSeparator = nonce + separator;
-  const otherNoncesWithSeparators = new Map();
-  for (const [otherNonce, otherName] of otherNonces.entries()) {
-    if (otherNonce === nonce) {
-      throw new Error(
-        `primary nonce listed as otherNonce: ${stringify(nonce)}`
-      );
+  const otherNoncesWithSeparators = MapUtil.mapKeys(
+    otherNonces,
+    (otherNonce) => {
+      if (otherNonce === nonce) {
+        throw new Error(
+          `primary nonce listed as otherNonce: ${stringify(nonce)}`
+        );
+      }
+      if (otherNonce.indexOf(separator) !== -1) {
+        throw new Error(
+          `invalid otherNonce (contains NUL): ${stringify(otherNonce)}`
+        );
+      }
+      return otherNonce + separator;
     }
-    if (otherNonce.indexOf(separator) !== -1) {
-      throw new Error(
-        `invalid otherNonce (contains NUL): ${stringify(otherNonce)}`
-      );
-    }
-    otherNoncesWithSeparators.set(otherNonce + separator, otherName);
-  }
+  );
 
   function assertValid(address: Address, what?: string): void {
     // TODO(perf): If this function becomes a bottleneck, consider

--- a/src/core/attribution/graphToMarkovChain.js
+++ b/src/core/attribution/graphToMarkovChain.js
@@ -2,6 +2,7 @@
 
 import {type Edge, type Graph, type NodeAddressT, NodeAddress} from "../graph";
 import type {Distribution, SparseMarkovChain} from "./markovChain";
+import * as MapUtil from "../../util/map";
 
 export type Probability = number;
 export type Contributor =
@@ -132,10 +133,8 @@ export function createContributions(
 function createNodeAddressMarkovChain(
   ntc: NodeToContributions
 ): NodeAddressMarkovChain {
-  const result: NodeAddressMarkovChain = new Map();
-  for (const [target, contributions] of ntc.entries()) {
+  return MapUtil.mapValues(ntc, (target, contributions) => {
     const inNeighbors = new Map();
-    result.set(target, inNeighbors);
     for (const contribution of contributions) {
       const source = contributorSource(target, contribution.contributor);
       inNeighbors.set(
@@ -143,8 +142,8 @@ function createNodeAddressMarkovChain(
         contribution.weight + (inNeighbors.get(source) || 0)
       );
     }
-  }
-  return result;
+    return inNeighbors;
+  });
 }
 
 function nodeAddressMarkovChainToOrderedSparseMarkovChain(

--- a/src/core/attribution/graphToMarkovChain.test.js
+++ b/src/core/attribution/graphToMarkovChain.test.js
@@ -11,6 +11,7 @@ import {
   normalizeNeighbors,
   permute,
 } from "./graphToMarkovChain";
+import * as MapUtil from "../../util/map";
 
 import {advancedGraph} from "../graphTestUtil";
 
@@ -124,12 +125,7 @@ describe("core/attribution/graphToMarkovChain", () => {
           {contributor: {type: "OUT_EDGE", edge: e4}, weight: 3 / 16},
         ]);
       const canonicalize = (map) =>
-        new Map(
-          Array.from(map.entries()).map(([k, v]) => [
-            k,
-            sortBy(v, (x) => JSON.stringify(x)),
-          ])
-        );
+        MapUtil.mapValues(map, (_, v) => sortBy(v, (x) => JSON.stringify(x)));
       expect(canonicalize(actual)).toEqual(canonicalize(expected));
     });
   });

--- a/src/plugins/github/relationalView.js
+++ b/src/plugins/github/relationalView.js
@@ -15,6 +15,7 @@ import type {
 } from "./nodes";
 import * as Q from "./graphql";
 import * as GitNode from "../git/nodes";
+import * as MapUtil from "../../util/map";
 
 import {
   reviewUrlToId,
@@ -191,14 +192,14 @@ export class RelationalView {
 
   toJSON(): RelationalViewJSON {
     const rawJSON = {
-      repos: addressMapToObject(this._repos),
-      issues: addressMapToObject(this._issues),
-      pulls: addressMapToObject(this._pulls),
-      reviews: addressMapToObject(this._reviews),
-      comments: addressMapToObject(this._comments),
-      userlikes: addressMapToObject(this._userlikes),
-      references: addressMapToObject(this._mapReferences),
-      referencedBy: addressMapToObject(this._mapReferencedBy),
+      repos: MapUtil.toObject(this._repos),
+      issues: MapUtil.toObject(this._issues),
+      pulls: MapUtil.toObject(this._pulls),
+      reviews: MapUtil.toObject(this._reviews),
+      comments: MapUtil.toObject(this._comments),
+      userlikes: MapUtil.toObject(this._userlikes),
+      references: MapUtil.toObject(this._mapReferences),
+      referencedBy: MapUtil.toObject(this._mapReferencedBy),
     };
     return toCompat(COMPAT_INFO, rawJSON);
   }
@@ -206,14 +207,14 @@ export class RelationalView {
   static fromJSON(compatJson: RelationalViewJSON): RelationalView {
     const json = fromCompat(COMPAT_INFO, compatJson);
     const rv = new RelationalView();
-    rv._repos = objectToAddressMap(json.repos);
-    rv._issues = objectToAddressMap(json.issues);
-    rv._pulls = objectToAddressMap(json.pulls);
-    rv._reviews = objectToAddressMap(json.reviews);
-    rv._comments = objectToAddressMap(json.comments);
-    rv._userlikes = objectToAddressMap(json.userlikes);
-    rv._mapReferences = objectToAddressMap(json.references);
-    rv._mapReferencedBy = objectToAddressMap(json.referencedBy);
+    rv._repos = MapUtil.fromObject(json.repos);
+    rv._issues = MapUtil.fromObject(json.issues);
+    rv._pulls = MapUtil.fromObject(json.pulls);
+    rv._reviews = MapUtil.fromObject(json.reviews);
+    rv._comments = MapUtil.fromObject(json.comments);
+    rv._userlikes = MapUtil.fromObject(json.userlikes);
+    rv._mapReferences = MapUtil.fromObject(json.references);
+    rv._mapReferencedBy = MapUtil.fromObject(json.referencedBy);
     return rv;
   }
 
@@ -837,27 +838,6 @@ export type TextContentEntity = Issue | Pull | Review | Comment;
 export type ParentEntity = Repo | Issue | Pull | Review;
 export type ChildEntity = Issue | Pull | Review | Comment;
 export type ReferentEntity = Repo | Issue | Pull | Review | Comment | Userlike;
-
-function addressMapToObject<T>(
-  x: Map<N.RawAddress, T>
-): AddressEntryMapJSON<T> {
-  const result: {[N.RawAddress]: T} = {};
-  for (const [address, entry] of x.entries()) {
-    result[address] = entry;
-  }
-  return result;
-}
-
-function objectToAddressMap<T>(
-  x: AddressEntryMapJSON<T>
-): Map<N.RawAddress, T> {
-  const result = new Map();
-  for (const key of Object.keys(x)) {
-    const address: N.RawAddress = (key: any);
-    result.set(address, x[address]);
-  }
-  return result;
-}
 
 export opaque type AddressEntryMapJSON<T> = {[N.RawAddress]: T};
 export opaque type RelationalViewJSON = Compatible<{|


### PR DESCRIPTION
Summary:
These call sites were selected from `git grep Map`. In this commit, we
only add usage of the utility functions; we do not change any existing
object types to maps.

Test Plan:
Running `yarn travis --full` passes.

wchargin-branch: use-map-util