### PR TITLE
Rename Contributor & Contribution types

### DIFF
--- a/src/app/credExplorer/PagerankTable.js
+++ b/src/app/credExplorer/PagerankTable.js
@@ -11,9 +11,9 @@ import {
 } from "../../core/graph";
 import type {
   PagerankNodeDecomposition,
-  ScoredContribution,
+  ScoredConnection,
 } from "../../core/attribution/pagerankNodeDecomposition";
-import type {Contribution} from "../../core/attribution/graphToMarkovChain";
+import type {Connection} from "../../core/attribution/graphToMarkovChain";
 import type {DynamicPluginAdapter} from "../pluginAdapter";
 import * as NullUtil from "../../util/null";
 
@@ -173,7 +173,7 @@ export class PagerankTable extends React.PureComponent<
         <thead>
           <tr>
             <th style={{textAlign: "left"}}>Description</th>
-            <th style={{textAlign: "right"}}>Contribution</th>
+            <th style={{textAlign: "right"}}>Connection</th>
             <th style={{textAlign: "right"}}>Score</th>
           </tr>
         </thead>
@@ -250,7 +250,7 @@ export class NodeRow extends React.PureComponent<NodeRowProps, RowState> {
           <td style={{textAlign: "right"}}>{scoreDisplay(score)}</td>
         </tr>
         {expanded && (
-          <ContributionRowList
+          <ConnectionRowList
             key="children"
             depth={1}
             node={node}
@@ -262,29 +262,29 @@ export class NodeRow extends React.PureComponent<NodeRowProps, RowState> {
   }
 }
 
-type ContributionRowListProps = {|
+type ConnectionRowListProps = {|
   +depth: number,
   +node: NodeAddressT,
   +sharedProps: SharedProps,
 |};
 
-export class ContributionRowList extends React.PureComponent<
-  ContributionRowListProps
+export class ConnectionRowList extends React.PureComponent<
+  ConnectionRowListProps
 > {
   render() {
     const {depth, node, sharedProps} = this.props;
     const {pnd, maxEntriesPerList} = sharedProps;
-    const {scoredContributions} = NullUtil.get(pnd.get(node));
+    const {scoredConnections} = NullUtil.get(pnd.get(node));
     return (
       <React.Fragment>
-        {scoredContributions
+        {scoredConnections
           .slice(0, maxEntriesPerList)
           .map((sc) => (
-            <ContributionRow
-              key={JSON.stringify(sc.contribution.contributor)}
+            <ConnectionRow
+              key={JSON.stringify(sc.connection.adjacency)}
               depth={depth}
               target={node}
-              scoredContribution={sc}
+              scoredConnection={sc}
               sharedProps={sharedProps}
             />
           ))}
@@ -293,15 +293,15 @@ export class ContributionRowList extends React.PureComponent<
   }
 }
 
-type ContributionRowProps = {|
+type ConnectionRowProps = {|
   +depth: number,
   +target: NodeAddressT,
-  +scoredContribution: ScoredContribution,
+  +scoredConnection: ScoredConnection,
   +sharedProps: SharedProps,
 |};
 
-export class ContributionRow extends React.PureComponent<
-  ContributionRowProps,
+export class ConnectionRow extends React.PureComponent<
+  ConnectionRowProps,
   RowState
 > {
   constructor() {
@@ -313,18 +313,13 @@ export class ContributionRow extends React.PureComponent<
       sharedProps,
       target,
       depth,
-      scoredContribution: {
-        contribution,
-        source,
-        sourceScore,
-        contributionScore,
-      },
+      scoredConnection: {connection, source, sourceScore, connectionScore},
     } = this.props;
     const {pnd, adapters} = sharedProps;
     const {expanded} = this.state;
     const {score: targetScore} = NullUtil.get(pnd.get(target));
-    const contributionProportion = contributionScore / targetScore;
-    const contributionPercent = (contributionProportion * 100).toFixed(2);
+    const connectionProportion = connectionScore / targetScore;
+    const connectionPercent = (connectionProportion * 100).toFixed(2);
 
     return (
       <React.Fragment>
@@ -346,13 +341,13 @@ export class ContributionRow extends React.PureComponent<
             >
               {expanded ? "\u2212" : "+"}
             </button>
-            <ContributionView contribution={contribution} adapters={adapters} />
+            <ConnectionView connection={connection} adapters={adapters} />
           </td>
-          <td style={{textAlign: "right"}}>{contributionPercent}%</td>
+          <td style={{textAlign: "right"}}>{connectionPercent}%</td>
           <td style={{textAlign: "right"}}>{scoreDisplay(sourceScore)}</td>
         </tr>
         {expanded && (
-          <ContributionRowList
+          <ConnectionRowList
             key="children"
             depth={depth + 1}
             node={source}
@@ -364,12 +359,12 @@ export class ContributionRow extends React.PureComponent<
   }
 }
 
-export class ContributionView extends React.PureComponent<{|
-  +contribution: Contribution,
+export class ConnectionView extends React.PureComponent<{|
+  +connection: Connection,
   +adapters: $ReadOnlyArray<DynamicPluginAdapter>,
 |}> {
   render() {
-    const {contribution, adapters} = this.props;
+    const {connection, adapters} = this.props;
     function Badge({children}) {
       return (
         // The outer <span> acts as a strut to ensure that the badge
@@ -387,30 +382,30 @@ export class ContributionView extends React.PureComponent<{|
         </span>
       );
     }
-    const {contributor} = contribution;
-    switch (contributor.type) {
+    const {adjacency} = connection;
+    switch (adjacency.type) {
       case "SYNTHETIC_LOOP":
         return <Badge>synthetic loop</Badge>;
       case "IN_EDGE":
         return (
           <span>
             <Badge>
-              {edgeVerb(contributor.edge.address, "BACKWARD", adapters)}
+              {edgeVerb(adjacency.edge.address, "BACKWARD", adapters)}
             </Badge>{" "}
-            <span>{nodeDescription(contributor.edge.src, adapters)}</span>
+            <span>{nodeDescription(adjacency.edge.src, adapters)}</span>
           </span>
         );
       case "OUT_EDGE":
         return (
           <span>
             <Badge>
-              {edgeVerb(contributor.edge.address, "FORWARD", adapters)}
+              {edgeVerb(adjacency.edge.address, "FORWARD", adapters)}
             </Badge>{" "}
-            <span>{nodeDescription(contributor.edge.dst, adapters)}</span>
+            <span>{nodeDescription(adjacency.edge.dst, adapters)}</span>
           </span>
         );
       default:
-        throw new Error((contributor.type: empty));
+        throw new Error((adjacency.type: empty));
     }
   }
 }

--- a/src/app/credExplorer/__snapshots__/PagerankTable.test.js.snap
+++ b/src/app/credExplorer/__snapshots__/PagerankTable.test.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`app/credExplorer/PagerankTable ContributionRow has proper depth-based styling 1`] = `
+exports[`app/credExplorer/PagerankTable ConnectionRow has proper depth-based styling 1`] = `
 Object {
   "buttonStyle": Object {
     "marginLeft": 30,

--- a/src/core/attribution/__snapshots__/pagerankNodeDecomposition.test.js.snap
+++ b/src/core/attribution/__snapshots__/pagerankNodeDecomposition.test.js.snap
@@ -1,13 +1,13 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`core/attribution/contributions decompose has the expected output on a simple asymmetric chain 1`] = `
+exports[`core/attribution/connections decompose has the expected output on a simple asymmetric chain 1`] = `
 Map {
   "NodeAddress[\\"n1\\"]" => Object {
     "score": 0.19117656878499834,
-    "scoredContributions": Array [
+    "scoredConnections": Array [
       Object {
-        "contribution": Object {
-          "contributor": Object {
+        "connection": Object {
+          "adjacency": Object {
             "edge": Object {
               "address": "EdgeAddress[\\"e3\\"]",
               "dst": "NodeAddress[\\"sink\\"]",
@@ -17,13 +17,13 @@ Map {
           },
           "weight": 0.1875,
         },
-        "contributionScore": 0.1102941261444197,
+        "connectionScore": 0.1102941261444197,
         "source": "NodeAddress[\\"sink\\"]",
         "sourceScore": 0.5882353394369051,
       },
       Object {
-        "contribution": Object {
-          "contributor": Object {
+        "connection": Object {
+          "adjacency": Object {
             "edge": Object {
               "address": "EdgeAddress[\\"e1\\"]",
               "dst": "NodeAddress[\\"n2\\"]",
@@ -33,18 +33,18 @@ Map {
           },
           "weight": 0.3,
         },
-        "contributionScore": 0.066176427533429,
+        "connectionScore": 0.066176427533429,
         "source": "NodeAddress[\\"n2\\"]",
         "sourceScore": 0.22058809177809668,
       },
       Object {
-        "contribution": Object {
-          "contributor": Object {
+        "connection": Object {
+          "adjacency": Object {
             "type": "SYNTHETIC_LOOP",
           },
           "weight": 0.07692307692307693,
         },
-        "contributionScore": 0.014705889906538334,
+        "connectionScore": 0.014705889906538334,
         "source": "NodeAddress[\\"n1\\"]",
         "sourceScore": 0.19117656878499834,
       },
@@ -52,10 +52,10 @@ Map {
   },
   "NodeAddress[\\"n2\\"]" => Object {
     "score": 0.22058809177809668,
-    "scoredContributions": Array [
+    "scoredConnections": Array [
       Object {
-        "contribution": Object {
-          "contributor": Object {
+        "connection": Object {
+          "adjacency": Object {
             "edge": Object {
               "address": "EdgeAddress[\\"e2\\"]",
               "dst": "NodeAddress[\\"sink\\"]",
@@ -65,13 +65,13 @@ Map {
           },
           "weight": 0.1875,
         },
-        "contributionScore": 0.1102941261444197,
+        "connectionScore": 0.1102941261444197,
         "source": "NodeAddress[\\"sink\\"]",
         "sourceScore": 0.5882353394369051,
       },
       Object {
-        "contribution": Object {
-          "contributor": Object {
+        "connection": Object {
+          "adjacency": Object {
             "edge": Object {
               "address": "EdgeAddress[\\"e1\\"]",
               "dst": "NodeAddress[\\"n2\\"]",
@@ -81,18 +81,18 @@ Map {
           },
           "weight": 0.46153846153846156,
         },
-        "contributionScore": 0.08823533943923001,
+        "connectionScore": 0.08823533943923001,
         "source": "NodeAddress[\\"n1\\"]",
         "sourceScore": 0.19117656878499834,
       },
       Object {
-        "contribution": Object {
-          "contributor": Object {
+        "connection": Object {
+          "adjacency": Object {
             "type": "SYNTHETIC_LOOP",
           },
           "weight": 0.1,
         },
-        "contributionScore": 0.02205880917780967,
+        "connectionScore": 0.02205880917780967,
         "source": "NodeAddress[\\"n2\\"]",
         "sourceScore": 0.22058809177809668,
       },
@@ -100,10 +100,10 @@ Map {
   },
   "NodeAddress[\\"sink\\"]" => Object {
     "score": 0.5882353394369051,
-    "scoredContributions": Array [
+    "scoredConnections": Array [
       Object {
-        "contribution": Object {
-          "contributor": Object {
+        "connection": Object {
+          "adjacency": Object {
             "edge": Object {
               "address": "EdgeAddress[\\"e4\\"]",
               "dst": "NodeAddress[\\"sink\\"]",
@@ -113,13 +113,13 @@ Map {
           },
           "weight": 0.375,
         },
-        "contributionScore": 0.2205882522888394,
+        "connectionScore": 0.2205882522888394,
         "source": "NodeAddress[\\"sink\\"]",
         "sourceScore": 0.5882353394369051,
       },
       Object {
-        "contribution": Object {
-          "contributor": Object {
+        "connection": Object {
+          "adjacency": Object {
             "edge": Object {
               "address": "EdgeAddress[\\"e2\\"]",
               "dst": "NodeAddress[\\"sink\\"]",
@@ -129,13 +129,13 @@ Map {
           },
           "weight": 0.6,
         },
-        "contributionScore": 0.132352855066858,
+        "connectionScore": 0.132352855066858,
         "source": "NodeAddress[\\"n2\\"]",
         "sourceScore": 0.22058809177809668,
       },
       Object {
-        "contribution": Object {
-          "contributor": Object {
+        "connection": Object {
+          "adjacency": Object {
             "edge": Object {
               "address": "EdgeAddress[\\"e4\\"]",
               "dst": "NodeAddress[\\"sink\\"]",
@@ -145,13 +145,13 @@ Map {
           },
           "weight": 0.1875,
         },
-        "contributionScore": 0.1102941261444197,
+        "connectionScore": 0.1102941261444197,
         "source": "NodeAddress[\\"sink\\"]",
         "sourceScore": 0.5882353394369051,
       },
       Object {
-        "contribution": Object {
-          "contributor": Object {
+        "connection": Object {
+          "adjacency": Object {
             "edge": Object {
               "address": "EdgeAddress[\\"e3\\"]",
               "dst": "NodeAddress[\\"sink\\"]",
@@ -161,18 +161,18 @@ Map {
           },
           "weight": 0.46153846153846156,
         },
-        "contributionScore": 0.08823533943923001,
+        "connectionScore": 0.08823533943923001,
         "source": "NodeAddress[\\"n1\\"]",
         "sourceScore": 0.19117656878499834,
       },
       Object {
-        "contribution": Object {
-          "contributor": Object {
+        "connection": Object {
+          "adjacency": Object {
             "type": "SYNTHETIC_LOOP",
           },
           "weight": 0.0625,
         },
-        "contributionScore": 0.03676470871480657,
+        "connectionScore": 0.03676470871480657,
         "source": "NodeAddress[\\"sink\\"]",
         "sourceScore": 0.5882353394369051,
       },

--- a/src/core/attribution/graphToMarkovChain.test.js
+++ b/src/core/attribution/graphToMarkovChain.test.js
@@ -5,7 +5,7 @@ import sortBy from "lodash.sortby";
 import {EdgeAddress, Graph, NodeAddress} from "../graph";
 import {
   distributionToNodeDistribution,
-  createContributions,
+  createConnections,
   createOrderedSparseMarkovChain,
   normalize,
   normalizeNeighbors,
@@ -81,9 +81,9 @@ describe("core/attribution/graphToMarkovChain", () => {
     expect(actual).toEqual(expected);
   });
 
-  describe("createContributions", () => {
+  describe("createConnections", () => {
     // The tests for `createOrderedSparseMarkovChain` also must invoke
-    // `createContributions`, so we add only light testing separately.
+    // `createConnections`, so we add only light testing separately.
     it("works on a simple asymmetric chain", () => {
       const n1 = NodeAddress.fromParts(["n1"]);
       const n2 = NodeAddress.fromParts(["n2"]);
@@ -101,28 +101,28 @@ describe("core/attribution/graphToMarkovChain", () => {
         .addEdge(e3)
         .addEdge(e4);
       const edgeWeight = () => ({toWeight: 6.0, froWeight: 3.0});
-      const actual = createContributions(g, edgeWeight, 1.0);
+      const actual = createConnections(g, edgeWeight, 1.0);
       // Total out-weights (for normalization factors):
       //   - for `n1`: 2 out, 0 in, 1 synthetic: 12 + 0 + 1 = 13
       //   - for `n2`: 1 out, 1 in, 1 synthetic: 6 + 3 + 1 = 10
       //   - for `n3`: 1 out, 3 in, 1 synthetic: 6 + 9 + 1 = 16
       const expected = new Map()
         .set(n1, [
-          {contributor: {type: "SYNTHETIC_LOOP"}, weight: 1 / 13},
-          {contributor: {type: "OUT_EDGE", edge: e1}, weight: 3 / 10},
-          {contributor: {type: "OUT_EDGE", edge: e3}, weight: 3 / 16},
+          {adjacency: {type: "SYNTHETIC_LOOP"}, weight: 1 / 13},
+          {adjacency: {type: "OUT_EDGE", edge: e1}, weight: 3 / 10},
+          {adjacency: {type: "OUT_EDGE", edge: e3}, weight: 3 / 16},
         ])
         .set(n2, [
-          {contributor: {type: "SYNTHETIC_LOOP"}, weight: 1 / 10},
-          {contributor: {type: "IN_EDGE", edge: e1}, weight: 6 / 13},
-          {contributor: {type: "OUT_EDGE", edge: e2}, weight: 3 / 16},
+          {adjacency: {type: "SYNTHETIC_LOOP"}, weight: 1 / 10},
+          {adjacency: {type: "IN_EDGE", edge: e1}, weight: 6 / 13},
+          {adjacency: {type: "OUT_EDGE", edge: e2}, weight: 3 / 16},
         ])
         .set(n3, [
-          {contributor: {type: "SYNTHETIC_LOOP"}, weight: 1 / 16},
-          {contributor: {type: "IN_EDGE", edge: e2}, weight: 6 / 10},
-          {contributor: {type: "IN_EDGE", edge: e3}, weight: 6 / 13},
-          {contributor: {type: "IN_EDGE", edge: e4}, weight: 6 / 16},
-          {contributor: {type: "OUT_EDGE", edge: e4}, weight: 3 / 16},
+          {adjacency: {type: "SYNTHETIC_LOOP"}, weight: 1 / 16},
+          {adjacency: {type: "IN_EDGE", edge: e2}, weight: 6 / 10},
+          {adjacency: {type: "IN_EDGE", edge: e3}, weight: 6 / 13},
+          {adjacency: {type: "IN_EDGE", edge: e4}, weight: 6 / 16},
+          {adjacency: {type: "OUT_EDGE", edge: e4}, weight: 3 / 16},
         ]);
       const canonicalize = (map) =>
         MapUtil.mapValues(map, (_, v) => sortBy(v, (x) => JSON.stringify(x)));
@@ -138,7 +138,7 @@ describe("core/attribution/graphToMarkovChain", () => {
         throw new Error("Don't even look at me");
       };
       const osmc = createOrderedSparseMarkovChain(
-        createContributions(g, edgeWeight, 1e-3)
+        createConnections(g, edgeWeight, 1e-3)
       );
       const expected = {
         nodeOrder: [n],
@@ -167,7 +167,7 @@ describe("core/attribution/graphToMarkovChain", () => {
         .addEdge(e4);
       const edgeWeight = () => ({toWeight: 1, froWeight: 0});
       const osmc = createOrderedSparseMarkovChain(
-        createContributions(g, edgeWeight, 0.0)
+        createConnections(g, edgeWeight, 0.0)
       );
       const expected = {
         nodeOrder: [n1, n2, n3],
@@ -205,7 +205,7 @@ describe("core/attribution/graphToMarkovChain", () => {
         .addEdge(e3);
       const edgeWeight = () => ({toWeight: 1, froWeight: 1});
       const osmc = createOrderedSparseMarkovChain(
-        createContributions(g, edgeWeight, 0.0)
+        createConnections(g, edgeWeight, 0.0)
       );
       const expected = {
         nodeOrder: [n1, n2, n3],
@@ -237,7 +237,7 @@ describe("core/attribution/graphToMarkovChain", () => {
         return {toWeight: 4 - epsilon / 2, froWeight: 1 - epsilon / 2};
       }
       const osmc = createOrderedSparseMarkovChain(
-        createContributions(g, edgeWeight, epsilon)
+        createConnections(g, edgeWeight, epsilon)
       );
       // Edges from `src`:
       //   - to `src` with weight `epsilon`

--- a/src/core/attribution/pagerank.js
+++ b/src/core/attribution/pagerank.js
@@ -3,7 +3,7 @@
 import {type Edge, Graph} from "../graph";
 import {
   distributionToNodeDistribution,
-  createContributions,
+  createConnections,
   createOrderedSparseMarkovChain,
   type EdgeWeight,
 } from "./graphToMarkovChain";
@@ -44,12 +44,12 @@ export async function pagerank(
     ...defaultOptions(),
     ...(options || {}),
   };
-  const contributions = createContributions(
+  const connections = createConnections(
     graph,
     edgeWeight,
     fullOptions.selfLoopWeight
   );
-  const osmc = createOrderedSparseMarkovChain(contributions);
+  const osmc = createOrderedSparseMarkovChain(connections);
   const distribution = await findStationaryDistribution(osmc.chain, {
     verbose: fullOptions.verbose,
     convergenceThreshold: fullOptions.convergenceThreshold,
@@ -57,5 +57,5 @@ export async function pagerank(
     yieldAfterMs: 30,
   });
   const pi = distributionToNodeDistribution(osmc.nodeOrder, distribution);
-  return decompose(pi, contributions);
+  return decompose(pi, connections);
 }


### PR DESCRIPTION
Consider the following types:

```
// Used to be called "Contributor"
export type Adjacency =
  | {|+type: "SYNTHETIC_LOOP"|}
  | {|+type: "IN_EDGE", +edge: Edge|}
  | {|+type: "OUT_EDGE", +edge: Edge|};

// Used to be called "Contribution"
export type Connection = {|
  +adjacency: Adjacency,
  // This `weight` is a conditional probability: given that you're at
  // the source of this connection's adjacency, what's the
  // probability that you travel along this connection to the target?
  +weight: Probability,
|};

// Used to be called "ScoredContribution"
export type ScoredConnection = {|
  +connection: Connection,
  +source: NodeAddressT,
  +sourceScore: number,
  +connectionScore: number,
|};
```

These types represent how a node's PagerankScore is influenced by its
connections in the markov chain. The previous names, "Contributor",
"Contribution" and "ScoredContribution", were quite confusing as
elsewhere in the project "contributon" means something that added value
to the project, and "contributor" means the author of contributions.
While these new names aren't necessarily much better a priori, in the
context of the project's vernacular they are much less confusing.

Test plan: It's just a rename, and `yarn test` passes.

Please read our [guide for contributors][guide] before submitting your
pull request.

[guide]: https://github.com/sourcecred/sourcecred/blob/master/CONTRIBUTING.md

Summary:
[Please describe your changes.]

Test Plan:
[Please list the steps required to verify that your change is correct.]
