### PR TITLE
backend: remove superfluous file existence check

### DIFF
--- a/scripts/backend.js
+++ b/scripts/backend.js
@@ -31,11 +31,6 @@ const printFileSizesAfterBuild = FileSizeReporter.printFileSizesAfterBuild;
 const WARN_AFTER_BUNDLE_GZIP_SIZE = 512 * 1024;
 const WARN_AFTER_CHUNK_GZIP_SIZE = 1024 * 1024;
 
-// Warn and crash if required files are missing
-if (!checkRequiredFiles(Object.values(paths.backendEntryPoints))) {
-  process.exit(1);
-}
-
 const outputPath = process.argv.some((s) => s === "--dry-run" || s === "-n")
   ? tmp.dirSync({unsafeCleanup: true, prefix: "sourcecred-"}).name
   : paths.backendBuild;


### PR DESCRIPTION
Summary:
Webpack will fail (quickly) if any required entry points do not exist.
The `scripts/backend.js` script superfluously checks this, too. This
patch removes that check.

Test Plan:
In `config/paths.js`, change `src/cli/main.js` to `src/cli/wat.js`.
Then, `yarn backend`, and note that Webpack fails quickly, with an error
“entry module not found”. Note that Webpack fails equally quickly if you
change the path of the last entry point rather than the first one.

wchargin-branch: backend-remove-exists-check