### PR TITLE
Make PagerankTable props non-nullable

### DIFF
--- a/src/app/credExplorer/PagerankTable.js
+++ b/src/app/credExplorer/PagerankTable.js
@@ -77,8 +77,8 @@ type SharedProps = {|
 |};
 
 type PagerankTableProps = {|
-  +pnd: ?PagerankNodeDecomposition,
-  +adapters: ?$ReadOnlyArray<DynamicPluginAdapter>,
+  +pnd: PagerankNodeDecomposition,
+  +adapters: $ReadOnlyArray<DynamicPluginAdapter>,
   +maxEntriesPerList: number,
 |};
 type PagerankTableState = {|topLevelFilter: NodeAddressT|};
@@ -92,15 +92,6 @@ export class PagerankTable extends React.PureComponent<
   }
 
   render() {
-    if (this.props.adapters == null) {
-      return <p>You must load a graph before seeing PageRank analysis.</p>;
-    }
-    if (this.props.pnd == null) {
-      return <p>Please run PageRank to see analysis.</p>;
-    }
-    if (this.props.maxEntriesPerList == null) {
-      throw new Error("maxEntriesPerList not set");
-    }
     return (
       <div style={{marginTop: 10}}>
         {this.renderFilterSelect()}

--- a/src/app/credExplorer/PagerankTable.test.js
+++ b/src/app/credExplorer/PagerankTable.test.js
@@ -1,7 +1,6 @@
 // @flow
 import React from "react";
 import {shallow} from "enzyme";
-import enzymeToJSON from "enzyme-to-json";
 
 import type {DynamicPluginAdapter} from "../pluginAdapter";
 
@@ -175,32 +174,6 @@ describe("app/credExplorer/PagerankTable", () => {
   });
 
   describe("PagerankTable", () => {
-    it("renders expected message with null props", () => {
-      const element = shallow(
-        <PagerankTable pnd={null} adapters={null} maxEntriesPerList={1} />
-      );
-      expect(enzymeToJSON(element)).toMatchSnapshot();
-    });
-    it("renders expected message with just adapters", async () => {
-      const {adapters} = await example();
-      const element = shallow(
-        <PagerankTable pnd={null} adapters={adapters} maxEntriesPerList={1} />
-      );
-      expect(enzymeToJSON(element)).toMatchSnapshot();
-    });
-    it("throws an error if maxEntriesPerList not set", async () => {
-      const {pnd, adapters} = await example();
-      expect(() =>
-        shallow(
-          <PagerankTable
-            pnd={pnd}
-            adapters={adapters}
-            // $ExpectFlowError
-            maxEntriesPerList={null}
-          />
-        )
-      ).toThrowError("maxEntriesPerList");
-    });
     it("renders thead column order properly", async () => {
       const {pnd, adapters} = await example();
       const element = shallow(

--- a/src/app/credExplorer/__snapshots__/PagerankTable.test.js.snap
+++ b/src/app/credExplorer/__snapshots__/PagerankTable.test.js.snap
@@ -66,15 +66,3 @@ Array [
   },
 ]
 `;
-
-exports[`app/credExplorer/PagerankTable PagerankTable renders expected message with just adapters 1`] = `
-<p>
-  Please run PageRank to see analysis.
-</p>
-`;
-
-exports[`app/credExplorer/PagerankTable PagerankTable renders expected message with null props 1`] = `
-<p>
-  You must load a graph before seeing PageRank analysis.
-</p>
-`;


### PR DESCRIPTION
Historically, `credExplorer/App.js` instantiated a PagerankTable
regardless of its state, and would pass null props when the App didn't
have data needed to load the table. As of #583, we just don't create the
PagerankTable before its data is available, which is a simpler/better
contract. As such, the type signature of PagerankTable's props can be
simplified, and some logic for handling the null case may be removed.

Test plan: `yarn test` passes, which is sufficient.
