### PR TITLE
backend: export a normal Webpack config object

### DIFF
--- a/config/webpack.config.backend.js
+++ b/config/webpack.config.backend.js
@@ -11,7 +11,7 @@ const env = getClientEnvironment();
 
 // This is the backend configuration. It builds applications that target
 // Node and will not run in a browser.
-module.exports = (outputPath) => ({
+module.exports = {
   // Don't attempt to continue if there are any errors.
   bail: true,
   // Target Node instead of the browser.
@@ -19,7 +19,7 @@ module.exports = (outputPath) => ({
   entry: paths.backendEntryPoints,
   externals: [nodeExternals()],
   output: {
-    path: outputPath,
+    path: paths.backendBuild,
     // Generated JS file names (with nested folders).
     // There will be one main bundle, and one file per asynchronous chunk.
     // We don't currently advertise code splitting but Webpack supports it.
@@ -62,4 +62,4 @@ module.exports = (outputPath) => ({
     new RemoveBuildDirectoryPlugin(),
     new webpack.DefinePlugin(env.individuallyStringified),
   ],
-});
+};


### PR DESCRIPTION
Summary:
Previously, our `webpack.config.backend.js` file actually exported a
function that could be used to make a Webpack configuration object.
(This is not to be confused with the late `makeWebpackConfig.js`, which
actually exported a configuration object!)

In addition to being confusing nomenclature, this was a sneaky trap for
CLI users. Invoking `webpack --config config/webpack.config.backend.js`
would actually work, but do the wrong thing: Webpack _allows_ your
configuration object to be a function, but with different semantics. In
particular, the result was that Webpack would emit the build output into
your current directory instead of into `bin/`.

This commit fixes that by making `webpack.config.backend.js` export the
Webpack configuration object for the backend JavaScript applications.
The logic to change the path is now handled by the caller, by
overwriting `config.output.path`; this is exactly [the same approach
that the Webpack CLI takes when given an `--output-path`][1], so it’s
okay with me.

[1]: https://github.com/webpack/webpack-cli/blob/368e2640e62c57eba4dde8b13c4c4470a293047c/bin/convert-argv.js#L406-L409

Test Plan:
Run `yarn backend` and `yarn backend --dry-run`. Note that each runs
with appropriate output (both emitted files and console logs).

wchargin-branch: backend-webpack-config-object