### PR TITLE
build_static_site.sh: create target if nonexistent

### DIFF
--- a/scripts/build_static_site.sh
+++ b/scripts/build_static_site.sh
@@ -45,9 +45,7 @@ parse_args() {
                 fi
                 shift
                 if [ $# -eq 0 ]; then die 'missing value for --target'; fi
-                if ! target="$(readlink -e "$1")"; then
-                    die "target does not exist: $1"
-                fi
+                target="$1"
                 ;;
             --repo)
                 shift
@@ -79,12 +77,16 @@ parse_args() {
     if [ -z "${target}" ]; then
         die 'target directory not specified'
     fi
+    if ! [ -e "${target}" ]; then
+        mkdir -p -- "${target}"
+    fi
     if ! [ -d "${target}" ]; then
         die "target is not a directory: ${target}"
     fi
     if [ "$(command ls -A "${target}" | wc -l)" != 0 ]; then
         die "target directory is nonempty: ${target}"
     fi
+    target="$(readlink -e "${target}")"
 }
 
 build() {


### PR DESCRIPTION
Summary:
The current version of the build script has the safe but annoying
property that the target directory must be an existing, empty directory.
It seems reasonable and convenient to allow the build script to create
the directory with `mkdir -p`. It still fails if the directory is not
empty or is a file.

Test Plan:
Unit tests updated; run `yarn sharness-full`.

wchargin-branch: build-mkdir-p