### PR TITLE
Cleanup unnecessary lint suppresions

### DIFF
--- a/src/plugins/git/createGraph.js
+++ b/src/plugins/git/createGraph.js
@@ -71,9 +71,7 @@ class GraphCreator {
           target = {type: GN.COMMIT_TYPE, hash: entry.hash};
           break;
         default:
-          // eslint-disable-next-line no-unused-expressions
-          (entry.type: empty);
-          throw new Error(String(entry.type));
+          throw new Error(String((entry.type: empty)));
       }
       this.graph.addNode(GN.toRaw(target));
       this.graph.addEdge(GE.createEdge.hasContents(entryNode, target));

--- a/src/plugins/git/edges.js
+++ b/src/plugins/git/edges.js
@@ -237,8 +237,6 @@ export function toRaw(x: StructuredAddress): RawAddress {
         ...lengthEncode(GitNode.toRaw(x.treeEntry))
       );
     default:
-      // eslint-disable-next-line no-unused-expressions
-      (x.type: empty);
-      throw new Error(x.type);
+      throw new Error((x.type: empty));
   }
 }

--- a/src/plugins/git/nodes.js
+++ b/src/plugins/git/nodes.js
@@ -102,8 +102,6 @@ export function toRaw(x: StructuredAddress): RawAddress {
     case TREE_ENTRY_TYPE:
       return NodeAddress.append(_Prefix.treeEntry, x.treeHash, x.name);
     default:
-      // eslint-disable-next-line no-unused-expressions
-      (x.type: empty);
-      throw new Error(`Unexpected type ${x.type}`);
+      throw new Error(`Unexpected type ${(x.type: empty)}`);
   }
 }

--- a/src/plugins/github/edges.js
+++ b/src/plugins/github/edges.js
@@ -215,8 +215,6 @@ export function toRaw(x: StructuredAddress): RawAddress {
         ...lengthEncode(GithubNode.toRaw(x.referent))
       );
     default:
-      // eslint-disable-next-line no-unused-expressions
-      (x.type: empty);
-      throw new Error(x.type);
+      throw new Error((x.type: empty));
   }
 }

--- a/src/plugins/github/nodes.js
+++ b/src/plugins/github/nodes.js
@@ -261,15 +261,11 @@ export function toRaw(x: StructuredAddress): RawAddress {
             x.id
           );
         default:
-          // eslint-disable-next-line no-unused-expressions
-          (x.parent.type: empty);
-          throw new Error(`Bad comment parent type: ${x.parent.type}`);
+          throw new Error(`Bad comment parent type: ${(x.parent.type: empty)}`);
       }
     case USERLIKE_TYPE:
       return NodeAddress.append(_Prefix.userlike, x.login);
     default:
-      // eslint-disable-next-line no-unused-expressions
-      (x.type: empty);
-      throw new Error(`Unexpected type ${x.type}`);
+      throw new Error(`Unexpected type ${(x.type: empty)}`);
   }
 }

--- a/src/plugins/github/parseMarkdown.js
+++ b/src/plugins/github/parseMarkdown.js
@@ -108,9 +108,7 @@ export function deformat(ast: Node): void {
       case "custom_block":
         break;
       default:
-        // eslint-disable-next-line no-unused-expressions
-        (type: empty);
-        throw new Error("unexpected type: " + type);
+        throw new Error("unexpected type: " + (type: empty));
     }
   }
 }

--- a/src/plugins/github/relationalView.js
+++ b/src/plugins/github/relationalView.js
@@ -322,9 +322,9 @@ export class RelationalView {
         case N.REVIEW_TYPE:
           return reviewCommentUrlToId(json.url);
         default:
-          // eslint-disable-next-line no-unused-expressions
-          (parent.type: empty);
-          throw new Error(`Unexpected comment parent type: ${parent.type}`);
+          throw new Error(
+            `Unexpected comment parent type: ${(parent.type: empty)}`
+          );
       }
     })();
     const address: CommentAddress = {type: N.COMMENT_TYPE, id, parent};
@@ -405,9 +405,7 @@ export class RelationalView {
               this._addExtraAuthor(e, userlike);
               break;
             default:
-              // eslint-disable-next-line no-unused-expressions
-              (refType: empty);
-              throw new Error(`Unexpected refType: ${refType}`);
+              throw new Error(`Unexpected refType: ${(refType: empty)}`);
           }
         }
       }
@@ -461,10 +459,8 @@ export class RelationalView {
             entity = this.comment(address);
             break;
           default:
-            // eslint-disable-next-line no-unused-expressions
-            (address.type: empty);
             throw new Error(
-              `Unexpected referrer address type: ${address.type}`
+              `Unexpected referrer address type: ${(address.type: empty)}`
             );
         }
         if (entity == null) {
@@ -506,10 +502,8 @@ export class RelationalView {
             entity = this.userlike(address);
             break;
           default:
-            // eslint-disable-next-line no-unused-expressions
-            (address.type: empty);
             throw new Error(
-              `Unexpected referent address type: ${address.type}`
+              `Unexpected referent address type: ${(address.type: empty)}`
             );
         }
         if (entity == null) {
@@ -758,9 +752,7 @@ export class Comment extends _Entity<CommentEntry> {
         parent = this._view.review(address);
         break;
       default:
-        // eslint-disable-next-line no-unused-expressions
-        (address.type: empty);
-        throw new Error(`Unexpected parent address: ${stringify(address)}`);
+        throw new Error(`Bad parent address type: ${(address.type: empty)}`);
     }
     return assertExists(parent, address);
   }


### PR DESCRIPTION
We often construct case statements over union-typed variables, and then
in the default case, we use a `(type: empty)` assertion to ensure that
failing to account for all the cases results in a flow error.

In the past, we created an extra line for this assertion, which required
some eslint suppressions. We've realized it's cleaner to inline the type
assertion in the runtime error that we throw in these defaults.

This code cleans everything to the new style, and removes every existing
`// no-unused-expressions` invocation in the codebase.

Test plan: `yarn test`