### PR TITLE
Remove remaining public URL logic

### DIFF
--- a/config/env.js
+++ b/config/env.js
@@ -59,7 +59,7 @@ process.env.NODE_PATH = (process.env.NODE_PATH || "")
 // injected into the application via DefinePlugin in Webpack configuration.
 const REACT_APP = /^REACT_APP_/i;
 
-function getClientEnvironment(publicUrl /*: string */) {
+function getClientEnvironment() {
   const raw = Object.keys(process.env)
     .filter((key) => REACT_APP.test(key))
     .reduce(
@@ -71,11 +71,6 @@ function getClientEnvironment(publicUrl /*: string */) {
         // Useful for determining whether we’re running in production mode.
         // Most importantly, it switches React into the correct mode.
         NODE_ENV: process.env.NODE_ENV || "development",
-        // Useful for resolving the correct path to static assets in `public`.
-        // For example, <img src={process.env.PUBLIC_URL + '/img/logo.png'} />.
-        // This should only be used as an escape hatch. Normally you would put
-        // images into the `src` and `import` them in code to get their paths.
-        PUBLIC_URL: publicUrl,
       }
     );
   // Stringify all values so we can feed into Webpack DefinePlugin

--- a/config/makeWebpackConfig.js
+++ b/config/makeWebpackConfig.js
@@ -21,7 +21,7 @@ const getClientEnvironment = require("./env");
 // Source maps are resource heavy and can cause out of memory issue for large source files.
 const shouldUseSourceMap = process.env.GENERATE_SOURCEMAP !== "false";
 // Get environment variables to inject into our app.
-const env = getClientEnvironment(/* publicUrl: */ "");
+const env = getClientEnvironment();
 
 function makeConfig(mode /*: "production" | "development" */) {
   return {

--- a/config/paths.js
+++ b/config/paths.js
@@ -7,31 +7,6 @@ const fs = require("fs");
 const appDirectory = fs.realpathSync(process.cwd());
 const resolveApp = (relativePath) => path.resolve(appDirectory, relativePath);
 
-const envPublicUrl = process.env.PUBLIC_URL;
-
-function ensureSlash(path /*: string */, needsSlash /*: bool */) {
-  const hasSlash = path.endsWith("/");
-  if (hasSlash && !needsSlash) {
-    return path.substr(0, path.length - 1);
-  } else if (!hasSlash && needsSlash) {
-    return `${path}/`;
-  } else {
-    return path;
-  }
-}
-
-const getPublicUrl = () => envPublicUrl || "/";
-
-// We use `PUBLIC_URL` environment variable field to infer "public path" at
-// which the app is served. Defaults to "/"
-// Webpack needs to know it to put the right <script> hrefs into HTML even in
-// single-page apps that may serve index.html for nested URLs like /todos/42.
-// We can't use a relative path in HTML because we don't want to load something
-// like /todos/42/static/js/bundle.7289d.js. We have to know the root.
-function getServedPath() {
-  return ensureSlash(getPublicUrl(), true);
-}
-
 // config after eject: we're in ./config/
 module.exports = {
   root: appDirectory,
@@ -45,8 +20,6 @@ module.exports = {
   appSrc: resolveApp("src"),
   yarnLockFile: resolveApp("yarn.lock"),
   appNodeModules: resolveApp("node_modules"),
-  publicUrl: getPublicUrl(),
-  servedPath: getServedPath(),
 
   backendBuild: resolveApp("bin"),
   // This object should have one key-value pair per entry point. For


### PR DESCRIPTION
Summary:
Now that the main functionality of #643 has been implemented, we no
longer have any use for the “public URL” property. In fact, its presence
is actively harmful, as it suggests that the gateway may be known before
runtime, which is confusing and false.

Closes #643.

Test Plan:
Running `yarn start` works. Building the static site works.
Invoking `git grep -i 'public.\?url'` finds no matches.
Also, `yarn test --full` passes.

wchargin-branch: remove-public-url