### PR TITLE
 Factor out NodeTypeConfig

### DIFF
--- a/src/app/credExplorer/weights/NodeTypeConfig.js
+++ b/src/app/credExplorer/weights/NodeTypeConfig.js
@@ -1,0 +1,34 @@
+// @flow
+
+import React from "react";
+import {WeightSlider} from "./WeightSlider";
+import {type NodeType} from "../../adapters/pluginAdapter";
+
+export type WeightedNodeType = {|+type: NodeType, +weight: number|};
+
+export function defaultWeightedNodeType(type: NodeType): WeightedNodeType {
+  return {
+    type,
+    weight: type.defaultWeight,
+  };
+}
+
+export class NodeTypeConfig extends React.Component<{
+  +weightedType: WeightedNodeType,
+  +onChange: (WeightedNodeType) => void,
+}> {
+  render() {
+    return (
+      <WeightSlider
+        name={this.props.weightedType.type.name}
+        weight={this.props.weightedType.weight}
+        onChange={(weight) => {
+          this.props.onChange({
+            ...this.props.weightedType,
+            weight,
+          });
+        }}
+      />
+    );
+  }
+}

--- a/src/app/credExplorer/weights/NodeTypeConfig.test.js
+++ b/src/app/credExplorer/weights/NodeTypeConfig.test.js
@@ -1,0 +1,45 @@
+// @flow
+
+import React from "react";
+import {shallow} from "enzyme";
+
+import {WeightSlider} from "./WeightSlider";
+import {defaultWeightedNodeType, NodeTypeConfig} from "./NodeTypeConfig";
+import {inserterNodeType} from "../../adapters/demoAdapters";
+
+require("../../testUtil").configureEnzyme();
+
+describe("app/credExplorer/weights/NodeTypeConfig", () => {
+  describe("defaultWeightedNodeType", () => {
+    it("sets default weight as specified in type", () => {
+      const wnt = defaultWeightedNodeType(inserterNodeType);
+      expect(wnt.weight).toEqual(wnt.type.defaultWeight);
+    });
+  });
+  describe("NodeTypeConfig", () => {
+    function example() {
+      const onChange = jest.fn();
+      const wnt = {
+        type: inserterNodeType,
+        weight: 0.125,
+      };
+      const element = shallow(
+        <NodeTypeConfig onChange={onChange} weightedType={wnt} />
+      );
+      const slider = element.find(WeightSlider);
+      return {onChange, wnt, slider};
+    }
+    it("sets up the weight slider", () => {
+      const {wnt, slider} = example();
+      expect(slider.props().name).toBe(wnt.type.name);
+      expect(slider.props().weight).toBe(wnt.weight);
+    });
+    it("weight slider onChange works", () => {
+      const {wnt, slider, onChange} = example();
+      slider.props().onChange(9);
+      const updated = {...wnt, weight: 9};
+      expect(onChange).toHaveBeenCalledTimes(1);
+      expect(onChange.mock.calls[0][0]).toEqual(updated);
+    });
+  });
+});


### PR DESCRIPTION
This factors `NodeTypeConfig` out of the `WeightConfig` component. The
scope for a `NodeTypeConfig` is that it configures a single node type.
Right now it just renders a single `WeightSlider`, but I like factoring
out both for consistency with the `EdgeTypeConfig` (see #749) and
because I expect we may want to add more complexity later.

Test plan: The new component has some tests, also I manually tested the
frontend.