### PR TITLE
new-webpack: serve static files

### DIFF
--- a/config/makeWebpackConfig.js
+++ b/config/makeWebpackConfig.js
@@ -1,4 +1,7 @@
 // @flow
+const express = require("express");
+/*:: import type {$Application as ExpressApp} from "express"; */
+const os = require("os");
 const path = require("path");
 const webpack = require("webpack");
 const ManifestPlugin = require("webpack-manifest-plugin");
@@ -38,6 +41,16 @@ function makeConfig(mode /*: "production" | "development" */) {
     },
     devServer: {
       inline: false,
+      before: (app /*: ExpressApp */) => {
+        // TODO(@wchargin): De-duplicate this code.
+        app.use(
+          "/api/v1/data",
+          express.static(
+            process.env.SOURCECRED_DIRECTORY ||
+              path.join(os.tmpdir(), "sourcecred")
+          )
+        );
+      },
     },
     output: {
       // The build folder.


### PR DESCRIPTION
Summary:
This commit makes the Webpack dev server fully functional under the new
config, by serving the static SourceCred directory via a piece of
injected middleware.

Test Plan:
Run

```
NODE_ENV=development node ./node_modules/.bin/webpack-dev-server \
    --config config/makeWebpackConfig.js
```

and navigate to the cred explorer. Note that the repository registry is
fetched, and the whole cred explorer works.

wchargin-branch: webpack-statics