### PR TITLE
Split PluginAdapter into Dynamic and Static parts

### DIFF
--- a/src/app/credExplorer/PagerankTable.test.js
+++ b/src/app/credExplorer/PagerankTable.test.js
@@ -56,71 +56,87 @@ function example() {
 
   const adapters = [
     {
-      name: () => "foo",
+      static: () => ({
+        name: () => "foo",
+        nodePrefix: () => NodeAddress.fromParts(["foo"]),
+        edgePrefix: () => EdgeAddress.fromParts(["foo"]),
+        nodeTypes: () => [
+          {name: "alpha", prefix: NodeAddress.fromParts(["foo", "a"])},
+          {name: "beta", prefix: NodeAddress.fromParts(["foo", "b"])},
+        ],
+        edgeTypes: () => [
+          {
+            prefix: EdgeAddress.fromParts(["foo"]),
+            forwardName: "foos",
+            backwardName: "is fooed by",
+          },
+        ],
+        load: (_unused_repoOwner, _unused_repoName) => {
+          throw new Error("unused");
+        },
+      }),
       graph: () => {
         throw new Error("unused");
       },
-      renderer: () => ({
-        edgeVerb: (_unused_e, direction) =>
-          direction === "FORWARD" ? "foos" : "is fooed by",
-      }),
       nodeDescription: (x) => `foo: ${NodeAddress.toString(x)}`,
-      nodePrefix: () => NodeAddress.fromParts(["foo"]),
-      edgePrefix: () => EdgeAddress.fromParts(["foo"]),
-      nodeTypes: () => [
-        {name: "alpha", prefix: NodeAddress.fromParts(["foo", "a"])},
-        {name: "beta", prefix: NodeAddress.fromParts(["foo", "b"])},
-      ],
-      edgeTypes: () => [
-        {
-          prefix: EdgeAddress.fromParts(["foo"]),
-          forwardName: "foos",
-          backwardName: "is fooed by",
-        },
-      ],
     },
     {
-      name: () => "bar",
+      static: () => ({
+        name: () => "bar",
+        nodePrefix: () => NodeAddress.fromParts(["bar"]),
+        edgePrefix: () => EdgeAddress.fromParts(["bar"]),
+        nodeTypes: () => [
+          {name: "alpha", prefix: NodeAddress.fromParts(["bar", "a"])},
+        ],
+        edgeTypes: () => [
+          {
+            prefix: EdgeAddress.fromParts(["bar"]),
+            forwardName: "bars",
+            backwardName: "is barred by",
+          },
+        ],
+        load: (_unused_repoOwner, _unused_repoName) => {
+          throw new Error("unused");
+        },
+      }),
       graph: () => {
         throw new Error("unused");
       },
       nodeDescription: (x) => `bar: ${NodeAddress.toString(x)}`,
-      nodePrefix: () => NodeAddress.fromParts(["bar"]),
-      edgePrefix: () => EdgeAddress.fromParts(["bar"]),
-      nodeTypes: () => [
-        {name: "alpha", prefix: NodeAddress.fromParts(["bar", "a"])},
-      ],
-      edgeTypes: () => [
-        {
-          prefix: EdgeAddress.fromParts(["bar"]),
-          forwardName: "bars",
-          backwardName: "is barred by",
-        },
-      ],
     },
     {
-      name: () => "xox",
+      static: () => ({
+        name: () => "xox",
+        nodePrefix: () => NodeAddress.fromParts(["xox"]),
+        edgePrefix: () => EdgeAddress.fromParts(["xox"]),
+        nodeTypes: () => [],
+        edgeTypes: () => [],
+        load: (_unused_repoOwner, _unused_repoName) => {
+          throw new Error("unused");
+        },
+      }),
       graph: () => {
         throw new Error("unused");
       },
       nodeDescription: (_unused_arg) => `xox node!`,
-      nodePrefix: () => NodeAddress.fromParts(["xox"]),
-      edgePrefix: () => EdgeAddress.fromParts(["xox"]),
-      nodeTypes: () => [],
-      edgeTypes: () => [],
     },
     {
-      name: () => "unused",
+      static: () => ({
+        nodePrefix: () => NodeAddress.fromParts(["unused"]),
+        edgePrefix: () => EdgeAddress.fromParts(["unused"]),
+        nodeTypes: () => [],
+        edgeTypes: () => [],
+        name: () => "unused",
+        load: (_unused_repoOwner, _unused_repoName) => {
+          throw new Error("unused");
+        },
+      }),
       graph: () => {
         throw new Error("unused");
       },
       nodeDescription: () => {
         throw new Error("Unused");
       },
-      nodePrefix: () => NodeAddress.fromParts(["unused"]),
-      edgePrefix: () => EdgeAddress.fromParts(["unused"]),
-      nodeTypes: () => [],
-      edgeTypes: () => [],
     },
   ];
 

--- a/src/app/pluginAdapter.js
+++ b/src/app/pluginAdapter.js
@@ -2,19 +2,24 @@
 
 import type {Graph, NodeAddressT, EdgeAddressT} from "../core/graph";
 
-export interface PluginAdapter {
+export interface StaticPluginAdapter {
   name(): string;
-  graph(): Graph;
   nodePrefix(): NodeAddressT;
   edgePrefix(): EdgeAddressT;
   nodeTypes(): Array<{|
     +name: string,
     +prefix: NodeAddressT,
   |}>;
-  nodeDescription(NodeAddressT): string;
   edgeTypes(): Array<{|
     +forwardName: string,
     +backwardName: string,
     +prefix: EdgeAddressT,
   |}>;
+  load(repoOwner: string, repoName: string): Promise<DynamicPluginAdapter>;
+}
+
+export interface DynamicPluginAdapter {
+  graph(): Graph;
+  nodeDescription(NodeAddressT): string;
+  static (): StaticPluginAdapter;
 }


### PR DESCRIPTION
In some cases (e.g. WeightConfig) we want to have information from the
PluginAdapater before loading any data from the server. In other cases,
we need to combine the PluginAdapater with actual data, e.g. so we can
get the description of a GitHub node.

To support this, we split the PluginAdapter into a Static and Dynamic
component. The Dynamic component has data needed to give node
descriptions, etc. Given a static adapter, you can get a promise to load
the dynamic adapter. Given the dynamic adapter, you can immediately get
the static adapter. (There's a parallel to NodeReference (static) and
NodePorcelain (dynamic)).

Test plan:
Travis passes, as does manual testing of the frontend.