### PR TITLE
`credExplorer/App` stores weights, not evaluator

### DIFF
--- a/src/app/credExplorer/App.test.js
+++ b/src/app/credExplorer/App.test.js
@@ -8,6 +8,8 @@ import {makeRepo} from "../../core/repo";
 import {Assets} from "../assets";
 import testLocalStore from "../testLocalStore";
 import {DynamicAdapterSet, StaticAdapterSet} from "../adapters/adapterSet";
+import {FactorioStaticAdapter} from "../adapters/demoAdapters";
+import {defaultWeightsForAdapter} from "./weights/weights";
 
 import RepositorySelect from "./RepositorySelect";
 import {PagerankTable} from "./pagerankTable/Table";
@@ -56,12 +58,6 @@ describe("app/credExplorer/App", () => {
       runPagerank,
       loadGraphAndRunPagerank,
       localStore,
-    };
-  }
-
-  function createEvaluator() {
-    return function(_unused_edge) {
-      return {toWeight: 1, froWeight: 1};
     };
   }
 
@@ -135,9 +131,10 @@ describe("app/credExplorer/App", () => {
         const {el, setState} = example();
         setState(stateFn());
         const wc = el.find(WeightConfig);
-        const ee = createEvaluator();
-        wc.props().onChange(ee);
-        expect(el.state().edgeEvaluator).toBe(ee);
+        const wt = defaultWeightsForAdapter(new FactorioStaticAdapter());
+        wc.props().onChange(wt);
+        expect(el.state().weightedTypes).toBe(wt);
+        expect(wc.props().adapters).toBe(el.instance().props.adapters);
       });
     }
 
@@ -146,8 +143,6 @@ describe("app/credExplorer/App", () => {
       it(`has a ${adjective} analyze cred button`, () => {
         const {el, loadGraphAndRunPagerank, setState} = example();
         setState(stateFn());
-        const edgeEvaluator = createEvaluator();
-        el.setState({edgeEvaluator});
         el.update();
         const button = el.findWhere(
           (b) => b.text() === "Analyze cred" && b.is("button")
@@ -161,22 +156,11 @@ describe("app/credExplorer/App", () => {
           expect(loadGraphAndRunPagerank).toBeCalledWith(
             el.instance().props.assets,
             el.instance().props.adapters,
-            edgeEvaluator,
+            el.instance().state.weightedTypes,
             GithubPrefix.user
           );
         }
       });
-      if (!disabled) {
-        it("...unless the EdgeEvaluator is not available", () => {
-          const {el, setState} = example();
-          setState(stateFn());
-          el.update();
-          const button = el.findWhere(
-            (b) => b.text() === "Analyze cred" && b.is("button")
-          );
-          expect(button.props().disabled).toBe(true);
-        });
-      }
     }
 
     function testPagerankTable(stateFn, present: boolean) {

--- a/src/app/credExplorer/WeightConfig.js
+++ b/src/app/credExplorer/WeightConfig.js
@@ -3,8 +3,6 @@
 import React from "react";
 import * as NullUtil from "../../util/null";
 
-import {type EdgeEvaluator} from "../../core/attribution/pagerank";
-import {weightsToEdgeEvaluator} from "./weights/weightsToEdgeEvaluator";
 import type {StaticPluginAdapter} from "../adapters/pluginAdapter";
 import type {StaticAdapterSet} from "../adapters/adapterSet";
 import {
@@ -17,7 +15,7 @@ import {FALLBACK_NAME} from "../adapters/fallbackAdapter";
 
 type Props = {|
   +adapters: StaticAdapterSet,
-  +onChange: (EdgeEvaluator) => void,
+  +onChange: (WeightedTypes) => void,
 |};
 
 type State = {
@@ -94,7 +92,6 @@ export class WeightConfig extends React.Component<Props, State> {
           )
         )
     );
-    const edgeEvaluator = weightsToEdgeEvaluator(weights);
-    this.props.onChange(edgeEvaluator);
+    this.props.onChange(weights);
   }
 }


### PR DESCRIPTION
This commit refactors `credExplorer/App` so that instead of storing an
`EdgeEvaulator` in its state, it stores `WeightedTypes` instead. This
has a few benefits:

- It's trivial to generate the right default value for `WeightedTypes`,
so we no longer allow the variable to be nullable in the state. This
simplifies logic, removes an error case, and means that we don't require
the `WeightConfig` to mount before the app is usable.
- `WeightedTypes` are serializable and can be tested for equality, so
they are a better-behaved piece of state
- We put off the information-destroying transformation as long as
possible
- In the future, I think we may want to move the weights/types concept
into core, at which point the `WeightedTypes` will directly be consumed
by the `core/attribution` module.

Test plan: Unit tests are pretty thorough; to be safe, I tested the UI
myself.