### PR TITLE
Expose `env` to backend applications

### DIFF
--- a/config/webpack.config.backend.js
+++ b/config/webpack.config.backend.js
@@ -1,9 +1,13 @@
 // @no-flow
+
 const webpack = require("webpack");
 const eslintFormatter = require("react-dev-utils/eslintFormatter");
 const ModuleScopePlugin = require("react-dev-utils/ModuleScopePlugin");
 const paths = require("./paths");
 const nodeExternals = require("webpack-node-externals");
+const getClientEnvironment = require("./env");
+
+const env = getClientEnvironment();
 
 // This is the backend configuration. It builds applications that target
 // Node and will not run in a browser.
@@ -70,11 +74,5 @@ module.exports = (outputPath) => ({
       },
     ],
   },
-  plugins: [
-    new webpack.DefinePlugin({
-      "process.env.NODE_ENV": JSON.stringify(
-        process.env.NODE_ENV || "development"
-      ),
-    }),
-  ],
+  plugins: [new webpack.DefinePlugin(env.stringified)],
 });


### PR DESCRIPTION
Test Plan:
Add `console.log(require("../../app/version").VERSION_SHORT);` to the
top of `async run()` in `src/cli/commands/load.js`. Run `yarn backend`
and `node bin/sourcecred.js load`, and note that it prints the current
version number. Before this change, it would have raised an error:

```
Error: gitState: not a string: undefined
    at parseGitState (~/git/sourcecred/bin/commands/load.js:1160:64)
```

because the requisite environment variables were not included.

Also, `yarn test --full` passes.

wchargin-branch: backend-env