### PR TITLE
StateTransitionMachine.loadGraph reports success

### DIFF
--- a/src/app/credExplorer/state.test.js
+++ b/src/app/credExplorer/state.test.js
@@ -226,7 +226,8 @@ describe("app/credExplorer/state", () => {
       const {getState, stm, loadGraphMock} = example(readyToLoadGraph());
       const gwa = graphWithAdapters();
       loadGraphMock.mockResolvedValue(gwa);
-      await stm.loadGraph(new Assets("/my/gateway/"));
+      const succeeded = await stm.loadGraph(new Assets("/my/gateway/"));
+      expect(succeeded).toBe(true);
       const state = getState();
       const substate = getSubstate(state);
       expect(loading(state)).toBe("NOT_LOADING");
@@ -246,7 +247,8 @@ describe("app/credExplorer/state", () => {
             resolve(graphWithAdapters());
           })
       );
-      await stm.loadGraph(new Assets("/my/gateway/"));
+      const succeeded = await stm.loadGraph(new Assets("/my/gateway/"));
+      expect(succeeded).toBe(false);
       const state = getState();
       const substate = getSubstate(state);
       expect(loading(state)).toBe("NOT_LOADING");
@@ -259,7 +261,8 @@ describe("app/credExplorer/state", () => {
       // $ExpectFlowError
       console.error = jest.fn();
       loadGraphMock.mockRejectedValue(error);
-      await stm.loadGraph(new Assets("/my/gateway/"));
+      const succeeded = await stm.loadGraph(new Assets("/my/gateway/"));
+      expect(succeeded).toBe(false);
       const state = getState();
       const substate = getSubstate(state);
       expect(loading(state)).toBe("FAILED");


### PR DESCRIPTION
Step one towards #586. This will enable us to chain runPagerank after
loadGraph only if the load went through successfully.

Test plan: Unit tests included.