### PR TITLE
Tries allow multiple values for the same key

### DIFF
--- a/src/core/trie.test.js
+++ b/src/core/trie.test.js
@@ -82,13 +82,12 @@ describe("core/trie", () => {
     expect(x.get(fooBarZod)).toEqual([0, 2, 3]);
   });
 
-  it("overwriting a value is illegal", () => {
-    expect(() =>
-      new NodeTrie()
-        .add(foo, 3)
-        .add(empty, 1)
-        .add(foo, 4)
-    ).toThrowError("overwrite");
+  it("when a key has multiple values, they are returned in insertion order", () => {
+    const trie = new NodeTrie()
+      .add(foo, 3)
+      .add(empty, 1)
+      .add(foo, 4);
+    expect(trie.get(fooBarZod)).toEqual([1, 3, 4]);
   });
 
   it("null and undefined are legal values", () => {


### PR DESCRIPTION
Given the type signature of tries, it is quite natural to allow storing
multiple values for the same key: get always returns an array, so if
multiple values are present for the key, they can all be added to the
array (in insertion order).

This also happens to be the correct semantics for implementing an
AdapterSet; having multiple (say) node types defined for the empty node
addresse is OK, so long as the order in which they are returned is
well-defined.

Test plan: unit tests