### PR TITLE
Expose a cache directory to plugins at load time

### DIFF
--- a/scripts/build_static_site.sh
+++ b/scripts/build_static_site.sh
@@ -113,6 +113,11 @@ build() {
     # must fail.)
     mkdir "${target}/api/"
     mkdir "${target}/api/v1/"
+    # Eliminate the cache, which is only an intermediate target used to
+    # load the actual data. The development server similarly forbids
+    # access to the cache so that the dev and prod environments have the
+    # same semantics.
+    rm -rf "${sourcecred_data}/cache"
     cp -r "${sourcecred_data}" "${target}/api/v1/data"
 
     if [ -n "${cname:-}" ]; then

--- a/sharness/test_build_static_site.t
+++ b/sharness/test_build_static_site.t
@@ -141,6 +141,10 @@ run_build() {
         test_path_is_dir "${api_dir}" &&
         test_set_prereq "${prereq_name}"
     '
+    test_expect_success "${prereq_name}" \
+        "${prereq_name}: should have no cache" '
+        test_must_fail test_path_is_dir "${api_dir}/cache"
+    '
 }
 
 # test_pages PREREQ_NAME

--- a/src/cli/commands/load.js
+++ b/src/cli/commands/load.js
@@ -114,13 +114,13 @@ function loadAllPlugins({basedir, repo, githubToken, maxOldSpaceSize}) {
 }
 
 function loadPlugin({basedir, plugin, repo, githubToken}) {
-  const outputDirectory = path.join(
-    basedir,
-    "data",
-    repoToString(repo),
-    plugin
-  );
-  mkdirp.sync(outputDirectory);
+  function scopedDirectory(key) {
+    const directory = path.join(basedir, key, repoToString(repo), plugin);
+    mkdirp.sync(directory);
+    return directory;
+  }
+  const outputDirectory = scopedDirectory("data");
+  const cacheDirectory = scopedDirectory("cache");
   switch (plugin) {
     case "github":
       if (githubToken == null) {
@@ -135,11 +135,12 @@ function loadPlugin({basedir, plugin, repo, githubToken}) {
           token: githubToken,
           repo,
           outputDirectory,
+          cacheDirectory,
         });
       }
       break;
     case "git":
-      loadGitData({repo, outputDirectory});
+      loadGitData({repo, outputDirectory, cacheDirectory});
       break;
     default:
       console.error("fatal: Unknown plugin: " + (plugin: empty));

--- a/src/plugins/git/loadGitData.js
+++ b/src/plugins/git/loadGitData.js
@@ -10,6 +10,7 @@ import type {Repo} from "../../core/repo";
 export type Options = {|
   +repo: Repo,
   +outputDirectory: string,
+  +cacheDirectory: string,
 |};
 
 export function loadGitData(options: Options): Promise<void> {

--- a/src/plugins/github/loadGithubData.js
+++ b/src/plugins/github/loadGithubData.js
@@ -11,6 +11,7 @@ export type Options = {|
   +token: string,
   +repo: Repo,
   +outputDirectory: string,
+  +cacheDirectory: string,
 |};
 
 export async function loadGithubData(options: Options): Promise<void> {


### PR DESCRIPTION
Summary:
The `node ./bin/sourcecred.js load` command invokes plugin code by
providing an output directory into which the plugin may store data.
As of this patch, it also provides a cache directory that the plugin may
use to store data that will not be available at runtime. For instance,
the Git plugin might choose to clone the repository herein, or the
GitHub plugin may choose to store partial GraphQL query results to deal
with interruptions. The contract is that the cache directory may be
removed at any time and that the plugin should continue to operate
normally.

Test Plan:
The build script has been updated and tested. Reverting the change to
the build script causes the newly added test to fail. (Each plugin has a
cache directory, though the cache directories are empty for now.)

wchargin-branch: create-plugin-cache
