### PR TITLE
Revert "Move PluginAdapter to core (#615)"

### DIFF
--- a/src/app/credExplorer/PagerankTable.js
+++ b/src/app/credExplorer/PagerankTable.js
@@ -14,7 +14,7 @@ import type {
   ScoredConnection,
 } from "../../core/attribution/pagerankNodeDecomposition";
 import type {Connection} from "../../core/attribution/graphToMarkovChain";
-import type {DynamicPluginAdapter} from "../../core/pluginAdapter";
+import type {DynamicPluginAdapter} from "../pluginAdapter";
 import * as NullUtil from "../../util/null";
 
 // TODO: Factor this out and test it (#465)

--- a/src/app/credExplorer/PagerankTable.test.js
+++ b/src/app/credExplorer/PagerankTable.test.js
@@ -2,7 +2,7 @@
 import React from "react";
 import {shallow} from "enzyme";
 
-import type {DynamicPluginAdapter} from "../../core/pluginAdapter";
+import type {DynamicPluginAdapter} from "../pluginAdapter";
 
 import {
   PagerankTable,

--- a/src/app/credExplorer/WeightConfig.js
+++ b/src/app/credExplorer/WeightConfig.js
@@ -15,7 +15,7 @@ import {byEdgeType, byNodeType} from "./edgeWeights";
 import * as MapUtil from "../../util/map";
 import * as NullUtil from "../../util/null";
 
-import type {StaticPluginAdapter} from "../../core/pluginAdapter";
+import type {StaticPluginAdapter} from "../pluginAdapter";
 import {StaticPluginAdapter as GithubAdapter} from "../../plugins/github/pluginAdapter";
 import {StaticPluginAdapter as GitAdapter} from "../../plugins/git/pluginAdapter";
 

--- a/src/app/credExplorer/state.js
+++ b/src/app/credExplorer/state.js
@@ -12,7 +12,7 @@ import {
   pagerank,
 } from "../../core/attribution/pagerank";
 
-import type {DynamicPluginAdapter} from "../../core/pluginAdapter";
+import type {DynamicPluginAdapter} from "../pluginAdapter";
 import {StaticPluginAdapter as GitAdapter} from "../../plugins/git/pluginAdapter";
 import {StaticPluginAdapter as GithubAdapter} from "../../plugins/github/pluginAdapter";
 

--- a/src/app/pluginAdapter.js
+++ b/src/app/pluginAdapter.js
@@ -1,7 +1,7 @@
 // @flow
 
-import type {Graph, NodeAddressT, EdgeAddressT} from "./graph";
-import type {Repo} from "./repo";
+import type {Graph, NodeAddressT, EdgeAddressT} from "../core/graph";
+import type {Repo} from "../core/repo";
 
 export type EdgeType = {|
   +forwardName: string,

--- a/src/plugins/git/pluginAdapter.js
+++ b/src/plugins/git/pluginAdapter.js
@@ -2,7 +2,7 @@
 import type {
   StaticPluginAdapter as IStaticPluginAdapter,
   DynamicPluginAdapter as IDynamicPluginAdapter,
-} from "../../core/pluginAdapter";
+} from "../../app/pluginAdapter";
 import {Graph} from "../../core/graph";
 import * as N from "./nodes";
 import * as E from "./edges";
@@ -64,7 +64,7 @@ export class StaticPluginAdapter implements IStaticPluginAdapter {
     }
     const json = await response.json();
     const graph = Graph.fromJSON(json);
-    return (new DynamicPluginAdapter(graph): IDynamicPluginAdapter);
+    return new DynamicPluginAdapter(graph);
   }
 }
 

--- a/src/plugins/github/pluginAdapter.js
+++ b/src/plugins/github/pluginAdapter.js
@@ -2,7 +2,7 @@
 import type {
   StaticPluginAdapter as IStaticPluginAdapter,
   DynamicPluginAdapter as IDynamicPluginAdapater,
-} from "../../core/pluginAdapter";
+} from "../../app/pluginAdapter";
 import {type Graph, NodeAddress} from "../../core/graph";
 import {createGraph} from "./createGraph";
 import * as N from "./nodes";


### PR DESCRIPTION
This reverts commit 25b0124b56caaa93ff1c15fec20c1376ba609280.

@wchargin had an extensive offline conversation about PluginAdapters,
and decided that for now we awnt to punt on figuring out the right
abstraction for having a "core"-scoped plugin adapter. Instead, we'll
keep on using plugin adapters as something of a kitchen sink where we
throw in all the per-plugin logic that we need to run the app.

This necessitates reverting #615 because we don't think that React
should be a dependency in core, but we will need the
DynamicPluginAdapter to have a type dependency on React so that we can
solve issues like #590.

Test plan: Yarn test suffices.