### PR TITLE
flow: add typing to Jest transform modules

### DIFF
--- a/config/jest/cssTransform.js
+++ b/config/jest/cssTransform.js
@@ -1,4 +1,4 @@
-// @no-flow
+// @flow
 // This is a custom Jest transformer turning style imports into empty objects.
 // http://facebook.github.io/jest/docs/en/webpack.html
 

--- a/config/jest/fileTransform.js
+++ b/config/jest/fileTransform.js
@@ -1,11 +1,11 @@
-// @no-flow
+// @flow
 const path = require("path");
 
 // This is a custom Jest transformer turning file imports into filenames.
 // http://facebook.github.io/jest/docs/en/webpack.html
 
 module.exports = {
-  process(src, filename) {
+  process(src /*: string */, filename /*: string */) {
     return `module.exports = ${JSON.stringify(path.basename(filename))};`;
   },
 };


### PR DESCRIPTION
Test Plan:
`yarn flow` passes, and the [Jest docs][1] suggest that the added type
annotations are correct.

[1]: https://jestjs.io/docs/en/configuration#transform-object-string-string

wchargin-branch: flow-jest-transforms