### PR TITLE
ensure-flow.sh: simplify, removing dep on GNU grep

### DIFF
--- a/scripts/ensure-flow.sh
+++ b/scripts/ensure-flow.sh
@@ -1,7 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 set -eu
-git grep -Fz --files-without-match -e '@flow' -e '@no-flow' -- '*.js' \
-    | grep -zv '^flow-typed/' \
-    | tr '\0' '\n' \
-    | tee >(cat >&2) \
-    | diff -q /dev/null - >/dev/null
+! git grep -F --files-without-match -e '@flow' -e '@no-flow' \
+        -- ':/*.js' ':!/flow-typed/' >&2


### PR DESCRIPTION
Summary:
By using Git’s magic pathspecs instead of post-processing stream
operations, we reduce the pipeline to a single operation. Git implements
its own version of `grep`, so this should be platform-independent.
Previously, we had needed the `-z` argument to `grep(1)`, which is a GNU
extension.

Fixes #594.

Test Plan:
Ensure that the script passes with no output. Then,

```shell
mkdir -p src/flow-typed/
touch src/foo.js src/flow-typed.js src/flow-typed/foo.js
git add src/foo.js src/flow-typed.js src/flow-typed/foo.js
cd scripts
./ensure-flow.sh
```

and ensure that script exits with code 1, empty stdout, and stderr with:

```
../src/flow-typed.js
../src/flow-typed/foo.js
../src/foo.js
```

This verifies that the pathspec is properly excluding the root directory
`flow-typed`, but not files that just happen to have `flow-typed` in
their paths.

wchargin-branch: simplify-ensure-flow
