### PR TITLE
Re-disable the Git plugin

### DIFF
--- a/sharness/test_build_static_site.t
+++ b/sharness/test_build_static_site.t
@@ -197,7 +197,7 @@ test_expect_success TWO_REPOS \
 test_expect_success TWO_REPOS \
     "TWO_REPOS: should have data for the two repositories" '
     for repo in sourcecred/example-git sourcecred/example-github; do
-        for file in git/graph.json github/view.json; do
+        for file in github/view.json; do
             test -s "${data_dir}/${repo}/${file}" || return
         done
     done

--- a/src/app/adapters/defaultPlugins.js
+++ b/src/app/adapters/defaultPlugins.js
@@ -1,9 +1,8 @@
 // @flow
 
 import {StaticAdapterSet} from "./adapterSet";
-import {StaticPluginAdapter as GitAdapter} from "../../plugins/git/pluginAdapter";
 import {StaticPluginAdapter as GithubAdapter} from "../../plugins/github/pluginAdapter";
 
 export function defaultStaticAdapters(): StaticAdapterSet {
-  return new StaticAdapterSet([new GitAdapter(), new GithubAdapter()]);
+  return new StaticAdapterSet([new GithubAdapter()]);
 }

--- a/src/cli/commands/load.js
+++ b/src/cli/commands/load.js
@@ -10,6 +10,7 @@ import {loadGithubData} from "../../plugins/github/loadGithubData";
 import {loadGitData} from "../../plugins/git/loadGitData";
 import {
   pluginNames,
+  defaultPlugins,
   nodeMaxOldSpaceSizeFlag,
   sourcecredDirectoryFlag,
 } from "../common";
@@ -39,7 +40,8 @@ export default class PluginGraphCommand extends Command {
 
   static flags = {
     plugin: flags.string({
-      description: "plugin whose data to load (loads all plugins if not set)",
+      description:
+        "plugin whose data to load (loads default plugins if not set)",
       required: false,
       options: pluginNames(),
     }),
@@ -66,7 +68,7 @@ export default class PluginGraphCommand extends Command {
     } = this.parse(PluginGraphCommand);
     const repo = stringToRepo(args.repo);
     if (!plugin) {
-      loadAllPlugins({
+      loadDefaultPlugins({
         basedir,
         plugin,
         repo,
@@ -79,7 +81,7 @@ export default class PluginGraphCommand extends Command {
   }
 }
 
-function loadAllPlugins({basedir, repo, githubToken, maxOldSpaceSize}) {
+function loadDefaultPlugins({basedir, repo, githubToken, maxOldSpaceSize}) {
   if (githubToken == null) {
     // TODO: This check should be abstracted so that plugins can
     // specify their argument dependencies and get nicely
@@ -89,7 +91,7 @@ function loadAllPlugins({basedir, repo, githubToken, maxOldSpaceSize}) {
     return;
   }
   const tasks = [
-    ...pluginNames().map((pluginName) => ({
+    ...defaultPlugins().map((pluginName) => ({
       id: `load-${pluginName}`,
       cmd: [
         "node",

--- a/src/cli/common.js
+++ b/src/cli/common.js
@@ -9,6 +9,10 @@ export function pluginNames(): PluginName[] {
   return ["github", "git"];
 }
 
+export function defaultPlugins(): PluginName[] {
+  return ["github"];
+}
+
 function defaultStorageDirectory() {
   return path.join(os.tmpdir(), "sourcecred");
 }


### PR DESCRIPTION
Thanks to #642, it should now be safe to disable the Git plugin, reaping
the benefits described in #628, without causing the cred explorer to
crash (#631).

Test plan:
- `yarn travis --full` passes
- The full cred explorer works:
  - Running PageRank does not crash the explorer
  - Expanding a pull request does not crash the explorer
  - (After clearing state) the weight config doesn't show Git weights
  - The filter doesn't show Git nodes