### PR TITLE
Move PluginAdapter to core

### DIFF
--- a/src/app/credExplorer/PagerankTable.js
+++ b/src/app/credExplorer/PagerankTable.js
@@ -14,7 +14,7 @@ import type {
   ScoredConnection,
 } from "../../core/attribution/pagerankNodeDecomposition";
 import type {Connection} from "../../core/attribution/graphToMarkovChain";
-import type {DynamicPluginAdapter} from "../pluginAdapter";
+import type {DynamicPluginAdapter} from "../../core/pluginAdapter";
 import * as NullUtil from "../../util/null";
 
 // TODO: Factor this out and test it (#465)

--- a/src/app/credExplorer/PagerankTable.test.js
+++ b/src/app/credExplorer/PagerankTable.test.js
@@ -2,7 +2,7 @@
 import React from "react";
 import {shallow} from "enzyme";
 
-import type {DynamicPluginAdapter} from "../pluginAdapter";
+import type {DynamicPluginAdapter} from "../../core/pluginAdapter";
 
 import {
   PagerankTable,

--- a/src/app/credExplorer/WeightConfig.js
+++ b/src/app/credExplorer/WeightConfig.js
@@ -15,7 +15,7 @@ import {byEdgeType, byNodeType} from "./edgeWeights";
 import * as MapUtil from "../../util/map";
 import * as NullUtil from "../../util/null";
 
-import type {StaticPluginAdapter} from "../pluginAdapter";
+import type {StaticPluginAdapter} from "../../core/pluginAdapter";
 import {StaticPluginAdapter as GithubAdapter} from "../../plugins/github/pluginAdapter";
 import {StaticPluginAdapter as GitAdapter} from "../../plugins/git/pluginAdapter";
 

--- a/src/app/credExplorer/state.js
+++ b/src/app/credExplorer/state.js
@@ -12,7 +12,7 @@ import {
   pagerank,
 } from "../../core/attribution/pagerank";
 
-import type {DynamicPluginAdapter} from "../pluginAdapter";
+import type {DynamicPluginAdapter} from "../../core/pluginAdapter";
 import {StaticPluginAdapter as GitAdapter} from "../../plugins/git/pluginAdapter";
 import {StaticPluginAdapter as GithubAdapter} from "../../plugins/github/pluginAdapter";
 

--- a/src/core/pluginAdapter.js
+++ b/src/core/pluginAdapter.js
@@ -1,7 +1,7 @@
 // @flow
 
-import type {Graph, NodeAddressT, EdgeAddressT} from "../core/graph";
-import type {Repo} from "../core/repo";
+import type {Graph, NodeAddressT, EdgeAddressT} from "./graph";
+import type {Repo} from "./repo";
 
 export type EdgeType = {|
   +forwardName: string,

--- a/src/plugins/git/pluginAdapter.js
+++ b/src/plugins/git/pluginAdapter.js
@@ -2,7 +2,7 @@
 import type {
   StaticPluginAdapter as IStaticPluginAdapter,
   DynamicPluginAdapter as IDynamicPluginAdapter,
-} from "../../app/pluginAdapter";
+} from "../../core/pluginAdapter";
 import {Graph} from "../../core/graph";
 import * as N from "./nodes";
 import * as E from "./edges";
@@ -64,7 +64,7 @@ export class StaticPluginAdapter implements IStaticPluginAdapter {
     }
     const json = await response.json();
     const graph = Graph.fromJSON(json);
-    return new DynamicPluginAdapter(graph);
+    return (new DynamicPluginAdapter(graph): IDynamicPluginAdapter);
   }
 }
 

--- a/src/plugins/github/pluginAdapter.js
+++ b/src/plugins/github/pluginAdapter.js
@@ -2,7 +2,7 @@
 import type {
   StaticPluginAdapter as IStaticPluginAdapter,
   DynamicPluginAdapter as IDynamicPluginAdapater,
-} from "../../app/pluginAdapter";
+} from "../../core/pluginAdapter";
 import {type Graph, NodeAddress} from "../../core/graph";
 import {createGraph} from "./createGraph";
 import * as N from "./nodes";


### PR DESCRIPTION
There's no reason for it to be in `app` - the concepts it contains are
core concepts, e.g. node types and graphs.

For now I'm leaving the `NodeType` and `EdgeType` interfaces with the
PluginAdapter. They may move later, but I'm relucant to clutter the
graph class more, and all I need for now is that they live in core.

Test plan: It's just a move/rename, so `yarn test` is amply sufficient.
