### PR TITLE
Downcase `sourcecred` URL on homepage

### DIFF
--- a/src/app/HomePage.js
+++ b/src/app/HomePage.js
@@ -18,7 +18,7 @@ export default class HomePage extends React.Component<{||}> {
       discord: "https://discord.gg/tsBTgc9",
       github: "https://github.com/sourcecred/sourcecred",
       contributionsWelcome:
-        "https://github.com/SourceCred/SourceCred/issues?q=is%3Aissue+is%3Aopen+label%3A%22contributions+welcome%22",
+        "https://github.com/sourcecred/sourcecred/issues?q=is%3Aissue+is%3Aopen+label%3A%22contributions+welcome%22",
       readme: "https://github.com/sourcecred/sourcecred/blob/master/README.md",
     };
     return (


### PR DESCRIPTION
Summary:
This is minor, but we might as well point to the canonical
capitalization.

Test Plan:
None.

wchargin-branch: downcase-sourcecred-url
