### PR TITLE
Extract a `LocalStore` interface

### DIFF
--- a/src/app/browserLocalStore.js
+++ b/src/app/browserLocalStore.js
@@ -1,5 +1,7 @@
 // @flow
 
+import {LocalStore} from "./localStore";
+
 /*
  * A simple abstraction over 'localStorage' to provide transparent JSON
  * serialization and deserialization.
@@ -7,7 +9,7 @@
  * The implementation is borrowed heavily from Khan Academy's LocalStore
  * module, and also KaVideoPlayer's SafeLocalStore module.
  */
-export default class LocalStore {
+export default class BrowserLocalStore implements LocalStore {
   version: string;
   keyPrefix: string;
 
@@ -23,7 +25,7 @@ export default class LocalStore {
     return [this.keyPrefix, this.version, key].join(":");
   }
 
-  get(key: string, whenUnavailable: any): any {
+  get<T>(key: string, whenUnavailable: T): T {
     if (!this.isEnabled()) {
       return whenUnavailable;
     }
@@ -41,7 +43,7 @@ export default class LocalStore {
     }
   }
 
-  set(key: string, data: any): void {
+  set(key: string, data: mixed): void {
     if (!this.isEnabled()) {
       return;
     }

--- a/src/app/credExplorer/LocalStore.js
+++ b/src/app/credExplorer/LocalStore.js
@@ -1,5 +1,5 @@
 // @flow
 
-import LocalStore from "../LocalStore";
+import LocalStore from "../browserLocalStore";
 
 export default new LocalStore({version: "1", keyPrefix: "cred-explorer"});

--- a/src/app/localStore.js
+++ b/src/app/localStore.js
@@ -1,0 +1,26 @@
+// @flow
+
+/**
+ * An abstraction over the browser's `localStorage` API. This enables
+ * persistently storing and retrieving JSON-serializable values by a
+ * string key.
+ */
+export interface LocalStore {
+  /**
+   * Get the value stored under the given key, or `whenUnavailable` if
+   * this API is unavailable or the key does not exist or is corrupt.
+   */
+  get<T>(key: string, whenUnavailable: T): T;
+
+  /**
+   * Store the given value under the given key. The value must be a
+   * plain old JSON object: i.e., `data` and
+   * `JSON.parse(JSON.stringify(data))` must be deep-equal.
+   */
+  set(key: string, data: mixed): void;
+
+  /**
+   * Remove any value with the given key. If none exists, do nothing.
+   */
+  del(key: string): void;
+}


### PR DESCRIPTION
Summary:
We’d really like to be able to test components that use `LocalStore`. We
can do this by dependency-injecting the storage backend. This commit
begins that process by extracting `LocalStore` to its interface,
preserving the unique existing implementation.

wchargin-branch: extract-localstore