### PR TITLE
Add findEdgeType and findNodeType

### DIFF
--- a/src/app/credExplorer/PagerankTable.js
+++ b/src/app/credExplorer/PagerankTable.js
@@ -6,7 +6,6 @@ import React from "react";
 import {
   type EdgeAddressT,
   type NodeAddressT,
-  EdgeAddress,
   NodeAddress,
 } from "../../core/graph";
 import type {
@@ -18,6 +17,7 @@ import {
   type DynamicPluginAdapter,
   dynamicDispatchByNode,
   dynamicDispatchByEdge,
+  findEdgeType,
 } from "../pluginAdapter";
 import * as NullUtil from "../../util/null";
 
@@ -41,16 +41,7 @@ function edgeVerb(
   adapters: $ReadOnlyArray<DynamicPluginAdapter>
 ): string {
   const adapter = dynamicDispatchByEdge(adapters, address);
-
-  const edgeType = adapter
-    .static()
-    .edgeTypes()
-    .find(({prefix}) => EdgeAddress.hasPrefix(address, prefix));
-  if (edgeType == null) {
-    const result = EdgeAddress.toString(address);
-    console.warn(`No edge type for ${result}`);
-    return result;
-  }
+  const edgeType = findEdgeType(adapter.static(), address);
   return direction === "FORWARD" ? edgeType.forwardName : edgeType.backwardName;
 }
 

--- a/src/app/pluginAdapter.js
+++ b/src/app/pluginAdapter.js
@@ -85,3 +85,27 @@ export function dynamicDispatchByEdge(
     EdgeAddress.hasPrefix(x, a.static().edgePrefix())
   );
 }
+
+export function findNodeType(
+  adapter: StaticPluginAdapter,
+  x: NodeAddressT
+): NodeType {
+  if (!NodeAddress.hasPrefix(x, adapter.nodePrefix())) {
+    throw new Error("Trying to find NodeType from the wrong plugin adapter");
+  }
+  return findUniqueMatch(adapter.nodeTypes(), (t) =>
+    NodeAddress.hasPrefix(x, t.prefix)
+  );
+}
+
+export function findEdgeType(
+  adapter: StaticPluginAdapter,
+  x: EdgeAddressT
+): EdgeType {
+  if (!EdgeAddress.hasPrefix(x, adapter.edgePrefix())) {
+    throw new Error("Trying to find EdgeType from the wrong plugin adapter");
+  }
+  return findUniqueMatch(adapter.edgeTypes(), (t) =>
+    EdgeAddress.hasPrefix(x, t.prefix)
+  );
+}

