### PR TITLE
Add default weights for edge types

### DIFF
--- a/src/app/adapters/demoAdapters.js
+++ b/src/app/adapters/demoAdapters.js
@@ -33,13 +33,17 @@ export const machineNodeType: NodeType = Object.freeze({
 
 export const assemblesEdgeType: EdgeType = Object.freeze({
   forwardName: "assembles",
+  defaultForwardWeight: 2,
   backwardName: "is assembled by",
+  defaultBackwardWeight: 2 ** -2,
   prefix: EdgeAddress.fromParts(["factorio", "assembles"]),
 });
 
 export const transportsEdgeType: EdgeType = Object.freeze({
   forwardName: "transports",
+  defaultForwardWeight: 1,
   backwardName: "is transported by",
+  defaultBackwardWeight: 2 ** -1,
   prefix: EdgeAddress.fromParts(["factorio", "transports"]),
 });
 

--- a/src/app/adapters/fallbackAdapter.js
+++ b/src/app/adapters/fallbackAdapter.js
@@ -42,6 +42,8 @@ export class FallbackStaticAdapter implements StaticPluginAdapter {
       {
         forwardName: "unknown edge→",
         backwardName: "unknown edge←",
+        defaultForwardWeight: 1,
+        defaultBackwardWeight: 1,
         prefix: EdgeAddress.empty,
       },
     ];

--- a/src/app/adapters/pluginAdapter.js
+++ b/src/app/adapters/pluginAdapter.js
@@ -7,6 +7,8 @@ import type {Repo} from "../../core/repo";
 export type EdgeType = {|
   +forwardName: string,
   +backwardName: string,
+  +defaultForwardWeight: number,
+  +defaultBackwardWeight: number,
   +prefix: EdgeAddressT,
 |};
 

--- a/src/app/credExplorer/pagerankTable/Aggregation.test.js
+++ b/src/app/credExplorer/pagerankTable/Aggregation.test.js
@@ -163,6 +163,8 @@ describe("app/credExplorer/pagerankTable/Aggregation", () => {
     const edgeType: EdgeType = {
       forwardName: "marsellus",
       backwardName: "wallace",
+      defaultForwardWeight: 1,
+      defaultBackwardWeight: 1,
       prefix: EdgeAddress.fromParts(["look", "like"]),
     };
     function aggView(aggregation: FlatAggregation) {

--- a/src/app/credExplorer/pagerankTable/aggregate.test.js
+++ b/src/app/credExplorer/pagerankTable/aggregate.test.js
@@ -54,16 +54,22 @@ describe("app/credExplorer/aggregate", () => {
       foo: {
         forwardName: "foos",
         backwardName: "foo'd by",
+        defaultForwardWeight: 1,
+        defaultBackwardWeight: 1,
         prefix: EdgeAddress.fromParts(["foo"]),
       },
       bar: {
         forwardName: "bars",
         backwardName: "bar'd by",
+        defaultForwardWeight: 1,
+        defaultBackwardWeight: 1,
         prefix: EdgeAddress.fromParts(["bar"]),
       },
       empty: {
         forwardName: "empty",
         backwardName: "emptied-by",
+        defaultForwardWeight: 1,
+        defaultBackwardWeight: 1,
         prefix: EdgeAddress.empty,
       },
     };

--- a/src/app/credExplorer/weights/EdgeTypeConfig.js
+++ b/src/app/credExplorer/weights/EdgeTypeConfig.js
@@ -13,8 +13,8 @@ export type WeightedEdgeType = {|
 export function defaultWeightedEdgeType(type: EdgeType): WeightedEdgeType {
   return {
     type,
-    forwardWeight: 1,
-    backwardWeight: 1,
+    forwardWeight: type.defaultForwardWeight,
+    backwardWeight: type.defaultBackwardWeight,
   };
 }
 

--- a/src/app/credExplorer/weights/EdgeTypeConfig.test.js
+++ b/src/app/credExplorer/weights/EdgeTypeConfig.test.js
@@ -15,10 +15,10 @@ require("../../testUtil").configureEnzyme();
 
 describe("app/credExplorer/weights/EdgeTypeConfig", () => {
   describe("defaultWeightedEdgeType", () => {
-    it("sets default weights to 1, 1", () => {
+    it("sets default weights as specified in the type", () => {
       const wet = defaultWeightedEdgeType(assemblesEdgeType);
-      expect(wet.forwardWeight).toEqual(1);
-      expect(wet.backwardWeight).toEqual(1);
+      expect(wet.forwardWeight).toEqual(wet.type.defaultForwardWeight);
+      expect(wet.backwardWeight).toEqual(wet.type.defaultBackwardWeight);
     });
   });
   describe("EdgeTypeConfig", () => {

--- a/src/plugins/git/minimalPluginAdapter.js
+++ b/src/plugins/git/minimalPluginAdapter.js
@@ -36,6 +36,8 @@ export class StaticPluginAdapter implements IStaticPluginAdapter {
         forwardName: "has parent",
         backwardName: "is parent of",
         prefix: E._Prefix.hasParent,
+        defaultForwardWeight: 1,
+        defaultBackwardWeight: 1,
       },
     ];
   }

--- a/src/plugins/git/pluginAdapter.js
+++ b/src/plugins/git/pluginAdapter.js
@@ -53,26 +53,36 @@ export class StaticPluginAdapter implements IStaticPluginAdapter {
       {
         forwardName: "has tree",
         backwardName: "owned by",
+        defaultForwardWeight: 1,
+        defaultBackwardWeight: 1,
         prefix: E._Prefix.hasTree,
       },
       {
         forwardName: "has parent",
         backwardName: "is parent of",
+        defaultForwardWeight: 1,
+        defaultBackwardWeight: 1,
         prefix: E._Prefix.hasParent,
       },
       {
         forwardName: "includes",
         backwardName: "is included by",
+        defaultForwardWeight: 1,
+        defaultBackwardWeight: 1,
         prefix: E._Prefix.includes,
       },
       {
         forwardName: "evolves to",
         backwardName: "evolves from",
+        defaultForwardWeight: 1,
+        defaultBackwardWeight: 1,
         prefix: E._Prefix.becomes,
       },
       {
         forwardName: "has contents",
         backwardName: "is contents of",
+        defaultForwardWeight: 1,
+        defaultBackwardWeight: 1,
         prefix: E._Prefix.hasContents,
       },
     ];

--- a/src/plugins/github/pluginAdapter.js
+++ b/src/plugins/github/pluginAdapter.js
@@ -75,21 +75,29 @@ export class StaticPluginAdapter implements IStaticPluginAdapter {
       {
         forwardName: "authors",
         backwardName: "is authored by",
+        defaultForwardWeight: 1 / 2,
+        defaultBackwardWeight: 1,
         prefix: E._Prefix.authors,
       },
       {
         forwardName: "has parent",
         backwardName: "has child",
+        defaultForwardWeight: 1,
+        defaultBackwardWeight: 1 / 4,
         prefix: E._Prefix.hasParent,
       },
       {
         forwardName: "merges",
         backwardName: "is merged by",
+        defaultForwardWeight: 1 / 2,
+        defaultBackwardWeight: 1,
         prefix: E._Prefix.mergedAs,
       },
       {
         forwardName: "references",
         backwardName: "is referenced by",
+        defaultForwardWeight: 1,
+        defaultBackwardWeight: 1 / 16,
         prefix: E._Prefix.references,
       },
     ];


### PR DESCRIPTION
This commit modifies the edge type so that it has a
`defaultForwardWeight` and `defaultBackwardWeight`, and these defaults
are respected by the `WeightConfig`.

I came up with reasonable-seeming defaults for the Git and GitHub
plugins; these will undoubtably be more methodically tuned in the
future.

Test plan: `yarn test` passes, also opening the cred explorer now has
the specified default weights in the WeightConfig. (Note that the
forward/backward directions are reversed as described in #749.)