### PR TITLE
Modify sourcecred.github.io's example repos

### DIFF
--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -77,8 +77,7 @@ build_and_deploy() {
         yarn
         yarn backend
         yarn build
-        node ./bin/sourcecred.js load sourcecred example-github
-        node ./bin/sourcecred.js load sourcecred example-git
+        node ./bin/sourcecred.js load ipfs js-ipfs
         node ./bin/sourcecred.js load sourcecred sourcecred
     )
 


### PR DESCRIPTION
Showing our example-github and example-git repos on sourcecred.github.io
is not particularly interesting. Let's show ipfs/js-ipfs instead!

Since sourcecred/sourcecred is the last repo to load, as of #531 it will
be the default option.

Test plan: Dry run of deploy script