### PR TITLE
backend: set Babel flags in Webpack config

### DIFF
--- a/config/webpack.config.backend.js
+++ b/config/webpack.config.backend.js
@@ -1,5 +1,10 @@
 // @flow
 
+// Do this as the first thing so that any code reading it knows the right env.
+process.env.NODE_ENV = process.env.NODE_ENV || "development";
+process.env.BABEL_ENV = process.env.NODE_ENV;
+process.env.SOURCECRED_BACKEND = "true";
+
 const webpack = require("webpack");
 const ModuleScopePlugin = require("react-dev-utils/ModuleScopePlugin");
 const RemoveBuildDirectoryPlugin = require("./RemoveBuildDirectoryPlugin");


### PR DESCRIPTION
Summary:
We currently configure the Babel config with environment variables: in
particular, the `SOURCECRED_BACKEND` environment variable causes Babel
to target Node instead of the browser. The relevant lines are copied
from `scripts/backend.js`.

The environment variable mechanism is slightly clunky, especially as it
requires the Webpack config module to be impure, but it works okay for
our purposes. We could adopt a more principled solution—setting the
`options` argument to the Babel loader in the backend Webpack config—but
this would require redesigning the Babel config system, which would take
a moderate amount of effort.

Test Plan:
As of this commit, `yarn backend` has bitwise identical output to
directly invoking Webpack:

```shell
$ yarn backend >/dev/null 2>/dev/null
$ shasum -a 256 bin/* | shasum -a 256
c4f7494c3ba70e5488ff4a8b44550e478a2a8b27fa96f286123f9566fd28f7be  -
$ NODE_ENV=development node ./node_modules/.bin/webpack \
> --config ./config/webpack.config.backend.js >/dev/null 2>/dev/null
$ shasum -a 256 bin/* | shasum -a 256
c4f7494c3ba70e5488ff4a8b44550e478a2a8b27fa96f286123f9566fd28f7be  -
```

wchargin-branch: backend-set-babel-flags