### PR TITLE
Add type signatures for aggregation logic

### DIFF
--- a/src/app/credExplorer/pagerankTable/aggregate.js
+++ b/src/app/credExplorer/pagerankTable/aggregate.js
@@ -1,0 +1,39 @@
+// @flow
+
+import type {NodeType, EdgeType} from "../../pluginAdapter";
+import type {ScoredConnection} from "../../../core/attribution/pagerankNodeDecomposition";
+
+// Sorted by descending `summary.score`
+export type ConnectionAggregations = $ReadOnlyArray<ConnectionAggregation>;
+
+export type AggregationSummary = {|
+  +size: number,
+  +score: number,
+|};
+
+export type NodeAggregation = {|
+  +nodeType: NodeType,
+  +summary: AggregationSummary,
+  +connections: $ReadOnlyArray<ScoredConnection>,
+|};
+
+export type ConnectionType =
+  | {|+type: "IN_EDGE", +edgeType: EdgeType|}
+  | {|+type: "OUT_EDGE", +edgeType: EdgeType|}
+  | {|+type: "SYNTHETIC_LOOP"|};
+
+export type ConnectionAggregation = {|
+  +connectionType: ConnectionType,
+  +summary: AggregationSummary,
+  // Sorted by descending `summary.score`
+  +nodeAggregations: $ReadOnlyArray<NodeAggregation>,
+|};
+
+export function aggregateByConnectionType(
+  xs: $ReadOnlyArray<ScoredConnection>,
+  nodeTypes: $ReadOnlyArray<NodeType>,
+  edgeTypes: $ReadOnlyArray<EdgeType>
+): ConnectionAggregations {
+  const _unused_stuff = [xs, edgeTypes, nodeTypes];
+  throw new Error("Not yet implemented");
+}

--- a/src/app/credExplorer/pagerankTable/aggregate.test.js
+++ b/src/app/credExplorer/pagerankTable/aggregate.test.js
@@ -1,0 +1,7 @@
+// @flow
+
+describe("app/credExplorer/aggregation", () => {
+  it("is not yet implemented", () => {
+    return;
+  });
+});


### PR DESCRIPTION
This is the first real step towards #502.

Factoring this out because deciding the type signatures was non-trivial,
and the work was paired with @wchargin.

Test plan: `yarn test`