### PR TITLE
Dependency-inject `LocalStore`

### DIFF
--- a/src/app/credExplorer/App.test.js
+++ b/src/app/credExplorer/App.test.js
@@ -2,8 +2,9 @@
 import React from "react";
 import {shallow} from "enzyme";
 
+import BrowserLocalStore from "../browserLocalStore";
 import {pagerank} from "../../core/attribution/pagerank";
-import App from "./App";
+import {App} from "./App";
 
 import {Graph, NodeAddress, EdgeAddress} from "../../core/graph";
 
@@ -95,17 +96,27 @@ function example() {
 }
 
 describe("app/credExplorer/App", () => {
+  function makeLocalStore() {
+    // TODO(@wchargin): This should be an in-memory implementation of
+    // LocalStore, not the browser version. This only works because the
+    // store is not actually needed for the shallow render to complete
+    // successfully.
+    return new BrowserLocalStore({
+      version: "1",
+      keyPrefix: "cred-explorer",
+    });
+  }
   it("renders with clean state", () => {
-    shallow(<App />);
+    shallow(<App localStore={makeLocalStore()} />);
   });
   it("renders with graph and adapters set", () => {
-    const app = shallow(<App />);
+    const app = shallow(<App localStore={makeLocalStore()} />);
     const {graph, adapters} = example();
     const data = {graph, adapters, pagerankResult: null};
     app.setState({data});
   });
   it("renders with graph and adapters and pagerankResult", () => {
-    const app = shallow(<App />);
+    const app = shallow(<App localStore={makeLocalStore()} />);
     const {graph, adapters, pagerankResult} = example();
     const data = {graph, adapters, pagerankResult};
     app.setState({data});

--- a/src/app/credExplorer/LocalStore.js
+++ b/src/app/credExplorer/LocalStore.js
@@ -1,5 +1,0 @@
-// @flow
-
-import LocalStore from "../browserLocalStore";
-
-export default new LocalStore({version: "1", keyPrefix: "cred-explorer"});

--- a/src/app/credExplorer/WeightConfig.js
+++ b/src/app/credExplorer/WeightConfig.js
@@ -9,9 +9,9 @@ import {
   NodeAddress,
 } from "../../core/graph";
 
+import type {LocalStore} from "../localStore";
 import {type EdgeEvaluator} from "../../core/attribution/pagerank";
 import {byEdgeType, byNodeType} from "./edgeWeights";
-import LocalStore from "./LocalStore";
 import * as MapUtil from "../../util/map";
 import * as NullUtil from "../../util/null";
 
@@ -19,9 +19,10 @@ import type {StaticPluginAdapter} from "../pluginAdapter";
 import {StaticPluginAdapter as GithubAdapter} from "../../plugins/github/pluginAdapter";
 import {StaticPluginAdapter as GitAdapter} from "../../plugins/git/pluginAdapter";
 
-type Props = {
-  onChange: (EdgeEvaluator) => void,
-};
+type Props = {|
+  +localStore: LocalStore,
+  +onChange: (EdgeEvaluator) => void,
+|};
 
 type EdgeWeights = Map<EdgeAddressT, UserEdgeWeight>;
 type UserEdgeWeight = {|+logWeight: number, +directionality: number|};
@@ -71,15 +72,16 @@ export class WeightConfig extends React.Component<Props, State> {
   }
 
   componentDidMount() {
+    const {localStore} = this.props;
     this.setState(
       (state) => {
         return {
           edgeWeights: NullUtil.orElse(
-            NullUtil.map(LocalStore.get(EDGE_WEIGHTS_KEY), MapUtil.fromObject),
+            NullUtil.map(localStore.get(EDGE_WEIGHTS_KEY), MapUtil.fromObject),
             state.edgeWeights
           ),
           nodeWeights: NullUtil.orElse(
-            NullUtil.map(LocalStore.get(NODE_WEIGHTS_KEY), MapUtil.fromObject),
+            NullUtil.map(localStore.get(NODE_WEIGHTS_KEY), MapUtil.fromObject),
             state.nodeWeights
           ),
         };
@@ -126,9 +128,10 @@ export class WeightConfig extends React.Component<Props, State> {
   }
 
   fire() {
+    const {localStore} = this.props;
     const {edgeWeights, nodeWeights} = this.state;
-    LocalStore.set(EDGE_WEIGHTS_KEY, MapUtil.toObject(edgeWeights));
-    LocalStore.set(NODE_WEIGHTS_KEY, MapUtil.toObject(nodeWeights));
+    localStore.set(EDGE_WEIGHTS_KEY, MapUtil.toObject(edgeWeights));
+    localStore.set(NODE_WEIGHTS_KEY, MapUtil.toObject(nodeWeights));
     const edgePrefixes = Array.from(edgeWeights.entries()).map(
       ([prefix, {logWeight, directionality}]) => ({
         prefix,


### PR DESCRIPTION
Summary:
This commit modifies components that directly depend on the
browser-specific local store implementation to instead have their
dependencies injected.

Test Plan:
Tests pass, but are likely not sufficient. Manual testing indicates that
the local storage still works, for both reads and writes, on a fresh
profile or with existing data, for both the repository owner/name and
the weight configuration.

wchargin-branch: di-localstore