### PR TITLE
Add GitHub commit entity

### DIFF
--- a/src/plugins/github/__snapshots__/relationalView.test.js.snap
+++ b/src/plugins/github/__snapshots__/relationalView.test.js.snap
@@ -18,6 +18,16 @@ Object {
 
 exports[`plugins/github/relationalView Comment has url 1`] = `"https://github.com/sourcecred/example-github/pull/5#discussion_r171460198"`;
 
+exports[`plugins/github/relationalView Commit authors has expected number of authors 1`] = `1`;
+
+exports[`plugins/github/relationalView Commit authors have expected urls 1`] = `
+Array [
+  "https://github.com/decentralion",
+]
+`;
+
+exports[`plugins/github/relationalView Commit has url 1`] = `"https://github.com/sourcecred/example-github/commit/0a223346b4e6dec0127b1e6aa892c4ee0424b66a"`;
+
 exports[`plugins/github/relationalView Issue authors has expected number of authors 1`] = `1`;
 
 exports[`plugins/github/relationalView Issue authors have expected urls 1`] = `
@@ -134,6 +144,15 @@ Array [
   "https://github.com/sourcecred/example-github/pull/3#issuecomment-369162222",
   "https://github.com/sourcecred/example-github/pull/5#issuecomment-396430464",
   "https://github.com/sourcecred/example-github/pull/5#discussion_r171460198",
+]
+`;
+
+exports[`plugins/github/relationalView RelationalView entity: commits has expected number of them 1`] = `2`;
+
+exports[`plugins/github/relationalView RelationalView entity: commits they have expected urls 1`] = `
+Array [
+  "https://github.com/sourcecred/example-github/commit/0a223346b4e6dec0127b1e6aa892c4ee0424b66a",
+  "https://github.com/sourcecred/example-github/commit/6d5b3aa31ebb68a06ceb46bbd6cf49b6ccd6f5e6",
 ]
 `;
 

--- a/src/plugins/github/__snapshots__/render.test.js.snap
+++ b/src/plugins/github/__snapshots__/render.test.js.snap
@@ -3,6 +3,7 @@
 exports[`plugins/github/render descriptions are as expected 1`] = `
 Object {
   "comment": "comment by @wchargin on review by @wchargin of #5 (+1/−0): This pull request will be more contentious. I can feel it...",
+  "commit": "commit 0a223346b4e6dec0127b1e6aa892c4ee0424b66a",
   "issue": "#2: A referencing issue.",
   "pull": "#5 (+1/−0): This pull request will be more contentious. I can feel it...",
   "repo": "sourcecred/example-github",

--- a/src/plugins/github/createGraph.js
+++ b/src/plugins/github/createGraph.js
@@ -58,7 +58,7 @@ class GraphCreator {
     this.graph.addNode(N.toRaw(addr));
   }
 
-  addAuthors(entity: R.Issue | R.Pull | R.Comment | R.Review) {
+  addAuthors(entity: R.AuthoredEntity) {
     for (const author of entity.authors()) {
       this.graph.addEdge(
         createEdge.authors(author.address(), entity.address())

--- a/src/plugins/github/example/example.js
+++ b/src/plugins/github/example/example.js
@@ -27,6 +27,7 @@ export function exampleEntities() {
   const pull = Array.from(repo.pulls())[1];
   const review = Array.from(pull.reviews())[0];
   const comment = Array.from(review.comments())[0];
+  const commit = Array.from(view.commits())[0];
   const userlike = Array.from(review.authors())[0];
   return {
     repo,
@@ -34,6 +35,7 @@ export function exampleEntities() {
     pull,
     review,
     comment,
+    commit,
     userlike,
   };
 }

--- a/src/plugins/github/nodes.js
+++ b/src/plugins/github/nodes.js
@@ -82,7 +82,8 @@ export type AuthorableAddress =
   | IssueAddress
   | PullAddress
   | ReviewAddress
-  | CommentAddress;
+  | CommentAddress
+  | GitNode.CommitAddress;
 
 // Each of these types has text content, which means
 // it may be the source of a reference to a ReferentAddress.

--- a/src/plugins/github/relationalView.test.js
+++ b/src/plugins/github/relationalView.test.js
@@ -61,6 +61,7 @@ describe("plugins/github/relationalView", () => {
     hasEntityMethods("pulls", () => view.pulls(), (x) => view.pull(x));
     hasEntityMethods("reviews", () => view.reviews(), (x) => view.review(x));
     hasEntityMethods("comments", () => view.comments(), (x) => view.comment(x));
+    hasEntityMethods("commits", () => view.commits(), (x) => view.commit(x));
     hasEntityMethods(
       "userlikes",
       () => view.userlikes(),
@@ -133,6 +134,13 @@ describe("plugins/github/relationalView", () => {
     hasEntities("authors", () => entity.authors());
   });
 
+  const commit = Array.from(view.commits())[0];
+  describe("Commit", () => {
+    const entity = commit;
+    has("url", () => entity.url());
+    hasEntities("authors", () => entity.authors());
+  });
+
   const userlike = Array.from(review.authors())[0];
   describe("Userlike", () => {
     const entity = userlike;
@@ -155,6 +163,9 @@ describe("plugins/github/relationalView", () => {
     });
     it("works for comment", () => {
       expect(view.entity(comment.address())).toEqual(comment);
+    });
+    it("works for commit", () => {
+      expect(view.entity(commit.address())).toEqual(commit);
     });
     it("works for userlike", () => {
       expect(view.entity(userlike.address())).toEqual(userlike);
@@ -179,10 +190,11 @@ describe("plugins/github/relationalView", () => {
       pull: (x: R.Pull) => [x.address(), "PULL"],
       review: (x: R.Review) => [x.address(), "REVIEW"],
       comment: (x: R.Comment) => [x.address(), "COMMENT"],
+      commit: (x: R.Commit) => [x.address(), "COMMIT"],
       userlike: (x: R.Userlike) => [x.address(), "USERLIKE"],
     };
 
-    const instances = [repo, issue, pull, review, comment, userlike];
+    const instances = [repo, issue, pull, review, comment, commit, userlike];
     for (const instance of instances) {
       const [actualAddress, functionType] = R.match(handlers, instance);
       expect(actualAddress.type).toEqual(functionType);

--- a/src/plugins/github/render.js
+++ b/src/plugins/github/render.js
@@ -20,6 +20,11 @@ export function description(e: R.Entity) {
     },
     review: (x) => `review ${withAuthors(x)}of ${description(x.parent())}`,
     comment: (x) => `comment ${withAuthors(x)}on ${description(x.parent())}`,
+    // The commit type is included for completeness's sake and to
+    // satisfy the typechecker, but won't ever be seen in the frontend
+    // because the commit has a Git plugin prefix and will therefore by
+    // handled by the git plugin adapter
+    commit: (x) => `commit ${x.address().hash}`,
     userlike: (x) => `@${x.login()}`,
   };
   return R.match(handlers, e);


### PR DESCRIPTION
This adds a `Commit` entity to the GitHub relational view. It has all
the standard methods: commits can be retrieved en masse or by particular
address, they have a URL and authors, and (de)serialize appropriately.

The code for adding pull requests has been modified so that the merge
commits are added as commit entities. This does not have any effect on
the ultimate graph being created; the same edge is added either way.

Test plan: I've extended the standard RelationalView tests to cover the
`Commit` entity. The case where the commit has 0 authors is not yet
tested, but will be once I add support for getting all of the commits
from the example-github (we have one example of a commit that doesn't
map to a user).

Progress on #815.