### PR TITLE
Fail on console errors when testing enzyme

### DIFF
--- a/src/app/createRelativeHistory.test.js
+++ b/src/app/createRelativeHistory.test.js
@@ -12,17 +12,6 @@ import createRelativeHistory from "./createRelativeHistory";
 require("./testUtil").configureEnzyme();
 
 describe("app/createRelativeHistory", () => {
-  beforeEach(() => {
-    // $ExpectFlowError
-    console.error = jest.fn();
-    // $ExpectFlowError
-    console.warn = jest.fn();
-  });
-  afterEach(() => {
-    expect(console.warn).not.toHaveBeenCalled();
-    expect(console.error).not.toHaveBeenCalled();
-  });
-
   function createHistory(basename, path) {
     const memoryHistory = createMemoryHistory(path);
     const relativeHistory = createRelativeHistory(memoryHistory, basename);

--- a/src/app/credExplorer/RepositorySelect.test.js
+++ b/src/app/credExplorer/RepositorySelect.test.js
@@ -22,14 +22,6 @@ require("../testUtil").configureAphrodite();
 describe("app/credExplorer/RepositorySelect", () => {
   beforeEach(() => {
     fetch.resetMocks();
-    // $ExpectFlowError
-    console.error = jest.fn();
-    // $ExpectFlowError
-    console.warn = jest.fn();
-  });
-  afterEach(() => {
-    expect(console.warn).not.toHaveBeenCalled();
-    expect(console.error).not.toHaveBeenCalled();
   });
 
   function mockRegistry(registry: RepoRegistry) {

--- a/src/app/credExplorer/pagerankTable/Aggregation.test.js
+++ b/src/app/credExplorer/pagerankTable/Aggregation.test.js
@@ -21,16 +21,6 @@ import {factorioNodes} from "../../adapters/demoAdapters";
 require("../../testUtil").configureEnzyme();
 
 describe("app/credExplorer/pagerankTable/Aggregation", () => {
-  beforeEach(() => {
-    // $ExpectFlowError
-    console.error = jest.fn();
-    // $ExpectFlowError
-    console.warn = jest.fn();
-  });
-  afterEach(() => {
-    expect(console.warn).not.toHaveBeenCalled();
-    expect(console.error).not.toHaveBeenCalled();
-  });
   describe("AggregationRowList", () => {
     it("instantiates AggregationRows for each aggregation", async () => {
       const {adapters, pnd} = await example();

--- a/src/app/credExplorer/pagerankTable/Connection.test.js
+++ b/src/app/credExplorer/pagerankTable/Connection.test.js
@@ -14,17 +14,6 @@ import {factorioNodes} from "../../adapters/demoAdapters";
 require("../../testUtil").configureEnzyme();
 
 describe("app/credExplorer/pagerankTable/Connection", () => {
-  beforeEach(() => {
-    // $ExpectFlowError
-    console.error = jest.fn();
-    // $ExpectFlowError
-    console.warn = jest.fn();
-  });
-  afterEach(() => {
-    expect(console.warn).not.toHaveBeenCalled();
-    expect(console.error).not.toHaveBeenCalled();
-  });
-
   describe("ConnectionRowList", () => {
     async function setup(maxEntriesPerList: number = 100000) {
       const {adapters, pnd} = await example();

--- a/src/app/credExplorer/pagerankTable/Node.test.js
+++ b/src/app/credExplorer/pagerankTable/Node.test.js
@@ -17,16 +17,6 @@ import {factorioNodes} from "../../adapters/demoAdapters";
 require("../../testUtil").configureEnzyme();
 
 describe("app/credExplorer/pagerankTable/Node", () => {
-  beforeEach(() => {
-    // $ExpectFlowError
-    console.error = jest.fn();
-    // $ExpectFlowError
-    console.warn = jest.fn();
-  });
-  afterEach(() => {
-    expect(console.warn).not.toHaveBeenCalled();
-    expect(console.error).not.toHaveBeenCalled();
-  });
   describe("NodeRowList", () => {
     function sortedByScore(nodes: $ReadOnlyArray<NodeAddressT>, pnd) {
       return sortBy(nodes, (node) => -NullUtil.get(pnd.get(node)).score);

--- a/src/app/credExplorer/pagerankTable/Table.test.js
+++ b/src/app/credExplorer/pagerankTable/Table.test.js
@@ -10,16 +10,6 @@ import {example, COLUMNS} from "./sharedTestUtils";
 
 require("../../testUtil").configureEnzyme();
 describe("app/credExplorer/pagerankTable/Table", () => {
-  beforeEach(() => {
-    // $ExpectFlowError
-    console.error = jest.fn();
-    // $ExpectFlowError
-    console.warn = jest.fn();
-  });
-  afterEach(() => {
-    expect(console.warn).not.toHaveBeenCalled();
-    expect(console.error).not.toHaveBeenCalled();
-  });
   describe("PagerankTable", () => {
     it("renders thead column order properly", async () => {
       const {pnd, adapters} = await example();

--- a/src/app/testUtil.js
+++ b/src/app/testUtil.js
@@ -4,6 +4,16 @@ export function configureEnzyme() {
   const Enzyme = require("enzyme");
   const Adapter = require("enzyme-adapter-react-16");
   Enzyme.configure({adapter: new Adapter()});
+  beforeEach(() => {
+    // $ExpectFlowError
+    console.error = jest.fn();
+    // $ExpectFlowError
+    console.warn = jest.fn();
+  });
+  afterEach(() => {
+    expect(console.warn).not.toHaveBeenCalled();
+    expect(console.error).not.toHaveBeenCalled();
+  });
 }
 
 export function configureAphrodite() {


### PR DESCRIPTION
`testUtil.configureEnzyme` now additionally asserts, after every test,
that `console.error` and `console.warn` were not called. Tests that
explicitly expect such calls can still be written by manually re-mocking
the relevant console method (and several examples already exist).

The code that explicitly specifies this for various enzyme test files
has been removed.

Test plan: `git grep "not.toHaveBeenCalled"` shows only unrelated usage.
`yarn test` passes. Adding a spurious console.warn to a passing test
causes it to fail.

Fixes #668