### PR TITLE
new-webpack: clean `build/` before prod

### DIFF
--- a/config/makeWebpackConfig.js
+++ b/config/makeWebpackConfig.js
@@ -4,6 +4,7 @@ const express = require("express");
 const os = require("os");
 const path = require("path");
 const webpack = require("webpack");
+const CleanPlugin = require("clean-webpack-plugin");
 const ManifestPlugin = require("webpack-manifest-plugin");
 const SWPrecacheWebpackPlugin = require("sw-precache-webpack-plugin");
 const StaticSiteGeneratorPlugin = require("static-site-generator-webpack-plugin");
@@ -257,6 +258,8 @@ function plugins(mode /*: "development" | "production" */) {
     new webpack.IgnorePlugin(/^\.\/locale$/, /moment$/),
   ];
   const prodOnlyPlugins = [
+    // Remove the output directory before starting the build.
+    new CleanPlugin([paths.appBuild], {root: paths.root}),
     // Minify the code.
     new webpack.optimize.UglifyJsPlugin({
       compress: {

--- a/config/paths.js
+++ b/config/paths.js
@@ -34,6 +34,7 @@ function getServedPath() {
 
 // config after eject: we're in ./config/
 module.exports = {
+  root: appDirectory,
   dotenv: resolveApp(".env"),
   appBuild: resolveApp("build"),
   appPublic: resolveApp("src/app/public"),

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "babel-preset-react-app": "^3.1.1",
     "babel-runtime": "6.26.0",
     "case-sensitive-paths-webpack-plugin": "2.1.1",
+    "clean-webpack-plugin": "^0.1.19",
     "css-loader": "0.28.7",
     "dotenv": "4.0.0",
     "dotenv-expand": "4.0.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1586,6 +1586,12 @@ clean-stack@^1.3.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/clean-stack/-/clean-stack-1.3.0.tgz#9e821501ae979986c46b1d66d2d432db2fd4ae31"
 
+clean-webpack-plugin@^0.1.19:
+  version "0.1.19"
+  resolved "https://registry.yarnpkg.com/clean-webpack-plugin/-/clean-webpack-plugin-0.1.19.tgz#ceda8bb96b00fe168e9b080272960d20fdcadd6d"
+  dependencies:
+    rimraf "^2.6.1"
+
 cli-boxes@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/cli-boxes/-/cli-boxes-1.0.0.tgz#4fa917c3e59c94a004cd61f8ee509da651687143"


### PR DESCRIPTION
Summary:
In our current system, we build by invoking `scripts/build.js`, which
begins by removing the `build/` directory. This behavior is nice,
because it prevents cross-contamination between builds. In this commit,
we add a plugin to achieve the same result from directly within Webpack.

Test Plan:
Run

```
mkdir -p ./build
touch ./build/wat
NODE_ENV=production node ./node_modules/.bin/webpack \
    --config config/makeWebpackConfig.js
```

and ensure that `./build/wat` does not exist after the build completes.

wchargin-branch: webpack-clean-build