### PR TITLE
Add a `.gitignore` for Sharness

### DIFF
--- a/sharness/.gitignore
+++ b/sharness/.gitignore
@@ -1,0 +1,3 @@
+/trash directory*
+/test-results
+/.prove


### PR DESCRIPTION
Summary:
This is copied from the Sharness repository’s `test/.gitignore`, and is
also the same as Git’s `t/.gitignore` minus a Git-specific exclusion.

Suggested by @decentralion.

Test Plan:
Run `yarn sharness` and interrupt it (SIGINT) while `make` is running.
Note that `sharness/` now contains a `trash directory.*`, which Git
ignores.

wchargin-branch: sharness-gitignore