### PR TITLE
Separate bots and users in the UI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## [Unreleased]
+- Separate bots from users in the UI (#720)
 - Add a feedback link to the prototype (#715)
 - Support combining multiple repositories into a single graph (#711)
 - Normalize scores so that 1000 cred is split amongst users (#709)

--- a/src/app/credExplorer/App.js
+++ b/src/app/credExplorer/App.js
@@ -73,7 +73,7 @@ export function createApp(
         const pnd = appState.substate.pagerankNodeDecomposition;
         pagerankTable = (
           <PagerankTable
-            defaultNodeFilter={GithubPrefix.userlike}
+            defaultNodeFilter={GithubPrefix.user}
             adapters={adapters}
             pnd={pnd}
             maxEntriesPerList={100}
@@ -114,7 +114,7 @@ export function createApp(
               )
             }
             onClick={() =>
-              this.stateTransitionMachine.runPagerank(GithubPrefix.userlike)
+              this.stateTransitionMachine.runPagerank(GithubPrefix.user)
             }
           >
             Run PageRank

--- a/src/plugins/github/pluginAdapter.js
+++ b/src/plugins/github/pluginAdapter.js
@@ -57,8 +57,14 @@ export class StaticPluginAdapter implements IStaticPluginAdapter {
       {
         name: "User",
         pluralName: "Users",
-        prefix: N._Prefix.userlike,
+        prefix: N._Prefix.user,
         defaultWeight: 1,
+      },
+      {
+        name: "Bot",
+        pluralName: "Bots",
+        prefix: N._Prefix.bot,
+        defaultWeight: 0.25,
       },
     ];
   }


### PR DESCRIPTION
Fixes #696.

Test plan: This is basically a config change, so I manually tested it.
I ran SourceCred on gitcoinco/web, which has two bots,
and verified that the bots are correctly removed from the list of users.
Selecting "Bots" in the dropdown filter shows the two bots. Changing
the user weight does not affect the bots' scores, and changing the bot
weight does affect the bots' scores.