--- a/src/app/pluginAdapter.test.js
+++ b/src/app/pluginAdapter.test.js
@@ -13,6 +13,8 @@ import {
   staticDispatchByEdge,
   dynamicDispatchByNode,
   dynamicDispatchByEdge,
+  findNodeType,
+  findEdgeType,
 } from "./pluginAdapter";
 
 describe("app/pluginAdapter", () => {
@@ -21,8 +23,50 @@ describe("app/pluginAdapter", () => {
       name: () => "foo",
       nodePrefix: () => NodeAddress.fromParts(["foo"]),
       edgePrefix: () => EdgeAddress.fromParts(["foo"]),
-      nodeTypes: () => [],
-      edgeTypes: () => [],
+      nodeTypes: () => [
+        {
+          name: "zap",
+          prefix: NodeAddress.fromParts(["foo", "zap"]),
+          defaultWeight: 0,
+        },
+        {
+          name: "kif",
+          prefix: NodeAddress.fromParts(["foo", "kif"]),
+          defaultWeight: 0,
+        },
+        {
+          name: "bad-duplicate-1",
+          prefix: NodeAddress.fromParts(["foo", "bad"]),
+          defaultWeight: 0,
+        },
+        {
+          name: "bad-duplicate-2",
+          prefix: NodeAddress.fromParts(["foo", "bad"]),
+          defaultWeight: 0,
+        },
+      ],
+      edgeTypes: () => [
+        {
+          forwardName: "kifs",
+          backwardName: "kiffed by",
+          prefix: EdgeAddress.fromParts(["foo", "kif"]),
+        },
+        {
+          forwardName: "zaps",
+          backwardName: "zapped by",
+          prefix: EdgeAddress.fromParts(["foo", "zap"]),
+        },
+        {
+          forwardName: "bad1",
+          backwardName: "bad1'd by",
+          prefix: EdgeAddress.fromParts(["foo", "bad"]),
+        },
+        {
+          forwardName: "bad2",
+          backwardName: "bad2'd by",
+          prefix: EdgeAddress.fromParts(["foo", "bad"]),
+        },
+      ],
       load: (_unused_repo) => Promise.resolve(dynamicFooAdapter),
     };
     const dynamicFooAdapter: DynamicPluginAdapter = {
@@ -95,6 +139,66 @@ describe("app/pluginAdapter", () => {
       const fooSubedge = EdgeAddress.fromParts(["foo", "sub"]);
       expect(dynamicDispatchByEdge(dynamics, fooSubedge)).toBe(
         dynamicFooAdapter
+      );
+    });
+  });
+
+  describe("findNodeType", () => {
+    it("works in a simple case", () => {
+      const {staticFooAdapter} = example();
+      const kifNode = NodeAddress.fromParts(["foo", "kif", "node"]);
+      expect(findNodeType(staticFooAdapter, kifNode).name).toEqual("kif");
+    });
+    it("errors if node doesn't match the plugin", () => {
+      const {staticFooAdapter} = example();
+      const wrongNode = NodeAddress.fromParts(["bar", "kif", "node"]);
+      expect(() => findNodeType(staticFooAdapter, wrongNode)).toThrowError(
+        "wrong plugin adapter"
+      );
+    });
+    it("errors if there's no matching type", () => {
+      const {staticFooAdapter} = example();
+      const wrongNode = NodeAddress.fromParts(["foo", "leela", "node"]);
+      expect(() => findNodeType(staticFooAdapter, wrongNode)).toThrowError(
+        "No entity matches"
+      );
+    });
+    it("errors if there's multiple matching types", () => {
+      const {staticFooAdapter} = example();
+      const wrongNode = NodeAddress.fromParts(["foo", "bad", "brannigan"]);
+      expect(() => findNodeType(staticFooAdapter, wrongNode)).toThrowError(
+        "Multiple entities match"
+      );
+    });
+  });
+
+  describe("findEdgeType", () => {
+    it("works in a simple case", () => {
+      const {staticFooAdapter} = example();
+      const kifEdge = EdgeAddress.fromParts(["foo", "kif", "edge"]);
+      expect(findEdgeType(staticFooAdapter, kifEdge).forwardName).toEqual(
+        "kifs"
+      );
+    });
+    it("errors if edge doesn't match the plugin", () => {
+      const {staticFooAdapter} = example();
+      const wrongEdge = EdgeAddress.fromParts(["bar", "kif", "edge"]);
+      expect(() => findEdgeType(staticFooAdapter, wrongEdge)).toThrowError(
+        "wrong plugin adapter"
+      );
+    });
+    it("errors if there's no matching type", () => {
+      const {staticFooAdapter} = example();
+      const wrongEdge = EdgeAddress.fromParts(["foo", "leela", "edge"]);
+      expect(() => findEdgeType(staticFooAdapter, wrongEdge)).toThrowError(
+        "No entity matches"
+      );
+    });
+    it("errors if there's multiple matching types", () => {
+      const {staticFooAdapter} = example();
+      const wrongEdge = EdgeAddress.fromParts(["foo", "bad", "brannigan"]);
+      expect(() => findEdgeType(staticFooAdapter, wrongEdge)).toThrowError(
+        "Multiple entities match"
       );
     });
   });


### PR DESCRIPTION
These methods find the unique matching node or edge type for a node,
from a given pluginAdapter.

Test plan: unit tests