### PR TITLE
Add some margin on the TableRow score column

### DIFF
--- a/src/app/credExplorer/pagerankTable/TableRow.js
+++ b/src/app/credExplorer/pagerankTable/TableRow.js
@@ -70,7 +70,9 @@ export class TableRow extends React.PureComponent<
             {description}
           </td>
           <td style={{textAlign: "right"}}>{percent}</td>
-          <td style={{textAlign: "right"}}>{scoreDisplay(score)}</td>
+          <td style={{textAlign: "right"}}>
+            <span style={{marginRight: 5}}>{scoreDisplay(score)}</span>
+          </td>
         </tr>
         {expanded && children}
         {showPadding && <PaddingRow backgroundColor={backgroundColor} />}


### PR DESCRIPTION
The TableRow currently has some margin on the left, but not on the
right. This is visually unbalanced, especially when expanded so depth>0,
as the content on the right is at the very edge of the shaded rectangle.

This commit cleans that up a bit!

Test plan: Visual inspection (see screenshots in the pull request). I
don't think unit tests are necessary for small visual tweaks like this.

UI **AFTER** the change:
![image](https://user-images.githubusercontent.com/1400023/44171980-9deba100-a090-11e8-849d-81b634a1a954.png)

Compare to **BEFORE**:
![image](https://user-images.githubusercontent.com/1400023/44172012-bf4c8d00-a090-11e8-9bcb-4703d154b62a.png)
