### PR TITLE
PagerankTable: separate indentDepth and colorDepth

### DIFF
--- a/src/app/credExplorer/pagerankTable/Connection.js
+++ b/src/app/credExplorer/pagerankTable/Connection.js
@@ -17,7 +17,8 @@ import {
 } from "./shared";
 
 type ConnectionRowListProps = {|
-  +depth: number,
+  +colorDepth: number,
+  +indentDepth: number,
   +node: NodeAddressT,
   +sharedProps: SharedProps,
 |};
@@ -26,7 +27,7 @@ export class ConnectionRowList extends React.PureComponent<
   ConnectionRowListProps
 > {
   render() {
-    const {depth, node, sharedProps} = this.props;
+    const {colorDepth, indentDepth, node, sharedProps} = this.props;
     const {pnd, maxEntriesPerList} = sharedProps;
     const {scoredConnections} = NullUtil.get(pnd.get(node));
     return (
@@ -36,7 +37,8 @@ export class ConnectionRowList extends React.PureComponent<
           .map((sc) => (
             <ConnectionRow
               key={JSON.stringify(sc.connection.adjacency)}
-              depth={depth}
+              colorDepth={colorDepth}
+              indentDepth={indentDepth}
               target={node}
               scoredConnection={sc}
               sharedProps={sharedProps}
@@ -48,7 +50,8 @@ export class ConnectionRowList extends React.PureComponent<
 }
 
 type ConnectionRowProps = {|
-  +depth: number,
+  +colorDepth: number,
+  +indentDepth: number,
   +target: NodeAddressT,
   +scoredConnection: ScoredConnection,
   +sharedProps: SharedProps,
@@ -66,7 +69,8 @@ export class ConnectionRow extends React.PureComponent<
     const {
       sharedProps,
       target,
-      depth,
+      colorDepth,
+      indentDepth,
       scoredConnection: {connection, source, sourceScore, connectionScore},
     } = this.props;
     const {pnd, adapters} = sharedProps;
@@ -79,13 +83,15 @@ export class ConnectionRow extends React.PureComponent<
       <React.Fragment>
         <tr
           key="self"
-          style={{backgroundColor: `rgba(0,143.4375,0,${1 - 0.9 ** depth})`}}
+          style={{
+            backgroundColor: `rgba(0,143.4375,0,${1 - 0.9 ** colorDepth})`,
+          }}
         >
           <td style={{display: "flex", alignItems: "flex-start"}}>
             <button
               style={{
                 marginRight: 5,
-                marginLeft: 15 * depth,
+                marginLeft: 15 * indentDepth,
               }}
               onClick={() => {
                 this.setState(({expanded}) => ({
@@ -103,7 +109,8 @@ export class ConnectionRow extends React.PureComponent<
         {expanded && (
           <ConnectionRowList
             key="children"
-            depth={depth + 1}
+            colorDepth={colorDepth + 1}
+            indentDepth={indentDepth + 1}
             node={source}
             sharedProps={sharedProps}
           />

--- a/src/app/credExplorer/pagerankTable/Node.js
+++ b/src/app/credExplorer/pagerankTable/Node.js
@@ -73,7 +73,8 @@ export class NodeRow extends React.PureComponent<NodeRowProps, RowState> {
         {expanded && (
           <ConnectionRowList
             key="children"
-            depth={1}
+            colorDepth={1}
+            indentDepth={1}
             node={node}
             sharedProps={sharedProps}
           />

--- a/src/app/credExplorer/pagerankTable/Node.test.js
+++ b/src/app/credExplorer/pagerankTable/Node.test.js
@@ -7,6 +7,7 @@ import * as NullUtil from "../../../util/null";
 
 import {type NodeAddressT, NodeAddress} from "../../../core/graph";
 
+import {ConnectionRowList} from "./Connection";
 import {example, COLUMNS} from "./sharedTestUtils";
 import {NodeRowList, NodeRow} from "./Node";
 
@@ -130,23 +131,34 @@ describe("app/credExplorer/pagerankTable/Node", () => {
     });
     it("does not render children by default", async () => {
       const {element} = await setup();
-      expect(element.find("ConnectionRowList")).toHaveLength(0);
+      expect(element.find(ConnectionRowList)).toHaveLength(0);
     });
     it('has a working "expand" button', async () => {
       const {element, sharedProps, node} = await setup();
       expect(element.find("button").text()).toEqual("+");
+      expect(element.state().expanded).toBe(false);
 
       element.find("button").simulate("click");
       expect(element.find("button").text()).toEqual("\u2212");
-      const crl = element.find("ConnectionRowList");
-      expect(crl).toHaveLength(1);
-      expect(crl.prop("sharedProps")).toEqual(sharedProps);
-      expect(crl.prop("depth")).toBe(1);
-      expect(crl.prop("node")).toBe(node);
+      expect(element.find(ConnectionRowList)).toHaveLength(1);
+      expect(element.state().expanded).toBe(true);
 
       element.find("button").simulate("click");
       expect(element.find("button").text()).toEqual("+");
-      expect(element.find("ConnectionRowList")).toHaveLength(0);
+      expect(element.find(ConnectionRowList)).toHaveLength(0);
+      expect(element.state().expanded).toBe(false);
+    });
+    it("child ConnectionRowList has correct props", async () => {
+      const {element, sharedProps, node} = await setup();
+      element.setState({expanded: true});
+      const crl = element.find(ConnectionRowList);
+      const props = crl.props();
+      expect(props.colorDepth).toBe(1);
+      expect(props.indentDepth).toBe(1);
+      expect(props.sharedProps).toBe(sharedProps);
+      expect(props.node).toBe(node);
+      expect(crl.props().sharedProps).toBe(sharedProps);
+      expect(crl.props().node).toBe(source);
     });
   });
 });

--- a/src/app/credExplorer/pagerankTable/__snapshots__/Connection.test.js.snap
+++ b/src/app/credExplorer/pagerankTable/__snapshots__/Connection.test.js.snap
@@ -3,11 +3,55 @@
 exports[`app/credExplorer/pagerankTable/Connection ConnectionRow has proper depth-based styling 1`] = `
 Object {
   "buttonStyle": Object {
-    "marginLeft": 30,
+    "marginLeft": 0,
     "marginRight": 5,
   },
+  "colorDepth": 0,
+  "indentDepth": 0,
   "trStyle": Object {
-    "backgroundColor": "rgba(0,143.4375,0,0.18999999999999995)",
+    "backgroundColor": "rgba(0,143.4375,0,0)",
+  },
+}
+`;
+
+exports[`app/credExplorer/pagerankTable/Connection ConnectionRow has proper depth-based styling 2`] = `
+Object {
+  "buttonStyle": Object {
+    "marginLeft": 15,
+    "marginRight": 5,
+  },
+  "colorDepth": 0,
+  "indentDepth": 1,
+  "trStyle": Object {
+    "backgroundColor": "rgba(0,143.4375,0,0)",
+  },
+}
+`;
+
+exports[`app/credExplorer/pagerankTable/Connection ConnectionRow has proper depth-based styling 3`] = `
+Object {
+  "buttonStyle": Object {
+    "marginLeft": 0,
+    "marginRight": 5,
+  },
+  "colorDepth": 1,
+  "indentDepth": 0,
+  "trStyle": Object {
+    "backgroundColor": "rgba(0,143.4375,0,0.09999999999999998)",
+  },
+}
+`;
+
+exports[`app/credExplorer/pagerankTable/Connection ConnectionRow has proper depth-based styling 4`] = `
+Object {
+  "buttonStyle": Object {
+    "marginLeft": 15,
+    "marginRight": 5,
+  },
+  "colorDepth": 1,
+  "indentDepth": 1,
+  "trStyle": Object {
+    "backgroundColor": "rgba(0,143.4375,0,0.09999999999999998)",
   },
 }
 `;


### PR DESCRIPTION
This commit splits up the "depth" concept in PagerankTable into two
separate values: indentDepth, which determines how many steps the table
is indented, and colorDepth, which determines how many steps of color
shift are applied.

This is in preparation for #502 so that we can correctly indent within
the aggregated summary, without changing the color. Then, color can
represent "changing scope" to a different node, while indenting just
keeps things visually organized.

Test plan: There's no change in observed behavior right now (which I
verified), because the indent depth and color depth always change in
sync. The snapshot test for depth-based styling now shows how the styles
vary based on independent changes in the indent and color depth:
examining that snapshot should persuade the reader that the code works
as intended.

I made some minor improvements to the test code while I was in the area;
these should not be controversial.