### PR TITLE
Upgrade Flow to v0.76.0

### DIFF
--- a/flow-typed/npm/express_v4.16.x.js
+++ b/flow-typed/npm/express_v4.16.x.js
@@ -1,5 +1,5 @@
-// flow-typed signature: 106bbf49ff0c0b351c95d483d617ffba
-// flow-typed version: 7fe23c8e85/express_v4.16.x/flow_>=v0.32.x
+// flow-typed signature: cc24a4e737d9dfb8e1381c3bd4ebaa65
+// flow-typed version: d11eab7bb5/express_v4.16.x/flow_>=v0.32.x
 
 import type { Server } from "http";
 import type { Socket } from "net";
@@ -195,13 +195,11 @@ declare class express$Router extends express$Route {
       id: string
     ) => mixed
   ): void;
-
-  // Can't use regular callable signature syntax due to https://github.com/facebook/flow/issues/3084
-  $call: (
+  (
     req: http$IncomingMessage,
     res: http$ServerResponse,
     next?: ?express$NextFunction
-  ) => void;
+  ): void;
 }
 
 /*
@@ -246,6 +244,12 @@ declare class express$Application extends express$Router mixins events$EventEmit
     callback: express$RenderCallback
   ): void;
   handle(
+    req: http$IncomingMessage,
+    res: http$ServerResponse,
+    next?: ?express$NextFunction
+  ): void;
+  // callable signature is not inherited
+  (
     req: http$IncomingMessage,
     res: http$ServerResponse,
     next?: ?express$NextFunction

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "eslint-plugin-react": "7.4.0",
     "extract-text-webpack-plugin": "3.0.2",
     "file-loader": "1.1.5",
-    "flow-bin": "^0.73.0",
+    "flow-bin": "^0.77.0",
     "html-webpack-plugin": "2.29.0",
     "jest": "23.4.1",
     "jest-fetch-mock": "^1.6.5",

--- a/src/plugins/github/relationalView.js
+++ b/src/plugins/github/relationalView.js
@@ -532,7 +532,10 @@ export class _Entity<+T: Entry> {
     this._entry = entry;
   }
   address(): $ElementType<T, "address"> {
-    return this._entry.address;
+    // Relevant Flow bugs:
+    //   - https://github.com/facebook/flow/issues/6648
+    //   - https://github.com/facebook/flow/issues/6649
+    return ((this._entry: T).address: any);
   }
   url(): string {
     return this._entry.url;

--- a/yarn.lock
+++ b/yarn.lock
@@ -3131,9 +3131,9 @@ flatten@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/flatten/-/flatten-1.0.2.tgz#dae46a9d78fbe25292258cc1e780a41d95c03782"
 
-flow-bin@^0.73.0:
-  version "0.73.0"
-  resolved "https://registry.yarnpkg.com/flow-bin/-/flow-bin-0.73.0.tgz#da1b90a02b0ef9c439f068c2fc14968db83be425"
+flow-bin@^0.77.0:
+  version "0.77.0"
+  resolved "https://registry.yarnpkg.com/flow-bin/-/flow-bin-0.77.0.tgz#4e5c93929f289a0c28e08fb361a9734944a11297"
 
 for-in@^1.0.1, for-in@^1.0.2:
   version "1.0.2"


### PR DESCRIPTION
Summary:
In addition to a routine libdef update, we also need to work around a
particularly nasty new bug in Flow, which requires `any`-casts that are
even more unsafe than usual. That said, I think that it’s worth that
cost to remain up to date with Flow, so that we can amortize future such
issues.

Test Plan:
Running `yarn travis --full` passes.

wchargin-branch: upgrade-flow-v0.76.0