### PR TITLE
Detect a hardcoded list of bots

### DIFF
--- a/src/plugins/github/__snapshots__/createGraph.test.js.snap
+++ b/src/plugins/github/__snapshots__/createGraph.test.js.snap
@@ -15,7 +15,7 @@ Array [
           "AUTHORS",
           "3",
           "USERLIKE",
-          "USER",
+          "BOT",
           "credbot",
           "6",
           "COMMENT",
@@ -1633,7 +1633,7 @@ Array [
         "sourcecred",
         "github",
         "USERLIKE",
-        "USER",
+        "BOT",
         "credbot",
       ],
       Array [

--- a/src/plugins/github/bots.js
+++ b/src/plugins/github/bots.js
@@ -1,0 +1,19 @@
+// @flow
+
+// TODO(#638): Allow projects to specify bots via configuration,
+// rather than depending on this single souce of truth
+export function botSet(): Set<string> {
+  return new Set([
+    "credbot",
+    "facebook-github-bot",
+    "gitcoinbot",
+    "googlebot",
+    "greenkeeper",
+    "greenkeeperio-bot",
+    "metamaskbot",
+    "nodejs-github-bot",
+    "stickler-ci",
+    "tensorflow-jenkins",
+    "tensorflowbutler",
+  ]);
+}

--- a/src/plugins/github/relationalView.js
+++ b/src/plugins/github/relationalView.js
@@ -25,6 +25,7 @@ import type {
 } from "./graphql";
 import * as GitNode from "../git/nodes";
 import * as MapUtil from "../../util/map";
+import {botSet} from "./bots";
 
 import {
   reviewUrlToId,
@@ -342,11 +343,12 @@ export class RelationalView {
     if (json == null) {
       return [];
     } else {
+      const login = json.login;
+      const subtype = botSet().has(login) ? N.BOT_SUBTYPE : N.USER_SUBTYPE;
       const address: UserlikeAddress = {
         type: N.USERLIKE_TYPE,
-        // TODO: Detect bots and give them a different subtype (#696)
-        subtype: N.USER_SUBTYPE,
-        login: json.login,
+        subtype,
+        login,
       };
       const entry: UserlikeEntry = {address, url: json.url};
       this._userlikes.set(N.toRaw(address), entry);


### PR DESCRIPTION
This commit adds a hardcoded list of known bots. Building on #713, it
categorizes those userlikes with the bot subtype. (Note that those users
may not be bots in the GitHub ontology - GitHub doesn't actually have a
clear record of which userlikes are bots.)

Progress towards #696.

Test plan:
Observe the single snapshot change, which demonstrates that @credbot is
now correctly categorized as a bot.