### PR TITLE
Tweak the cred explorer highlight color

### DIFF
--- a/src/app/credExplorer/pagerankTable/TableRow.js
+++ b/src/app/credExplorer/pagerankTable/TableRow.js
@@ -48,7 +48,7 @@ export class TableRow extends React.PureComponent<
       connectionProportion == null
         ? ""
         : (connectionProportion * 100).toFixed(2) + "%";
-    const backgroundColor = `rgba(0,143.4375,0,${1 - 0.9 ** depth})`;
+    const backgroundColor = `hsla(150,100%,28%,${1 - 0.9 ** depth})`;
     return (
       <React.Fragment>
         {showPadding && <PaddingRow backgroundColor={backgroundColor} />}

--- a/src/app/credExplorer/pagerankTable/__snapshots__/TableRow.test.js.snap
+++ b/src/app/credExplorer/pagerankTable/__snapshots__/TableRow.test.js.snap
@@ -8,7 +8,7 @@ Object {
   },
   "depth": 0,
   "trStyle": Object {
-    "backgroundColor": "rgba(0,143.4375,0,0)",
+    "backgroundColor": "hsla(150,100%,28%,0)",
   },
 }
 `;
@@ -21,7 +21,7 @@ Object {
   },
   "depth": 1,
   "trStyle": Object {
-    "backgroundColor": "rgba(0,143.4375,0,0.09999999999999998)",
+    "backgroundColor": "hsla(150,100%,28%,0.09999999999999998)",
   },
 }
 `;
@@ -34,7 +34,7 @@ Object {
   },
   "depth": 2,
   "trStyle": Object {
-    "backgroundColor": "rgba(0,143.4375,0,0.18999999999999995)",
+    "backgroundColor": "hsla(150,100%,28%,0.18999999999999995)",
   },
 }
 `;
@@ -47,7 +47,7 @@ Object {
   },
   "indent": 0,
   "trStyle": Object {
-    "backgroundColor": "rgba(0,143.4375,0,0.2709999999999999)",
+    "backgroundColor": "hsla(150,100%,28%,0.2709999999999999)",
   },
 }
 `;
@@ -60,7 +60,7 @@ Object {
   },
   "indent": 1,
   "trStyle": Object {
-    "backgroundColor": "rgba(0,143.4375,0,0.2709999999999999)",
+    "backgroundColor": "hsla(150,100%,28%,0.2709999999999999)",
   },
 }
 `;
@@ -73,7 +73,7 @@ Object {
   },
   "indent": 2,
   "trStyle": Object {
-    "backgroundColor": "rgba(0,143.4375,0,0.2709999999999999)",
+    "backgroundColor": "hsla(150,100%,28%,0.2709999999999999)",
   },
 }
 `;


### PR DESCRIPTION
William and I were experimenting, and felt that this color is slightly
more pleasing / harmonious with the rest of the site, and still quite
legibile.

Test plan: Examine the new UI, and conclude that the color choice is
harmonious and legible :). Screenshot included with the PR.

Paired with @wchargin