### PR TITLE
Use `hydrate` instead of `render` on the client

### DIFF
--- a/src/app/index.js
+++ b/src/app/index.js
@@ -9,5 +9,5 @@ const root = document.getElementById("root");
 if (root == null) {
   throw new Error("Unable to find root element!");
 }
-ReactDOM.render(<App />, root);
+ReactDOM.hydrate(<App />, root);
 unregister();


### PR DESCRIPTION
Summary:
This fixes the following warning on our development instance:

> Warning: render(): Calling ReactDOM.render() to hydrate
> server-rendered markup will stop working in React v17. Replace the
> ReactDOM.render() call with ReactDOM.hydrate() if you want React to
> attach to the server HTML.

We do in fact want to attach to the server HTML, so we apply the
suggested patch.

(The warning of course also applies to production, but warnings do not
appear in production.)

Test Plan:
Running `yarn start` shows that the above warning has disappeared, and
that the cred explorer still works. (Also, `yarn test --full` passes,
but that tells us effectively nothing because this code path is never
hit in tests: it only affects the HTML that is executed in the browser.
Erasing the entire module, leaving only `// @flow`, still lets tests
pass.)

wchargin-branch: migrate-to-hydrate