### PR TITLE
Make `execDependencyGraph` a CommonJS module

### DIFF
--- a/config/test.js
+++ b/config/test.js
@@ -1,6 +1,6 @@
 // @flow
 
-const execDependencyGraph = require("../src/tools/execDependencyGraph").default;
+const execDependencyGraph = require("../src/tools/execDependencyGraph");
 
 main();
 

--- a/src/cli/load.js
+++ b/src/cli/load.js
@@ -12,10 +12,9 @@ import dedent from "../util/dedent";
 import type {Command} from "./command";
 import * as Common from "./common";
 
+import execDependencyGraph from "../tools/execDependencyGraph";
 import {loadGithubData} from "../plugins/github/loadGithubData";
 import {loadGitData} from "../plugins/git/loadGitData";
-
-const execDependencyGraph = require("../tools/execDependencyGraph").default;
 
 function usage(print: (string) => void): void {
   print(

--- a/src/cli/load.test.js
+++ b/src/cli/load.test.js
@@ -10,9 +10,7 @@ import load, {help} from "./load";
 import * as RepoRegistry from "../app/credExplorer/repoRegistry";
 import {stringToRepo} from "../core/repo";
 
-jest.mock("../tools/execDependencyGraph", () => ({
-  default: jest.fn(),
-}));
+jest.mock("../tools/execDependencyGraph", () => jest.fn());
 jest.mock("../plugins/github/loadGithubData", () => ({
   loadGithubData: jest.fn(),
 }));
@@ -21,8 +19,7 @@ jest.mock("../plugins/git/loadGitData", () => ({
 }));
 
 type JestMockFn = $Call<typeof jest.fn>;
-const execDependencyGraph: JestMockFn = (require("../tools/execDependencyGraph")
-  .default: any);
+const execDependencyGraph: JestMockFn = (require("../tools/execDependencyGraph"): any);
 const loadGithubData: JestMockFn = (require("../plugins/github/loadGithubData")
   .loadGithubData: any);
 const loadGitData: JestMockFn = (require("../plugins/git/loadGitData")

--- a/src/tools/execDependencyGraph.js
+++ b/src/tools/execDependencyGraph.js
@@ -48,7 +48,7 @@ const defaultOptions = {
   overallFailLabel: "FAILURE",
 };
 
-exports.default = async function execDependencyGraph(
+module.exports = async function execDependencyGraph(
   tasks /*: $ReadOnlyArray<Task> */,
   options /*:: ?: RunOptions */
 ) /*: Promise<OverallResult> */ {


### PR DESCRIPTION
Summary:
This simplifies interfaces everywhere.

See also #216, which did the opposite of this as a temporary fix due to
a Babel/Webpack interaction that no longer exists as of #766.

Test Plan:
Note that `node bin/sourcecred.js load sourcecred/example-git` still
works (after `yarn backend`). Note that `yarn test` still works. These
demonstrate that the module works from both a Webpack context and a Node
context. Note that `git grep --name-only execDependencyGraph` yields
exactly those files touched in this commit. Note that `yarn test --full`
passes.

wchargin-branch: commonjs-execDependencyGraph