### PR TITLE
Forbid accessing the `cache/` directory at runtime

### DIFF
--- a/config/makeWebpackConfig.js
+++ b/config/makeWebpackConfig.js
@@ -1,6 +1,11 @@
 // @flow
 const express = require("express");
-/*:: import type {$Application as ExpressApp} from "express"; */
+/*::
+import type {
+  $Application as ExpressApp,
+  $Response as ExpressResponse,
+} from "express";
+*/
 const os = require("os");
 const path = require("path");
 const webpack = require("webpack");
@@ -43,8 +48,14 @@ function makeConfig(mode /*: "production" | "development" */) {
     devServer: {
       inline: false,
       before: (app /*: ExpressApp */) => {
+        const apiRoot = "/api/v1/data";
+        const rejectCache = (_unused_req, res /*: ExpressResponse */) => {
+          res.status(400).send("Bad Request: Cache unavailable at runtime\n");
+        };
+        app.get(`${apiRoot}/cache`, rejectCache);
+        app.get(`${apiRoot}/cache/*`, rejectCache);
         app.use(
-          "/api/v1/data",
+          apiRoot,
           express.static(
             process.env.SOURCECRED_DIRECTORY ||
               path.join(os.tmpdir(), "sourcecred")


### PR DESCRIPTION
Summary:
We plan to allow plugins to store permanent data in `$SC/data/` and
temporary, ephemeral, or intermediate data in `$SC/cache/`. The latter
subtree will be excluded from the static site at build time, so it
behooves us to also exclude it from the development environment.

Test Plan:
Run `yarn start`. Then,

```shell
$ root='localhost:8080/api/v1/data'
$ curl -sI "${root}/repositoryRegistry.json" | head -1
HTTP/1.1 200 OK
$ curl -sI "${root}/data/sourcecred/example-git/github/view.json" | head -1
HTTP/1.1 200 OK
$ curl -sI "${root}/cache" | head -1
HTTP/1.1 400 Bad Request
$ curl -sI "${root}/cache/" | head -1
HTTP/1.1 400 Bad Request
$ curl -sI "${root}/cache/foo" | head -1
HTTP/1.1 400 Bad Request
$ curl -sI "${root}/cache/foo/bar/baz" | head -1
HTTP/1.1 400 Bad Request
```

Also, check that the app still works.

wchargin-branch: exclude-cache-from-dev-server
