### PR TITLE
Move core plugin adapter code to its own directory

### DIFF
--- a/src/app/adapters/defaultPlugins.js
+++ b/src/app/adapters/defaultPlugins.js
@@ -1,8 +1,8 @@
 // @flow
 
 import type {StaticPluginAdapter} from "./pluginAdapter";
-import {StaticPluginAdapter as GitAdapter} from "../plugins/git/pluginAdapter";
-import {StaticPluginAdapter as GithubAdapter} from "../plugins/github/pluginAdapter";
+import {StaticPluginAdapter as GitAdapter} from "../../plugins/git/pluginAdapter";
+import {StaticPluginAdapter as GithubAdapter} from "../../plugins/github/pluginAdapter";
 
 export function defaultStaticAdapters(): $ReadOnlyArray<StaticPluginAdapter> {
   return [new GitAdapter(), new GithubAdapter()];

--- a/src/app/adapters/pluginAdapter.js
+++ b/src/app/adapters/pluginAdapter.js
@@ -6,8 +6,8 @@ import {
   EdgeAddress,
   type NodeAddressT,
   type EdgeAddressT,
-} from "../core/graph";
-import type {Repo} from "../core/repo";
+} from "../../core/graph";
+import type {Repo} from "../../core/repo";
 
 export type EdgeType = {|
   +forwardName: string,

--- a/src/app/adapters/pluginAdapter.test.js
+++ b/src/app/adapters/pluginAdapter.test.js
@@ -5,7 +5,7 @@ import {
   NodeAddress,
   EdgeAddress,
   type NodeAddressT,
-} from "../core/graph";
+} from "../../core/graph";
 import {
   type StaticPluginAdapter,
   type DynamicPluginAdapter,
@@ -17,7 +17,7 @@ import {
   findEdgeType,
 } from "./pluginAdapter";
 
-describe("app/pluginAdapter", () => {
+describe("app/adapters/pluginAdapter", () => {
   function example() {
     const staticFooAdapter: StaticPluginAdapter = {
       name: () => "foo",

--- a/src/app/credExplorer/WeightConfig.js
+++ b/src/app/credExplorer/WeightConfig.js
@@ -14,7 +14,7 @@ import {type EdgeEvaluator} from "../../core/attribution/pagerank";
 import {byEdgeType, byNodeType} from "./edgeWeights";
 import * as MapUtil from "../../util/map";
 import * as NullUtil from "../../util/null";
-import {defaultStaticAdapters} from "../defaultPlugins";
+import {defaultStaticAdapters} from "../adapters/defaultPlugins";
 
 type Props = {|
   +localStore: LocalStore,

--- a/src/app/credExplorer/pagerankTable/Connection.js
+++ b/src/app/credExplorer/pagerankTable/Connection.js
@@ -6,7 +6,7 @@ import * as NullUtil from "../../../util/null";
 import type {NodeAddressT} from "../../../core/graph";
 import type {Connection} from "../../../core/attribution/graphToMarkovChain";
 import type {ScoredConnection} from "../../../core/attribution/pagerankNodeDecomposition";
-import type {DynamicPluginAdapter} from "../../pluginAdapter";
+import type {DynamicPluginAdapter} from "../../adapters/pluginAdapter";
 
 import {
   edgeVerb,

--- a/src/app/credExplorer/pagerankTable/Table.js
+++ b/src/app/credExplorer/pagerankTable/Table.js
@@ -5,7 +5,7 @@ import sortBy from "lodash.sortby";
 
 import {type NodeAddressT, NodeAddress} from "../../../core/graph";
 import type {PagerankNodeDecomposition} from "../../../core/attribution/pagerankNodeDecomposition";
-import type {DynamicPluginAdapter} from "../../pluginAdapter";
+import type {DynamicPluginAdapter} from "../../adapters/pluginAdapter";
 
 import {NodeRowList} from "./Node";
 

--- a/src/app/credExplorer/pagerankTable/aggregate.js
+++ b/src/app/credExplorer/pagerankTable/aggregate.js
@@ -3,7 +3,7 @@
 import sortBy from "lodash.sortby";
 import {NodeAddress, edgeToString} from "../../../core/graph";
 import {NodeTrie, EdgeTrie} from "../../../core/trie";
-import type {NodeType, EdgeType} from "../../pluginAdapter";
+import type {NodeType, EdgeType} from "../../adapters/pluginAdapter";
 import type {ScoredConnection} from "../../../core/attribution/pagerankNodeDecomposition";
 
 // Sorted by descending `summary.score`

--- a/src/app/credExplorer/pagerankTable/shared.js
+++ b/src/app/credExplorer/pagerankTable/shared.js
@@ -13,7 +13,7 @@ import {
   dynamicDispatchByNode,
   dynamicDispatchByEdge,
   findEdgeType,
-} from "../../pluginAdapter";
+} from "../../adapters/pluginAdapter";
 
 export function nodeDescription(
   address: NodeAddressT,

--- a/src/app/credExplorer/pagerankTable/sharedTestUtils.js
+++ b/src/app/credExplorer/pagerankTable/sharedTestUtils.js
@@ -2,7 +2,7 @@
 
 import {Graph, NodeAddress, EdgeAddress} from "../../../core/graph";
 
-import type {DynamicPluginAdapter} from "../../pluginAdapter";
+import type {DynamicPluginAdapter} from "../../adapters/pluginAdapter";
 import {pagerank} from "../../../core/attribution/pagerank";
 
 export const COLUMNS = () => ["Description", "Connection", "Score"];

--- a/src/app/credExplorer/state.js
+++ b/src/app/credExplorer/state.js
@@ -12,9 +12,9 @@ import {
   pagerank,
 } from "../../core/attribution/pagerank";
 
-import type {DynamicPluginAdapter} from "../pluginAdapter";
+import type {DynamicPluginAdapter} from "../adapters/pluginAdapter";
 
-import {defaultStaticAdapters} from "../defaultPlugins";
+import {defaultStaticAdapters} from "../adapters/defaultPlugins";
 
 /*
   This models the UI states of the credExplorer/App as a state machine.

--- a/src/plugins/git/pluginAdapter.js
+++ b/src/plugins/git/pluginAdapter.js
@@ -2,7 +2,7 @@
 import type {
   StaticPluginAdapter as IStaticPluginAdapter,
   DynamicPluginAdapter as IDynamicPluginAdapter,
-} from "../../app/pluginAdapter";
+} from "../../app/adapters/pluginAdapter";
 import {Graph} from "../../core/graph";
 import * as N from "./nodes";
 import * as E from "./edges";

--- a/src/plugins/github/pluginAdapter.js
+++ b/src/plugins/github/pluginAdapter.js
@@ -2,7 +2,7 @@
 import type {
   StaticPluginAdapter as IStaticPluginAdapter,
   DynamicPluginAdapter as IDynamicPluginAdapater,
-} from "../../app/pluginAdapter";
+} from "../../app/adapters/pluginAdapter";
 import {type Graph, NodeAddress} from "../../core/graph";
 import {createGraph} from "./createGraph";
 import * as N from "./nodes";


### PR DESCRIPTION
This commit creates the directory `src/app/adapters` and moves the
following three files into it:
- `src/app/pluginAdapter.js`
- `src/app/pluginAdapter.test.js`
- `src/app/defaultPlugins.js`

This is in preparation for a principled fix for #631, which will add a
base plugin and some logic that ensures it's always included.