### PR TITLE
Add pluralized node names

### DIFF
--- a/src/app/adapters/adapterSet.test.js
+++ b/src/app/adapters/adapterSet.test.js
@@ -30,11 +30,13 @@ describe("app/adapters/adapterSet", () => {
       return [
         {
           name: "other1",
+          pluralName: "others1",
           defaultWeight: 0,
           prefix: NodeAddress.fromParts(["other", "1"]),
         },
         {
           name: "other2",
+          pluralName: "others2",
           defaultWeight: 0,
           prefix: NodeAddress.fromParts(["other", "2"]),
         },
@@ -145,14 +147,14 @@ describe("app/adapters/adapterSet", () => {
       const type = sas.typeMatchingNode(
         NodeAddress.fromParts(["wombat", "1", "foo"])
       );
-      expect(type.name).toBe("(unknown node)");
+      expect(type.name).toBe("unknown node");
     });
     it("finds fallback type for unregistered edge", () => {
       const {sas} = example();
       const type = sas.typeMatchingEdge(
         EdgeAddress.fromParts(["wombat", "1", "foo"])
       );
-      expect(type.forwardName).toBe("(unknown edge→)");
+      expect(type.forwardName).toBe("unknown edge→");
     });
     it("loads a dynamicAdapterSet", async () => {
       const {x, sas} = example();

--- a/src/app/adapters/fallbackAdapter.js
+++ b/src/app/adapters/fallbackAdapter.js
@@ -27,15 +27,20 @@ export class FallbackStaticAdapter implements StaticPluginAdapter {
 
   nodeTypes() {
     return [
-      {name: "(unknown node)", prefix: NodeAddress.empty, defaultWeight: 1},
+      {
+        name: "unknown node",
+        pluralName: "unknown nodes",
+        prefix: NodeAddress.empty,
+        defaultWeight: 1,
+      },
     ];
   }
 
   edgeTypes() {
     return [
       {
-        forwardName: "(unknown edge→)",
-        backwardName: "(unknown edge←)",
+        forwardName: "unknown edge→",
+        backwardName: "unknown edge←",
         prefix: EdgeAddress.empty,
       },
     ];

--- a/src/app/adapters/pluginAdapter.js
+++ b/src/app/adapters/pluginAdapter.js
@@ -11,6 +11,7 @@ export type EdgeType = {|
 
 export type NodeType = {|
   +name: string,
+  +pluralName: string,
   +prefix: NodeAddressT,
   +defaultWeight: number,
 |};

--- a/src/app/credExplorer/pagerankTable/aggregate.test.js
+++ b/src/app/credExplorer/pagerankTable/aggregate.test.js
@@ -18,10 +18,30 @@ describe("app/credExplorer/aggregate", () => {
     };
 
     const nodeTypes = {
-      root: {name: "root", prefix: nodes.root, defaultWeight: 0},
-      zap: {name: "zap", prefix: nodes.zap, defaultWeight: 0},
-      kif: {name: "kif", prefix: nodes.kif, defaultWeight: 0},
-      empty: {name: "empty", prefix: NodeAddress.empty, defaultWeight: 0},
+      root: {
+        name: "root",
+        pluralName: "roots",
+        prefix: nodes.root,
+        defaultWeight: 0,
+      },
+      zap: {
+        name: "zap",
+        pluralName: "zaps",
+        prefix: nodes.zap,
+        defaultWeight: 0,
+      },
+      kif: {
+        name: "kif",
+        pluralName: "kifs",
+        prefix: nodes.kif,
+        defaultWeight: 0,
+      },
+      empty: {
+        name: "empty",
+        pluralName: "empties",
+        prefix: NodeAddress.empty,
+        defaultWeight: 0,
+      },
     };
 
     const nodeTypesArray = [nodeTypes.root, nodeTypes.zap, nodeTypes.kif];

--- a/src/app/credExplorer/pagerankTable/sharedTestUtils.js
+++ b/src/app/credExplorer/pagerankTable/sharedTestUtils.js
@@ -43,11 +43,13 @@ export async function example() {
         edgePrefix: () => EdgeAddress.fromParts(["foo"]),
         nodeTypes: () => [
           {
+            pluralName: "alphas",
             name: "alpha",
             prefix: NodeAddress.fromParts(["foo", "a"]),
             defaultWeight: 1,
           },
           {
+            pluralName: "betas",
             name: "beta",
             prefix: NodeAddress.fromParts(["foo", "b"]),
             defaultWeight: 1,
@@ -77,6 +79,7 @@ export async function example() {
         nodeTypes: () => [
           {
             name: "alpha",
+            pluralName: "alphas",
             prefix: NodeAddress.fromParts(["bar", "a"]),
             defaultWeight: 1,
           },

--- a/src/plugins/git/pluginAdapter.js
+++ b/src/plugins/git/pluginAdapter.js
@@ -21,10 +21,30 @@ export class StaticPluginAdapter implements IStaticPluginAdapter {
   }
   nodeTypes() {
     return [
-      {name: "Blob", prefix: N._Prefix.blob, defaultWeight: 0.125},
-      {name: "Commit", prefix: N._Prefix.commit, defaultWeight: 2},
-      {name: "Tree", prefix: N._Prefix.tree, defaultWeight: 0.125},
-      {name: "Tree entry", prefix: N._Prefix.treeEntry, defaultWeight: 0.125},
+      {
+        name: "Blob",
+        pluralName: "Blobs",
+        prefix: N._Prefix.blob,
+        defaultWeight: 0.125,
+      },
+      {
+        name: "Commit",
+        pluralName: "Commits",
+        prefix: N._Prefix.commit,
+        defaultWeight: 2,
+      },
+      {
+        name: "Tree",
+        pluralName: "Trees",
+        prefix: N._Prefix.tree,
+        defaultWeight: 0.125,
+      },
+      {
+        name: "Tree entry",
+        pluralName: "Tree entries",
+        prefix: N._Prefix.treeEntry,
+        defaultWeight: 0.125,
+      },
     ];
   }
   edgeTypes() {

--- a/src/plugins/github/pluginAdapter.js
+++ b/src/plugins/github/pluginAdapter.js
@@ -23,12 +23,42 @@ export class StaticPluginAdapter implements IStaticPluginAdapter {
   }
   nodeTypes() {
     return [
-      {name: "Repository", prefix: N._Prefix.repo, defaultWeight: 4},
-      {name: "Issue", prefix: N._Prefix.issue, defaultWeight: 2},
-      {name: "Pull request", prefix: N._Prefix.pull, defaultWeight: 4},
-      {name: "Pull request review", prefix: N._Prefix.review, defaultWeight: 1},
-      {name: "Comment", prefix: N._Prefix.comment, defaultWeight: 1},
-      {name: "User", prefix: N._Prefix.userlike, defaultWeight: 1},
+      {
+        name: "Repository",
+        pluralName: "Repositories",
+        prefix: N._Prefix.repo,
+        defaultWeight: 4,
+      },
+      {
+        name: "Issue",
+        pluralName: "Issues",
+        prefix: N._Prefix.issue,
+        defaultWeight: 2,
+      },
+      {
+        name: "Pull request",
+        pluralName: "Pull requests",
+        prefix: N._Prefix.pull,
+        defaultWeight: 4,
+      },
+      {
+        name: "Pull request review",
+        pluralName: "Pull request reviews",
+        prefix: N._Prefix.review,
+        defaultWeight: 1,
+      },
+      {
+        name: "Comment",
+        pluralName: "Comments",
+        prefix: N._Prefix.comment,
+        defaultWeight: 1,
+      },
+      {
+        name: "User",
+        pluralName: "Users",
+        prefix: N._Prefix.userlike,
+        defaultWeight: 1,
+      },
     ];
   }
   edgeTypes() {


### PR DESCRIPTION
This is preparation for #502 - we want to be able to describe groups of
nodes, e.g. "52 repositories", so we need a plural form for every node
name.

As a fly-by fix, I removed the parentheses around the node names in the
fallback adapter, as these proved to look ugly/inconsistent in the UI.

Test plan: `yarn test` is sufficient.