### PR TITLE
backend: use Flow in Webpack config

### DIFF
--- a/config/webpack.config.backend.js
+++ b/config/webpack.config.backend.js
@@ -1,4 +1,4 @@
-// @no-flow
+// @flow
 
 const webpack = require("webpack");
 const ModuleScopePlugin = require("react-dev-utils/ModuleScopePlugin");


### PR DESCRIPTION
Summary:
Over the past few commits, I have accidentally removed all Flow errors
from the Webpack config. We can now use Flow on that file to prevent any
new errors from creeping in.

Test Plan:
Running `yarn flow` suffices.

wchargin-branch: backend-flow