### PR TITLE
new-webpack: allow running in dev

### DIFF
--- a/config/makeWebpackConfig.js
+++ b/config/makeWebpackConfig.js
@@ -21,15 +21,6 @@ const publicUrl = publicPath.slice(0, -1);
 // Get environment variables to inject into our app.
 const env = getClientEnvironment(publicUrl);
 
-// Assert this just to be safe.
-// Development builds of React are slow and not intended for production.
-if (env.stringified["process.env"].NODE_ENV !== '"production"') {
-  throw new Error("Production builds must have NODE_ENV=production.");
-}
-
-// This is the production configuration.
-// It compiles slowly and is focused on producing a fast and minimal bundle.
-// The development configuration is different and lives in a separate file.
 function makeConfig(_unused_mode /*: "production" | "development" */) {
   return {
     // Don't attempt to continue if there are any errors.
@@ -44,6 +35,9 @@ function makeConfig(_unused_mode /*: "production" | "development" */) {
         require.resolve("./polyfills"),
         paths.appServerSideRenderingIndexJs,
       ],
+    },
+    devServer: {
+      inline: false,
     },
     output: {
       // The build folder.


### PR DESCRIPTION
Summary:
In addition to simply disabling the prod-only check, we apply a
workaround for a known bug that breaks static site generation in Webpack
versions >= 2.0.

Test Plan:
Run

```
NODE_ENV=development node ./node_modules/.bin/webpack-dev-server \
    --config config/makeWebpackConfig.js
```

and visit http://localhost:8080/webpack-dev-server/ (note the trailing
slash) or just http://localhost:8080/. Expect the server to be slow, as
it is actually building for production.

wchargin-branch: webpack-enable-dev