### PR TITLE
Fix expected error message in build test

### DIFF
--- a/sharness/test_build_static_site.t
+++ b/sharness/test_build_static_site.t
@@ -151,7 +151,7 @@ run_build() {
         fi &&
         run '"${flags}"' 2>err &&
         test_must_fail grep -vF \
-            -e "Removing build directory: " \
+            -e "Removing contents of build directory: " \
             -e "warn: running `yarn backend`" \
             -e "warn: if this offends you" \
             -e "info: loading repository" \


### PR DESCRIPTION
Summary:
This change should have happened in #768. However, I didn’t catch it
then because `yarn test --full` passes even before this commit, despite
the expected error being clearly wrong! It turns out that a very sneaky
bug conspires with this one to result in the test passing no matter what
kinds of warnings `yarn backend` may output. This bug is fixed in #772.

Test Plan:
Observe that the error message is now correct by comparing against the
source in `config/RemoveBuildDirectoryPlugin.js`. Then, apply #772 and
note that `yarn test --full` still passes, but does not pass when #772
is applied and this change is reverted.

wchargin-branch: fix-expected-error-message