### PR TITLE
Move WeightConfig button to the right

### DIFF
--- a/src/app/credExplorer/WeightConfig.js
+++ b/src/app/credExplorer/WeightConfig.js
@@ -63,6 +63,7 @@ export class WeightConfig extends React.Component<Props, State> {
     return (
       <React.Fragment>
         <button
+          style={{float: "right"}}
           onClick={() => {
             this.setState(({expanded}) => ({expanded: !expanded}));
           }}


### PR DESCRIPTION
By moving the WeightConfig button to the side and away from the main
controls, I think we visually signal that this button is less important
/ isn't part of the main flow.

Test plan: Change is purely visual.

![image](https://user-images.githubusercontent.com/1400023/44975810-42d2fe80-af18-11e8-9087-af7e5aa85219.png)
