### PR TITLE
Create `EdgeEvaluator` and `NodeEvaluator` APIs

### DIFF
--- a/src/app/credExplorer/App.js
+++ b/src/app/credExplorer/App.js
@@ -10,7 +10,7 @@ import {Graph} from "../../core/graph";
 import {pagerank, type NodeDistribution} from "../../core/attribution/pagerank";
 import {PagerankTable} from "./PagerankTable";
 import type {PluginAdapter} from "../pluginAdapter";
-import {type EdgeEvaluator} from "../../core/attribution/pagerank";
+import {type EdgeEvaluator} from "../../core/attribution/weights";
 import {WeightConfig} from "./WeightConfig";
 
 import * as NullUtil from "../../util/null";

--- a/src/app/credExplorer/WeightConfig.js
+++ b/src/app/credExplorer/WeightConfig.js
@@ -9,8 +9,11 @@ import {
   NodeAddress,
 } from "../../core/graph";
 
-import {type EdgeEvaluator} from "../../core/attribution/pagerank";
-import {byEdgeType, byNodeType} from "./edgeWeights";
+import {edgeByPrefix, nodeByPrefix} from "./edgeWeights";
+import {
+  type EdgeEvaluator,
+  liftNodeEvaluator,
+} from "../../core/attribution/weights";
 import LocalStore from "./LocalStore";
 import * as MapUtil from "../../util/map";
 import * as NullUtil from "../../util/null";
@@ -127,8 +130,10 @@ export class WeightConfig extends React.Component<Props, State> {
         weight: 2 ** logWeight,
       })
     );
-    const edgeEvaluator = byNodeType(byEdgeType(edgePrefixes), nodePrefixes);
-    this.props.onChange(edgeEvaluator);
+    const nodeEvaluator = nodeByPrefix(nodePrefixes);
+    const edgeEvaluator = edgeByPrefix(edgePrefixes);
+    const composedEvaluator = liftNodeEvaluator(nodeEvaluator, edgeEvaluator);
+    this.props.onChange(composedEvaluator);
   }
 }
 

--- a/src/core/attribution/pagerank.js
+++ b/src/core/attribution/pagerank.js
@@ -1,15 +1,15 @@
 // @flow
 
-import {type Edge, Graph} from "../graph";
+import {Graph} from "../graph";
 import {
   type NodeDistribution,
   distributionToNodeDistribution,
   createContributions,
   createOrderedSparseMarkovChain,
-  type EdgeWeight,
 } from "./graphToMarkovChain";
 
 import {findStationaryDistribution} from "./markovChain";
+import type {EdgeEvaluator} from "./weights";
 
 export type {NodeDistribution} from "./graphToMarkovChain";
 export type PagerankOptions = {|
@@ -18,9 +18,6 @@ export type PagerankOptions = {|
   +convergenceThreshold?: number,
   +maxIterations?: number,
 |};
-
-export type {EdgeWeight} from "./graphToMarkovChain";
-export type EdgeEvaluator = (Edge) => EdgeWeight;
 
 function defaultOptions(): PagerankOptions {
   return {

--- a/src/core/attribution/weights.js
+++ b/src/core/attribution/weights.js
@@ -1,0 +1,54 @@
+// @flow
+
+import {type Edge, type NodeAddressT} from "../graph";
+// Weights are interpreted as base-2 logarithmic relative values
+// weight 0 = baseline
+// weight 1 = 2x as important as baseline
+// weight -1 = 1/2 as important as baseline
+export type Weight = number;
+export type EdgeWeight = {|
+  +toWeight: number, // weight from src to dst
+  +froWeight: number, // weight from dst to src
+|};
+export type NodeEvaluator = (NodeAddressT) => Weight;
+export type EdgeEvaluator = (Edge) => EdgeWeight;
+
+// Semantics TBD
+export function composeNodeEvaluators(
+  n1: NodeEvaluator,
+  n2: NodeEvaluator
+): NodeEvaluator {
+  return (n) => {
+    // Placeholder - we do not believe these are the right semantics
+    return n1(n) + n2(n);
+  };
+}
+
+// Semantics TBD
+export function composeEdgeEvaluators(
+  e1: EdgeEvaluator,
+  e2: EdgeEvaluator
+): EdgeEvaluator {
+  return (e) => {
+    // Placeholder - we do not believe these are the right semantics
+    const r1 = e1(e);
+    const r2 = e2(e);
+    return {
+      toWeight: r1.toWeight + r2.toWeight,
+      froWeight: r1.froWeight + r2.froWeight,
+    };
+  };
+}
+
+export function liftNodeEvaluator(
+  n: NodeEvaluator,
+  e: EdgeEvaluator
+): EdgeEvaluator {
+  return (edge) => {
+    const {toWeight, froWeight} = e(edge);
+    return {
+      toWeight: toWeight * n(edge.dst),
+      froWeight: froWeight * n(edge.src),
+    };
+  };
+}


### PR DESCRIPTION
These APIs are for applying weights to nodes and edges in the graph, so
as to implement weighted PageRank as described in #476. As yet, we
are reasonably confident what the type signatures should be, but do not
know what functions will get the theoretical properties we want.

For now, I've implemented placeholder implementations. These are clearly
deficient in some ways, but at least allow us to start experimenting.

Paired with @wchargin.

Test plan:
No tests were added, as the code modifies prototype parts of our
codebase that are, themselves, not yet tested, and because we already
know these functions have bad semantics.

To ensure that this commit is reasonably correct, I experimented with
changing node/edge weights in the UI and verified that PageRank results
changed as expected.

(for emphasis): #476 has all the context on this PR.