### PR TITLE
deps: upgrade `flow-bin@^0.80.0`

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "eslint-plugin-jsx-a11y": "5.1.1",
     "eslint-plugin-react": "7.4.0",
     "file-loader": "1.1.5",
-    "flow-bin": "^0.77.0",
+    "flow-bin": "^0.80.0",
     "jest": "23.4.1",
     "jest-fetch-mock": "^1.6.5",
     "prettier": "^1.13.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2992,9 +2992,9 @@ flatten@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/flatten/-/flatten-1.0.2.tgz#dae46a9d78fbe25292258cc1e780a41d95c03782"
 
-flow-bin@^0.77.0:
-  version "0.77.0"
-  resolved "https://registry.yarnpkg.com/flow-bin/-/flow-bin-0.77.0.tgz#4e5c93929f289a0c28e08fb361a9734944a11297"
+flow-bin@^0.80.0:
+  version "0.80.0"
+  resolved "https://registry.yarnpkg.com/flow-bin/-/flow-bin-0.80.0.tgz#04cc1ee626a6f50786f78170c92ebe1745235403"
 
 flush-write-stream@^1.0.0:
   version "1.0.3"


### PR DESCRIPTION
Summary:
This upgrade didn’t require fixing any new errors, but Flow is a good
dependency to keep on top of.

Test Plan:
Running `yarn flow` suffices.

wchargin-branch: flow-v0.80.0