### PR TITLE
Add `GitState`, `Environment` to the `VersionInfo`

### DIFF
--- a/config/jest/setupJest.js
+++ b/config/jest/setupJest.js
@@ -1,3 +1,6 @@
 // @flow
 
+// Set up the environment before we include any other modules.
+require("../env");
+
 global.fetch = require("jest-fetch-mock");

--- a/src/app/Page.js
+++ b/src/app/Page.js
@@ -9,7 +9,7 @@ import GithubLogo from "./GithubLogo";
 import TwitterLogo from "./TwitterLogo";
 import {routeData} from "./routeData";
 import * as NullUtil from "../util/null";
-import {VERSION} from "./version";
+import {VERSION_SHORT, VERSION_FULL} from "./version";
 
 export default class Page extends React.Component<{|
   +assets: Assets,
@@ -71,7 +71,9 @@ export default class Page extends React.Component<{|
         </div>
         <footer className={css(style.footer)}>
           <div className={css(style.footerWrapper)}>
-            <span className={css(style.footerText)}>{VERSION}</span>
+            <span className={css(style.footerText)}>
+              ({VERSION_FULL}) <strong>{VERSION_SHORT}</strong>
+            </span>
           </div>
         </footer>
       </React.Fragment>

--- a/src/app/version.js
+++ b/src/app/version.js
@@ -4,6 +4,8 @@ export type VersionInfo = {|
   +major: number,
   +minor: number,
   +patch: number,
+  +gitState: GitState,
+  +environment: Environment,
 |};
 export type GitState = {|
   +commitHash: string,
@@ -38,6 +40,7 @@ export function parseGitState(raw: ?string): GitState {
   }
   return gitState;
 }
+const gitState = parseGitState(process.env.SOURCECRED_GIT_STATE);
 
 /**
  * Parse the given string as an `Environment`, throwing an error if it
@@ -51,15 +54,30 @@ export function parseEnvironment(raw: ?string): Environment {
   }
   return raw;
 }
+const environment = parseEnvironment(process.env.NODE_ENV);
 
-export const VERSION_INFO = Object.freeze({
+export const VERSION_INFO: VersionInfo = Object.freeze({
   major: 0,
   minor: 0,
   patch: 0,
+  gitState,
+  environment,
 });
 
-export function format(info: VersionInfo): string {
+export function formatShort(info: VersionInfo): string {
   return `v${info.major}.${info.minor}.${info.patch}`;
 }
 
-export const VERSION = format(VERSION_INFO);
+export function formatFull(info: VersionInfo): string {
+  const parts = [
+    `v${info.major}.${info.minor}.${info.patch}`,
+    info.gitState.commitHash,
+    info.gitState.commitTimestamp,
+    info.gitState.dirty ? "dirty" : "clean",
+    info.environment,
+  ];
+  return parts.join("-");
+}
+
+export const VERSION_SHORT: string = formatShort(VERSION_INFO);
+export const VERSION_FULL: string = formatFull(VERSION_INFO);

--- a/src/app/version.test.js
+++ b/src/app/version.test.js
@@ -1,11 +1,16 @@
 // @flow
 
-import {type Environment, parseEnvironment, parseGitState} from "./version";
+import {
+  type Environment,
+  type VersionInfo,
+  formatFull,
+  formatShort,
+  parseEnvironment,
+  parseGitState,
+} from "./version";
 
 describe("app/version", () => {
-  // Like `VersionInfo`, but with some extra properties that will
-  // shortly be added to that type.
-  const version = () => ({
+  const version = (): VersionInfo => ({
     major: 3,
     minor: 13,
     patch: 37,
@@ -104,6 +109,33 @@ describe("app/version", () => {
     });
     it("fails given a non-environment string", () => {
       expect(() => parseEnvironment("wat")).toThrow('environment: "wat"');
+    });
+  });
+
+  describe("formatShort", () => {
+    it("includes the major, minor, and patch versions", () => {
+      expect(formatShort(version())).toContain("3.13.37");
+    });
+    it("does not include the Git hash", () => {
+      expect(formatShort(version())).not.toContain("d0e1");
+    });
+    it("does not include the Node environment", () => {
+      expect(formatShort(version())).not.toContain("-test");
+    });
+  });
+
+  describe("formatFull", () => {
+    it("includes the major, minor, and patch versions", () => {
+      expect(formatFull(version())).toContain("3.13.37");
+    });
+    it("includes the Git hash and timestamp", () => {
+      expect(formatFull(version())).toContain("d0e1a2d3b4e5-20010203-0405");
+    });
+    it("includes the dirty state", () => {
+      expect(formatFull(version())).toContain("-dirty");
+    });
+    it("includes the Node environment", () => {
+      expect(formatFull(version())).toContain("-test");
     });
   });
 });


### PR DESCRIPTION
Summary:
The version number displayed in the application now displays much more
specific information. It now lists the Git commit from which the build
was constructed, and will identify whether we have accidentally deployed
a development instance (which would be slow) or an instance with
uncommitted changes (which would be bad).

The version information is computed during the initialization of the
Webpack config. For development, this means that it is computed when you
run `yarn start`, and not updated thenafter. If the stale information
presents actual confusion, we would need to backport Webpack 4’s support
for runtime values in `DefinePlugin` to Webpack 3 (or upgrade Webpack
by a major version).

Test Plan:
The logic for `GitState` and `Environment` has existing tests. With both
a clean tree and a dirty tree, run `yarn start` and build the static
site, and check that the resulting versions are correct.

wchargin-branch: use-rich-version-types