### PR TITLE
Default to selecting last loaded repository

### DIFF
--- a/src/app/credExplorer/App.js
+++ b/src/app/credExplorer/App.js
@@ -16,7 +16,8 @@ import type {DynamicPluginAdapter} from "../pluginAdapter";
 import {type EdgeEvaluator} from "../../core/attribution/pagerank";
 import {WeightConfig} from "./WeightConfig";
 import type {PagerankNodeDecomposition} from "../../core/attribution/pagerankNodeDecomposition";
-import RepositorySelect, {type Repo} from "./RepositorySelect";
+import RepositorySelect from "./RepositorySelect";
+import type {Repo} from "./repoRegistry";
 
 import * as NullUtil from "../../util/null";
 

--- a/src/app/credExplorer/repoRegistry.js
+++ b/src/app/credExplorer/repoRegistry.js
@@ -1,0 +1,32 @@
+// @flow
+
+// The repoRegistry is written by the CLI load command
+// (src/cli/commands/load.js) and is read by the RepositorySelect component
+// (src/app/credExplorer/RepositorySelect.js)
+import deepEqual from "lodash.isequal";
+import {toCompat, fromCompat, type Compatible} from "../../util/compat";
+
+export const REPO_REGISTRY_FILE = "repositoryRegistry.json";
+export const REPO_REGISTRY_API = "/api/v1/data/repositoryRegistry.json";
+
+const REPO_REGISTRY_COMPAT = {type: "REPO_REGISTRY", version: "0.1.0"};
+
+export type Repo = {|+name: string, +owner: string|};
+export type RepoRegistry = $ReadOnlyArray<Repo>;
+export type RepoRegistryJSON = Compatible<RepoRegistry>;
+
+export function toJSON(r: RepoRegistry): RepoRegistryJSON {
+  return toCompat(REPO_REGISTRY_COMPAT, r);
+}
+
+export function fromJSON(j: RepoRegistryJSON): RepoRegistry {
+  return fromCompat(REPO_REGISTRY_COMPAT, j);
+}
+
+export function addRepo(r: Repo, reg: RepoRegistry): RepoRegistry {
+  return [...reg.filter((x) => !deepEqual(x, r)), r];
+}
+
+export function emptyRegistry(): RepoRegistry {
+  return [];
+}

--- a/src/app/credExplorer/repoRegistry.test.js
+++ b/src/app/credExplorer/repoRegistry.test.js
@@ -1,0 +1,53 @@
+// @flow
+
+import {
+  toJSON,
+  fromJSON,
+  addRepo,
+  emptyRegistry,
+  type RepoRegistry,
+} from "./repoRegistry";
+
+describe("app/credExplorer/repoRegistry", () => {
+  const r = (owner, name) => ({owner, name});
+  describe("to/fromJSON compose on", () => {
+    function checkExample(x: RepoRegistry) {
+      expect(fromJSON(toJSON(x))).toEqual(x);
+      expect(toJSON(fromJSON(toJSON(x)))).toEqual(toJSON(x));
+    }
+    it("empty registry", () => {
+      checkExample(emptyRegistry());
+    });
+    it("nonempty registry", () => {
+      checkExample([r("foo", "bar"), r("zoo", "zod")]);
+    });
+  });
+  describe("addRepo", () => {
+    it("adds to empty registry", () => {
+      expect(addRepo(r("foo", "bar"), emptyRegistry())).toEqual([
+        r("foo", "bar"),
+      ]);
+    });
+    it("adds to nonempty registry", () => {
+      const registry = [r("foo", "bar")];
+      expect(addRepo(r("zoo", "zod"), registry)).toEqual([
+        r("foo", "bar"),
+        r("zoo", "zod"),
+      ]);
+    });
+    it("adding repo that is already the last has no effect", () => {
+      const registry = [r("zoo", "zod"), r("foo", "bar")];
+      expect(addRepo(r("foo", "bar"), registry)).toEqual(registry);
+    });
+    it("adding already-existing repo shifts it to the end", () => {
+      const registry = [r("zoo", "zod"), r("foo", "bar")];
+      expect(addRepo(r("zoo", "zod"), registry)).toEqual([
+        r("foo", "bar"),
+        r("zoo", "zod"),
+      ]);
+    });
+  });
+  it("empty registry is empty", () => {
+    expect(emptyRegistry()).toEqual([]);
+  });
+});

--- a/src/cli/commands/load.js
+++ b/src/cli/commands/load.js
@@ -14,6 +14,14 @@ import {
   sourcecredDirectoryFlag,
 } from "../common";
 
+import {
+  toJSON,
+  fromJSON,
+  addRepo,
+  emptyRegistry,
+  REPO_REGISTRY_FILE,
+} from "../../app/credExplorer/repoRegistry";
+
 const execDependencyGraph = require("../../tools/execDependencyGraph").default;
 
 export default class PluginGraphCommand extends Command {
@@ -152,21 +160,21 @@ function loadPlugin({basedir, plugin, repoOwner, repoName, githubToken}) {
   }
 }
 
-const REPO_REGISTRY_FILE = "repositoryRegistry.json";
-
 function addToRepoRegistry(options) {
   // TODO: Make this function transactional before loading repositories in
   // parallel.
   const {basedir, repoOwner, repoName} = options;
+  const repo = {owner: repoOwner, name: repoName};
   const outputFile = path.join(basedir, REPO_REGISTRY_FILE);
   let registry = null;
   if (fs.existsSync(outputFile)) {
     const contents = fs.readFileSync(outputFile);
-    registry = JSON.parse(contents.toString());
+    const registryJSON = JSON.parse(contents.toString());
+    registry = fromJSON(registryJSON);
   } else {
-    registry = {};
+    registry = emptyRegistry();
   }
+  registry = addRepo(repo, registry);
 
-  registry[`${repoOwner}/${repoName}`] = true;
-  fs.writeFileSync(outputFile, stringify(registry));
+  fs.writeFileSync(outputFile, stringify(toJSON(registry)));
 }


### PR DESCRIPTION
In #529, I made the cred explorer populate a dropdown with the list of
repositories that are available to explore. That dropdown defaults to
selecting the alphabetically first repository.

This has an unfortunate consequence in that it makes it impossible for
us to explicitly set a default - for example, we would like
sourcecred.github.io/explorer to show sourcecred/sourcecred by default,
but instead it shows example-git.

So that we can choose the default, I've changed the logic so that it
instead shows the most-recently-loaded data first. This required
a breaking change to the repoRegistry serialized format, so I've also
refactored the module to use compat, which I should have done from the
beginning.

Test plan:
Unit tests for the repo selector are updated. The CLI load command
unfortunately has no tests, so I manually tested that it always provides
the lastest repository last, and appropriately handles the case where
the same repository is loaded multiple times.