### PR TITLE
Move WeightConfig into PagerankTable

### DIFF
--- a/src/app/credExplorer/App.js
+++ b/src/app/credExplorer/App.js
@@ -9,7 +9,6 @@ import BrowserLocalStore from "../browserLocalStore";
 
 import {defaultStaticAdapters} from "../adapters/defaultPlugins";
 import {PagerankTable} from "./pagerankTable/Table";
-import {WeightConfig} from "./weights/WeightConfig";
 import {
   type WeightedTypes,
   defaultWeightsForAdapterSet,
@@ -86,6 +85,10 @@ export function createApp(
           <PagerankTable
             defaultNodeFilter={GithubPrefix.user}
             adapters={adapters}
+            weightedTypes={this.state.weightedTypes}
+            onWeightedTypesChange={(weightedTypes) =>
+              this.setState({weightedTypes})
+            }
             pnd={pnd}
             maxEntriesPerList={100}
           />
@@ -130,11 +133,6 @@ export function createApp(
           >
             Analyze cred
           </button>
-          <WeightConfig
-            onChange={(weightedTypes) => this.setState({weightedTypes})}
-            weightedTypes={this.state.weightedTypes}
-            adapters={this.props.adapters}
-          />
           <LoadingIndicator appState={this.state.appState} />
           {pagerankTable}
         </div>

--- a/src/app/credExplorer/App.test.js
+++ b/src/app/credExplorer/App.test.js
@@ -13,7 +13,6 @@ import {defaultWeightsForAdapter} from "./weights/weights";
 
 import RepositorySelect from "./RepositorySelect";
 import {PagerankTable} from "./pagerankTable/Table";
-import {WeightConfig} from "./weights/WeightConfig";
 import {createApp, LoadingIndicator} from "./App";
 import {uninitializedState} from "./state";
 import {_Prefix as GithubPrefix} from "../../plugins/github/nodes";
@@ -126,18 +125,6 @@ describe("app/credExplorer/App", () => {
       });
     }
 
-    function testWeightConfig(stateFn) {
-      it("creates a working WeightConfig", () => {
-        const {el, setState} = example();
-        setState(stateFn());
-        const wc = el.find(WeightConfig);
-        const wt = defaultWeightsForAdapter(new FactorioStaticAdapter());
-        wc.props().onChange(wt);
-        expect(el.state().weightedTypes).toBe(wt);
-        expect(wc.props().adapters).toBe(el.instance().props.adapters);
-      });
-    }
-
     function testAnalyzeCredButton(stateFn, {disabled}) {
       const adjective = disabled ? "disabled" : "working";
       it(`has a ${adjective} analyze cred button`, () => {
@@ -178,8 +165,16 @@ describe("app/credExplorer/App", () => {
           }
           const adapters = state.graphWithAdapters.adapters;
           const pnd = state.pagerankNodeDecomposition;
+          const weightedTypes = el.instance().state.weightedTypes;
           expect(prt.props().adapters).toBe(adapters);
           expect(prt.props().pnd).toBe(pnd);
+          expect(prt.props().weightedTypes).toBe(weightedTypes);
+          const prtWeightedTypesChange = prt.props().onWeightedTypesChange;
+          const newTypes = defaultWeightsForAdapter(
+            new FactorioStaticAdapter()
+          );
+          prtWeightedTypesChange(newTypes);
+          expect(el.instance().state.weightedTypes).toBe(newTypes);
         } else {
           expect(prt).toHaveLength(0);
         }
@@ -203,7 +198,6 @@ describe("app/credExplorer/App", () => {
       {analyzeCredDisabled, hasPagerankTable}
     ) {
       describe(suiteName, () => {
-        testWeightConfig(stateFn);
         testRepositorySelect(stateFn);
         testAnalyzeCredButton(stateFn, {disabled: analyzeCredDisabled});
         testPagerankTable(stateFn, hasPagerankTable);

--- a/src/app/credExplorer/pagerankTable/Table.js
+++ b/src/app/credExplorer/pagerankTable/Table.js
@@ -9,16 +9,23 @@ import type {PagerankNodeDecomposition} from "../../../core/attribution/pagerank
 import {DynamicAdapterSet} from "../../adapters/adapterSet";
 import type {DynamicPluginAdapter} from "../../adapters/pluginAdapter";
 import {FALLBACK_NAME} from "../../adapters/fallbackAdapter";
+import {type WeightedTypes} from "../weights/weights";
+import {WeightConfig} from "../weights/WeightConfig";
 
 import {NodeRowList} from "./Node";
 
 type PagerankTableProps = {|
   +pnd: PagerankNodeDecomposition,
   +adapters: DynamicAdapterSet,
+  +weightedTypes: WeightedTypes,
+  +onWeightedTypesChange: (WeightedTypes) => void,
   +maxEntriesPerList: number,
   +defaultNodeFilter: ?NodeAddressT,
 |};
-type PagerankTableState = {|topLevelFilter: NodeAddressT|};
+type PagerankTableState = {|
+  topLevelFilter: NodeAddressT,
+  showWeightConfig: boolean,
+|};
 export class PagerankTable extends React.PureComponent<
   PagerankTableProps,
   PagerankTableState
@@ -38,13 +45,42 @@ export class PagerankTable extends React.PureComponent<
       props.defaultNodeFilter,
       NodeAddress.empty
     );
-    this.state = {topLevelFilter};
+    this.state = {topLevelFilter, showWeightConfig: false};
+  }
+
+  renderConfigurationRow() {
+    const {showWeightConfig} = this.state;
+    return (
+      <div style={{display: "flex"}}>
+        {this.renderFilterSelect()}
+        <span style={{flexGrow: 1}} />
+        <button
+          onClick={() => {
+            this.setState(({showWeightConfig}) => ({
+              showWeightConfig: !showWeightConfig,
+            }));
+          }}
+        >
+          {showWeightConfig
+            ? "Hide weight configuration"
+            : "Show weight configuration"}
+        </button>
+      </div>
+    );
   }
 
   render() {
+    const {showWeightConfig} = this.state;
     return (
       <div style={{marginTop: 10}}>
-        {this.renderFilterSelect()}
+        {this.renderConfigurationRow()}
+        {showWeightConfig && (
+          <WeightConfig
+            adapters={this.props.adapters.static()}
+            weightedTypes={this.props.weightedTypes}
+            onChange={(wt) => this.props.onWeightedTypesChange(wt)}
+          />
+        )}
         {this.renderTable()}
       </div>
     );

--- a/src/app/credExplorer/pagerankTable/sharedTestUtils.js
+++ b/src/app/credExplorer/pagerankTable/sharedTestUtils.js
@@ -2,16 +2,18 @@
 
 import {dynamicAdapterSet} from "../../adapters/demoAdapters";
 import {pagerank} from "../../../core/attribution/pagerank";
+import {defaultWeightsForAdapterSet} from "../weights/weights";
 
 export const COLUMNS = () => ["Description", "", "Cred"];
 
 export async function example() {
   const adapters = await dynamicAdapterSet();
+  const weightedTypes = defaultWeightsForAdapterSet(adapters.static());
   const graph = adapters.graph();
   const pnd = await pagerank(graph, (_unused_Edge) => ({
     toWeight: 1,
     froWeight: 1,
   }));
 
-  return {adapters, pnd};
+  return {adapters, pnd, weightedTypes};
 }

--- a/src/app/credExplorer/weights/WeightConfig.js
+++ b/src/app/credExplorer/weights/WeightConfig.js
@@ -15,40 +15,23 @@ type Props = {|
   +onChange: (WeightedTypes) => void,
 |};
 
-type State = {|
-  expanded: boolean,
-|};
-
-export class WeightConfig extends React.Component<Props, State> {
+export class WeightConfig extends React.Component<Props> {
   constructor(props: Props): void {
     super(props);
-    this.state = {
-      expanded: false,
-    };
   }
 
   render() {
-    const {expanded} = this.state;
     return (
       <React.Fragment>
-        <button
-          onClick={() => {
-            this.setState(({expanded}) => ({expanded: !expanded}));
+        <div
+          style={{
+            display: "flex",
+            flexWrap: "wrap",
+            justifyContent: "space-between",
           }}
         >
-          {expanded ? "Hide weight configuration" : "Show weight configuration"}
-        </button>
-        {expanded && (
-          <div
-            style={{
-              display: "flex",
-              flexWrap: "wrap",
-              justifyContent: "space-between",
-            }}
-          >
-            {this._renderPluginWeightConfigs()}
-          </div>
-        )}
+          {this._renderPluginWeightConfigs()}
+        </div>
       </React.Fragment>
     );
   }

--- a/src/app/credExplorer/weights/WeightConfig.test.js
+++ b/src/app/credExplorer/weights/WeightConfig.test.js
@@ -31,8 +31,6 @@ describe("app/credExplorer/weights/WeightConfig", () => {
           onChange={onChange}
         />
       );
-      // TODO(@decentralion): WeightConfig stops expanding itself
-      el.setState({expanded: true});
       return {el, adapters, types, onChange};
     }
     it("creates a PluginWeightConfig for every non-fallback adapter", () => {


### PR DESCRIPTION
Previously, the WeightConfig (and the button that expanded it) were in
the credExplorer App. This was a little weird, as there's no reason to
play with the weights before you have some Pagerank results to
investigate; additionally, it risked confusing new users with a concept
that was not yet applicable.

Also, the implementation was wonky: the WeightConfig had responsibility
for expanding/hiding itself, which gave poor ability to position the
button and the WeightConfig separately.

Finally, the codepath was untested (vestiges of #604).

This commit fixes all three issues:
- The WeightConfig and button have moved into PagerankTable
- The WeightConfig is now a stateless component, and the parent takes
responsibility for deciding when to mount it
- Logic for showing/hiding the WeightConfig is now tested.