### PR TITLE
webpack: remove superfluous linting step

### DIFF
--- a/config/webpack.config.backend.js
+++ b/config/webpack.config.backend.js
@@ -1,7 +1,6 @@
 // @no-flow
 
 const webpack = require("webpack");
-const eslintFormatter = require("react-dev-utils/eslintFormatter");
 const ModuleScopePlugin = require("react-dev-utils/ModuleScopePlugin");
 const paths = require("./paths");
 const nodeExternals = require("webpack-node-externals");
@@ -41,22 +40,6 @@ module.exports = (outputPath) => ({
   module: {
     strictExportPresence: true,
     rules: [
-      // First, run the linter.
-      // It's important to do this before Babel processes the JS.
-      {
-        test: /\.(js|jsx|mjs)$/,
-        enforce: "pre",
-        use: [
-          {
-            options: {
-              formatter: eslintFormatter,
-              eslintPath: require.resolve("eslint"),
-            },
-            loader: require.resolve("eslint-loader"),
-          },
-        ],
-        include: paths.appSrc,
-      },
       {
         // "oneOf" will traverse all following loaders until one will
         // match the requirements. If no loader matches, it will fail.

--- a/config/webpack.config.web.js
+++ b/config/webpack.config.web.js
@@ -13,7 +13,6 @@ const RemoveBuildDirectoryPlugin = require("./RemoveBuildDirectoryPlugin");
 const CopyPlugin = require("copy-webpack-plugin");
 const ManifestPlugin = require("webpack-manifest-plugin");
 const StaticSiteGeneratorPlugin = require("static-site-generator-webpack-plugin");
-const eslintFormatter = require("react-dev-utils/eslintFormatter");
 const ModuleScopePlugin = require("react-dev-utils/ModuleScopePlugin");
 const paths = require("./paths");
 const getClientEnvironment = require("./env");
@@ -123,23 +122,6 @@ function makeConfig(mode /*: "production" | "development" */) {
         // TODO: Disable require.ensure as it's not a standard language feature.
         // We are waiting for https://github.com/facebookincubator/create-react-app/issues/2176.
         // { parser: { requireEnsure: false } },
-
-        // First, run the linter.
-        // It's important to do this before Babel processes the JS.
-        {
-          test: /\.(js|jsx|mjs)$/,
-          enforce: "pre",
-          use: [
-            {
-              options: {
-                formatter: eslintFormatter,
-                eslintPath: require.resolve("eslint"),
-              },
-              loader: require.resolve("eslint-loader"),
-            },
-          ],
-          include: paths.appSrc,
-        },
         {
           // "oneOf" will traverse all following loaders until one will
           // match the requirements. When no loader matches it will fall


### PR DESCRIPTION
Summary:
We lint separately, with `yarn lint`. There’s no need to duplicate this
effort.

Test Plan:
Introduce a lint error, for instance by adding `("unused expression");`
to `src/cli/main.js` and `src/app/App.js`. Note that `yarn lint` fails
but `yarn backend` and `yarn start` and `yarn build` succeed.

wchargin-branch: webpack-no-lint