### PR TITLE
Permit STOPSHIPs in Markdown files

### DIFF
--- a/scripts/check-stopships.sh
+++ b/scripts/check-stopships.sh
@@ -1,2 +1,2 @@
 #!/bin/sh
-! git grep -n -i "STOP""SHIP" -- :/
+! git grep -n -i "STOP""SHIP" -- :/ ':/!*.md'


### PR DESCRIPTION
Summary:
This way, we can document what STOPSHIPs are without having to tip-toe
around the phrase.

Test Plan:
Add `STOPSHIP` to `README.md`, and note that `yarn test` fails before
this change but passes after it.

wchargin-branch: stopship-markdown-okay