### PR TITLE
Disable the Git plugin

### DIFF
--- a/sharness/test_build_static_site.t
+++ b/sharness/test_build_static_site.t
@@ -191,7 +191,7 @@ test_expect_success TWO_REPOS \
 test_expect_success TWO_REPOS \
     "TWO_REPOS: should have data for the two repositories" '
     for repo in sourcecred/example-git sourcecred/example-github; do
-        for file in git/graph.json github/view.json; do
+        for file in github/view.json; do
             test -s "${data_dir}/${repo}/${file}" || return
         done
     done

--- a/src/app/defaultPlugins.js
+++ b/src/app/defaultPlugins.js
@@ -1,9 +1,8 @@
 // @flow
 
 import type {StaticPluginAdapter} from "./pluginAdapter";
-import {StaticPluginAdapter as GitAdapter} from "../plugins/git/pluginAdapter";
 import {StaticPluginAdapter as GithubAdapter} from "../plugins/github/pluginAdapter";
 
 export function defaultStaticAdapters(): $ReadOnlyArray<StaticPluginAdapter> {
-  return [new GitAdapter(), new GithubAdapter()];
+  return [new GithubAdapter()];
 }

--- a/src/cli/commands/load.js
+++ b/src/cli/commands/load.js
@@ -10,6 +10,7 @@ import {loadGithubData} from "../../plugins/github/loadGithubData";
 import {loadGitData} from "../../plugins/git/loadGitData";
 import {
   pluginNames,
+  defaultPlugins,
   nodeMaxOldSpaceSizeFlag,
   sourcecredDirectoryFlag,
 } from "../common";
@@ -39,7 +40,8 @@ export default class PluginGraphCommand extends Command {
 
   static flags = {
     plugin: flags.string({
-      description: "plugin whose data to load (loads all plugins if not set)",
+      description:
+        "plugin whose data to load (loads default plugins if not set)",
       required: false,
       options: pluginNames(),
     }),
@@ -66,7 +68,7 @@ export default class PluginGraphCommand extends Command {
     } = this.parse(PluginGraphCommand);
     const repo = stringToRepo(args.repo);
     if (!plugin) {
-      loadAllPlugins({
+      loadDefaultPlugins({
         basedir,
         plugin,
         repo,
@@ -79,7 +81,7 @@ export default class PluginGraphCommand extends Command {
   }
 }
 
-function loadAllPlugins({basedir, repo, githubToken, maxOldSpaceSize}) {
+function loadDefaultPlugins({basedir, repo, githubToken, maxOldSpaceSize}) {
   if (githubToken == null) {
     // TODO: This check should be abstracted so that plugins can
     // specify their argument dependencies and get nicely
@@ -89,7 +91,7 @@ function loadAllPlugins({basedir, repo, githubToken, maxOldSpaceSize}) {
     return;
   }
   const tasks = [
-    ...pluginNames().map((pluginName) => ({
+    ...defaultPlugins().map((pluginName) => ({
       id: `load-${pluginName}`,
       cmd: [
         "node",

--- a/src/cli/common.js
+++ b/src/cli/common.js
@@ -9,6 +9,10 @@ export function pluginNames(): PluginName[] {
   return ["github", "git"];
 }
 
+export function defaultPlugins(): PluginName[] {
+  return ["github"];
+}
+
 function defaultStorageDirectory() {
   return path.join(os.tmpdir(), "sourcecred");
 }


### PR DESCRIPTION
See #627 for context.

Removing the Git plugin results in an enormous performance improvement.
In my testing on `metamask/metamask-extension`: before this change, load
took 23s, and PageRank took >9 mins and then crashed. After this change,
load+PageRank took 5s combined.

Test plan: All unit tests pass; loading new data from the CLI works; and
I poked around the UI to make sure there were no spurious references to
the Git plugin.

Note: This does not break backcompat, there's no need to regenerate any
already-loaded data.