### PR TITLE
Add `edgeToStrings` for easy snapshotting

### DIFF
--- a/src/core/graph.js
+++ b/src/core/graph.js
@@ -614,6 +614,25 @@ export function edgeToString(edge: Edge): string {
   return `{address: ${address}, src: ${src}, dst: ${dst}}`;
 }
 
+/**
+ * Convert an edge to an object whose fields are human-readable strings.
+ * This is useful for storing edges in human-readable formats that
+ * should not include NUL characters, such as Jest snapshots.
+ */
+export function edgeToStrings(
+  edge: Edge
+): {|
+  +address: string,
+  +src: string,
+  +dst: string,
+|} {
+  return {
+    address: EdgeAddress.toString(edge.address),
+    src: NodeAddress.toString(edge.src),
+    dst: NodeAddress.toString(edge.dst),
+  };
+}
+
 export function edgeToParts(
   edge: Edge
 ): {|+addressParts: string[], +srcParts: string[], +dstParts: string[]|} {

--- a/src/core/graph.test.js
+++ b/src/core/graph.test.js
@@ -14,6 +14,7 @@ import {
   Graph,
   NodeAddress,
   edgeToString,
+  edgeToStrings,
   edgeToParts,
 } from "./graph";
 import {advancedGraph} from "./graphTestUtil";
@@ -1388,6 +1389,22 @@ describe("core/graph", () => {
         'dst: NodeAddress["five","six"]' +
         "}";
       expect(edgeToString(edge)).toEqual(expected);
+    });
+  });
+
+  describe("edgeToStrings", () => {
+    it("works", () => {
+      const edge = {
+        address: EdgeAddress.fromParts(["one", "two"]),
+        dst: NodeAddress.fromParts(["five", "six"]),
+        src: NodeAddress.fromParts(["three", "four"]),
+      };
+      const expected = {
+        address: 'EdgeAddress["one","two"]',
+        src: 'NodeAddress["three","four"]',
+        dst: 'NodeAddress["five","six"]',
+      };
+      expect(edgeToStrings(edge)).toEqual(expected);
     });
   });
 


### PR DESCRIPTION
Summary:
If we want to snapshot an edge, then none of the available options is
ideal:

  - Snapshotting the edge directly includes literal NUL bytes in the
    snapshot file, so it is treated as binary. This is bad.

  - Using `edgeToString` works, but all fields of the edge are combined
    into a single string, which is somewhat hard to read.

  - Using `edgeToParts` works, but each address in the edge takes up a
    lot of visual space: one line per part in the address. This is also
    somewhat hard to read.

This commit adds `edgeToStrings`, which simply applies the appropriate
`toString` operation to each field of an edge.

Test Plan:
Unit tests added; run `yarn travis`.

wchargin-branch: edge-to-strings