### PR TITLE
backend: move build dir removal into Webpack

### DIFF
--- a/config/webpack.config.backend.js
+++ b/config/webpack.config.backend.js
@@ -3,6 +3,7 @@
 const webpack = require("webpack");
 const eslintFormatter = require("react-dev-utils/eslintFormatter");
 const ModuleScopePlugin = require("react-dev-utils/ModuleScopePlugin");
+const RemoveBuildDirectoryPlugin = require("./RemoveBuildDirectoryPlugin");
 const paths = require("./paths");
 const nodeExternals = require("webpack-node-externals");
 const getClientEnvironment = require("./env");
@@ -74,5 +75,8 @@ module.exports = (outputPath) => ({
       },
     ],
   },
-  plugins: [new webpack.DefinePlugin(env.individuallyStringified)],
+  plugins: [
+    new RemoveBuildDirectoryPlugin(),
+    new webpack.DefinePlugin(env.individuallyStringified),
+  ],
 });

--- a/scripts/backend.js
+++ b/scripts/backend.js
@@ -44,9 +44,6 @@ const outputPath = process.argv.some((s) => s === "--dry-run" || s === "-n")
 // This lets us display how much they changed later.
 measureFileSizesBeforeBuild(outputPath)
   .then((previousFileSizes) => {
-    // Remove all content but keep the directory so that
-    // if you're in it, you don't end up in Trash
-    fs.emptyDirSync(outputPath);
     // Start the webpack build
     return build(previousFileSizes);
   })


### PR DESCRIPTION
Summary:
Both the backend and the web builds want to empty the build directory
before starting. This commit makes them use the same codepath, reducing
the amount of work that `scripts/backend.js` does so that we can more
easily remove it (#765).

Test Plan:

```shell
$ touch ./bin/wat
$ yarn backend >/dev/null 2>/dev/null
$ file ./bin/wat
./bin/wat: cannot open `./bin/wat' (No such file or directory)
```

wchargin-branch: backend-empty-backend-build-directory