### PR TITLE
new-webpack: replace old scripts in `package.json`

### DIFF
--- a/package.json
+++ b/package.json
@@ -72,8 +72,8 @@
   "scripts": {
     "prettify": "prettier --write '**/*.js'",
     "check-pretty": "prettier --list-different '**/*.js'",
-    "start": "node scripts/start.js",
-    "build": "node scripts/build.js",
+    "start": "NODE_ENV=development webpack-dev-server --config config/makeWebpackConfig.js",
+    "build": "NODE_ENV=production webpack --config config/makeWebpackConfig.js",
     "backend": "node scripts/backend.js",
     "test": "node scripts/test.js --env=jsdom",
     "ci-test": "CI=1 npm run test",


### PR DESCRIPTION
Test Plan:
Run `yarn start` and note that everything checks out.

Run `yarn build && (cd build/ && python -m SimpleHTTPServer)` and note
that everything checks out, except that the static assets are of course
not included in the build.

wchargin-branch: webpack-replace-scripts