### PR TITLE
Use `NullUtil` functions where appropriate

### DIFF
--- a/src/app/credExplorer/App.js
+++ b/src/app/credExplorer/App.js
@@ -13,6 +13,8 @@ import type {PluginAdapter} from "../pluginAdapter";
 import {type EdgeEvaluator} from "../../core/attribution/pagerank";
 import {WeightConfig} from "./WeightConfig";
 
+import * as NullUtil from "../../util/null";
+
 type Props = {};
 type State = {
   repoOwner: string,
@@ -121,8 +123,8 @@ export default class App extends React.Component<Props, State> {
           )}
           <WeightConfig onChange={(ee) => this.setState({edgeEvaluator: ee})} />
           <PagerankTable
-            graph={graphWithMetadata ? graphWithMetadata.graph : null}
-            adapters={graphWithMetadata ? graphWithMetadata.adapters : null}
+            graph={NullUtil.map(graphWithMetadata, (x) => x.graph)}
+            adapters={NullUtil.map(graphWithMetadata, (x) => x.adapters)}
             pagerankResult={pagerankResult}
           />
         </div>

--- a/src/app/credExplorer/WeightConfig.js
+++ b/src/app/credExplorer/WeightConfig.js
@@ -13,6 +13,7 @@ import {type EdgeEvaluator} from "../../core/attribution/pagerank";
 import {byEdgeType, byNodeType} from "./edgeWeights";
 import LocalStore from "./LocalStore";
 import * as MapUtil from "../../util/map";
+import * as NullUtil from "../../util/null";
 
 // Hacks...
 import * as GithubNode from "../../plugins/github/nodes";
@@ -73,19 +74,13 @@ export class WeightConfig extends React.Component<Props, State> {
   componentDidMount() {
     this.setState(
       (state) => {
-        function rehydrate<K: string, V>(
-          x: ?{[K]: V},
-          default_: Map<K, V>
-        ): Map<K, V> {
-          return x ? MapUtil.fromObject(x) : default_;
-        }
         return {
-          edgeWeights: rehydrate(
-            LocalStore.get(EDGE_WEIGHTS_KEY),
+          edgeWeights: NullUtil.orElse(
+            NullUtil.map(LocalStore.get(EDGE_WEIGHTS_KEY), MapUtil.fromObject),
             state.edgeWeights
           ),
-          nodeWeights: rehydrate(
-            LocalStore.get(NODE_WEIGHTS_KEY),
+          nodeWeights: NullUtil.orElse(
+            NullUtil.map(LocalStore.get(NODE_WEIGHTS_KEY), MapUtil.fromObject),
             state.nodeWeights
           ),
         };

--- a/src/app/credExplorer/edgeWeights.js
+++ b/src/app/credExplorer/edgeWeights.js
@@ -8,6 +8,8 @@ import {
 } from "../../core/graph";
 import type {EdgeEvaluator} from "../../core/attribution/pagerank";
 
+import * as NullUtil from "../../util/null";
+
 export function byEdgeType(
   prefixes: $ReadOnlyArray<{|
     +prefix: EdgeAddressT,
@@ -16,13 +18,9 @@ export function byEdgeType(
   |}>
 ): EdgeEvaluator {
   return function evaluator(edge: Edge) {
-    const datum = prefixes.find(({prefix}) =>
-      EdgeAddress.hasPrefix(edge.address, prefix)
+    const {weight, directionality} = NullUtil.get(
+      prefixes.find(({prefix}) => EdgeAddress.hasPrefix(edge.address, prefix))
     );
-    if (datum == null) {
-      throw new Error(EdgeAddress.toString(edge.address));
-    }
-    const {weight, directionality} = datum;
     return {
       toWeight: directionality * weight,
       froWeight: (1 - directionality) * weight,

--- a/src/core/attribution/pagerankNodeDecomposition.js
+++ b/src/core/attribution/pagerankNodeDecomposition.js
@@ -2,7 +2,7 @@
 
 import sortBy from "lodash.sortby";
 
-import {type NodeAddressT, NodeAddress} from "../graph";
+import type {NodeAddressT} from "../graph";
 import {
   type Contribution,
   type NodeToContributions,
@@ -10,6 +10,7 @@ import {
 } from "./graphToMarkovChain";
 import type {NodeDistribution} from "./pagerank";
 import * as MapUtil from "../../util/map";
+import * as NullUtil from "../../util/null";
 
 export type ScoredContribution = {|
   +contribution: Contribution,
@@ -33,18 +34,12 @@ export function decompose(
   contributions: NodeToContributions
 ): PagerankNodeDecomposition {
   return MapUtil.mapValues(contributions, (target, contributions) => {
-    const score = pr.get(target);
-    if (score == null) {
-      throw new Error("missing target: " + NodeAddress.toString(target));
-    }
+    const score = NullUtil.get(pr.get(target));
     const scoredContributions = sortBy(
       contributions.map(
         (contribution): ScoredContribution => {
           const source = contributorSource(target, contribution.contributor);
-          const sourceScore = pr.get(source);
-          if (sourceScore == null) {
-            throw new Error("missing source: " + NodeAddress.toString(source));
-          }
+          const sourceScore = NullUtil.get(pr.get(source));
           const contributionScore = contribution.weight * sourceScore;
           return {contribution, source, sourceScore, contributionScore};
         }

--- a/src/plugins/git/bin/createExampleRepo.js
+++ b/src/plugins/git/bin/createExampleRepo.js
@@ -6,6 +6,7 @@ import {
   createExampleRepo,
   createExampleSubmoduleRepo,
 } from "../example/exampleRepo";
+import * as NullUtil from "../../../util/null";
 
 function parseArgs() {
   const argv = process.argv.slice(2);
@@ -31,13 +32,9 @@ function parseArgs() {
     }
   }
 
-  if (target == null) {
-    fail();
-    throw new Error("Unreachable"); // for Flow
-  }
   return {
     submodule,
-    target: (target: string),
+    target: NullUtil.get(target),
   };
 }
 


### PR DESCRIPTION
Summary:
The aesthetically nicest win is in `WeightConfig`. Other changes are
nice to have.

In many cases, we reduce the specificity of error messages thrown. For
instance, if an invariant was violated on an edge `e`, then we might
have thrown an error with message `EdgeAddress.toString(e.address)`. But
we did so not because we thought that this was genuinely worth it, but
only because we were forced to explicitly throw an error at all. These
errors should never be hit, anyway, so we don’t feel bad about replacing
these with errors that are simply the string `"null"` or `"undefined"`,
as appropriate.

Test Plan:
Running `yarn travis --full` passes, and the cred explorer still seems
to work with both populated and empty `localStorage`.

wchargin-branch: use-null-util