### PR TITLE
Reverse the order of CHANGELOG entries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,11 @@
 # Changelog
 
 ## [Unreleased]
-- Start tracking changes in `CHANGELOG.md`
-- Aggregate over connection types in the cred explorer (#502)
-- Support hosting SourceCred instances at arbitrary gateways, not just the root of a domain (#643)
-- Display version string in the app's footer
 - Rename cred explorer table columns (#680)
+- Display version string in the app's footer
+- Support hosting SourceCred instances at arbitrary gateways, not just
+  the root of a domain (#643)
+- Aggregate over connection types in the cred explorer (#502)
+- Start tracking changes in `CHANGELOG.md`
+<!-- Please add new entries to the _top_ of this section. -->
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -123,7 +123,8 @@ This is the same set of tests that is run on our CI system, Travis.
 
 If your patch makes a change that would be visible or interesting to a
 user of SourceCred—for example, fixing a bug—please add a description of
-the change under the `[Unreleased]` heading of `CHANGELOG.md`.
+the change under the `[Unreleased]` heading of `CHANGELOG.md`. Your new
+change should be the first entry in the section.
 
 ## When writing commit messages
 


### PR DESCRIPTION
It's more consistent to prepend entries to the [Unreleased] section of
the changelog, so that entries are all in reverse-chronological order.
Since we've appended the first few entries, we reverse them now.

Test plan: Not needed