### PR TITLE
Revert "Disable the Git plugin (#628)"

### DIFF
--- a/sharness/test_build_static_site.t
+++ b/sharness/test_build_static_site.t
@@ -191,7 +191,7 @@ test_expect_success TWO_REPOS \
 test_expect_success TWO_REPOS \
     "TWO_REPOS: should have data for the two repositories" '
     for repo in sourcecred/example-git sourcecred/example-github; do
-        for file in github/view.json; do
+        for file in git/graph.json github/view.json; do
             test -s "${data_dir}/${repo}/${file}" || return
         done
     done

--- a/src/app/defaultPlugins.js
+++ b/src/app/defaultPlugins.js
@@ -1,8 +1,9 @@
 // @flow
 
 import type {StaticPluginAdapter} from "./pluginAdapter";
+import {StaticPluginAdapter as GitAdapter} from "../plugins/git/pluginAdapter";
 import {StaticPluginAdapter as GithubAdapter} from "../plugins/github/pluginAdapter";
 
 export function defaultStaticAdapters(): $ReadOnlyArray<StaticPluginAdapter> {
-  return [new GithubAdapter()];
+  return [new GitAdapter(), new GithubAdapter()];
 }

--- a/src/cli/commands/load.js
+++ b/src/cli/commands/load.js
@@ -10,7 +10,6 @@ import {loadGithubData} from "../../plugins/github/loadGithubData";
 import {loadGitData} from "../../plugins/git/loadGitData";
 import {
   pluginNames,
-  defaultPlugins,
   nodeMaxOldSpaceSizeFlag,
   sourcecredDirectoryFlag,
 } from "../common";
@@ -40,8 +39,7 @@ export default class PluginGraphCommand extends Command {
 
   static flags = {
     plugin: flags.string({
-      description:
-        "plugin whose data to load (loads default plugins if not set)",
+      description: "plugin whose data to load (loads all plugins if not set)",
       required: false,
       options: pluginNames(),
     }),
@@ -68,7 +66,7 @@ export default class PluginGraphCommand extends Command {
     } = this.parse(PluginGraphCommand);
     const repo = stringToRepo(args.repo);
     if (!plugin) {
-      loadDefaultPlugins({
+      loadAllPlugins({
         basedir,
         plugin,
         repo,
@@ -81,7 +79,7 @@ export default class PluginGraphCommand extends Command {
   }
 }
 
-function loadDefaultPlugins({basedir, repo, githubToken, maxOldSpaceSize}) {
+function loadAllPlugins({basedir, repo, githubToken, maxOldSpaceSize}) {
   if (githubToken == null) {
     // TODO: This check should be abstracted so that plugins can
     // specify their argument dependencies and get nicely
@@ -91,7 +89,7 @@ function loadDefaultPlugins({basedir, repo, githubToken, maxOldSpaceSize}) {
     return;
   }
   const tasks = [
-    ...defaultPlugins().map((pluginName) => ({
+    ...pluginNames().map((pluginName) => ({
       id: `load-${pluginName}`,
       cmd: [
         "node",

--- a/src/cli/common.js
+++ b/src/cli/common.js
@@ -9,10 +9,6 @@ export function pluginNames(): PluginName[] {
   return ["github", "git"];
 }
 
-export function defaultPlugins(): PluginName[] {
-  return ["github"];
-}
-
 function defaultStorageDirectory() {
   return path.join(os.tmpdir(), "sourcecred");
 }


### PR DESCRIPTION
This reverts commit 8c70f03122ed0de24ce7382dcb5fd098f199a9dd.

Context: This introduced a serious bug (#631), so we're reverting it to
get the codebase back in a working state. Meanwhile, I'll develop a
principled solution.

Test plan:
I rebuilt the backend, re-loaded a graph, and loaded it in the frontend.
PageRank, the cred explorer, and the weight config all work. Opening a
pull request does not trigger a crash.