### PR TITLE
Add StateTransitionMachine.loadGraphAndRunPagerank

### DIFF
--- a/src/app/credExplorer/App.test.js
+++ b/src/app/credExplorer/App.test.js
@@ -24,6 +24,7 @@ describe("app/credExplorer/App", () => {
     const setEdgeEvaluator = jest.fn();
     const loadGraph = jest.fn();
     const runPagerank = jest.fn();
+    const loadGraphAndRunPagerank = jest.fn();
     const localStore = testLocalStore();
     function createMockSTM(_getState, _setState) {
       setState = _setState;
@@ -33,6 +34,7 @@ describe("app/credExplorer/App", () => {
         setEdgeEvaluator,
         loadGraph,
         runPagerank,
+        loadGraphAndRunPagerank,
       };
     }
     const App = createApp(createMockSTM);

--- a/src/app/credExplorer/state.test.js
+++ b/src/app/credExplorer/state.test.js
@@ -343,4 +343,57 @@ describe("app/credExplorer/state", () => {
       expect(console.error).toHaveBeenCalledWith(error);
     });
   });
+
+  describe("loadGraphAndRunPagerank", () => {
+    it("errors if called with uninitialized state", async () => {
+      const {stm} = example(initialState());
+      await expect(
+        stm.loadGraphAndRunPagerank(new Assets("gateway"), NodeAddress.empty)
+      ).rejects.toThrow("incorrect state");
+    });
+    it("when READY_TO_LOAD_GRAPH, loads graph then runs pagerank", async () => {
+      const {stm} = example(readyToLoadGraph());
+      (stm: any).loadGraph = jest.fn();
+      (stm: any).runPagerank = jest.fn();
+      stm.loadGraph.mockResolvedValue(true);
+      const assets = new Assets("/gateway/");
+      const prefix = NodeAddress.fromParts(["bar"]);
+      await stm.loadGraphAndRunPagerank(assets, prefix);
+      expect(stm.loadGraph).toHaveBeenCalledTimes(1);
+      expect(stm.loadGraph).toHaveBeenCalledWith(assets);
+      expect(stm.runPagerank).toHaveBeenCalledTimes(1);
+      expect(stm.runPagerank).toHaveBeenCalledWith(prefix);
+    });
+    it("does not run pagerank if loadGraph did not succeed", async () => {
+      const {stm} = example(readyToLoadGraph());
+      (stm: any).loadGraph = jest.fn();
+      (stm: any).runPagerank = jest.fn();
+      stm.loadGraph.mockResolvedValue(false);
+      const assets = new Assets("/gateway/");
+      const prefix = NodeAddress.fromParts(["bar"]);
+      await stm.loadGraphAndRunPagerank(assets, prefix);
+      expect(stm.loadGraph).toHaveBeenCalledTimes(1);
+      expect(stm.runPagerank).toHaveBeenCalledTimes(0);
+    });
+    it("when READY_TO_RUN_PAGERANK, runs pagerank", async () => {
+      const {stm} = example(readyToRunPagerank());
+      (stm: any).loadGraph = jest.fn();
+      (stm: any).runPagerank = jest.fn();
+      const prefix = NodeAddress.fromParts(["bar"]);
+      await stm.loadGraphAndRunPagerank(new Assets("/gateway/"), prefix);
+      expect(stm.loadGraph).toHaveBeenCalledTimes(0);
+      expect(stm.runPagerank).toHaveBeenCalledTimes(1);
+      expect(stm.runPagerank).toHaveBeenCalledWith(prefix);
+    });
+    it("when PAGERANK_EVALUATED, runs pagerank", async () => {
+      const {stm} = example(pagerankEvaluated());
+      (stm: any).loadGraph = jest.fn();
+      (stm: any).runPagerank = jest.fn();
+      const prefix = NodeAddress.fromParts(["bar"]);
+      await stm.loadGraphAndRunPagerank(new Assets("/gateway/"), prefix);
+      expect(stm.loadGraph).toHaveBeenCalledTimes(0);
+      expect(stm.runPagerank).toHaveBeenCalledTimes(1);
+      expect(stm.runPagerank).toHaveBeenCalledWith(prefix);
+    });
+  });
 });

--- a/src/app/credExplorer/state.test.js
+++ b/src/app/credExplorer/state.test.js
@@ -226,7 +226,8 @@ describe("app/credExplorer/state", () => {
       const {getState, stm, loadGraphMock} = example(readyToLoadGraph());
       const gwa = graphWithAdapters();
       loadGraphMock.mockResolvedValue(gwa);
-      await stm.loadGraph(new Assets("/my/gateway/"));
+      const succeeded = await stm.loadGraph(new Assets("/my/gateway/"));
+      expect(succeeded).toBe(true);
       const state = getState();
       const substate = getSubstate(state);
       expect(loading(state)).toBe("NOT_LOADING");
@@ -246,7 +247,8 @@ describe("app/credExplorer/state", () => {
             resolve(graphWithAdapters());
           })
       );
-      await stm.loadGraph(new Assets("/my/gateway/"));
+      const succeeded = await stm.loadGraph(new Assets("/my/gateway/"));
+      expect(succeeded).toBe(false);
       const state = getState();
       const substate = getSubstate(state);
       expect(loading(state)).toBe("NOT_LOADING");
@@ -259,7 +261,8 @@ describe("app/credExplorer/state", () => {
       // $ExpectFlowError
       console.error = jest.fn();
       loadGraphMock.mockRejectedValue(error);
-      await stm.loadGraph(new Assets("/my/gateway/"));
+      const succeeded = await stm.loadGraph(new Assets("/my/gateway/"));
+      expect(succeeded).toBe(false);
       const state = getState();
       const substate = getSubstate(state);
       expect(loading(state)).toBe("FAILED");


### PR DESCRIPTION
This methods combines `loadGraph` and `runPagerank` into one method
which internally chains the two method. `runPagerank` is only called if
`loadGraph` was successful.

Progress on #586.

Test plan:
The new method has attached unit tests. I implemented the unit tests via
mocking, which seemed quite convenient as the method is basically a
wrapper for chaining two other function calls.