### PR TITLE
Remove vestigial GITHUB_DELAY_MS code

### DIFF
--- a/src/plugins/github/fetchGithubRepo.js
+++ b/src/plugins/github/fetchGithubRepo.js
@@ -120,13 +120,6 @@ function retryGithubFetch(fetch, fetchOptions) {
 }
 
 async function postQuery({body, variables}, token): Promise<any> {
-  // TODO(#638): Find a more principled way to ingest this parameter.
-  const delayMs: number = parseInt(process.env.GITHUB_DELAY_MS || "0", 10) || 0;
-  await new Promise((resolve) => {
-    setTimeout(() => {
-      resolve();
-    }, delayMs);
-  });
   const postBody = JSON.stringify({
     query: stringify.body(body, inlineLayout()),
     variables: variables,


### PR DESCRIPTION
As of #699, the GITHUB_DELAY_MS code is vestigial. It should be removed.

Test plan: After rebuilding the backend, loading a repository still
works.