### PR TITLE
Change nav bar styling

### DIFF
--- a/src/app/Page.js
+++ b/src/app/Page.js
@@ -102,8 +102,7 @@ const style = StyleSheet.create({
     minHeight: `calc(100vh - ${footerHeight}px)`,
   },
   nav: {
-    height: 60,
-    padding: "20px 100px",
+    padding: "20px 50px 0 50px",
     maxWidth: 900,
     margin: "0 auto",
   },


### PR DESCRIPTION
The nav bar now takes up less vertical space, by virtue of not having a
fixed height and not having bottom padding.

Test plan: Visual inspection.

![image](https://user-images.githubusercontent.com/1400023/44825456-87306880-abbf-11e8-9548-b9e477f8aab4.png)
![image](https://user-images.githubusercontent.com/1400023/44825461-8c8db300-abbf-11e8-9f9c-b0dca4658b1b.png)
