### PR TITLE
Remove `clean-webpack-plugin`

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,6 @@
     "babel-preset-react-app": "^3.1.1",
     "babel-runtime": "6.26.0",
     "case-sensitive-paths-webpack-plugin": "2.1.1",
-    "clean-webpack-plugin": "^0.1.19",
     "css-loader": "0.28.7",
     "dotenv": "4.0.0",
     "dotenv-expand": "4.0.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1586,12 +1586,6 @@ clean-stack@^1.3.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/clean-stack/-/clean-stack-1.3.0.tgz#9e821501ae979986c46b1d66d2d432db2fd4ae31"
 
-clean-webpack-plugin@^0.1.19:
-  version "0.1.19"
-  resolved "https://registry.yarnpkg.com/clean-webpack-plugin/-/clean-webpack-plugin-0.1.19.tgz#ceda8bb96b00fe168e9b080272960d20fdcadd6d"
-  dependencies:
-    rimraf "^2.6.1"
-
 cli-boxes@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/cli-boxes/-/cli-boxes-1.0.0.tgz#4fa917c3e59c94a004cd61f8ee509da651687143"


### PR DESCRIPTION
Summary:
As of #577, this is no longer needed.

Test Plan:
Running `yarn && yarn test --full` suffices.

wchargin-branch: remove-clean-webpack-plugin
