### PR TITLE
Allow backend `process.env` to see the runtime env

### DIFF
--- a/config/env.js
+++ b/config/env.js
@@ -134,11 +134,14 @@ function getClientEnvironment() {
 
   // Stringify all values so we can feed into Webpack's DefinePlugin.
   const stringified = {"process.env": {}};
+  const individuallyStringified = {};
   for (const key of Object.keys(raw)) {
-    stringified["process.env"][key] = JSON.stringify(raw[key]);
+    const value = JSON.stringify(raw[key]);
+    stringified["process.env"][key] = value;
+    individuallyStringified["process.env." + key] = value;
   }
 
-  return {raw, stringified};
+  return {raw, stringified, individuallyStringified};
 }
 
 module.exports = getClientEnvironment;

--- a/config/webpack.config.backend.js
+++ b/config/webpack.config.backend.js
@@ -74,5 +74,5 @@ module.exports = (outputPath) => ({
       },
     ],
   },
-  plugins: [new webpack.DefinePlugin(env.stringified)],
+  plugins: [new webpack.DefinePlugin(env.individuallyStringified)],
 });


### PR DESCRIPTION
Summary:
This is a follow-up to #746, wherein we exposed our fixed `env` to the
backend applications. We now extend that environment so that it can also
access the user’s runtime environment—i.e., the native values of
`process.env`.

(This is in contrast to the frontend bundles `main.js` and especially
`ssr.js`, where this is not and should not be the case: the environment
must be fixed at build time.)

Test Plan:
Add to the top of `async run()` in `src/cli/commands/load.js`:

```js
    console.log(require("../../app/version").VERSION_SHORT);
    console.log(process.env.AT_RUNTIME);
```

Run `yarn backend` and `AT_RUNTIME=wat node bin/sourcecred.js load`.
Ensure that the version number and the string `wat` are both printed.
(Before this patch, the string `undefined` would be printed instead of
`wat`.)

wchargin-branch: backend-extensible-env