### PR TITLE
webpack: empty build dir instead of removing it

### DIFF
--- a/config/RemoveBuildDirectoryPlugin.js
+++ b/config/RemoveBuildDirectoryPlugin.js
@@ -1,8 +1,7 @@
 // @flow
 
-const fs = require("fs");
+const fs = require("fs-extra");
 const path = require("path");
-const rimraf = require("rimraf");
 
 // Note: the following type-import just resolves to `any`.
 /*:: import type {Compiler} from "webpack"; */
@@ -32,8 +31,8 @@ module.exports = class RemoveBuildDirectoryPlugin {
             outputPath
         );
       }
-      console.warn("Removing build directory: " + outputPath);
-      rimraf.sync(outputPath);
+      console.warn("Removing contents of build directory: " + outputPath);
+      fs.emptyDirSync(outputPath);
     });
   }
 };

--- a/package.json
+++ b/package.json
@@ -60,7 +60,6 @@
     "prettier": "^1.13.4",
     "raf": "3.4.0",
     "react-dev-utils": "^5.0.0",
-    "rimraf": "^2.6.2",
     "static-site-generator-webpack-plugin": "^3.4.1",
     "style-loader": "0.19.0",
     "url-loader": "0.6.2",


### PR DESCRIPTION
Test Plan:
Run `mkdir /tmp/out; cd /tmp/out; python -m SimpleHTTPServer`. In
another shell, run `./scripts/build_static_site.sh --target /tmp/out`.
Then, `curl localhost:8000`. Before this commit, this would have yielded
an `OSError` because the cwd of the Python process had been removed.
As of this commit, it works fine.

Also, run `git grep -c rimraf` and note only `yarn.lock:15`.

wchargin-branch: webpack-empty-build-directory