### PR TITLE
Rename "Explore(r)" to "Prototype" in route and navigation

### DIFF
--- a/src/app/routeData.js
+++ b/src/app/routeData.js
@@ -28,13 +28,13 @@ const routeData /*: $ReadOnlyArray<RouteDatum> */ = [
     navTitle: "Home",
   },
   {
-    path: "/explorer",
+    path: "/prototype",
     contents: {
       type: "PAGE",
       component: () => require("./credExplorer/App").default,
     },
-    title: "SourceCred explorer",
-    navTitle: "Explore",
+    title: "SourceCred prototype",
+    navTitle: "Prototype",
   },
   {
     path: "/discord-invite",


### PR DESCRIPTION
"Explore(r)" does not accurately convey the current state of the
project. In order to more accurately convey the current state,
"Explore(r)" has been updated to "Prototype"

Addresses #584

Test plan: Visual inspection and manual testing of pathing
