### PR TITLE
Fix a bug that can lock the cred explorer UI

### DIFF
--- a/src/app/credExplorer/state.test.js
+++ b/src/app/credExplorer/state.test.js
@@ -2,7 +2,7 @@
 
 import {
   StateTransitionMachine,
-  initialState,
+  uninitializedState,
   type AppState,
   type GraphWithAdapters,
 } from "./state";
@@ -41,31 +41,29 @@ describe("app/credExplorer/state", () => {
     );
     return {getState, stm, loadGraphMock, pagerankMock};
   }
-  function initialized(substate): AppState {
+  function readyToLoadGraph(): AppState {
     return {
-      type: "INITIALIZED",
+      type: "READY_TO_LOAD_GRAPH",
       repo: makeRepo("foo", "bar"),
-      edgeEvaluator: edgeEvaluator(),
-      substate,
+      loading: "NOT_LOADING",
     };
   }
-  function readyToLoadGraph(): AppState {
-    return initialized({type: "READY_TO_LOAD_GRAPH", loading: "NOT_LOADING"});
-  }
   function readyToRunPagerank(): AppState {
-    return initialized({
+    return {
       type: "READY_TO_RUN_PAGERANK",
+      repo: makeRepo("foo", "bar"),
       loading: "NOT_LOADING",
       graphWithAdapters: graphWithAdapters(),
-    });
+    };
   }
   function pagerankEvaluated(): AppState {
-    return initialized({
+    return {
       type: "PAGERANK_EVALUATED",
+      repo: makeRepo("foo", "bar"),
       graphWithAdapters: graphWithAdapters(),
       pagerankNodeDecomposition: pagerankNodeDecomposition(),
       loading: "NOT_LOADING",
-    });
+    };
   }
   function edgeEvaluator(): EdgeEvaluator {
     return (_unused_Edge) => ({toWeight: 3, froWeight: 4});
@@ -79,122 +77,60 @@ describe("app/credExplorer/state", () => {
   function pagerankNodeDecomposition() {
     return new Map();
   }
-  function getSubstate(state: AppState) {
-    if (state.type !== "INITIALIZED") {
-      throw new Error("Tried to get invalid substate");
-    }
-    return state.substate;
-  }
   function loading(state: AppState) {
-    if (
-      state.type !== "INITIALIZED" ||
-      state.substate.type === "PAGERANK_EVALUATED"
-    ) {
+    if (state.type === "UNINITIALIZED") {
       throw new Error("Tried to get invalid loading");
     }
-    return state.substate.loading;
+    return state.loading;
+  }
+  function getRepo(state: AppState) {
+    if (state.type === "UNINITIALIZED") {
+      throw new Error("Tried to get invalid repo");
+    }
+    return state.repo;
   }
 
   describe("setRepo", () => {
     describe("in UNINITIALIZED", () => {
-      it("stays UNINITIALIZED if edge evaluator not set", () => {
-        const {getState, stm} = example(initialState());
+      it("transitions to READY_TO_LOAD_GRAPH", () => {
+        const {getState, stm} = example(uninitializedState());
         const repo = makeRepo("foo", "bar");
         stm.setRepo(repo);
         const state = getState();
-        expect(state.type).toBe("UNINITIALIZED");
-        expect(state.repo).toEqual(repo);
-      });
-      it("transitions to INITIALIZED if an edge evaluator was set", () => {
-        const {getState, stm} = example(initialState());
-        stm.setEdgeEvaluator(edgeEvaluator());
-        const repo = makeRepo("foo", "bar");
-        stm.setRepo(repo);
-        const state = getState();
-        expect(state.type).toBe("INITIALIZED");
-        expect(state.repo).toEqual(repo);
+        expect(state.type).toBe("READY_TO_LOAD_GRAPH");
+        expect(getRepo(state)).toEqual(repo);
       });
     });
-    describe("in INITIALIZED", () => {
-      it("stays in READY_TO_LOAD_GRAPH with new repo", () => {
-        const {getState, stm} = example(readyToLoadGraph());
-        const repo = makeRepo("zoink", "zod");
-        stm.setRepo(repo);
-        const state = getState();
-        expect(getSubstate(state).type).toBe("READY_TO_LOAD_GRAPH");
-        expect(state.repo).toEqual(repo);
-      });
-      it("transitions READY_TO_RUN_PAGERANK to READY_TO_LOAD_GRAPH with new repo", () => {
-        const {getState, stm} = example(readyToRunPagerank());
-        const repo = makeRepo("zoink", "zod");
-        stm.setRepo(repo);
-        const state = getState();
-        expect(getSubstate(state).type).toBe("READY_TO_LOAD_GRAPH");
-        expect(state.repo).toEqual(repo);
-      });
-      it("transitions PAGERANK_EVALUATED to READY_TO_LOAD_GRAPH with new repo", () => {
-        const {getState, stm} = example(pagerankEvaluated());
-        const repo = makeRepo("zoink", "zod");
-        stm.setRepo(repo);
-        const state = getState();
-        expect(getSubstate(state).type).toBe("READY_TO_LOAD_GRAPH");
-        expect(state.repo).toEqual(repo);
-      });
+    it("stays in READY_TO_LOAD_GRAPH with new repo", () => {
+      const {getState, stm} = example(readyToLoadGraph());
+      const repo = makeRepo("zoink", "zod");
+      stm.setRepo(repo);
+      const state = getState();
+      expect(state.type).toBe("READY_TO_LOAD_GRAPH");
+      expect(getRepo(state)).toEqual(repo);
     });
-  });
-
-  describe("setEdgeEvaluator", () => {
-    describe("in UNINITIALIZED", () => {
-      it("sets ee without transitioning to INITIALIZE if repo not set", () => {
-        const {getState, stm} = example(initialState());
-        const ee = edgeEvaluator();
-        stm.setEdgeEvaluator(ee);
-        const state = getState();
-        expect(state.type).toBe("UNINITIALIZED");
-        expect(state.edgeEvaluator).toBe(ee);
-      });
-      it("triggers transition to INITIALIZED if repo was set", () => {
-        const {getState, stm} = example(initialState());
-        stm.setRepo(makeRepo("foo", "zod"));
-        const ee = edgeEvaluator();
-        stm.setEdgeEvaluator(ee);
-        const state = getState();
-        expect(state.type).toBe("INITIALIZED");
-        expect(state.edgeEvaluator).toBe(ee);
-      });
+    it("transitions READY_TO_RUN_PAGERANK to READY_TO_LOAD_GRAPH with new repo", () => {
+      const {getState, stm} = example(readyToRunPagerank());
+      const repo = makeRepo("zoink", "zod");
+      stm.setRepo(repo);
+      const state = getState();
+      expect(state.type).toBe("READY_TO_LOAD_GRAPH");
+      expect(getRepo(state)).toEqual(repo);
     });
-    describe("in INITIALIZED", () => {
-      it("does not transition READY_TO_LOAD_GRAPH", () => {
-        const {getState, stm} = example(readyToLoadGraph());
-        const ee = edgeEvaluator();
-        stm.setEdgeEvaluator(ee);
-        const state = getState();
-        expect(getSubstate(state).type).toBe("READY_TO_LOAD_GRAPH");
-        expect(state.edgeEvaluator).toBe(ee);
-      });
-      it("does not transition READY_TO_RUN_PAGERANK", () => {
-        const {getState, stm} = example(readyToRunPagerank());
-        const ee = edgeEvaluator();
-        stm.setEdgeEvaluator(ee);
-        const state = getState();
-        expect(getSubstate(state).type).toBe("READY_TO_RUN_PAGERANK");
-        expect(state.edgeEvaluator).toBe(ee);
-      });
-      it("does not transition PAGERANK_EVALUATED", () => {
-        const {getState, stm} = example(pagerankEvaluated());
-        const ee = edgeEvaluator();
-        stm.setEdgeEvaluator(ee);
-        const state = getState();
-        expect(getSubstate(state).type).toBe("PAGERANK_EVALUATED");
-        expect(state.edgeEvaluator).toBe(ee);
-      });
+    it("transitions PAGERANK_EVALUATED to READY_TO_LOAD_GRAPH with new repo", () => {
+      const {getState, stm} = example(pagerankEvaluated());
+      const repo = makeRepo("zoink", "zod");
+      stm.setRepo(repo);
+      const state = getState();
+      expect(state.type).toBe("READY_TO_LOAD_GRAPH");
+      expect(getRepo(state)).toEqual(repo);
     });
   });
 
   describe("loadGraph", () => {
     it("can only be called when READY_TO_LOAD_GRAPH", async () => {
       const badStates = [
-        initialState(),
+        uninitializedState(),
         readyToRunPagerank(),
         pagerankEvaluated(),
       ];
@@ -220,7 +156,7 @@ describe("app/credExplorer/state", () => {
       expect(loading(getState())).toBe("NOT_LOADING");
       stm.loadGraph(new Assets("/my/gateway/"));
       expect(loading(getState())).toBe("LOADING");
-      expect(getSubstate(getState()).type).toBe("READY_TO_LOAD_GRAPH");
+      expect(getState().type).toBe("READY_TO_LOAD_GRAPH");
     });
     it("transitions to READY_TO_RUN_PAGERANK on success", async () => {
       const {getState, stm, loadGraphMock} = example(readyToLoadGraph());
@@ -229,15 +165,14 @@ describe("app/credExplorer/state", () => {
       const succeeded = await stm.loadGraph(new Assets("/my/gateway/"));
       expect(succeeded).toBe(true);
       const state = getState();
-      const substate = getSubstate(state);
       expect(loading(state)).toBe("NOT_LOADING");
-      expect(substate.type).toBe("READY_TO_RUN_PAGERANK");
-      if (substate.type !== "READY_TO_RUN_PAGERANK") {
+      expect(state.type).toBe("READY_TO_RUN_PAGERANK");
+      if (state.type !== "READY_TO_RUN_PAGERANK") {
         throw new Error("Impossible");
       }
-      expect(substate.graphWithAdapters).toBe(gwa);
+      expect(state.graphWithAdapters).toBe(gwa);
     });
-    it("does not transition if another transition happens first", async () => {
+    it("does not transition if repo transition happens first", async () => {
       const {getState, stm, loadGraphMock} = example(readyToLoadGraph());
       const swappedRepo = makeRepo("too", "fast");
       loadGraphMock.mockImplementation(
@@ -250,10 +185,9 @@ describe("app/credExplorer/state", () => {
       const succeeded = await stm.loadGraph(new Assets("/my/gateway/"));
       expect(succeeded).toBe(false);
       const state = getState();
-      const substate = getSubstate(state);
       expect(loading(state)).toBe("NOT_LOADING");
-      expect(substate.type).toBe("READY_TO_LOAD_GRAPH");
-      expect(state.repo).toBe(swappedRepo);
+      expect(state.type).toBe("READY_TO_LOAD_GRAPH");
+      expect(getRepo(state)).toEqual(swappedRepo);
     });
     it("sets loading state FAILED on reject", async () => {
       const {getState, stm, loadGraphMock} = example(readyToLoadGraph());
@@ -264,9 +198,8 @@ describe("app/credExplorer/state", () => {
       const succeeded = await stm.loadGraph(new Assets("/my/gateway/"));
       expect(succeeded).toBe(false);
       const state = getState();
-      const substate = getSubstate(state);
       expect(loading(state)).toBe("FAILED");
-      expect(substate.type).toBe("READY_TO_LOAD_GRAPH");
+      expect(state.type).toBe("READY_TO_LOAD_GRAPH");
       expect(console.error).toHaveBeenCalledTimes(1);
       expect(console.error).toHaveBeenCalledWith(error);
     });
@@ -274,12 +207,12 @@ describe("app/credExplorer/state", () => {
 
   describe("runPagerank", () => {
     it("can only be called when READY_TO_RUN_PAGERANK or PAGERANK_EVALUATED", async () => {
-      const badStates = [initialState(), readyToLoadGraph()];
+      const badStates = [uninitializedState(), readyToLoadGraph()];
       for (const b of badStates) {
         const {stm} = example(b);
-        await expect(stm.runPagerank(NodeAddress.empty)).rejects.toThrow(
-          "incorrect state"
-        );
+        await expect(
+          stm.runPagerank(edgeEvaluator(), NodeAddress.empty)
+        ).rejects.toThrow("incorrect state");
       }
     });
     it("can be run when READY_TO_RUN_PAGERANK or PAGERANK_EVALUATED", async () => {
@@ -288,30 +221,31 @@ describe("app/credExplorer/state", () => {
         const {stm, getState, pagerankMock} = example(g);
         const pnd = pagerankNodeDecomposition();
         pagerankMock.mockResolvedValue(pnd);
-        await stm.runPagerank(NodeAddress.empty);
+        await stm.runPagerank(edgeEvaluator(), NodeAddress.empty);
         const state = getState();
-        const substate = getSubstate(state);
-        if (substate.type !== "PAGERANK_EVALUATED") {
+        if (state.type !== "PAGERANK_EVALUATED") {
           throw new Error("Impossible");
         }
-        expect(substate.type).toBe("PAGERANK_EVALUATED");
-        expect(substate.pagerankNodeDecomposition).toBe(pnd);
+        expect(state.type).toBe("PAGERANK_EVALUATED");
+        expect(state.pagerankNodeDecomposition).toBe(pnd);
       }
     });
     it("immediately sets loading status", () => {
       const {getState, stm} = example(readyToRunPagerank());
       expect(loading(getState())).toBe("NOT_LOADING");
-      stm.runPagerank(NodeAddress.empty);
+      stm.runPagerank(edgeEvaluator(), NodeAddress.empty);
       expect(loading(getState())).toBe("LOADING");
     });
     it("calls pagerank with the totalScoreNodePrefix option", async () => {
       const {pagerankMock, stm} = example(readyToRunPagerank());
       const foo = NodeAddress.fromParts(["foo"]);
-      await stm.runPagerank(foo);
+      const ee = edgeEvaluator();
+      await stm.runPagerank(ee, foo);
       const args = pagerankMock.mock.calls[0];
+      expect(args[1]).toBe(ee);
       expect(args[2].totalScoreNodePrefix).toBe(foo);
     });
-    it("does not transition if another transition happens first", async () => {
+    it("does not transition if a repo change happens first", async () => {
       const {getState, stm, pagerankMock} = example(readyToRunPagerank());
       const swappedRepo = makeRepo("too", "fast");
       pagerankMock.mockImplementation(
@@ -321,12 +255,11 @@ describe("app/credExplorer/state", () => {
             resolve(graphWithAdapters());
           })
       );
-      await stm.runPagerank(NodeAddress.empty);
+      await stm.runPagerank(edgeEvaluator(), NodeAddress.empty);
       const state = getState();
-      const substate = getSubstate(state);
       expect(loading(state)).toBe("NOT_LOADING");
-      expect(substate.type).toBe("READY_TO_LOAD_GRAPH");
-      expect(state.repo).toBe(swappedRepo);
+      expect(state.type).toBe("READY_TO_LOAD_GRAPH");
+      expect(getRepo(state)).toBe(swappedRepo);
     });
     it("sets loading state FAILED on reject", async () => {
       const {getState, stm, pagerankMock} = example(readyToRunPagerank());
@@ -334,11 +267,10 @@ describe("app/credExplorer/state", () => {
       // $ExpectFlowError
       console.error = jest.fn();
       pagerankMock.mockRejectedValue(error);
-      await stm.runPagerank(NodeAddress.empty);
+      await stm.runPagerank(edgeEvaluator(), NodeAddress.empty);
       const state = getState();
-      const substate = getSubstate(state);
       expect(loading(state)).toBe("FAILED");
-      expect(substate.type).toBe("READY_TO_RUN_PAGERANK");
+      expect(state.type).toBe("READY_TO_RUN_PAGERANK");
       expect(console.error).toHaveBeenCalledTimes(1);
       expect(console.error).toHaveBeenCalledWith(error);
     });
@@ -346,9 +278,13 @@ describe("app/credExplorer/state", () => {
 
   describe("loadGraphAndRunPagerank", () => {
     it("errors if called with uninitialized state", async () => {
-      const {stm} = example(initialState());
+      const {stm} = example(uninitializedState());
       await expect(
-        stm.loadGraphAndRunPagerank(new Assets("gateway"), NodeAddress.empty)
+        stm.loadGraphAndRunPagerank(
+          new Assets("gateway"),
+          edgeEvaluator(),
+          NodeAddress.empty
+        )
       ).rejects.toThrow("incorrect state");
     });
     it("when READY_TO_LOAD_GRAPH, loads graph then runs pagerank", async () => {
@@ -358,11 +294,12 @@ describe("app/credExplorer/state", () => {
       stm.loadGraph.mockResolvedValue(true);
       const assets = new Assets("/gateway/");
       const prefix = NodeAddress.fromParts(["bar"]);
-      await stm.loadGraphAndRunPagerank(assets, prefix);
+      const ee = edgeEvaluator();
+      await stm.loadGraphAndRunPagerank(assets, ee, prefix);
       expect(stm.loadGraph).toHaveBeenCalledTimes(1);
       expect(stm.loadGraph).toHaveBeenCalledWith(assets);
       expect(stm.runPagerank).toHaveBeenCalledTimes(1);
-      expect(stm.runPagerank).toHaveBeenCalledWith(prefix);
+      expect(stm.runPagerank).toHaveBeenCalledWith(ee, prefix);
     });
     it("does not run pagerank if loadGraph did not succeed", async () => {
       const {stm} = example(readyToLoadGraph());
@@ -371,7 +308,7 @@ describe("app/credExplorer/state", () => {
       stm.loadGraph.mockResolvedValue(false);
       const assets = new Assets("/gateway/");
       const prefix = NodeAddress.fromParts(["bar"]);
-      await stm.loadGraphAndRunPagerank(assets, prefix);
+      await stm.loadGraphAndRunPagerank(assets, edgeEvaluator(), prefix);
       expect(stm.loadGraph).toHaveBeenCalledTimes(1);
       expect(stm.runPagerank).toHaveBeenCalledTimes(0);
     });
@@ -380,20 +317,22 @@ describe("app/credExplorer/state", () => {
       (stm: any).loadGraph = jest.fn();
       (stm: any).runPagerank = jest.fn();
       const prefix = NodeAddress.fromParts(["bar"]);
-      await stm.loadGraphAndRunPagerank(new Assets("/gateway/"), prefix);
+      const ee = edgeEvaluator();
+      await stm.loadGraphAndRunPagerank(new Assets("/gateway/"), ee, prefix);
       expect(stm.loadGraph).toHaveBeenCalledTimes(0);
       expect(stm.runPagerank).toHaveBeenCalledTimes(1);
-      expect(stm.runPagerank).toHaveBeenCalledWith(prefix);
+      expect(stm.runPagerank).toHaveBeenCalledWith(ee, prefix);
     });
     it("when PAGERANK_EVALUATED, runs pagerank", async () => {
       const {stm} = example(pagerankEvaluated());
       (stm: any).loadGraph = jest.fn();
       (stm: any).runPagerank = jest.fn();
       const prefix = NodeAddress.fromParts(["bar"]);
-      await stm.loadGraphAndRunPagerank(new Assets("/gateway/"), prefix);
+      const ee = edgeEvaluator();
+      await stm.loadGraphAndRunPagerank(new Assets("/gateway/"), ee, prefix);
       expect(stm.loadGraph).toHaveBeenCalledTimes(0);
       expect(stm.runPagerank).toHaveBeenCalledTimes(1);
-      expect(stm.runPagerank).toHaveBeenCalledWith(prefix);
+      expect(stm.runPagerank).toHaveBeenCalledWith(ee, prefix);
     });
   });
 });


### PR DESCRIPTION
Fix a bug that can lock the cred explorer UI

Currently, it's possible to lock the cred explorer UI via the following
sequence of actions:

1. Press the analyze cred button
2. While it is running, modify the weights

After following this repro, the UI is stuck: it will say "loading"
forever, and the analyze cred button is disabled.

The issue is that loadGraph and runPagerank do not apply their success
(or failure) state transitions if they are pre-empted by another state
change. If a repo change occurs, that's the right behavior: the repo
change puts the state back to `"READY_TO_LOAD_GRAPH"`, which means the
UI is ready to re-load, and showing the PageRank results for the wrong
repo would be very confusing.

However, if an edge evaluator change occurs while loadGraph or
runPagerank is happening, the state is left in the "LOADING" status
(which means the analyze cred button  is disabled).

This commit fixes the issue via a refactor: per @wchargin's suggestion,
responsibility for the edge evaluator moves from the state module out to
`credExplorer/App.js`. This dramatically simplifies the state module, as
we no longer need a `Substate` concept: we can simplify the state into a
single sequence of states.

As of the refactor, the bug is impossible.

Test plan: Unit tests have been updated to maintain coverage on the
refactored code. I manually tested that the bug no longer repro's, and
that the cred explorer UI continues to function. I did not add a new
test to protect against regression, because in the new codepath, the bug
is basically impossible.
