### PR TITLE
credExplorer gets adapters from one point

### DIFF
--- a/src/app/credExplorer/App.js
+++ b/src/app/credExplorer/App.js
@@ -9,7 +9,6 @@ import CheckedLocalStore from "../checkedLocalStore";
 import BrowserLocalStore from "../browserLocalStore";
 
 import {type EdgeEvaluator} from "../../core/attribution/pagerank";
-import {defaultStaticAdapters} from "../adapters/defaultPlugins";
 import {PagerankTable} from "./pagerankTable/Table";
 import {WeightConfig} from "./WeightConfig";
 import RepositorySelect from "./RepositorySelect";
@@ -20,6 +19,8 @@ import {
   type StateTransitionMachineInterface,
   uninitializedState,
 } from "./state";
+import {StaticAdapterSet} from "../adapters/adapterSet";
+import {defaultStaticAdapters} from "../adapters/defaultPlugins";
 
 export default class AppPage extends React.Component<{|+assets: Assets|}> {
   static _LOCAL_STORE = new CheckedLocalStore(
@@ -31,11 +32,21 @@ export default class AppPage extends React.Component<{|+assets: Assets|}> {
 
   render() {
     const App = createApp(createStateTransitionMachine);
-    return <App assets={this.props.assets} localStore={AppPage._LOCAL_STORE} />;
+    return (
+      <App
+        assets={this.props.assets}
+        adapters={defaultStaticAdapters()}
+        localStore={AppPage._LOCAL_STORE}
+      />
+    );
   }
 }
 
-type Props = {|+assets: Assets, +localStore: LocalStore|};
+type Props = {|
+  +assets: Assets,
+  +localStore: LocalStore,
+  +adapters: StaticAdapterSet,
+|};
 type State = {|
   appState: AppState,
   edgeEvaluator: ?EdgeEvaluator,
@@ -110,6 +121,7 @@ export function createApp(
             onClick={() =>
               this.stateTransitionMachine.loadGraphAndRunPagerank(
                 this.props.assets,
+                this.props.adapters,
                 NullUtil.get(this.state.edgeEvaluator),
                 GithubPrefix.user
               )
@@ -119,7 +131,7 @@ export function createApp(
           </button>
           <WeightConfig
             onChange={(edgeEvaluator) => this.setState({edgeEvaluator})}
-            adapters={defaultStaticAdapters()}
+            adapters={this.props.adapters}
           />
           <LoadingIndicator appState={this.state.appState} />
           {pagerankTable}

--- a/src/app/credExplorer/App.test.js
+++ b/src/app/credExplorer/App.test.js
@@ -38,7 +38,11 @@ describe("app/credExplorer/App", () => {
     }
     const App = createApp(createMockSTM);
     const el = shallow(
-      <App assets={new Assets("/foo/")} localStore={localStore} />
+      <App
+        assets={new Assets("/foo/")}
+        adapters={new StaticAdapterSet([])}
+        localStore={localStore}
+      />
     );
     if (setState == null || getState == null) {
       throw new Error("Initialization problems");
@@ -156,6 +160,7 @@ describe("app/credExplorer/App", () => {
           expect(loadGraphAndRunPagerank).toBeCalledTimes(1);
           expect(loadGraphAndRunPagerank).toBeCalledWith(
             el.instance().props.assets,
+            el.instance().props.adapters,
             edgeEvaluator,
             GithubPrefix.user
           );


### PR DESCRIPTION
Currently, the `credExplorer` uses the `defaultStaticAdapters`, but it
imports these adapters in multiple places. If we decide to make the
adapters configurable (e.g. when we start supporting more plugins) this
will be a problem.

This change modifies the cred explorer so that the adapters always come
from a prop declaration on the app. Then the adapters are passed into
the `state` module's functional entry points, rather than letting
`state` depend on the default adapters directly.

This change is motivated by the fact that my WeightConfig cleanup can be
done more cleanly if the adapters are present as a prop on the App.

Test plan: Unit tests are updated. Also, `git grep
defaultStaticAdapters` reaveals that the adapters are only consumed
once.