### PR TITLE
test: invoke `yarn backend` only once

### DIFF
--- a/sharness/test_build_static_site.t
+++ b/sharness/test_build_static_site.t
@@ -152,8 +152,6 @@ run_build() {
         run '"${flags}"' 2>err &&
         test_must_fail grep -vF \
             -e "Removing contents of build directory: " \
-            -e "warn: running \`yarn backend\`" \
-            -e "warn: if this offends you" \
             -e "info: loading repository" \
             err &&
         test_path_is_dir "${output_dir}" &&
@@ -215,6 +213,7 @@ test_pages() {
 
 run_build TWO_REPOS \
     "should build the site with two repositories and a CNAME" \
+    --no-backend \
     --cname sourcecred.example.com \
     --feedback-url http://discuss.example.com/feedback/ \
     --repo sourcecred/example-git \
@@ -255,6 +254,7 @@ test_expect_success TWO_REPOS "TWO_REPOS: should have a correct CNAME record" '
 SOURCECRED_FEEDBACK_URL=http://wat.com/wat \
     run_build NO_REPOS \
     "should build the site with no repositories and no CNAME" \
+    --no-backend \
     # no arguments here
 
 test_pages NO_REPOS

--- a/src/plugins/git/loadRepositoryTest.sh
+++ b/src/plugins/git/loadRepositoryTest.sh
@@ -14,12 +14,17 @@ usage() {
   printf '      Default is --build.\n'
   printf '  --help\n'
   printf '      Show this message\n'
+  printf '\n'
+  printf 'Environment variables:'
+  printf '  SOURCECRED_BIN\n'
+  printf '      When using --no-build, directory containing the SourceCred\n'
+  printf '      executables (output of "yarn backend"). Default is ./bin.\n'
 }
 
 fetch() {
   tmpdir="$(mktemp -d)"
-  node bin/createExampleRepo.js "${tmpdir}"
-  node bin/loadAndPrintGitRepository.js "${tmpdir}"
+  node "${SOURCECRED_BIN:-./bin}/createExampleRepo.js" "${tmpdir}"
+  node "${SOURCECRED_BIN:-./bin}/loadAndPrintGitRepository.js" "${tmpdir}"
   rm -rf "${tmpdir}"
 }
 
@@ -35,6 +40,10 @@ update() {
 }
 
 main() {
+  if [ -n "${SOURCECRED_BIN:-}" ]; then
+    SOURCECRED_BIN="$(readlink -f "${SOURCECRED_BIN}")"
+  fi
+  cd "$(git rev-parse --show-toplevel)"
   UPDATE=
   BUILD=1
   while [ $# -gt 0 ]; do
@@ -54,7 +63,10 @@ main() {
     shift
   done
   if [ -n "${BUILD}" ]; then
+    unset SOURCECRED_BIN
     yarn backend
+  else
+    export NODE_PATH=./node_modules"${NODE_PATH:+:${NODE_PATH}}"
   fi
   if [ -n "${UPDATE}" ]; then
     update

--- a/src/plugins/github/fetchGithubRepoTest.sh
+++ b/src/plugins/github/fetchGithubRepoTest.sh
@@ -16,6 +16,11 @@ usage() {
   printf '      Default is --build.\n'
   printf '  --help\n'
   printf '      Show this message\n'
+  printf '\n'
+  printf 'Environment variables:'
+  printf '  SOURCECRED_BIN\n'
+  printf '      When using --no-build, directory containing the SourceCred\n'
+  printf '      executables (output of "yarn backend"). Default is ./bin.\n'
 }
 
 fetch() {
@@ -24,7 +29,7 @@ fetch() {
     printf >&2 'to a 40-character hex string API token from GitHub.\n'
     return 1
   fi
-  node bin/fetchAndPrintGithubRepo.js \
+  node "${SOURCECRED_BIN:-./bin}/fetchAndPrintGithubRepo.js" \
     sourcecred example-github "${GITHUB_TOKEN}"
 }
 
@@ -40,6 +45,9 @@ update() {
 }
 
 main() {
+  if [ -n "${SOURCECRED_BIN:-}" ]; then
+    SOURCECRED_BIN="$(readlink -f "${SOURCECRED_BIN}")"
+  fi
   cd "$(git rev-parse --show-toplevel)"
   UPDATE=
   BUILD=1
@@ -60,7 +68,10 @@ main() {
     shift
   done
   if [ -n "${BUILD}" ]; then
+    unset SOURCECRED_BIN
     yarn backend
+  else
+    export NODE_PATH="./node_modules${NODE_PATH:+:${NODE_PATH}}"
   fi
   if [ -n "${UPDATE}" ]; then
     update


### PR DESCRIPTION
Summary:
Lots of tests need the output of `yarn backend`. Before this commit,
they tended to create it themselves. This was slow and wasteful, and
also could in principle have race conditions (though in practice usually
tended not to).

This commit updates tests to respect a `SOURCECRED_BIN` environment
variable indicating the path to an existing directory of backend
applications.

Closes #765.

Test Plan:
Running `yarn test --full` passes.

Prepending `echo run >>/tmp/log &&` to the `backend` script in
`package.json` and running `yarn test --full` results in a log file
containing only one line, indicating that the script really is run only
once.

wchargin-branch: deduplicate-backend