### PR TITLE
Make js_bundle_path test POSIX-compliant

### DIFF
--- a/sharness/test_build_static_site.t
+++ b/sharness/test_build_static_site.t
@@ -166,10 +166,20 @@ run_build() {
     '
     test_expect_success "${prereq_name}" \
         "${prereq_name}: should have a bundle" '
-        _js_bundles=( "${output_dir}"/static/js/main.*.js ) &&
-        [ ${#_js_bundles[@]} -eq 1 ] &&
-        js_bundle_path="${_js_bundles[0]}" &&
-        test_path_is_file "${js_bundle_path}"
+        js_bundle_path= &&
+        js_bundle_path_glob="${output_dir}"/static/js/main.*.js &&
+        for main_js in ${js_bundle_path_glob}; do
+            if ! [ -e "${main_js}" ]; then
+                printf >&2 "fatal: no main bundle found\n" &&
+                return 1
+            elif [ -n "${js_bundle_path}" ]; then
+                printf >&2 "fatal: multiple main bundles found:\n" &&
+                printf >&2 "    %s\n" ${js_bundle_path_glob} &&
+                return 1
+            else
+                js_bundle_path="${main_js}"
+            fi
+        done
     '
 }
 


### PR DESCRIPTION
Summary:
In #715, I used Bash arrays for convenience. Our tests should run under
POSIX `sh` (as on Travis and standard GNU/Linux). This patch
reimplements the check using only POSIX features.

Fixes #752.

Test Plan:
As is, `yarn test --full` passes on GNU/Linux and macOS(+GNU coreutils).

Change the glob from `main.*.js` to `*.js` and note that running the
test emits an error:

```
fatal: multiple main bundles found:
    build_output/output_NO_REPOS/static/js/main.6307f660.js
    build_output/output_NO_REPOS/static/js/ssr.e92af807.js
```

Change the glob from `main.*.js` to `nope.*.js` and note that running
the test emits an error:

```
fatal: no main bundle found
```

Revert the glob to normal and note that all tests run and pass.

(To run tests, `./test_build_static_site.t --chain-lint --long -v` from
the `sharness/` directory.)

wchargin-branch: posix-bundle-check