### PR TITLE
Expose node/edge prefixes publicly

### DIFF
--- a/src/app/credExplorer/App.js
+++ b/src/app/credExplorer/App.js
@@ -14,7 +14,7 @@ import {
   defaultWeightsForAdapterSet,
 } from "./weights/weights";
 import RepositorySelect from "./RepositorySelect";
-import {_Prefix as GithubPrefix} from "../../plugins/github/nodes";
+import {Prefix as GithubPrefix} from "../../plugins/github/nodes";
 import {
   createStateTransitionMachine,
   type AppState,

--- a/src/app/credExplorer/App.test.js
+++ b/src/app/credExplorer/App.test.js
@@ -15,7 +15,7 @@ import RepositorySelect from "./RepositorySelect";
 import {PagerankTable} from "./pagerankTable/Table";
 import {createApp, LoadingIndicator} from "./App";
 import {uninitializedState} from "./state";
-import {_Prefix as GithubPrefix} from "../../plugins/github/nodes";
+import {Prefix as GithubPrefix} from "../../plugins/github/nodes";
 
 require("../testUtil").configureEnzyme();
 

--- a/src/plugins/git/createMinimalGraph.test.js
+++ b/src/plugins/git/createMinimalGraph.test.js
@@ -4,8 +4,8 @@ import cloneDeep from "lodash.clonedeep";
 
 import {createMinimalGraph} from "./createMinimalGraph";
 import {GraphView} from "./graphView";
-import {_Prefix as NodePrefix} from "./nodes";
-import {_Prefix as EdgePrefix} from "./edges";
+import {Prefix as NodePrefix} from "./nodes";
+import {Prefix as EdgePrefix} from "./edges";
 import {NodeAddress, EdgeAddress} from "../../core/graph";
 
 const makeData = () => cloneDeep(require("./example/example-git"));

--- a/src/plugins/git/edges.js
+++ b/src/plugins/git/edges.js
@@ -21,7 +21,7 @@ function gitEdgeAddress(...parts: string[]): RawAddress {
   return EdgeAddress.append(GIT_PREFIX, ...parts);
 }
 
-export const _Prefix = Object.freeze({
+export const Prefix = Object.freeze({
   base: GIT_PREFIX,
   hasTree: gitEdgeAddress(HAS_TREE_TYPE),
   hasParent: gitEdgeAddress(HAS_PARENT_TYPE),
@@ -211,29 +211,29 @@ export function toRaw(x: StructuredAddress): RawAddress {
   switch (x.type) {
     case HAS_TREE_TYPE:
       return EdgeAddress.append(
-        _Prefix.hasTree,
+        Prefix.hasTree,
         ...lengthEncode(GitNode.toRaw(x.commit))
       );
     case HAS_PARENT_TYPE:
       return EdgeAddress.append(
-        _Prefix.hasParent,
+        Prefix.hasParent,
         ...lengthEncode(GitNode.toRaw(x.child)),
         ...lengthEncode(GitNode.toRaw(x.parent))
       );
     case INCLUDES_TYPE:
       return EdgeAddress.append(
-        _Prefix.includes,
+        Prefix.includes,
         ...lengthEncode(GitNode.toRaw(x.treeEntry))
       );
     case BECOMES_TYPE:
       return EdgeAddress.append(
-        _Prefix.becomes,
+        Prefix.becomes,
         ...lengthEncode(GitNode.toRaw(x.was)),
         ...lengthEncode(GitNode.toRaw(x.becomes))
       );
     case HAS_CONTENTS_TYPE:
       return EdgeAddress.append(
-        _Prefix.hasContents,
+        Prefix.hasContents,
         ...lengthEncode(GitNode.toRaw(x.treeEntry))
       );
     default:

--- a/src/plugins/git/graphView.js
+++ b/src/plugins/git/graphView.js
@@ -25,7 +25,7 @@ export class GraphView {
     node: GN.StructuredAddress,
     options: NeighborsOptions
   ): Iterator<T> {
-    if (!NodeAddress.hasPrefix(options.nodePrefix, GN._Prefix.base)) {
+    if (!NodeAddress.hasPrefix(options.nodePrefix, GN.Prefix.base)) {
       throw new Error(`_neighbors must filter to Git nodes`);
     }
     const rawNode: GN.RawAddress = GN.toRaw(node);
@@ -51,7 +51,7 @@ export class GraphView {
   }
 
   *_commits(): Iterator<GN.CommitAddress> {
-    for (const node of this._graph.nodes({prefix: GN._Prefix.commit})) {
+    for (const node of this._graph.nodes({prefix: GN.Prefix.commit})) {
       const rawAddress: GN.RawAddress = ((node: NodeAddressT): any);
       const commit: GN.CommitAddress = (GN.fromRaw(rawAddress): any);
       this._maybeCheckInvariants();
@@ -64,8 +64,8 @@ export class GraphView {
     const result: GN.TreeAddress = Array.from(
       this._neighbors(commit, {
         direction: Direction.OUT,
-        nodePrefix: GN._Prefix.tree,
-        edgePrefix: GE._Prefix.hasTree,
+        nodePrefix: GN.Prefix.tree,
+        edgePrefix: GE.Prefix.hasTree,
       })
     )[0];
     this._maybeCheckInvariants();
@@ -75,8 +75,8 @@ export class GraphView {
   parents(commit: GN.CommitAddress): Iterator<GN.CommitAddress> {
     const result: Iterator<GN.CommitAddress> = this._neighbors(commit, {
       direction: Direction.OUT,
-      nodePrefix: GN._Prefix.commit,
-      edgePrefix: GE._Prefix.hasParent,
+      nodePrefix: GN.Prefix.commit,
+      edgePrefix: GE.Prefix.hasParent,
     });
     this._maybeCheckInvariants();
     return result;
@@ -85,8 +85,8 @@ export class GraphView {
   entries(tree: GN.TreeAddress): Iterator<GN.TreeEntryAddress> {
     const result: Iterator<GN.TreeEntryAddress> = this._neighbors(tree, {
       direction: Direction.OUT,
-      nodePrefix: GN._Prefix.treeEntry,
-      edgePrefix: GE._Prefix.includes,
+      nodePrefix: GN.Prefix.treeEntry,
+      edgePrefix: GE.Prefix.includes,
     });
     this._maybeCheckInvariants();
     return result;
@@ -97,8 +97,8 @@ export class GraphView {
       entry,
       {
         direction: Direction.OUT,
-        nodePrefix: GN._Prefix.base, // multiple kinds
-        edgePrefix: GE._Prefix.hasContents,
+        nodePrefix: GN.Prefix.base, // multiple kinds
+        edgePrefix: GE.Prefix.hasContents,
       }
     );
     this._maybeCheckInvariants();
@@ -108,8 +108,8 @@ export class GraphView {
   evolvesTo(entry: GN.TreeEntryAddress): Iterator<GN.TreeEntryAddress> {
     const result: Iterator<GN.TreeEntryAddress> = this._neighbors(entry, {
       direction: Direction.OUT,
-      nodePrefix: GN._Prefix.treeEntry,
-      edgePrefix: GE._Prefix.becomes,
+      nodePrefix: GN.Prefix.treeEntry,
+      edgePrefix: GE.Prefix.becomes,
     });
     this._maybeCheckInvariants();
     return result;
@@ -118,8 +118,8 @@ export class GraphView {
   evolvesFrom(entry: GN.TreeEntryAddress): Iterator<GN.TreeEntryAddress> {
     const result: Iterator<GN.TreeEntryAddress> = this._neighbors(entry, {
       direction: Direction.IN,
-      nodePrefix: GN._Prefix.treeEntry,
-      edgePrefix: GE._Prefix.becomes,
+      nodePrefix: GN.Prefix.treeEntry,
+      edgePrefix: GE.Prefix.becomes,
     });
     this._maybeCheckInvariants();
     return result;
@@ -135,7 +135,7 @@ export class GraphView {
 
   checkInvariants() {
     // All Git nodes and edges must have valid Git addresses.
-    for (const node of this._graph.nodes({prefix: GN._Prefix.base})) {
+    for (const node of this._graph.nodes({prefix: GN.Prefix.base})) {
       GN.fromRaw((((node: NodeAddressT): any): GN.RawAddress));
     }
     // (Edges are checked down below.)
@@ -150,35 +150,35 @@ export class GraphView {
     |};
     const edgeInvariants = {
       [GE.HAS_TREE_TYPE]: {
-        prefix: GE._Prefix.hasTree,
-        homs: [{srcPrefix: GN._Prefix.commit, dstPrefix: GN._Prefix.tree}],
+        prefix: GE.Prefix.hasTree,
+        homs: [{srcPrefix: GN.Prefix.commit, dstPrefix: GN.Prefix.tree}],
       },
       [GE.HAS_PARENT_TYPE]: {
-        prefix: GE._Prefix.hasParent,
-        homs: [{srcPrefix: GN._Prefix.commit, dstPrefix: GN._Prefix.commit}],
+        prefix: GE.Prefix.hasParent,
+        homs: [{srcPrefix: GN.Prefix.commit, dstPrefix: GN.Prefix.commit}],
       },
       [GE.INCLUDES_TYPE]: {
-        prefix: GE._Prefix.includes,
-        homs: [{srcPrefix: GN._Prefix.tree, dstPrefix: GN._Prefix.treeEntry}],
+        prefix: GE.Prefix.includes,
+        homs: [{srcPrefix: GN.Prefix.tree, dstPrefix: GN.Prefix.treeEntry}],
       },
       [GE.BECOMES_TYPE]: {
-        prefix: GE._Prefix.becomes,
+        prefix: GE.Prefix.becomes,
         homs: [
-          {srcPrefix: GN._Prefix.treeEntry, dstPrefix: GN._Prefix.treeEntry},
+          {srcPrefix: GN.Prefix.treeEntry, dstPrefix: GN.Prefix.treeEntry},
         ],
       },
       [GE.HAS_CONTENTS_TYPE]: {
-        prefix: GE._Prefix.hasContents,
+        prefix: GE.Prefix.hasContents,
         homs: [
-          {srcPrefix: GN._Prefix.treeEntry, dstPrefix: GN._Prefix.blob},
-          {srcPrefix: GN._Prefix.treeEntry, dstPrefix: GN._Prefix.tree},
-          {srcPrefix: GN._Prefix.treeEntry, dstPrefix: GN._Prefix.commit},
+          {srcPrefix: GN.Prefix.treeEntry, dstPrefix: GN.Prefix.blob},
+          {srcPrefix: GN.Prefix.treeEntry, dstPrefix: GN.Prefix.tree},
+          {srcPrefix: GN.Prefix.treeEntry, dstPrefix: GN.Prefix.commit},
         ],
       },
     };
 
     for (const edge of this._graph.edges({
-      addressPrefix: GE._Prefix.base,
+      addressPrefix: GE.Prefix.base,
       srcPrefix: NodeAddress.empty,
       dstPrefix: NodeAddress.empty,
     })) {
@@ -205,11 +205,11 @@ export class GraphView {
     // Any HAS_TREE edge to a commit must be properly named. This
     // implies that a commit has at most one such edge. (Normal commits
     // should have trees, but submodule commits might not.)
-    for (const rawNode of this._graph.nodes({prefix: GN._Prefix.commit})) {
+    for (const rawNode of this._graph.nodes({prefix: GN.Prefix.commit})) {
       for (const neighbor of this._graph.neighbors(rawNode, {
         direction: Direction.OUT,
         nodePrefix: NodeAddress.empty,
-        edgePrefix: GE._Prefix.hasTree,
+        edgePrefix: GE.Prefix.hasTree,
       })) {
         const rawEdge = neighbor.edge;
         const edge: GE.HasTreeAddress = (GE.fromRaw(
@@ -228,7 +228,7 @@ export class GraphView {
 
     // All HAS_PARENT edges must map between between the correct commits.
     for (const edge of this._graph.edges({
-      addressPrefix: GE._Prefix.hasParent,
+      addressPrefix: GE.Prefix.hasParent,
       srcPrefix: NodeAddress.empty,
       dstPrefix: NodeAddress.empty,
     })) {
@@ -247,12 +247,12 @@ export class GraphView {
     }
 
     // Each tree entry must have a unique and properly named INCLUDES edge.
-    for (const rawNode of this._graph.nodes({prefix: GN._Prefix.treeEntry})) {
+    for (const rawNode of this._graph.nodes({prefix: GN.Prefix.treeEntry})) {
       const treeNeighbors = Array.from(
         this._graph.neighbors(rawNode, {
           direction: Direction.IN,
           nodePrefix: NodeAddress.empty,
-          edgePrefix: GE._Prefix.includes,
+          edgePrefix: GE.Prefix.includes,
         })
       );
       if (treeNeighbors.length !== 1) {
@@ -278,7 +278,7 @@ export class GraphView {
 
     // All BECOMES edges must map between between the correct tree entries.
     for (const edge of this._graph.edges({
-      addressPrefix: GE._Prefix.becomes,
+      addressPrefix: GE.Prefix.becomes,
       srcPrefix: NodeAddress.empty,
       dstPrefix: NodeAddress.empty,
     })) {
@@ -298,7 +298,7 @@ export class GraphView {
 
     // All HAS_CONTENTS edges must be properly named.
     for (const edge of this._graph.edges({
-      addressPrefix: GE._Prefix.hasContents,
+      addressPrefix: GE.Prefix.hasContents,
       srcPrefix: NodeAddress.empty,
       dstPrefix: NodeAddress.empty,
     })) {

--- a/src/plugins/git/graphView.test.js
+++ b/src/plugins/git/graphView.test.js
@@ -160,7 +160,7 @@ describe("plugins/git/graphView", () => {
         const c1: GN.CommitAddress = {type: GN.COMMIT_TYPE, hash: "c1"};
         const c2: GN.CommitAddress = {type: GN.COMMIT_TYPE, hash: "c2"};
         const edge = {
-          address: EdgeAddress.append(GE._Prefix.base, "wat"),
+          address: EdgeAddress.append(GE.Prefix.base, "wat"),
           src: GN.toRaw(c1),
           dst: GN.toRaw(c2),
         };

--- a/src/plugins/git/minimalPluginAdapter.js
+++ b/src/plugins/git/minimalPluginAdapter.js
@@ -15,17 +15,17 @@ export class StaticPluginAdapter implements IStaticPluginAdapter {
     return "Git";
   }
   nodePrefix() {
-    return N._Prefix.base;
+    return N.Prefix.base;
   }
   edgePrefix() {
-    return E._Prefix.base;
+    return E.Prefix.base;
   }
   nodeTypes() {
     return [
       {
         name: "Commit",
         pluralName: "Commits",
-        prefix: N._Prefix.commit,
+        prefix: N.Prefix.commit,
         defaultWeight: 2,
       },
     ];
@@ -35,7 +35,7 @@ export class StaticPluginAdapter implements IStaticPluginAdapter {
       {
         forwardName: "has parent",
         backwardName: "is parent of",
-        prefix: E._Prefix.hasParent,
+        prefix: E.Prefix.hasParent,
         defaultForwardWeight: 1,
         defaultBackwardWeight: 1,
       },

--- a/src/plugins/git/nodes.js
+++ b/src/plugins/git/nodes.js
@@ -15,7 +15,7 @@ export const COMMIT_TYPE: "COMMIT" = "COMMIT";
 export const TREE_TYPE: "TREE" = "TREE";
 export const TREE_ENTRY_TYPE: "TREE_ENTRY" = "TREE_ENTRY";
 
-export const _Prefix = Object.freeze({
+export const Prefix = Object.freeze({
   base: GIT_PREFIX,
   blob: _gitAddress(BLOB_TYPE),
   commit: _gitAddress(COMMIT_TYPE),
@@ -94,13 +94,13 @@ export function fromRaw(x: RawAddress): StructuredAddress {
 export function toRaw(x: StructuredAddress): RawAddress {
   switch (x.type) {
     case BLOB_TYPE:
-      return NodeAddress.append(_Prefix.blob, x.hash);
+      return NodeAddress.append(Prefix.blob, x.hash);
     case COMMIT_TYPE:
-      return NodeAddress.append(_Prefix.commit, x.hash);
+      return NodeAddress.append(Prefix.commit, x.hash);
     case TREE_TYPE:
-      return NodeAddress.append(_Prefix.tree, x.hash);
+      return NodeAddress.append(Prefix.tree, x.hash);
     case TREE_ENTRY_TYPE:
-      return NodeAddress.append(_Prefix.treeEntry, x.treeHash, x.name);
+      return NodeAddress.append(Prefix.treeEntry, x.treeHash, x.name);
     default:
       throw new Error(`Unexpected type ${(x.type: empty)}`);
   }

--- a/src/plugins/git/pluginAdapter.js
+++ b/src/plugins/git/pluginAdapter.js
@@ -15,35 +15,35 @@ export class StaticPluginAdapter implements IStaticPluginAdapter {
     return "Git";
   }
   nodePrefix() {
-    return N._Prefix.base;
+    return N.Prefix.base;
   }
   edgePrefix() {
-    return E._Prefix.base;
+    return E.Prefix.base;
   }
   nodeTypes() {
     return [
       {
         name: "Blob",
         pluralName: "Blobs",
-        prefix: N._Prefix.blob,
+        prefix: N.Prefix.blob,
         defaultWeight: 0.125,
       },
       {
         name: "Commit",
         pluralName: "Commits",
-        prefix: N._Prefix.commit,
+        prefix: N.Prefix.commit,
         defaultWeight: 2,
       },
       {
         name: "Tree",
         pluralName: "Trees",
-        prefix: N._Prefix.tree,
+        prefix: N.Prefix.tree,
         defaultWeight: 0.125,
       },
       {
         name: "Tree entry",
         pluralName: "Tree entries",
-        prefix: N._Prefix.treeEntry,
+        prefix: N.Prefix.treeEntry,
         defaultWeight: 0.125,
       },
     ];
@@ -55,35 +55,35 @@ export class StaticPluginAdapter implements IStaticPluginAdapter {
         backwardName: "owned by",
         defaultForwardWeight: 1,
         defaultBackwardWeight: 1,
-        prefix: E._Prefix.hasTree,
+        prefix: E.Prefix.hasTree,
       },
       {
         forwardName: "has parent",
         backwardName: "is parent of",
         defaultForwardWeight: 1,
         defaultBackwardWeight: 1,
-        prefix: E._Prefix.hasParent,
+        prefix: E.Prefix.hasParent,
       },
       {
         forwardName: "includes",
         backwardName: "is included by",
         defaultForwardWeight: 1,
         defaultBackwardWeight: 1,
-        prefix: E._Prefix.includes,
+        prefix: E.Prefix.includes,
       },
       {
         forwardName: "evolves to",
         backwardName: "evolves from",
         defaultForwardWeight: 1,
         defaultBackwardWeight: 1,
-        prefix: E._Prefix.becomes,
+        prefix: E.Prefix.becomes,
       },
       {
         forwardName: "has contents",
         backwardName: "is contents of",
         defaultForwardWeight: 1,
         defaultBackwardWeight: 1,
-        prefix: E._Prefix.hasContents,
+        prefix: E.Prefix.hasContents,
       },
     ];
   }

--- a/src/plugins/github/edges.js
+++ b/src/plugins/github/edges.js
@@ -23,7 +23,7 @@ function githubEdgeAddress(...parts: string[]): RawAddress {
   return EdgeAddress.append(GITHUB_PREFIX, ...parts);
 }
 
-export const _Prefix = Object.freeze({
+export const Prefix = Object.freeze({
   base: GITHUB_PREFIX,
   authors: githubEdgeAddress(AUTHORS_TYPE),
   mergedAs: githubEdgeAddress(MERGED_AS_TYPE),
@@ -225,29 +225,29 @@ export function toRaw(x: StructuredAddress): RawAddress {
   switch (x.type) {
     case AUTHORS_TYPE:
       return EdgeAddress.append(
-        _Prefix.authors,
+        Prefix.authors,
         ...lengthEncode(GithubNode.toRaw(x.author)),
         ...lengthEncode(GithubNode.toRaw(x.content))
       );
     case MERGED_AS_TYPE:
       return EdgeAddress.append(
-        _Prefix.mergedAs,
+        Prefix.mergedAs,
         ...lengthEncode(GithubNode.toRaw(x.pull))
       );
     case HAS_PARENT_TYPE:
       return EdgeAddress.append(
-        _Prefix.hasParent,
+        Prefix.hasParent,
         ...lengthEncode(GithubNode.toRaw(x.child))
       );
     case REFERENCES_TYPE:
       return EdgeAddress.append(
-        _Prefix.references,
+        Prefix.references,
         ...lengthEncode(GithubNode.toRaw(x.referrer)),
         ...lengthEncode(GithubNode.toRaw(x.referent))
       );
     case MENTIONS_AUTHOR_TYPE:
       return EdgeAddress.append(
-        _Prefix.mentionsAuthor,
+        Prefix.mentionsAuthor,
         ...lengthEncode(GithubNode.toRaw(x.reference.src)),
         ...lengthEncode(GithubNode.toRaw(x.reference.dst)),
         ...lengthEncode(GithubNode.toRaw(x.reference.who))

--- a/src/plugins/github/graphView.test.js
+++ b/src/plugins/github/graphView.test.js
@@ -315,7 +315,7 @@ describe("plugins/github/graphView", () => {
           const otherParent = {
             src: GN.toRaw(issue),
             dst: GN.toRaw(otherRepo),
-            address: EdgeAddress.append(GE._Prefix.hasParent, "foobar"),
+            address: EdgeAddress.append(GE.Prefix.hasParent, "foobar"),
           };
           g.addEdge(otherParent);
           expect(() => new GraphView(g)).toThrow("Parent invariant");

--- a/src/plugins/github/nodes.js
+++ b/src/plugins/github/nodes.js
@@ -18,7 +18,7 @@ export const USERLIKE_TYPE: "USERLIKE" = "USERLIKE";
 export const USER_SUBTYPE: "USER" = "USER";
 export const BOT_SUBTYPE: "BOT" = "BOT";
 
-export const _Prefix = Object.freeze({
+export const Prefix = Object.freeze({
   base: GITHUB_PREFIX,
   repo: _githubAddress(REPO_TYPE),
   issue: _githubAddress(ISSUE_TYPE),
@@ -218,24 +218,24 @@ export function fromRaw(x: RawAddress): StructuredAddress {
 export function toRaw(x: StructuredAddress): RawAddress {
   switch (x.type) {
     case REPO_TYPE:
-      return NodeAddress.append(_Prefix.repo, x.owner, x.name);
+      return NodeAddress.append(Prefix.repo, x.owner, x.name);
     case ISSUE_TYPE:
       return NodeAddress.append(
-        _Prefix.issue,
+        Prefix.issue,
         x.repo.owner,
         x.repo.name,
         x.number
       );
     case PULL_TYPE:
       return NodeAddress.append(
-        _Prefix.pull,
+        Prefix.pull,
         x.repo.owner,
         x.repo.name,
         x.number
       );
     case REVIEW_TYPE:
       return NodeAddress.append(
-        _Prefix.review,
+        Prefix.review,
         x.pull.repo.owner,
         x.pull.repo.name,
         x.pull.number,
@@ -245,7 +245,7 @@ export function toRaw(x: StructuredAddress): RawAddress {
       switch (x.parent.type) {
         case ISSUE_TYPE:
           return NodeAddress.append(
-            _Prefix.issueComment,
+            Prefix.issueComment,
             x.parent.repo.owner,
             x.parent.repo.name,
             x.parent.number,
@@ -253,7 +253,7 @@ export function toRaw(x: StructuredAddress): RawAddress {
           );
         case PULL_TYPE:
           return NodeAddress.append(
-            _Prefix.pullComment,
+            Prefix.pullComment,
             x.parent.repo.owner,
             x.parent.repo.name,
             x.parent.number,
@@ -261,7 +261,7 @@ export function toRaw(x: StructuredAddress): RawAddress {
           );
         case REVIEW_TYPE:
           return NodeAddress.append(
-            _Prefix.reviewComment,
+            Prefix.reviewComment,
             x.parent.pull.repo.owner,
             x.parent.pull.repo.name,
             x.parent.pull.number,
@@ -274,9 +274,9 @@ export function toRaw(x: StructuredAddress): RawAddress {
     case USERLIKE_TYPE:
       switch (x.subtype) {
         case "BOT":
-          return NodeAddress.append(_Prefix.bot, x.login);
+          return NodeAddress.append(Prefix.bot, x.login);
         case "USER":
-          return NodeAddress.append(_Prefix.user, x.login);
+          return NodeAddress.append(Prefix.user, x.login);
         default:
           throw new Error((x.subtype: empty));
       }

--- a/src/plugins/github/pluginAdapter.js
+++ b/src/plugins/github/pluginAdapter.js
@@ -19,53 +19,53 @@ export class StaticPluginAdapter implements IStaticPluginAdapter {
     return "GitHub";
   }
   nodePrefix() {
-    return N._Prefix.base;
+    return N.Prefix.base;
   }
   edgePrefix() {
-    return E._Prefix.base;
+    return E.Prefix.base;
   }
   nodeTypes() {
     return [
       {
         name: "Repository",
         pluralName: "Repositories",
-        prefix: N._Prefix.repo,
+        prefix: N.Prefix.repo,
         defaultWeight: 4,
       },
       {
         name: "Issue",
         pluralName: "Issues",
-        prefix: N._Prefix.issue,
+        prefix: N.Prefix.issue,
         defaultWeight: 2,
       },
       {
         name: "Pull request",
         pluralName: "Pull requests",
-        prefix: N._Prefix.pull,
+        prefix: N.Prefix.pull,
         defaultWeight: 4,
       },
       {
         name: "Pull request review",
         pluralName: "Pull request reviews",
-        prefix: N._Prefix.review,
+        prefix: N.Prefix.review,
         defaultWeight: 1,
       },
       {
         name: "Comment",
         pluralName: "Comments",
-        prefix: N._Prefix.comment,
+        prefix: N.Prefix.comment,
         defaultWeight: 1,
       },
       {
         name: "User",
         pluralName: "Users",
-        prefix: N._Prefix.user,
+        prefix: N.Prefix.user,
         defaultWeight: 1,
       },
       {
         name: "Bot",
         pluralName: "Bots",
-        prefix: N._Prefix.bot,
+        prefix: N.Prefix.bot,
         defaultWeight: 0.25,
       },
     ];
@@ -77,28 +77,28 @@ export class StaticPluginAdapter implements IStaticPluginAdapter {
         backwardName: "is authored by",
         defaultForwardWeight: 1 / 2,
         defaultBackwardWeight: 1,
-        prefix: E._Prefix.authors,
+        prefix: E.Prefix.authors,
       },
       {
         forwardName: "has parent",
         backwardName: "has child",
         defaultForwardWeight: 1,
         defaultBackwardWeight: 1 / 4,
-        prefix: E._Prefix.hasParent,
+        prefix: E.Prefix.hasParent,
       },
       {
         forwardName: "merges",
         backwardName: "is merged by",
         defaultForwardWeight: 1 / 2,
         defaultBackwardWeight: 1,
-        prefix: E._Prefix.mergedAs,
+        prefix: E.Prefix.mergedAs,
       },
       {
         forwardName: "references",
         backwardName: "is referenced by",
         defaultForwardWeight: 1,
         defaultBackwardWeight: 1 / 16,
-        prefix: E._Prefix.references,
+        prefix: E.Prefix.references,
       },
       {
         forwardName: "mentions author of",
@@ -106,7 +106,7 @@ export class StaticPluginAdapter implements IStaticPluginAdapter {
         defaultForwardWeight: 1,
         // TODO(#811): Probably change this to 0
         defaultBackwardWeight: 1 / 32,
-        prefix: E._Prefix.mentionsAuthor,
+        prefix: E.Prefix.mentionsAuthor,
       },
     ];
   }


### PR DESCRIPTION
Both the GitHub and Git plugins create a `_Prefix` object for nodes and
edges, which gives the respective prefixes for different node/edge
types. We named it `_Prefix` because we weren't sure if these should be
exported. In practice, these have proven quite useful to make generally
available, and despite the `_`-naming we expose the objects outside
their modules. This change renames `_Prefix` to `Prefix` to reflect the
reality that these are used as public consts.

Exporting them is safe as both objects are frozen.

Test plan: Simple rename, `yarn test` suffices.