### PR TITLE
backend: remove file size measurement logic

### DIFF
--- a/scripts/backend.js
+++ b/scripts/backend.js
@@ -23,10 +23,6 @@ const formatWebpackMessages = require("react-dev-utils/formatWebpackMessages");
 const FileSizeReporter = require("react-dev-utils/FileSizeReporter");
 const printBuildError = require("react-dev-utils/printBuildError");
 
-const measureFileSizesBeforeBuild =
-  FileSizeReporter.measureFileSizesBeforeBuild;
-const printFileSizesAfterBuild = FileSizeReporter.printFileSizesAfterBuild;
-
 // These sizes are pretty large. We'll warn for bundles exceeding them.
 const WARN_AFTER_BUNDLE_GZIP_SIZE = 512 * 1024;
 const WARN_AFTER_CHUNK_GZIP_SIZE = 1024 * 1024;
@@ -35,54 +31,37 @@ const outputPath = process.argv.some((s) => s === "--dry-run" || s === "-n")
   ? tmp.dirSync({unsafeCleanup: true, prefix: "sourcecred-"}).name
   : paths.backendBuild;
 
-// First, read the current file sizes in build directory.
-// This lets us display how much they changed later.
-measureFileSizesBeforeBuild(outputPath)
-  .then((previousFileSizes) => {
-    // Start the webpack build
-    return build(previousFileSizes);
-  })
-  .then(
-    ({stats, previousFileSizes, warnings}) => {
-      if (warnings.length) {
-        console.log(chalk.yellow("Compiled with warnings.\n"));
-        console.log(warnings.join("\n\n"));
-        console.log(
-          "\nSearch for the " +
-            chalk.underline(chalk.yellow("keywords")) +
-            " to learn more about each warning."
-        );
-        console.log(
-          "To ignore, add " +
-            chalk.cyan("// eslint-disable-next-line") +
-            " to the line before.\n"
-        );
-      } else {
-        console.log(chalk.green("Compiled successfully.\n"));
-      }
-
-      console.log("File sizes after gzip:\n");
-      printFileSizesAfterBuild(
-        stats,
-        previousFileSizes,
-        outputPath,
-        WARN_AFTER_BUNDLE_GZIP_SIZE,
-        WARN_AFTER_CHUNK_GZIP_SIZE
+build().then(
+  ({stats, warnings}) => {
+    if (warnings.length) {
+      console.log(chalk.yellow("Compiled with warnings.\n"));
+      console.log(warnings.join("\n\n"));
+      console.log(
+        "\nSearch for the " +
+          chalk.underline(chalk.yellow("keywords")) +
+          " to learn more about each warning."
       );
-      console.log();
-
-      const buildFolder = path.relative(process.cwd(), outputPath);
-      console.log(`Build completed; results in '${buildFolder}'.`);
-    },
-    (err) => {
-      console.log(chalk.red("Failed to compile.\n"));
-      printBuildError(err);
-      process.exit(1);
+      console.log(
+        "To ignore, add " +
+          chalk.cyan("// eslint-disable-next-line") +
+          " to the line before.\n"
+      );
+    } else {
+      console.log(chalk.green("Compiled successfully.\n"));
     }
-  );
+
+    const buildFolder = path.relative(process.cwd(), outputPath);
+    console.log(`Build completed; results in '${buildFolder}'.`);
+  },
+  (err) => {
+    console.log(chalk.red("Failed to compile.\n"));
+    printBuildError(err);
+    process.exit(1);
+  }
+);
 
 // Create the backend build
-function build(previousFileSizes) {
+function build() {
   console.log("Building backend applications...");
 
   let compiler = webpack(config(outputPath));
@@ -116,7 +95,6 @@ function build(previousFileSizes) {
       }
       return resolve({
         stats,
-        previousFileSizes,
         warnings: messages.warnings,
       });
     });


### PR DESCRIPTION
Summary:
This logic isn’t currently useful to us. If we want this functionality,
we should consider using a Webpack plugin like `size-limit`. In the
meantime, this removes functionality from `scripts/backend.js`,
continuing on the path to #765.

Recommend reviewing with `-w`.

Test Plan:
Run `yarn backend` and `yarn backend --dry-run`, noting that each works.

wchargin-branch: backend-remove-file-sizes