### PR TITLE
test: use proper top-level `describe` blocks

### DIFF
--- a/src/app/credExplorer/pagerankTable/aggregate.test.js
+++ b/src/app/credExplorer/pagerankTable/aggregate.test.js
@@ -10,7 +10,7 @@ import {
   aggregationKey,
 } from "./aggregate";
 
-describe("app/credExplorer/aggregate", () => {
+describe("app/credExplorer/pagerankTable/aggregate", () => {
   // TODO: If making major modifications to these tests, consider switching
   // from the hand-maintained connections and types, and instead use the demo
   // adadpters from app/adapters/demoAdapters

--- a/src/core/attribution/__snapshots__/pagerankNodeDecomposition.test.js.snap
+++ b/src/core/attribution/__snapshots__/pagerankNodeDecomposition.test.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`core/attribution/connections decompose has the expected output on a simple asymmetric chain 1`] = `
+exports[`core/attribution/pagerankNodeDecomposition decompose has the expected output on a simple asymmetric chain 1`] = `
 Map {
   "NodeAddress[\\"n1\\"]" => Object {
     "score": 0.19117656878499834,

--- a/src/core/attribution/pagerankNodeDecomposition.test.js
+++ b/src/core/attribution/pagerankNodeDecomposition.test.js
@@ -108,7 +108,7 @@ function validateDecomposition(decomposition) {
   }
 }
 
-describe("core/attribution/connections", () => {
+describe("core/attribution/pagerankNodeDecomposition", () => {
   describe("decompose", () => {
     it("has the expected output on a simple asymmetric chain", async () => {
       const n1 = NodeAddress.fromParts(["n1"]);

--- a/src/graphql/__snapshots__/queries.test.js.snap
+++ b/src/graphql/__snapshots__/queries.test.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`queries complex object stringification should build the object 1`] = `
+exports[`graphql/queries complex object stringification should build the object 1`] = `
 Object {
   "data": Object {
     "exampleBoolean": Object {
@@ -124,9 +124,9 @@ Object {
 }
 `;
 
-exports[`queries complex object stringification should work inline 1`] = `"{ exampleNumber: 123 exampleString: \\"hello\\" exampleBoolean: true exampleNull: null exampleEnum: WORLD exampleVariable: $widget exampleList: [ 12 14 16 ] exampleObject: { roses: \\"red\\" violets: \\"blue\\" } nestedList: [ [ \\"w\\" \\"x\\" ] [ \\"y\\" \\"z\\" ] ] nestedObject: { english: { n1: \\"one\\" n2: \\"two\\" } greek: { n1: \\"ένα\\" n2: \\"δύο\\" } } }"`;
+exports[`graphql/queries complex object stringification should work inline 1`] = `"{ exampleNumber: 123 exampleString: \\"hello\\" exampleBoolean: true exampleNull: null exampleEnum: WORLD exampleVariable: $widget exampleList: [ 12 14 16 ] exampleObject: { roses: \\"red\\" violets: \\"blue\\" } nestedList: [ [ \\"w\\" \\"x\\" ] [ \\"y\\" \\"z\\" ] ] nestedObject: { english: { n1: \\"one\\" n2: \\"two\\" } greek: { n1: \\"ένα\\" n2: \\"δύο\\" } } }"`;
 
-exports[`queries complex object stringification should work multiline 1`] = `
+exports[`graphql/queries complex object stringification should work multiline 1`] = `
 "{
   exampleNumber:
     123
@@ -184,7 +184,7 @@ exports[`queries complex object stringification should work multiline 1`] = `
 }"
 `;
 
-exports[`queries end-to-end-test cases for a query using lots of features should build the query 1`] = `
+exports[`graphql/queries end-to-end-test cases for a query using lots of features should build the query 1`] = `
 Array [
   Object {
     "name": "QueryWithParameters",
@@ -374,9 +374,9 @@ Array [
 ]
 `;
 
-exports[`queries end-to-end-test cases for a query using lots of features should stringify as inline 1`] = `"query QueryWithParameters($qp1: String! $qp2: String!) { thing(id: 12345 name: $qp1) { fruit(type: APPLE tasty: true) ...otherThings } more { ... on Widget { mcguffins { quantity } goo: slime(state: SLIMY) { availability } } ... on Gizmo { cogs(attributes: { teeth: [ 12 14 16 ] shaft: null }) } } } query QueryWithoutParameters { rateLimit { remaining } } fragment otherThings on Thing { __typename quality }"`;
+exports[`graphql/queries end-to-end-test cases for a query using lots of features should stringify as inline 1`] = `"query QueryWithParameters($qp1: String! $qp2: String!) { thing(id: 12345 name: $qp1) { fruit(type: APPLE tasty: true) ...otherThings } more { ... on Widget { mcguffins { quantity } goo: slime(state: SLIMY) { availability } } ... on Gizmo { cogs(attributes: { teeth: [ 12 14 16 ] shaft: null }) } } } query QueryWithoutParameters { rateLimit { remaining } } fragment otherThings on Thing { __typename quality }"`;
 
-exports[`queries end-to-end-test cases for a query using lots of features should stringify as multiline 1`] = `
+exports[`graphql/queries end-to-end-test cases for a query using lots of features should stringify as multiline 1`] = `
 "query QueryWithParameters($qp1: String! $qp2: String!) {
   thing(id: 12345 name: $qp1) {
     fruit(type: APPLE tasty: true)
@@ -407,7 +407,7 @@ fragment otherThings on Thing {
 }"
 `;
 
-exports[`queries end-to-end-test cases for a useful query should build the query 1`] = `
+exports[`graphql/queries end-to-end-test cases for a useful query should build the query 1`] = `
 Array [
   Object {
     "name": "FetchData",
@@ -926,9 +926,9 @@ Array [
 ]
 `;
 
-exports[`queries end-to-end-test cases for a useful query should stringify as inline 1`] = `"query FetchData($owner: String! $name: String!) { repository(owner: $owner name: $name) { issues(first: 100) { pageInfo { hasNextPage } nodes { id title body number author { ...whoami } comments(first: 20) { pageInfo { hasNextPage } nodes { id author { ...whoami } body url } } } } pullRequests(first: 100) { pageInfo { hasNextPage } nodes { id title body number author { ...whoami } comments(first: 20) { pageInfo { hasNextPage } nodes { id author { ...whoami } body url } } reviews(first: 10) { pageInfo { hasNextPage } nodes { id body author { ...whoami } state comments(first: 10) { pageInfo { hasNextPage } nodes { id body author { ...whoami } } } } } } } } } fragment whoami on Actor { __typename login ... on User { id } ... on Organization { id } ... on Bot { id } }"`;
+exports[`graphql/queries end-to-end-test cases for a useful query should stringify as inline 1`] = `"query FetchData($owner: String! $name: String!) { repository(owner: $owner name: $name) { issues(first: 100) { pageInfo { hasNextPage } nodes { id title body number author { ...whoami } comments(first: 20) { pageInfo { hasNextPage } nodes { id author { ...whoami } body url } } } } pullRequests(first: 100) { pageInfo { hasNextPage } nodes { id title body number author { ...whoami } comments(first: 20) { pageInfo { hasNextPage } nodes { id author { ...whoami } body url } } reviews(first: 10) { pageInfo { hasNextPage } nodes { id body author { ...whoami } state comments(first: 10) { pageInfo { hasNextPage } nodes { id body author { ...whoami } } } } } } } } } fragment whoami on Actor { __typename login ... on User { id } ... on Organization { id } ... on Bot { id } }"`;
 
-exports[`queries end-to-end-test cases for a useful query should stringify as multiline 1`] = `
+exports[`graphql/queries end-to-end-test cases for a useful query should stringify as multiline 1`] = `
 "query FetchData($owner: String! $name: String!) {
   repository(owner: $owner name: $name) {
     issues(first: 100) {

--- a/src/graphql/queries.test.js
+++ b/src/graphql/queries.test.js
@@ -3,7 +3,7 @@
 import type {Body} from "./queries";
 import {build, stringify, multilineLayout, inlineLayout} from "./queries";
 
-describe("queries", () => {
+describe("graphql/queries", () => {
   describe("end-to-end-test cases", () => {
     const testCases = {
       "a query using lots of features": featurefulQuery,

--- a/src/plugins/git/__snapshots__/loadRepository.test.js.snap
+++ b/src/plugins/git/__snapshots__/loadRepository.test.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`loadRepository processes an old commit 1`] = `
+exports[`plugins/git/loadRepository processes an old commit 1`] = `
 Object {
   "commits": Set {
     "c08ee3a4edea384d5291ffcbf06724a13ed72325",

--- a/src/plugins/git/example/__snapshots__/exampleRepo.test.js.snap
+++ b/src/plugins/git/example/__snapshots__/exampleRepo.test.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`createExampleRepo is deterministic 1`] = `
+exports[`plugins/git/example/exampleRepo createExampleRepo is deterministic 1`] = `
 Array [
   "c2b51945e7457546912a8ce158ed9d294558d294",
   "c08ee3a4edea384d5291ffcbf06724a13ed72325",
@@ -12,7 +12,7 @@ Array [
 ]
 `;
 
-exports[`createExampleSubmoduleRepo is deterministic 1`] = `
+exports[`plugins/git/example/exampleRepo createExampleSubmoduleRepo is deterministic 1`] = `
 Array [
   "762c062fbdc7ec198cd693e95d55b374a08ff3e3",
   "29ef158bc982733e2ba429fcf73e2f7562244188",

--- a/src/plugins/git/example/exampleRepo.test.js
+++ b/src/plugins/git/example/exampleRepo.test.js
@@ -22,21 +22,23 @@ function mkdtemp() {
   return result.name;
 }
 
-describe("createExampleRepo", () => {
-  it("is deterministic", () => {
-    expect(createExampleRepo(mkdtemp()).commits).toMatchSnapshot();
-  });
-});
-
-describe("createExampleSubmoduleRepo", () => {
-  it("is deterministic", () => {
-    expect(createExampleSubmoduleRepo(mkdtemp()).commits).toMatchSnapshot();
+describe("plugins/git/example/exampleRepo", () => {
+  describe("createExampleRepo", () => {
+    it("is deterministic", () => {
+      expect(createExampleRepo(mkdtemp()).commits).toMatchSnapshot();
+    });
   });
 
-  it("includes all the SHAs that it should", () => {
-    const commits = createExampleSubmoduleRepo(mkdtemp()).commits;
-    expect(commits).toEqual(
-      expect.arrayContaining([SUBMODULE_COMMIT_1, SUBMODULE_COMMIT_2])
-    );
+  describe("createExampleSubmoduleRepo", () => {
+    it("is deterministic", () => {
+      expect(createExampleSubmoduleRepo(mkdtemp()).commits).toMatchSnapshot();
+    });
+
+    it("includes all the SHAs that it should", () => {
+      const commits = createExampleSubmoduleRepo(mkdtemp()).commits;
+      expect(commits).toEqual(
+        expect.arrayContaining([SUBMODULE_COMMIT_1, SUBMODULE_COMMIT_2])
+      );
+    });
   });
 });

--- a/src/plugins/git/loadRepository.test.js
+++ b/src/plugins/git/loadRepository.test.js
@@ -18,7 +18,7 @@ function mkdtemp() {
   return result.name;
 }
 
-describe("loadRepository", () => {
+describe("plugins/git/loadRepository", () => {
   it("loads from HEAD", () => {
     const repository = createExampleRepo(mkdtemp());
     // In case of failure, run

--- a/src/plugins/github/__snapshots__/graphql.test.js.snap
+++ b/src/plugins/github/__snapshots__/graphql.test.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`graphql #postQueryExhaustive resolves a representative query 1`] = `
+exports[`plugins/github/graphql #postQueryExhaustive resolves a representative query 1`] = `
 Object {
   "repository": Object {
     "id": "opaque-repo",
@@ -201,7 +201,7 @@ Object {
 }
 `;
 
-exports[`graphql creates a query 1`] = `
+exports[`plugins/github/graphql creates a query 1`] = `
 "query FetchData($owner: String! $name: String!) {
   repository(owner: $owner name: $name) {
     url

--- a/src/plugins/github/graphql.test.js
+++ b/src/plugins/github/graphql.test.js
@@ -15,7 +15,7 @@ import {
 } from "./graphql";
 import {makeRepo} from "../../core/repo";
 
-describe("graphql", () => {
+describe("plugins/github/graphql", () => {
   describe("creates continuations", () => {
     const makeAuthor = (name) => ({
       __typename: "User",

--- a/src/plugins/github/parseReferences.test.js
+++ b/src/plugins/github/parseReferences.test.js
@@ -2,7 +2,7 @@
 
 import {parseReferences} from "./parseReferences.js";
 
-describe("parseReferences", () => {
+describe("plugins/github/parseReferences", () => {
   it("finds no references when not present", () => {
     expect(parseReferences("foo bar bod boink")).toHaveLength(0);
     expect(parseReferences("")).toHaveLength(0);

--- a/src/plugins/github/urlIdParse.test.js
+++ b/src/plugins/github/urlIdParse.test.js
@@ -7,7 +7,7 @@ import {
   reviewUrlToId,
 } from "./urlIdParse";
 
-describe("plugins/github/urlToId", () => {
+describe("plugins/github/urlIdParse", () => {
   const issueComment =
     "https://github.com/example-owner/exa_mple-rep.o0/issues/350#issuecomment-394939349";
   const pullComment =

--- a/src/util/compat.test.js
+++ b/src/util/compat.test.js
@@ -3,7 +3,7 @@
 import {toCompat, fromCompat} from "./compat";
 import type {Compatible} from "./compat";
 
-describe("compat utilities", () => {
+describe("util/compat", () => {
   type FooV1 = {foo: number};
   type FooV2 = {bar: {foo: number}};
   const type = "Foo Plugin's Experiment";


### PR DESCRIPTION
Summary:
Per #800, each test file should start with a `describe` block listing
its file path under `src`. Currently, nine of our tests do not do so.
Of these, eight had a top-level describe block with the wrong name
(either not a filepath or an outdated filepath), while only one short
test was missing a top-level describe block altogether. This patch fixes
each file to use the correct format.

Test Plan:
Apply the Sharness test in #802, and note that it fails before this
patch but passes after it.

wchargin-branch: describe-fix