### PR TITLE
Allow delay between GitHub queries

### DIFF
--- a/src/plugins/github/fetchGithubRepo.js
+++ b/src/plugins/github/fetchGithubRepo.js
@@ -49,7 +49,14 @@ export default function fetchGithubRepo(
 
 const GITHUB_GRAPHQL_SERVER = "https://api.github.com/graphql";
 
-function postQuery({body, variables}, token) {
+async function postQuery({body, variables}, token): Promise<any> {
+  // TODO(#638): Find a more principled way to ingest this parameter.
+  const delayMs: number = parseInt(process.env.GITHUB_DELAY_MS || "0", 10) || 0;
+  await new Promise((resolve) => {
+    setTimeout(() => {
+      resolve();
+    }, delayMs);
+  });
   const payload = {
     query: stringify.body(body, inlineLayout()),
     variables: variables,


### PR DESCRIPTION
This patch considers an environment variable `GITHUB_DELAY_MS`. If the
value is set to a positive integer, a delay of the given number of
milliseconds will be incurred before each query to GitHub. This is to
decrease the probability of being rate-limited; see #350 for details.
This in turn unblocks us to load SourceCred data for larger
repositories.

The use of an environment variable is something of a hack to get this
off the ground. See #638 for long-term plans.

Test Plan:
Run `time node ./bin/sourcecred.js load sourcecred/example-github` with
varying values for `GITHUB_DELAY_MS`. Note that with the variable unset,
set to zero, set to a negative number, or set to a non-numeric value,
the job completes quickly; when the delay is set to `5000`, the job
takes an extra five seconds.

wchargin-branch: delay-github-queries

