### PR TITLE
test: invoke Jest in CI mode

### DIFF
--- a/config/test.js
+++ b/config/test.js
@@ -68,7 +68,7 @@ function makeTasks(mode /*: "BASIC" | "FULL" */) {
     },
     {
       id: "unit",
-      cmd: ["npm", "run", "--silent", "unit"],
+      cmd: ["npm", "run", "--silent", "unit", "--", "--ci"],
       deps: [],
     },
     {


### PR DESCRIPTION
Summary:
CI mode prevents Jest from automatically writing snapshots, and also
causes obsolete snapshots to be an error instead of a warning. This is
consistent with the behavior on Travis, where the `CI=1` environment
variable is set. It should thus be the default when running `yarn test`
(but not `yarn unit`).

Test Plan:
Add a file `src/foo.test.js`:

```js
// @flow
describe("foo", () => {
  it("bar", () => {
    expect("baz").toMatchSnapshot();
  });
});
```

Note that `yarn test` fails with the message, “new snapshot was not
written”.

Revert this change, then re-run `yarn test`; note that it passes,
writing a snapshot.

Then, reinstate this change and delete `src/foo.test.js`. Note that
running `yarn test` fails, due to an obsolete snapshot. Revert the
change again, and watch `yarn test` pass despite the obsolete snapshot.

Finally, remove the snapshot. :-)

wchargin-branch: test-jest-ci