### PR TITLE
Update CHANGELOG.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## [Unreleased]
+- Add `MentionsAuthor` edges to the graph (#808)
 <!-- Please add new entries to the _top_ of this section. -->
 
 ## [0.1.0]


### PR DESCRIPTION
It now mentions that we added `MentionsAuthor` edges to the GitHub
graph in #808.

Thanks @whyrusleeping for suggesting this heuristic.

Test plan: n/a