### PR TITLE
Disable service workers

### DIFF
--- a/src/app/index.js
+++ b/src/app/index.js
@@ -3,11 +3,11 @@ import React from "react";
 import ReactDOM from "react-dom";
 import "./index.css";
 import App from "./App";
-import registerServiceWorker from "./registerServiceWorker";
+import {unregister} from "./registerServiceWorker";
 
 const root = document.getElementById("root");
 if (root == null) {
   throw new Error("Unable to find root element!");
 }
 ReactDOM.render(<App />, root);
-registerServiceWorker();
+unregister();


### PR DESCRIPTION
Summary:
We don’t need this to be a “progressive web app”—certainly not now. The
n+1 caching problem is not a good tradeoff for us, and furthermore
service workers are causing flashes of content on server-side rendered
pages.

This commit is a quick fix to remove them. We can remove the code
entirely if we want, or just keep it as is.

Test Plan:
On a machine has the service worker registered, run `yarn build`, then
`node bin/sourcecred.js start`. Note in the network panel that the
service worker is loaded on the first page load, but then deregistered.
On subsequent refreshes, it should not activate. In the “Application”
panel of the Chrome dev tools, it should appear as “deleted”.

wchargin-branch: disable-sw