### PR TITLE
Export fallback adapter's node and edge types

### DIFF
--- a/src/app/adapters/adapterSet.test.js
+++ b/src/app/adapters/adapterSet.test.js
@@ -3,7 +3,12 @@
 import {NodeAddress, EdgeAddress, Graph} from "../../core/graph";
 import {FactorioStaticAdapter} from "./demoAdapters";
 import {StaticAdapterSet} from "./adapterSet";
-import {FallbackStaticAdapter, FALLBACK_NAME} from "./fallbackAdapter";
+import {
+  FallbackStaticAdapter,
+  FALLBACK_NAME,
+  fallbackNodeType,
+  fallbackEdgeType,
+} from "./fallbackAdapter";
 import {Assets} from "../assets";
 import {makeRepo} from "../../core/repo";
 
@@ -87,14 +92,14 @@ describe("app/adapters/adapterSet", () => {
       const type = sas.typeMatchingNode(
         NodeAddress.fromParts(["wombat", "1", "foo"])
       );
-      expect(type.name).toBe("unknown node");
+      expect(type).toBe(fallbackNodeType);
     });
     it("finds fallback type for unregistered edge", () => {
       const {sas} = example();
       const type = sas.typeMatchingEdge(
         EdgeAddress.fromParts(["wombat", "1", "foo"])
       );
-      expect(type.forwardName).toBe("unknown edge→");
+      expect(type).toBe(fallbackEdgeType);
     });
     it("loads a dynamicAdapterSet", async () => {
       const {x, sas} = example();

--- a/src/app/adapters/fallbackAdapter.js
+++ b/src/app/adapters/fallbackAdapter.js
@@ -13,6 +13,21 @@ import type {StaticPluginAdapter, DynamicPluginAdapter} from "./pluginAdapter";
 
 export const FALLBACK_NAME = "FALLBACK_ADAPTER";
 
+export const fallbackNodeType = Object.freeze({
+  name: "node",
+  pluralName: "nodes",
+  prefix: NodeAddress.empty,
+  defaultWeight: 1,
+});
+
+export const fallbackEdgeType = Object.freeze({
+  forwardName: "forward edge",
+  backwardName: "backward edge",
+  defaultForwardWeight: 1,
+  defaultBackwardWeight: 1,
+  prefix: EdgeAddress.empty,
+});
+
 export class FallbackStaticAdapter implements StaticPluginAdapter {
   name() {
     return FALLBACK_NAME;
@@ -27,26 +42,11 @@ export class FallbackStaticAdapter implements StaticPluginAdapter {
   }
 
   nodeTypes() {
-    return [
-      {
-        name: "unknown node",
-        pluralName: "unknown nodes",
-        prefix: NodeAddress.empty,
-        defaultWeight: 1,
-      },
-    ];
+    return [fallbackNodeType];
   }
 
   edgeTypes() {
-    return [
-      {
-        forwardName: "unknown edge→",
-        backwardName: "unknown edge←",
-        defaultForwardWeight: 1,
-        defaultBackwardWeight: 1,
-        prefix: EdgeAddress.empty,
-      },
-    ];
+    return [fallbackEdgeType];
   }
 
   load(_unused_assets: Assets, _unused_repo: Repo) {


### PR DESCRIPTION
This is convenient for testing other code, where we may want to directly
use the fallback types. One test has been updated in this way.

I also changed the names for the fallback adapter's edges to be somewhat
more readable.

Test plan: Tests improved.