### PR TITLE
Add a `memoryLocalStore` implementation

### DIFF
--- a/src/app/memoryLocalStore.js
+++ b/src/app/memoryLocalStore.js
@@ -1,0 +1,29 @@
+// @flow
+
+import {LocalStore} from "./localStore";
+
+/*
+ * A completely in-memory `LocalStore` implementation that matches the
+ * happy path of browsers' `localStorage`: storage is always enabled and
+ * functioning, and there is no storage limit.
+ */
+export default class MemoryLocalStore implements LocalStore {
+  _data: Map<string, string>;
+
+  constructor(): void {
+    this._data = new Map();
+  }
+
+  get<T>(key: string, whenUnavailable: T): T {
+    const raw = this._data.get(key);
+    return raw == null ? whenUnavailable : JSON.parse(raw);
+  }
+
+  set(key: string, data: mixed): void {
+    this._data.set(key, JSON.stringify(data));
+  }
+
+  del(key: string): void {
+    this._data.delete(key);
+  }
+}

--- a/src/app/memoryLocalStore.test.js
+++ b/src/app/memoryLocalStore.test.js
@@ -1,0 +1,36 @@
+// @flow
+
+import MemoryLocalStore from "./memoryLocalStore";
+
+describe("src/app/memoryLocalStore", () => {
+  it("stores simple values", () => {
+    const ls = new MemoryLocalStore();
+    ls.set("one", 1);
+    expect(ls.get("one")).toBe(1);
+  });
+
+  it("stores complex values", () => {
+    const ls = new MemoryLocalStore();
+    ls.set("stuff", [{a: ["one"]}, {b: ["two"]}]);
+    expect(ls.get("stuff")).toEqual([{a: ["one"]}, {b: ["two"]}]);
+  });
+
+  it("stores null", () => {
+    const ls = new MemoryLocalStore();
+    ls.set("one", null);
+    expect(ls.get("one")).toBe(null);
+  });
+
+  it("overwrites values", () => {
+    const ls = new MemoryLocalStore();
+    ls.set("questions", 5);
+    ls.set("questions", 3);
+    expect(ls.get("questions")).toBe(3);
+  });
+
+  it("provides `whenUnavailable` for absent values", () => {
+    const ls = new MemoryLocalStore();
+    const expected = Symbol();
+    expect(ls.get("wat", expected)).toBe(expected);
+  });
+});


### PR DESCRIPTION
Summary:
We can use this in tests. If need be, we can enhance this class to allow
simulating failures, low storage limits, etc., but just having a pure
implementation at all is all we need right now.

Test Plan:
Unit tests added.

wchargin-branch: memory-local-store