### PR TITLE
Add `git/minimalPluginAdapter`

### DIFF
--- a/src/plugins/git/minimalPluginAdapter.js
+++ b/src/plugins/git/minimalPluginAdapter.js
@@ -1,0 +1,73 @@
+// @flow
+import type {
+  StaticPluginAdapter as IStaticPluginAdapter,
+  DynamicPluginAdapter as IDynamicPluginAdapter,
+} from "../../app/adapters/pluginAdapter";
+import {Graph} from "../../core/graph";
+import * as N from "./nodes";
+import * as E from "./edges";
+import {description} from "./render";
+import type {Assets} from "../../app/assets";
+import type {Repo} from "../../core/repo";
+
+export class StaticPluginAdapter implements IStaticPluginAdapter {
+  name() {
+    return "Git";
+  }
+  nodePrefix() {
+    return N._Prefix.base;
+  }
+  edgePrefix() {
+    return E._Prefix.base;
+  }
+  nodeTypes() {
+    return [
+      {
+        name: "Commit",
+        pluralName: "Commits",
+        prefix: N._Prefix.commit,
+        defaultWeight: 2,
+      },
+    ];
+  }
+  edgeTypes() {
+    return [
+      {
+        forwardName: "has parent",
+        backwardName: "is parent of",
+        prefix: E._Prefix.hasParent,
+      },
+    ];
+  }
+  async load(assets: Assets, repo: Repo): Promise<IDynamicPluginAdapter> {
+    const url = assets.resolve(
+      `/api/v1/data/data/${repo.owner}/${repo.name}/git/graph.json`
+    );
+    const response = await fetch(url);
+    if (!response.ok) {
+      return Promise.reject(response);
+    }
+    const json = await response.json();
+    const graph = Graph.fromJSON(json);
+    return new DynamicPluginAdapter(graph);
+  }
+}
+
+class DynamicPluginAdapter implements IDynamicPluginAdapter {
+  +_graph: Graph;
+  constructor(graph: Graph) {
+    this._graph = graph;
+  }
+  graph() {
+    return this._graph;
+  }
+  nodeDescription(node) {
+    // This cast is unsound, and might throw at runtime, but won't have
+    // silent failures or cause problems down the road.
+    const address = N.fromRaw((node: any));
+    return description(address);
+  }
+  static() {
+    return new StaticPluginAdapter();
+  }
+}


### PR DESCRIPTION
The minimal git plugin adapter only provides commit nodes and has_parent
edges. See #627 for context.

I forked this from `git/pluginAdapter.js`, and then deleted the
nodeTypes and edgeTypes which are no longer in scope.

Test plan: This is a fork of untested "glue" code, and is itself still
untested.