### PR TITLE
test: check that JS tests describe their filenames

### DIFF
--- a/sharness/test_js_tests_have_top_level_describe_block_with_filename.t
+++ b/sharness/test_js_tests_have_top_level_describe_block_with_filename.t
@@ -1,0 +1,32 @@
+#!/bin/sh
+# shellcheck disable=SC2016
+
+export GIT_CONFIG_NOSYSTEM=1
+export GIT_ATTR_NOSYSTEM=1
+
+# shellcheck disable=SC2034
+test_description='check that each JavaScript test has a "describe" block with its own filename'
+
+# shellcheck disable=SC1091
+. ./sharness.sh
+
+test_expect_success "setup" '
+    root="$(git rev-parse --show-toplevel)" &&
+    (cd "${root}/src" && git ls-files -z "*.test.js") >test_files_z &&
+    tr "\0" "\n" <test_files_z >test_files &&
+    test_set_prereq SETUP
+'
+
+# We read file names delimited by newline. This could theoretically fail
+# if we were to check in a test file with a newline in its name.
+# Happily, doing so would be highly questionable anyway.
+while read -r filename; do
+    test_expect_success SETUP "test file: ${filename}" '
+        grep "^describe(" -- "${root}/src/${filename}" >describes &&
+        grep -F -- "${filename%.test.js}" describes
+    '
+done <test_files
+
+test_done
+
+# vim: ft=sh


### PR DESCRIPTION
Summary:
Resolves #800. The newly added test takes about 2ms per file.

Test Plan:
Run `yarn sharness`, and note that it passes.

Then, edit (say) `src/main/test.js` to change the top-level describe
block from `"cli/main"` to something else, or to remove it altogether.
Re-run `yarn sharness` and note that it fails with a helpful message:

```
test_js_tests_have_top_level_describe_block_with_filename.t .. 1/?
not ok 31 - test file: cli/main.test.js
test_js_tests_describe_filename.t .. Dubious, test returned 1 (wstat 256, 0x100)
Failed 1/65 subtests
```

wchargin-branch: describe-test

