### PR TITLE
babel: transform ES6 modules to CommonJS

### DIFF
--- a/config/babel.js
+++ b/config/babel.js
@@ -113,8 +113,6 @@ if (env === "test") {
               },
           // Disable polyfill transforms
           useBuiltIns: false,
-          // Do not transform modules to CJS
-          modules: false,
         },
       ],
       // JSX, Flow


### PR DESCRIPTION
Summary:
The approach used by `create-react-app` (the source of this code) seems
to be the following: write everything as ES6 modules (`import`/`export`)
and bundle everything with Webpack—in particular, do not transform
modules with Babel.

This works fine until you want to also access some of these modules from
raw Node. Node only supports CommonJS modules, so these “polyglot”
modules must be CommonJS-compatible. But CommonJS modules are not nicely
compatible with ES6 modules: you need to set `exports.default` instead
of `module.exports` in the provider, and dereference `.default` after
each `require`. Babel will perform these transformations for us if we
ask it to. In this patch, we do so.

Test Plan:
Note that `yarn test --full` passes and `yarn start` still works.
(Follow-up commits will exercise this functionality.)

wchargin-branch: transform-es6-modules