### PR TITLE
Allow repo names with underscores

### DIFF
--- a/src/core/repo.js
+++ b/src/core/repo.js
@@ -6,11 +6,12 @@ export opaque type Repo: {|+name: string, +owner: string|} = {|
 |};
 
 export function makeRepo(owner: string, name: string): Repo {
-  const validRe = /^[A-Za-z0-9-.]+$/;
-  if (!owner.match(validRe)) {
+  const validOwner = /^[A-Za-z0-9-]+$/;
+  const validRepo = /^[A-Za-z0-9-._]+$/;
+  if (!owner.match(validOwner)) {
     throw new Error(`Invalid repository owner: ${JSON.stringify(owner)}`);
   }
-  if (!name.match(validRe)) {
+  if (!name.match(validRepo)) {
     throw new Error(`Invalid repository name: ${JSON.stringify(name)}`);
   }
   return {owner, name};

--- a/src/core/repo.test.js
+++ b/src/core/repo.test.js
@@ -14,7 +14,7 @@ describe("core/repo", () => {
       const _unused_name: string = repo.name;
     });
   });
-  describe("makeRepoRepo", () => {
+  describe("makeRepo", () => {
     it("allows a simple repo", () => {
       makeRepo("sourcecred", "sourcecred");
     });
@@ -30,8 +30,14 @@ describe("core/repo", () => {
     it("disallows a repo with no name", () => {
       expect(() => makeRepo("foo", "")).toThrow("Invalid");
     });
-    it("disallows a repo with underscores", () => {
-      expect(() => makeRepo("yep", "something_bad")).toThrow("Invalid");
+    it("disallows an owner with periods", () => {
+      expect(() => makeRepo("fo.o", "bar")).toThrow("Invalid");
+    });
+    it("disallows an owner with underscores", () => {
+      expect(() => makeRepo("fo_o", "bar")).toThrow("Invalid");
+    });
+    it("allows a repo with underscores", () => {
+      makeRepo("foo", "still_good");
     });
   });
   describe("repo<->string", () => {
@@ -45,7 +51,7 @@ describe("core/repo", () => {
       testInvertible("sourcecred", "sourcecred");
     });
     it("works for a complicated case", () => {
-      testInvertible("fooolio", "foo-bar.bar-99");
+      testInvertible("fooolio", "foo-bar.bar-99_x");
     });
   });
 });


### PR DESCRIPTION
Such repos exist in practice.

Test plan: Unit tests included. Also, I can now load ropensci/usgs_app