### PR TITLE
Annotate adapter set constructor return types

### DIFF
--- a/src/app/adapters/adapterSet.js
+++ b/src/app/adapters/adapterSet.js
@@ -20,7 +20,7 @@ export class StaticAdapterSet {
   _typeNodeTrie: NodeTrie<NodeType>;
   _typeEdgeTrie: EdgeTrie<EdgeType>;
 
-  constructor(adapters: $ReadOnlyArray<StaticPluginAdapter>) {
+  constructor(adapters: $ReadOnlyArray<StaticPluginAdapter>): void {
     this._adapters = [new FallbackStaticAdapter(), ...adapters];
     this._adapterNodeTrie = new NodeTrie();
     this._adapterEdgeTrie = new EdgeTrie();
@@ -84,7 +84,7 @@ export class DynamicAdapterSet {
   constructor(
     staticAdapterSet: StaticAdapterSet,
     adapters: $ReadOnlyArray<DynamicPluginAdapter>
-  ) {
+  ): void {
     this._staticAdapterSet = staticAdapterSet;
     this._adapters = adapters;
     this._adapterNodeTrie = new NodeTrie();


### PR DESCRIPTION
Summary:
Due to <https://github.com/facebook/flow/issues/6400>, patches like the
following weren’t raising Flow errors:

```diff
diff --git a/src/app/adapters/adapterSet.test.js b/src/app/adapters/adapterSet.test.js
index 67dd3ed..ccc6ac6 100644
--- a/src/app/adapters/adapterSet.test.js
+++ b/src/app/adapters/adapterSet.test.js
@@ -77,6 +77,7 @@ describe("app/adapters/adapterSet", () => {
       const x = new TestStaticPluginAdapter();
       const fallback = new FallbackStaticAdapter();
       const sas = new StaticAdapterSet([x]);
+      sas.wat();
       return {x, fallback, sas};
     }
     it("errors if two plugins have the same name", () => {
```

A `flow type-at-pos` check indicated that the type of `sas` was indeed
inferred as `any`.

This patch applies the usual nonsensical fix. Better safe than spooky.

Test Plan:
The above patch now raises a Flow error.

wchargin-branch: annotate-adapterset-constructors