### PR TITLE
Make deploy script wait for valid response

### DIFF
--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -113,8 +113,11 @@ build_and_deploy() {
     printf '\n'
     printf 'Please review the build output now---run:\n'
     printf '    cd "%s" && python -m SimpleHTTPServer\n' "${preview_dir}"
-    printf 'Do you want to deploy? yes/no> '
-    read -r line
+    line=
+    while [ "${line}" != yes ] && [ "${line}" != no ]; do
+        printf 'Do you want to deploy? yes/no> '
+        read -r line
+    done
     if [ "${line}" = yes ]; then
         (
             set -x;


### PR DESCRIPTION
Currently, any non-yes keystroke causes the deply script to abort.
This is frustrating, as it may take the user several minutes of waiting
to get to the prompt, only to have the program inadvertently terminate.

As of this change, the deploys script patiently re-prompts until it gets
a valid input.

Paired with @wchargin.

Test plan: Ran locally and tested the yes, no, and invalid response
cases. Also ran the script through shellcheck.