### PR TITLE
Add a template for pull requests

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,5 @@
+Summary:
+[Please describe your changes.]
+
+Test Plan:
+[Please list the steps required to verify that your change is correct.]


### PR DESCRIPTION
Summary:
By pre-filling the “summary” and “test plan” fields, we create a strong
suggestion that people fill them out.

I’ve written this template in accordance with Phabricator commit style
(which is also what I use personally). I don’t intend for this to be
normative. It is perfectly valid to leave off the “Summary” header, for
instance, and it is perfectly valid to spell “Test Plan” with a
lowercase “p”. However, for a template in particular I think that
including the “Summary” header is better than excluding it, to give
contributors an idea of what’s supposed to go there.

I expect that upon drafting a pull request with a single commit, the
commit’s body, if non-empty, will take precedence over the pull request
template. If this is not the case, then we can reconsider whether we
want to include this template.

Test Plan:
Note that [GitHub documentation][1] indicates that this is the correct
file path. Then, merge and hope for the best.

[1]: https://blog.github.com/2016-02-17-issue-and-pull-request-templates/

wchargin-branch: pull-request-template