### PR TITLE
Add type signatures for aggregation logic

### DIFF
--- a/src/app/pluginAdapter.js
+++ b/src/app/pluginAdapter.js
@@ -1,19 +1,13 @@
 // @flow
 
-import type {Graph, NodeAddressT, EdgeAddressT} from "../core/graph";
+import type {
+  Graph,
+  NodeAddressT,
+  EdgeAddressT,
+  NodeType,
+  EdgeType,
+} from "../core/graph";
 import type {Repo} from "../core/repo";
-
-export type EdgeType = {|
-  +forwardName: string,
-  +backwardName: string,
-  +prefix: EdgeAddressT,
-|};
-
-export type NodeType = {|
-  +name: string,
-  +prefix: NodeAddressT,
-  +defaultWeight: number,
-|};
 
 export interface StaticPluginAdapter {
   name(): string;

--- a/src/core/attribution/aggregation.js
+++ b/src/core/attribution/aggregation.js
@@ -1,0 +1,35 @@
+// @flow
+
+import type {NodeType, EdgeType} from "../graph";
+import type {ScoredConnection} from "./pagerankNodeDecomposition";
+
+export type ConnectionType =
+  | {|+type: "IN_EDGE", +edgeType: EdgeType|}
+  | {|+type: "OUT_EDGE", +edgeType: EdgeType|}
+  | {|+type: "SYNTHETIC_LOOP"|};
+
+export type AggregationSummary = {|
+  +size: number,
+  +aggregateScore: number,
+|};
+
+export type ConnectionAggregation = {|
+  +connectionType: ConnectionType,
+  +aggregationSummary: AggregationSummary,
+  +nodeAggregations: NodeAggregation[],
+|};
+
+export type NodeAggregation = {|
+  +nodeType: NodeType,
+  +aggregationSummary: AggregationSummary,
+  +connections: ScoredConnection,
+|};
+
+export function aggregateConnections(
+  xs: $ReadOnlyArray<ScoredConnection>,
+  edgeTypes: $ReadOnlyArray<EdgeType>,
+  nodeTypes: $ReadOnlyArray<NodeType>
+): ConnectionAggregation[] {
+  const _unused_stuff = [xs, edgeTypes, nodeTypes];
+  throw new Error("Not yet implemented");
+}

--- a/src/core/attribution/aggregation.test.js
+++ b/src/core/attribution/aggregation.test.js
@@ -1,0 +1,7 @@
+// @flow
+
+describe("app/credExplorer/aggregation", () => {
+  it("is not yet implemented", () => {
+    return;
+  });
+});

--- a/src/core/graph.js
+++ b/src/core/graph.js
@@ -26,6 +26,21 @@ export type Edge = {|
   +dst: NodeAddressT,
 |};
 
+// TODO: We should come up with a clear contract here, and
+// probably defaultWeights should not live in this type.
+// Discussion at #465
+export type EdgeType = {|
+  +forwardName: string,
+  +backwardName: string,
+  +prefix: EdgeAddressT,
+|};
+
+export type NodeType = {|
+  +name: string,
+  +prefix: NodeAddressT,
+  +defaultWeight: number,
+|};
+
 const COMPAT_INFO = {type: "sourcecred/graph", version: "0.4.0"};
 
 export type Neighbor = {|+node: NodeAddressT, +edge: Edge|};


### PR DESCRIPTION
This is the first real step towards #502.

Factoring this out because deciding the type signatures was non-trivial,
and the work was paired with @wchargin

Test plan: `yarn test`