### PR TITLE
Allow combining repositories at load time

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## [Unreleased]
+- Support combining multiple repositories into a single graph (#711)
 - Normalize scores so that 1000 cred is split amongst users (#709)
 - Stop persisting weights in local store (#706)
 - Execute GraphQL queries with exponential backoff (#699)

--- a/README.md
+++ b/README.md
@@ -57,6 +57,16 @@ replacing the big string of zeros with your actual token.
 
 [ipfs/js-ipfs]: https://github.com/ipfs/js-ipfs
 
+You can also combine data from multiple repositories into a single graph.
+To do so, pass multiple repositories to the `load` command, and specify an “output name” for the repository.
+For instance, the invocation
+
+```
+node bin/sourcecred.js load ipfs/js-ipfs ipfs/go-ipfs --output ipfs/meta-ipfs
+```
+
+will create a graph called `ipfs/meta-ipfs` in the cred explorer, containing the combined contents of the js-ipfs and go-ipfs repositories.
+
 ## Early Adopters
 
 We’re looking for projects who want to be early adopters of SourceCred!

--- a/src/plugins/git/loadGitData.js
+++ b/src/plugins/git/loadGitData.js
@@ -3,19 +3,23 @@
 import fs from "fs-extra";
 import path from "path";
 
+import {Graph} from "../../core/graph";
 import cloneAndLoadRepository from "./cloneAndLoadRepository";
 import {createMinimalGraph} from "./createMinimalGraph";
 import type {Repo} from "../../core/repo";
 
 export type Options = {|
-  +repo: Repo,
+  +repos: $ReadOnlyArray<Repo>,
   +outputDirectory: string,
   +cacheDirectory: string,
 |};
 
 export function loadGitData(options: Options): Promise<void> {
-  const repository = cloneAndLoadRepository(options.repo);
-  const graph = createMinimalGraph(repository);
+  const graphs = options.repos.map((repo) => {
+    const repository = cloneAndLoadRepository(repo);
+    return createMinimalGraph(repository);
+  });
+  const graph = Graph.merge(graphs);
   const blob = JSON.stringify(graph);
   const outputFilename = path.join(options.outputDirectory, "graph.json");
   return fs.writeFile(outputFilename, blob);


### PR DESCRIPTION
Summary:
As a first pass toward support for analyzing whole organizations, we
allow loading multiple repositories with `sourcecred load`, combining
them into a single relational view and a single Git graph at load time.

Test Plan:
Run

```
node bin/sourcecred.js \
    load \
    sourcecred/example-git \
    sourcecred/example-github \
    sourcecred/sourcecred \
    --output sourcecred/examples \
    ;
```

and select `sourcecred/examples` from the web view. Filter “Repository”
nodes, and note that there are three.

Note that loading a single repository without `--output` still works,
that loading a single repository with `--output` still works (respecting
the alias name), and loading not exactly one repository without
`--output` yields an appropriate error message.

Note that `yarn sharness-full` still works.

wchargin-branch: load-combined