### PR TITLE
Display cred explorer scores as -Log(score)

### DIFF
--- a/src/app/credExplorer/PagerankTable.js
+++ b/src/app/credExplorer/PagerankTable.js
@@ -67,8 +67,7 @@ function edgeVerb(
 }
 
 function scoreDisplay(probability: number) {
-  const modifiedLogScore = Math.log(probability) + 10;
-  return modifiedLogScore.toFixed(2);
+  return (-1 * Math.log(probability)).toFixed(2);
 }
 
 type SharedProps = {|

--- a/src/app/credExplorer/PagerankTable.test.js
+++ b/src/app/credExplorer/PagerankTable.test.js
@@ -364,7 +364,7 @@ describe("app/credExplorer/PagerankTable", () => {
     it("renders a score column with the node's log-score", async () => {
       const {element, sharedProps, node} = await setup();
       const {score: rawScore} = NullUtil.get(sharedProps.pnd.get(node));
-      const expectedScore = (Math.log(rawScore) + 10).toFixed(2);
+      const expectedScore = (-Math.log(rawScore)).toFixed(2);
       const contributionColumn = COLUMNS().indexOf("Score");
       expect(contributionColumn).not.toEqual(-1);
       expect(
@@ -514,9 +514,7 @@ describe("app/credExplorer/PagerankTable", () => {
     });
     it("renders a score column with the source's log-score", async () => {
       const {element, contribution} = await setup();
-      const expectedScore = (Math.log(contribution.sourceScore) + 10).toFixed(
-        2
-      );
+      const expectedScore = (-Math.log(contribution.sourceScore)).toFixed(2);
       const contributionColumn = COLUMNS().indexOf("Score");
       expect(contributionColumn).not.toEqual(-1);
       expect(


### PR DESCRIPTION
@wchargin suggested displaying scores this way. This way, lowest scores
are best, and higher scores are worse. This is a little
counterintuitive, but maybe less counterintuitive than the current
approach, which arbitrarily adds 10 to scores to keep them non-negative,
and results in an arbitrary crossing point where scores become negative
without any particular significance.

Test plan: Travis, and manual inspection of the frontend.

![image](https://user-images.githubusercontent.com/1400023/43338472-4d9822b4-918b-11e8-883b-bb7f622b3373.png)