### PR TITLE
Streamline the cred explorer UI

### DIFF
--- a/src/app/credExplorer/App.js
+++ b/src/app/credExplorer/App.js
@@ -1,7 +1,6 @@
 // @flow
 
 import React from "react";
-import {StyleSheet, css} from "aphrodite/no-important";
 
 import type {LocalStore} from "../localStore";
 import CheckedLocalStore from "../checkedLocalStore";
@@ -65,15 +64,13 @@ export class App extends React.Component<Props, State> {
     const {graphWithAdapters, pnd} = this.state.data;
     return (
       <div style={{maxWidth: "66em", margin: "0 auto", padding: "0 10px"}}>
-        <header className={css(styles.header)}>
-          <h1>Cred Explorer</h1>
-        </header>
         <div>
-          <RepositorySelect
-            localStore={localStore}
-            onChange={(selectedRepo) => this.setState({selectedRepo})}
-          />
-          <br />
+          <div style={{marginBottom: 10}}>
+            <RepositorySelect
+              localStore={localStore}
+              onChange={(selectedRepo) => this.setState({selectedRepo})}
+            />
+          </div>
           <button
             disabled={selectedRepo == null}
             onClick={() => this.loadData()}
@@ -102,9 +99,8 @@ export class App extends React.Component<Props, State> {
               });
             }}
           >
-            Run basic PageRank
+            Run PageRank
           </button>
-          {graphWithAdapters ? <p>Graph loaded.</p> : <p>Graph not loaded.</p>}
           <WeightConfig
             localStore={localStore}
             onChange={(ee) => this.setState({edgeEvaluator: ee})}
@@ -139,9 +135,3 @@ export class App extends React.Component<Props, State> {
     });
   }
 }
-
-const styles = StyleSheet.create({
-  header: {
-    color: "#090",
-  },
-});

--- a/src/app/credExplorer/PagerankTable.js
+++ b/src/app/credExplorer/PagerankTable.js
@@ -102,8 +102,7 @@ export class PagerankTable extends React.PureComponent<
       throw new Error("maxEntriesPerList not set");
     }
     return (
-      <div>
-        <h2>PageRank results</h2>
+      <div style={{marginTop: 10}}>
         {this.renderFilterSelect()}
         {this.renderTable()}
       </div>


### PR DESCRIPTION
This commit removes some unecessary text and whitespace from the cred
explorer. The result is more minimal. It's not super pretty, but that
will come later.

Test plan: Visual inspection

Before:
![image](https://user-images.githubusercontent.com/1400023/43498229-db28ea56-94fa-11e8-8a66-803b4ccea585.png)

After:
![image](https://user-images.githubusercontent.com/1400023/43498270-139cc5ba-94fb-11e8-8bf4-d08297105924.png)


