### PR TITLE
cli: add a `common` module for environment vars

### DIFF
--- a/src/cli/common.js
+++ b/src/cli/common.js
@@ -1,0 +1,26 @@
+// @flow
+// Configuration and environment variables used by the CLI.
+
+import os from "os";
+import path from "path";
+
+import * as NullUtil from "../util/null";
+
+export type PluginName = "git" | "github";
+
+export function defaultPlugins(): PluginName[] {
+  return ["git", "github"];
+}
+
+export function defaultSourcecredDirectory() {
+  return path.join(os.tmpdir(), "sourcecred");
+}
+
+export function sourcecredDirectory(): string {
+  const env = process.env.SOURCECRED_DIRECTORY;
+  return env != null ? env : defaultSourcecredDirectory();
+}
+
+export function githubToken(): string | null {
+  return NullUtil.orElse(process.env.SOURCECRED_GITHUB_TOKEN, null);
+}

--- a/src/cli/common.test.js
+++ b/src/cli/common.test.js
@@ -1,0 +1,57 @@
+// @flow
+
+import path from "path";
+
+import {
+  defaultPlugins,
+  defaultSourcecredDirectory,
+  sourcecredDirectory,
+  githubToken,
+} from "./common";
+
+describe("cli/common", () => {
+  beforeEach(() => {
+    jest
+      .spyOn(require("os"), "tmpdir")
+      .mockReturnValue(path.join("/", "your", "tmpdir"));
+  });
+
+  describe("defaultPlugins", () => {
+    it("gives an array including the Git plugin name", () => {
+      expect(defaultPlugins()).toEqual(expect.arrayContaining(["git"]));
+    });
+  });
+
+  describe("defaultSourcecredDirectory", () => {
+    it("gives a file under the OS's temporary directory", () => {
+      expect(defaultSourcecredDirectory()).toEqual(
+        path.join("/", "your", "tmpdir", "sourcecred")
+      );
+    });
+  });
+
+  describe("sourcecredDirectory", () => {
+    it("uses the environment variable when available", () => {
+      const dir = path.join("/", "my", "sourcecred");
+      process.env.SOURCECRED_DIRECTORY = dir;
+      expect(sourcecredDirectory()).toEqual(dir);
+    });
+    it("uses the default directory if no environment variable is set", () => {
+      delete process.env.SOURCECRED_DIRECTORY;
+      expect(sourcecredDirectory()).toEqual(
+        path.join("/", "your", "tmpdir", "sourcecred")
+      );
+    });
+  });
+
+  describe("githubToken", () => {
+    it("uses the environment variable when available", () => {
+      process.env.SOURCECRED_GITHUB_TOKEN = "010101";
+      expect(githubToken()).toEqual("010101");
+    });
+    it("returns `null` if the environment variable is not set", () => {
+      delete process.env.SOURCECRED_GITHUB_TOKEN;
+      expect(githubToken()).toBe(null);
+    });
+  });
+});


### PR DESCRIPTION
Summary:
This includes environment variables to specify the SourceCred directory
and the GitHub token. Parts of this may change once #638 is resolved.

Test Plan:
Unit tests included, with full coverage; run `yarn unit`.

wchargin-branch: cli-common