### PR TITLE
Load repo registry even when hosted at non-root

### DIFF
--- a/src/app/credExplorer/App.js
+++ b/src/app/credExplorer/App.js
@@ -84,6 +84,7 @@ export function createApp(
         <div style={{maxWidth: 900, margin: "0 auto", padding: "0 10px"}}>
           <div style={{marginBottom: 10}}>
             <RepositorySelect
+              assets={this.props.assets}
               localStore={localStore}
               onChange={(repo) => this.stateTransitionMachine.setRepo(repo)}
             />

--- a/src/app/credExplorer/RepositorySelect.js
+++ b/src/app/credExplorer/RepositorySelect.js
@@ -6,6 +6,7 @@ import deepEqual from "lodash.isequal";
 
 import * as NullUtil from "../../util/null";
 import type {LocalStore} from "../localStore";
+import type {Assets} from "../assets";
 
 import {fromJSON, REPO_REGISTRY_API} from "./repoRegistry";
 import {type Repo, stringToRepo, repoToString} from "../../core/repo";
@@ -22,6 +23,7 @@ export type Status =
   | {|+type: "FAILURE"|};
 
 type Props = {|
+  +assets: Assets,
   +onChange: (x: Repo) => void,
   +localStore: LocalStore,
 |};
@@ -35,7 +37,8 @@ export default class RepositorySelect extends React.Component<Props, State> {
   }
 
   componentDidMount() {
-    loadStatus(this.props.localStore).then((status) => {
+    const {assets, localStore} = this.props;
+    loadStatus(assets, localStore).then((status) => {
       this.setState({status});
       if (status.type === "VALID") {
         this.props.onChange(status.selectedRepo);
@@ -67,9 +70,12 @@ export default class RepositorySelect extends React.Component<Props, State> {
   }
 }
 
-export async function loadStatus(localStore: LocalStore): Promise<Status> {
+export async function loadStatus(
+  assets: Assets,
+  localStore: LocalStore
+): Promise<Status> {
   try {
-    const response = await fetch(REPO_REGISTRY_API);
+    const response = await fetch(assets.resolve(REPO_REGISTRY_API));
     if (response.status === 404) {
       return {type: "NO_REPOS"};
     }


### PR DESCRIPTION
Summary:
This commit is the next step in #643. It makes the `RepositorySelect`
robust to being hosted at arbitrary gateways by accepting `Assets` and
resolving the repository registry API route appropriately.

Test Plan:
Unit tests modified, but it would be good to also manually test this.
Run `./scripts/build_static_site.sh` to build the site to, say,
`/tmp/gateway/`. Then spin up a static HTTP server serving `/tmp/` and
navigate to `/gateway/` in the browser. Note that you can navigate
around the application and load the repository registry on the prototype
without any console warnings or errors, although you cannot yet load
actual graph data.

wchargin-branch: use-assets-in-RepositorySelect