### PR TITLE
ConnectionRow now shows the connection score

### DIFF
--- a/src/app/credExplorer/pagerankTable/Connection.js
+++ b/src/app/credExplorer/pagerankTable/Connection.js
@@ -56,7 +56,7 @@ export class ConnectionRow extends React.PureComponent<ConnectionRowProps> {
       sharedProps,
       target,
       depth,
-      scoredConnection: {connection, source, sourceScore, connectionScore},
+      scoredConnection: {connection, source, connectionScore},
     } = this.props;
     const {pnd, adapters} = sharedProps;
     const {score: targetScore} = NullUtil.get(pnd.get(target));
@@ -72,7 +72,7 @@ export class ConnectionRow extends React.PureComponent<ConnectionRowProps> {
         description={connectionView}
         connectionProportion={connectionProportion}
         showPadding={false}
-        score={sourceScore}
+        score={connectionScore}
       >
         <NodeRow
           depth={depth + 1}

--- a/src/app/credExplorer/pagerankTable/Connection.test.js
+++ b/src/app/credExplorer/pagerankTable/Connection.test.js
@@ -107,9 +107,9 @@ describe("app/credExplorer/pagerankTable/Connection", () => {
         const {row} = await setup();
         expect(row.props().showPadding).toBe(false);
       });
-      it("with the sourceScore", async () => {
+      it("with the connection score", async () => {
         const {row, scoredConnection} = await setup();
-        expect(row.props().score).toBe(scoredConnection.sourceScore);
+        expect(row.props().score).toBe(scoredConnection.connectionScore);
       });
       it("with the connectionProportion", async () => {
         const {row, target, scoredConnection, sharedProps} = await setup();

--- a/src/core/attribution/pagerankNodeDecomposition.js
+++ b/src/core/attribution/pagerankNodeDecomposition.js
@@ -15,6 +15,7 @@ import * as NullUtil from "../../util/null";
 export type ScoredConnection = {|
   +connection: Connection,
   +source: NodeAddressT,
+  // TODO(@decentralion): Consider removing this unused field
   +sourceScore: number,
   +connectionScore: number,
 |};


### PR DESCRIPTION
Previously, the ConnectionRow showed the score of the node that was the
source of the connection. I believe the UI will be more consistent and
useful if it instead shows the connection score, i.e. how important that
connection was to the node in scope. This combos well with PR #657.

Test plan: The change is very simple, and covered by unit tests. I also
verified the behavior by examining the cred explorer.