### PR TITLE
GitHub: Request commit authorship info

### DIFF
--- a/src/plugins/github/__snapshots__/graphql.test.js.snap
+++ b/src/plugins/github/__snapshots__/graphql.test.js.snap
@@ -263,7 +263,7 @@ fragment pulls on PullRequestConnection {
     body
     number
     mergeCommit {
-      oid
+      ...commit
     }
     additions
     deletions
@@ -320,6 +320,16 @@ fragment reviewComments on PullRequestReviewCommentConnection {
     url
     body
     author {
+      ...whoami
+    }
+  }
+}
+fragment commit on Commit {
+  id
+  url
+  oid
+  author {
+    user {
       ...whoami
     }
   }

--- a/src/plugins/github/example/example-github.json
+++ b/src/plugins/github/example/example-github.json
@@ -383,7 +383,17 @@
                     "deletions": 0,
                     "id": "MDExOlB1bGxSZXF1ZXN0MTcxODg3NzQx",
                     "mergeCommit": {
-                        "oid": "0a223346b4e6dec0127b1e6aa892c4ee0424b66a"
+                        "author": {
+                            "user": {
+                                "__typename": "User",
+                                "id": "MDQ6VXNlcjE0MDAwMjM=",
+                                "login": "decentralion",
+                                "url": "https://github.com/decentralion"
+                            }
+                        },
+                        "id": "MDY6Q29tbWl0MTIzMjU1MDA2OjBhMjIzMzQ2YjRlNmRlYzAxMjdiMWU2YWE4OTJjNGVlMDQyNGI2NmE=",
+                        "oid": "0a223346b4e6dec0127b1e6aa892c4ee0424b66a",
+                        "url": "https://github.com/sourcecred/example-github/commit/0a223346b4e6dec0127b1e6aa892c4ee0424b66a"
                     },
                     "number": 3,
                     "reviews": {
@@ -428,7 +438,17 @@
                     "deletions": 0,
                     "id": "MDExOlB1bGxSZXF1ZXN0MTcxODg4NTIy",
                     "mergeCommit": {
-                        "oid": "6d5b3aa31ebb68a06ceb46bbd6cf49b6ccd6f5e6"
+                        "author": {
+                            "user": {
+                                "__typename": "User",
+                                "id": "MDQ6VXNlcjE0MDAwMjM=",
+                                "login": "decentralion",
+                                "url": "https://github.com/decentralion"
+                            }
+                        },
+                        "id": "MDY6Q29tbWl0MTIzMjU1MDA2OjZkNWIzYWEzMWViYjY4YTA2Y2ViNDZiYmQ2Y2Y0OWI2Y2NkNmY1ZTY=",
+                        "oid": "6d5b3aa31ebb68a06ceb46bbd6cf49b6ccd6f5e6",
+                        "url": "https://github.com/sourcecred/example-github/commit/6d5b3aa31ebb68a06ceb46bbd6cf49b6ccd6f5e6"
                     },
                     "number": 5,
                     "reviews": {

--- a/src/plugins/github/graphql.js
+++ b/src/plugins/github/graphql.js
@@ -708,8 +708,7 @@ export type PullJSON = {|
   +author: NullableAuthorJSON,
   +comments: ConnectionJSON<CommentJSON>,
   +reviews: ConnectionJSON<ReviewJSON>,
-  // If present, oid is the commit SHA of the merged commit.
-  +mergeCommit: ?{|+oid: string|},
+  +mergeCommit: ?CommitJSON,
 |};
 function pullsFragment(): FragmentDefinition {
   const b = build;
@@ -721,7 +720,7 @@ function pullsFragment(): FragmentDefinition {
       b.field("title"),
       b.field("body"),
       b.field("number"),
-      b.field("mergeCommit", {}, [b.field("oid")]),
+      b.field("mergeCommit", {}, [b.fragmentSpread("commit")]),
       b.field("additions"),
       b.field("deletions"),
       makeAuthor(),
@@ -806,6 +805,23 @@ function reviewCommentsFragment(): FragmentDefinition {
   ]);
 }
 
+export type CommitJSON = {|
+  +id: string,
+  +url: string,
+  +oid: string, // the hash
+  +author: ?{|+user: NullableAuthorJSON|},
+|};
+
+function commitFragment(): FragmentDefinition {
+  const b = build;
+  return b.fragment("commit", "Commit", [
+    b.field("id"),
+    b.field("url"),
+    b.field("oid"),
+    b.field("author", {}, [b.field("user", {}, [b.fragmentSpread("whoami")])]),
+  ]);
+}
+
 /**
  * These fragments are used to construct the root query, and also to
  * fetch more pages of specific entity types.
@@ -818,6 +834,7 @@ export function createFragments(): FragmentDefinition[] {
     commentsFragment(),
     reviewsFragment(),
     reviewCommentsFragment(),
+    commitFragment(),
   ];
 }
 


### PR DESCRIPTION
This commit pulls the graphql fields to request commit information into
a fragment, and requests GitHub authorship information (when
available) for that fragment. We don't use that information yet, but we
will soon. Progress on #815.

Test plan: Observe that the example-github data is updated, so that we
now have urls and authorship for commits. Observe that the query has
updated, but no downstream code was affected. `yarn test --full` passes.