### PR TITLE
When repo registry fails, error to console

### DIFF
--- a/src/app/credExplorer/RepositorySelect.js
+++ b/src/app/credExplorer/RepositorySelect.js
@@ -90,6 +90,7 @@ export async function loadStatus(localStore: LocalStore): Promise<Status> {
   try {
     const response = await fetch(REPO_REGISTRY_API);
     if (!response.ok) {
+      console.error(response);
       return {type: "FAILURE"};
     }
     const json = await response.json();
@@ -105,6 +106,7 @@ export async function loadStatus(localStore: LocalStore): Promise<Status> {
     const sortedRepos = sortBy(availableRepos, (r) => r.owner, (r) => r.name);
     return {type: "VALID", availableRepos: sortedRepos, selectedRepo};
   } catch (e) {
+    console.error(e);
     return {type: "FAILURE"};
   }
 }
@@ -178,7 +180,10 @@ export class PureRepositorySelect extends React.PureComponent<
       case "NO_REPOS":
         return this.renderError("Error: No repositories found.");
       case "FAILURE":
-        return this.renderError("Error: Unable to load repository registry.");
+        return this.renderError(
+          "Error: Unable to load repository registry. " +
+            "See console for details."
+        );
       default:
         throw new Error((status.type: empty));
     }


### PR DESCRIPTION
Some slight changes were needed to the other test code to avoid spurious
errors. Specifically, we now always set up a mocked fetch response in
non-failure cases, even if we don't wait for it to resolve.

Test plan: I manually tested it, also see the new unit tests.
