### PR TITLE
Bundle the default plugins together

### DIFF
--- a/src/app/credExplorer/WeightConfig.js
+++ b/src/app/credExplorer/WeightConfig.js
@@ -14,10 +14,7 @@ import {type EdgeEvaluator} from "../../core/attribution/pagerank";
 import {byEdgeType, byNodeType} from "./edgeWeights";
 import * as MapUtil from "../../util/map";
 import * as NullUtil from "../../util/null";
-
-import type {StaticPluginAdapter} from "../pluginAdapter";
-import {StaticPluginAdapter as GithubAdapter} from "../../plugins/github/pluginAdapter";
-import {StaticPluginAdapter as GitAdapter} from "../../plugins/git/pluginAdapter";
+import {defaultStaticAdapters} from "../defaultPlugins";
 
 type Props = {|
   +localStore: LocalStore,
@@ -27,14 +24,10 @@ type Props = {|
 type EdgeWeights = Map<EdgeAddressT, UserEdgeWeight>;
 type UserEdgeWeight = {|+logWeight: number, +directionality: number|};
 
-const adapters = (): StaticPluginAdapter[] => {
-  return [new GithubAdapter(), new GitAdapter()];
-};
-
 const EDGE_WEIGHTS_KEY = "edgeWeights";
 const defaultEdgeWeights = (): EdgeWeights => {
   const result = new Map();
-  for (const adapter of adapters()) {
+  for (const adapter of defaultStaticAdapters()) {
     for (const {prefix} of adapter.edgeTypes()) {
       result.set(prefix, {logWeight: 0, directionality: 0.5});
     }
@@ -47,7 +40,7 @@ type UserNodeWeight = number /* in log space */;
 const NODE_WEIGHTS_KEY = "nodeWeights";
 const defaultNodeWeights = (): NodeWeights => {
   const result = new Map();
-  for (const adapter of adapters()) {
+  for (const adapter of defaultStaticAdapters()) {
     for (const {prefix, defaultWeight} of adapter.nodeTypes()) {
       result.set(prefix, Math.log2(defaultWeight));
     }

--- a/src/app/credExplorer/state.js
+++ b/src/app/credExplorer/state.js
@@ -13,8 +13,8 @@ import {
 } from "../../core/attribution/pagerank";
 
 import type {DynamicPluginAdapter} from "../pluginAdapter";
-import {StaticPluginAdapter as GitAdapter} from "../../plugins/git/pluginAdapter";
-import {StaticPluginAdapter as GithubAdapter} from "../../plugins/github/pluginAdapter";
+
+import {defaultStaticAdapters} from "../defaultPlugins";
 
 /*
   This models the UI states of the credExplorer/App as a state machine.
@@ -250,7 +250,7 @@ export type GraphWithAdapters = {|
   +adapters: $ReadOnlyArray<DynamicPluginAdapter>,
 |};
 export function loadGraphWithAdapters(repo: Repo): Promise<GraphWithAdapters> {
-  const statics = [new GitAdapter(), new GithubAdapter()];
+  const statics = defaultStaticAdapters();
   return Promise.all(statics.map((a) => a.load(repo))).then((adapters) => {
     const graph = Graph.merge(adapters.map((x) => x.graph()));
     return {graph, adapters};

--- a/src/app/defaultPlugins.js
+++ b/src/app/defaultPlugins.js
@@ -1,0 +1,9 @@
+// @flow
+
+import type {StaticPluginAdapter} from "./pluginAdapter";
+import {StaticPluginAdapter as GitAdapter} from "../plugins/git/pluginAdapter";
+import {StaticPluginAdapter as GithubAdapter} from "../plugins/github/pluginAdapter";
+
+export function defaultStaticAdapters(): $ReadOnlyArray<StaticPluginAdapter> {
+  return [new GitAdapter(), new GithubAdapter()];
+}


### PR DESCRIPTION
We manually import the set of plugins to be used by the app in a few
different places. That's a bad smell. This commit creates a centralized
import point instead.

Test plan: `yarn test`