### PR TITLE
Add default weights for node types

### DIFF
--- a/src/app/credExplorer/PagerankTable.test.js
+++ b/src/app/credExplorer/PagerankTable.test.js
@@ -3,6 +3,8 @@ import React from "react";
 import {shallow} from "enzyme";
 import enzymeToJSON from "enzyme-to-json";
 
+import type {DynamicPluginAdapter} from "../pluginAdapter";
+
 import {
   PagerankTable,
   NodeRowList,
@@ -54,15 +56,23 @@ async function example() {
     barF: addEdge(["bar", "f"], nodes.bar1, nodes.xox),
   };
 
-  const adapters = [
+  const adapters: DynamicPluginAdapter[] = [
     {
       static: () => ({
         name: () => "foo",
         nodePrefix: () => NodeAddress.fromParts(["foo"]),
         edgePrefix: () => EdgeAddress.fromParts(["foo"]),
         nodeTypes: () => [
-          {name: "alpha", prefix: NodeAddress.fromParts(["foo", "a"])},
-          {name: "beta", prefix: NodeAddress.fromParts(["foo", "b"])},
+          {
+            name: "alpha",
+            prefix: NodeAddress.fromParts(["foo", "a"]),
+            defaultWeight: 1,
+          },
+          {
+            name: "beta",
+            prefix: NodeAddress.fromParts(["foo", "b"]),
+            defaultWeight: 1,
+          },
         ],
         edgeTypes: () => [
           {
@@ -86,7 +96,11 @@ async function example() {
         nodePrefix: () => NodeAddress.fromParts(["bar"]),
         edgePrefix: () => EdgeAddress.fromParts(["bar"]),
         nodeTypes: () => [
-          {name: "alpha", prefix: NodeAddress.fromParts(["bar", "a"])},
+          {
+            name: "alpha",
+            prefix: NodeAddress.fromParts(["bar", "a"]),
+            defaultWeight: 1,
+          },
         ],
         edgeTypes: () => [
           {

--- a/src/app/credExplorer/WeightConfig.js
+++ b/src/app/credExplorer/WeightConfig.js
@@ -48,8 +48,8 @@ const NODE_WEIGHTS_KEY = "nodeWeights";
 const defaultNodeWeights = (): NodeWeights => {
   const result = new Map();
   for (const adapter of adapters()) {
-    for (const {prefix} of adapter.nodeTypes()) {
-      result.set(prefix, 0);
+    for (const {prefix, defaultWeight} of adapter.nodeTypes()) {
+      result.set(prefix, Math.log2(defaultWeight));
     }
   }
   return result;

--- a/src/app/pluginAdapter.js
+++ b/src/app/pluginAdapter.js
@@ -9,6 +9,7 @@ export interface StaticPluginAdapter {
   nodeTypes(): Array<{|
     +name: string,
     +prefix: NodeAddressT,
+    +defaultWeight: number,
   |}>;
   edgeTypes(): Array<{|
     +forwardName: string,

--- a/src/plugins/git/pluginAdapter.js
+++ b/src/plugins/git/pluginAdapter.js
@@ -20,10 +20,10 @@ export class StaticPluginAdapter implements IStaticPluginAdapter {
   }
   nodeTypes() {
     return [
-      {name: "Blob", prefix: N._Prefix.blob},
-      {name: "Commit", prefix: N._Prefix.commit},
-      {name: "Tree", prefix: N._Prefix.tree},
-      {name: "Tree entry", prefix: N._Prefix.treeEntry},
+      {name: "Blob", prefix: N._Prefix.blob, defaultWeight: 0.125},
+      {name: "Commit", prefix: N._Prefix.commit, defaultWeight: 2},
+      {name: "Tree", prefix: N._Prefix.tree, defaultWeight: 0.125},
+      {name: "Tree entry", prefix: N._Prefix.treeEntry, defaultWeight: 0.125},
     ];
   }
   edgeTypes() {

--- a/src/plugins/github/pluginAdapter.js
+++ b/src/plugins/github/pluginAdapter.js
@@ -22,12 +22,12 @@ export class StaticPluginAdapter implements IStaticPluginAdapter {
   }
   nodeTypes() {
     return [
-      {name: "Repository", prefix: N._Prefix.repo},
-      {name: "Issue", prefix: N._Prefix.issue},
-      {name: "Pull request", prefix: N._Prefix.pull},
-      {name: "Pull request review", prefix: N._Prefix.review},
-      {name: "Comment", prefix: N._Prefix.comment},
-      {name: "User", prefix: N._Prefix.userlike},
+      {name: "Repository", prefix: N._Prefix.repo, defaultWeight: 4},
+      {name: "Issue", prefix: N._Prefix.issue, defaultWeight: 2},
+      {name: "Pull request", prefix: N._Prefix.pull, defaultWeight: 4},
+      {name: "Pull request review", prefix: N._Prefix.review, defaultWeight: 1},
+      {name: "Comment", prefix: N._Prefix.comment, defaultWeight: 1},
+      {name: "User", prefix: N._Prefix.userlike, defaultWeight: 1},
     ];
   }
   edgeTypes() {


### PR DESCRIPTION
Modifies the PluginAdapter interface so that NodeTypes come with
default weights, and modify the WeightConfig so that it loads those
NodeTypes as the default weights.

The new weight choices are not super principled, but are clearly better
than the uniform default. Now, projects find that most pull requests are
more valuable than most git blobs. :)

Sadly, the WeightConfig does not yet have any tests, so there are no
test changes.

Test plan: I manually verified that it works as expected, by clearing
application data and reloading the cred explorer.