### PR TITLE
Stop persisting users' weight choices

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## [Unreleased]
+- Stop persisting weights in local store (#706)
 - Execute GraphQL queries with exponential backoff (#699)
 - Introduce a simplified Git plugin that only tracks commits (#685)
 - Rename cred explorer table columns (#680)

--- a/src/app/credExplorer/App.js
+++ b/src/app/credExplorer/App.js
@@ -110,7 +110,6 @@ export function createApp(
             Run PageRank
           </button>
           <WeightConfig
-            localStore={localStore}
             onChange={(ee) => this.stateTransitionMachine.setEdgeEvaluator(ee)}
           />
           <LoadingIndicator appState={this.state.appState} />

--- a/src/app/credExplorer/App.test.js
+++ b/src/app/credExplorer/App.test.js
@@ -129,13 +129,12 @@ describe("app/credExplorer/App", () => {
 
     function testWeightConfig(stateFn) {
       it("creates a working WeightConfig", () => {
-        const {el, setEdgeEvaluator, setState, localStore} = example();
+        const {el, setEdgeEvaluator, setState} = example();
         setState(stateFn());
         const wc = el.find(WeightConfig);
         const ee = createEvaluator();
         wc.props().onChange(ee);
         expect(setEdgeEvaluator).toHaveBeenCalledWith(ee);
-        expect(wc.props().localStore).toBe(localStore);
       });
     }
 

--- a/src/app/credExplorer/WeightConfig.js
+++ b/src/app/credExplorer/WeightConfig.js
@@ -3,15 +3,12 @@
 import React from "react";
 import sortBy from "lodash.sortby";
 
-import type {LocalStore} from "../localStore";
 import {type EdgeEvaluator} from "../../core/attribution/pagerank";
 import {byEdgeType, byNodeType} from "./edgeWeights";
-import * as NullUtil from "../../util/null";
 import {defaultStaticAdapters} from "../adapters/defaultPlugins";
 import type {NodeType, EdgeType} from "../adapters/pluginAdapter";
 
 type Props = {|
-  +localStore: LocalStore,
   +onChange: (EdgeEvaluator) => void,
 |};
 
@@ -21,7 +18,6 @@ type WeightedEdgeType = {|
   +directionality: number,
 |};
 type EdgeWeights = WeightedEdgeType[];
-const EDGE_WEIGHTS_KEY = "edgeWeights";
 const defaultEdgeWeights = (): EdgeWeights => {
   const result = [];
   for (const type of defaultStaticAdapters().edgeTypes()) {
@@ -32,7 +28,6 @@ const defaultEdgeWeights = (): EdgeWeights => {
 
 type NodeWeights = WeightedNodeType[];
 type WeightedNodeType = {|+type: NodeType, +logWeight: number|};
-const NODE_WEIGHTS_KEY = "nodeWeights";
 const defaultNodeWeights = (): NodeWeights => {
   const result = [];
   for (const type of defaultStaticAdapters().nodeTypes()) {
@@ -58,22 +53,7 @@ export class WeightConfig extends React.Component<Props, State> {
   }
 
   componentDidMount() {
-    const {localStore} = this.props;
-    this.setState(
-      (state) => {
-        return {
-          edgeWeights: NullUtil.orElse(
-            localStore.get(EDGE_WEIGHTS_KEY),
-            state.edgeWeights
-          ),
-          nodeWeights: NullUtil.orElse(
-            localStore.get(NODE_WEIGHTS_KEY),
-            state.nodeWeights
-          ),
-        };
-      },
-      () => this.fire()
-    );
+    this.fire();
   }
 
   render() {
@@ -114,10 +94,7 @@ export class WeightConfig extends React.Component<Props, State> {
   }
 
   fire() {
-    const {localStore} = this.props;
     const {edgeWeights, nodeWeights} = this.state;
-    localStore.set(EDGE_WEIGHTS_KEY, edgeWeights);
-    localStore.set(NODE_WEIGHTS_KEY, nodeWeights);
     const edgePrefixes = edgeWeights.map(
       ({type, logWeight, directionality}) => ({
         prefix: type.prefix,


### PR DESCRIPTION
Storing the user's weights in localStore enables a workflow where a
user chooses their preferred weights, and brings those weights with them
across projects and contexts. However, this is the wrong workflow:
actually, a project chooses its weights, and when a user visits a
particular project, they want to sync up with the project's choice.
Giving the user the ability to modify the weights and recalculate is
still important, so that they can propose improvements to the project
maintainer. But implicitly keeping their modified weights, and even
bringing them to other projects the user inspects, is
counter-productive.

This commit removes this dubious feature. (It's a feature we were likely
to drop anyway, as it conflicts with #703.) As an added bonus, this code
is untested, which means the feature is technical debt—so removing it
reduces our technical debt! It also removes at least one known bug.

Test plan: There are no tests. I manually verified that the frontend
still works, and that it no longer persists weights across refresh.