### PR TITLE
PagerankTable filter defaults to GitHub users

### DIFF
--- a/src/app/credExplorer/App.js
+++ b/src/app/credExplorer/App.js
@@ -9,6 +9,7 @@ import BrowserLocalStore from "../browserLocalStore";
 import {PagerankTable} from "./pagerankTable/Table";
 import {WeightConfig} from "./WeightConfig";
 import RepositorySelect from "./RepositorySelect";
+import {_Prefix as GithubPrefix} from "../../plugins/github/nodes";
 import {
   createStateTransitionMachine,
   type AppState,
@@ -71,6 +72,7 @@ export function createApp(
         const pnd = appState.substate.pagerankNodeDecomposition;
         pagerankTable = (
           <PagerankTable
+            defaultNodeFilter={GithubPrefix.userlike}
             adapters={adapters}
             pnd={pnd}
             maxEntriesPerList={100}

--- a/src/app/credExplorer/pagerankTable/Table.js
+++ b/src/app/credExplorer/pagerankTable/Table.js
@@ -2,6 +2,7 @@
 
 import React from "react";
 import sortBy from "lodash.sortby";
+import * as NullUtil from "../../../util/null";
 
 import {type NodeAddressT, NodeAddress} from "../../../core/graph";
 import type {PagerankNodeDecomposition} from "../../../core/attribution/pagerankNodeDecomposition";
@@ -15,15 +16,29 @@ type PagerankTableProps = {|
   +pnd: PagerankNodeDecomposition,
   +adapters: DynamicAdapterSet,
   +maxEntriesPerList: number,
+  +defaultNodeFilter: ?NodeAddressT,
 |};
 type PagerankTableState = {|topLevelFilter: NodeAddressT|};
 export class PagerankTable extends React.PureComponent<
   PagerankTableProps,
   PagerankTableState
 > {
-  constructor() {
+  constructor(props: PagerankTableProps): void {
     super();
-    this.state = {topLevelFilter: NodeAddress.empty};
+    const {defaultNodeFilter, adapters} = props;
+    if (defaultNodeFilter != null) {
+      const nodeTypes = adapters.static().nodeTypes();
+      if (!nodeTypes.some((x) => x.prefix === defaultNodeFilter)) {
+        throw new Error(
+          `invalid defaultNodeFilter ${defaultNodeFilter}: doesn't match any type`
+        );
+      }
+    }
+    const topLevelFilter = NullUtil.orElse(
+      props.defaultNodeFilter,
+      NodeAddress.empty
+    );
+    this.state = {topLevelFilter};
   }
 
   render() {


### PR DESCRIPTION
We humans tend to find information about humans more interesting than
information about commits or pulls. The UI should accomodate this by
defaulting to displaying GitHub user nodes in the cred explorer.

This is implemented as a new nullable argument to the PageRankTable. If
not present, then the filter defaults to showing all nodes. If the
default filter is present but doesn't match any available type, an error
is thrown.

Test plan: The new behavior is tested. Also, I checked it in the UI and
it works.

Closes #651