### PR TITLE
Load commit authorship from GitHub

### DIFF
--- a/src/plugins/github/__snapshots__/graphql.test.js.snap
+++ b/src/plugins/github/__snapshots__/graphql.test.js.snap
@@ -216,6 +216,16 @@ exports[`plugins/github/graphql creates a query 1`] = `
     pulls: pullRequests(first: 50) {
       ...pulls
     }
+    defaultBranchRef {
+      target {
+        __typename
+        ... on Commit {
+          history(first: 100) {
+            ...commitHistory
+          }
+        }
+      }
+    }
   }
 }
 fragment whoami on Actor {
@@ -322,6 +332,15 @@ fragment reviewComments on PullRequestReviewCommentConnection {
     author {
       ...whoami
     }
+  }
+}
+fragment commitHistory on CommitHistoryConnection {
+  pageInfo {
+    hasNextPage
+    endCursor
+  }
+  nodes {
+    ...commit
   }
 }
 fragment commit on Commit {

--- a/src/plugins/github/example/example-github.json
+++ b/src/plugins/github/example/example-github.json
@@ -1,5 +1,91 @@
 {
     "repository": {
+        "defaultBranchRef": {
+            "target": {
+                "__typename": "Commit",
+                "history": {
+                    "nodes": [
+                        {
+                            "author": {
+                                "user": null
+                            },
+                            "id": "MDY6Q29tbWl0MTIzMjU1MDA2OjZiZDFiNGMwYjcxOWMyMmM2ODhhNzQ4NjNiZTA3YTY5OWI3YjliMzQ=",
+                            "oid": "6bd1b4c0b719c22c688a74863be07a699b7b9b34",
+                            "url": "https://github.com/sourcecred/example-github/commit/6bd1b4c0b719c22c688a74863be07a699b7b9b34"
+                        },
+                        {
+                            "author": {
+                                "user": {
+                                    "__typename": "User",
+                                    "id": "MDQ6VXNlcjQyODE5Mzgy",
+                                    "login": "credbot",
+                                    "url": "https://github.com/credbot"
+                                }
+                            },
+                            "id": "MDY6Q29tbWl0MTIzMjU1MDA2OmM0MzBiZDc0NDU1MTA1Zjc3MjE1ZWNlNTE5NDUwOTRjZWVlZTZjODY=",
+                            "oid": "c430bd74455105f77215ece51945094ceeee6c86",
+                            "url": "https://github.com/sourcecred/example-github/commit/c430bd74455105f77215ece51945094ceeee6c86"
+                        },
+                        {
+                            "author": {
+                                "user": {
+                                    "__typename": "User",
+                                    "id": "MDQ6VXNlcjE0MDAwMjM=",
+                                    "login": "decentralion",
+                                    "url": "https://github.com/decentralion"
+                                }
+                            },
+                            "id": "MDY6Q29tbWl0MTIzMjU1MDA2OjZkNWIzYWEzMWViYjY4YTA2Y2ViNDZiYmQ2Y2Y0OWI2Y2NkNmY1ZTY=",
+                            "oid": "6d5b3aa31ebb68a06ceb46bbd6cf49b6ccd6f5e6",
+                            "url": "https://github.com/sourcecred/example-github/commit/6d5b3aa31ebb68a06ceb46bbd6cf49b6ccd6f5e6"
+                        },
+                        {
+                            "author": {
+                                "user": {
+                                    "__typename": "User",
+                                    "id": "MDQ6VXNlcjE0MDAwMjM=",
+                                    "login": "decentralion",
+                                    "url": "https://github.com/decentralion"
+                                }
+                            },
+                            "id": "MDY6Q29tbWl0MTIzMjU1MDA2OjBhMjIzMzQ2YjRlNmRlYzAxMjdiMWU2YWE4OTJjNGVlMDQyNGI2NmE=",
+                            "oid": "0a223346b4e6dec0127b1e6aa892c4ee0424b66a",
+                            "url": "https://github.com/sourcecred/example-github/commit/0a223346b4e6dec0127b1e6aa892c4ee0424b66a"
+                        },
+                        {
+                            "author": {
+                                "user": {
+                                    "__typename": "User",
+                                    "id": "MDQ6VXNlcjE0MDAwMjM=",
+                                    "login": "decentralion",
+                                    "url": "https://github.com/decentralion"
+                                }
+                            },
+                            "id": "MDY6Q29tbWl0MTIzMjU1MDA2OmVjYzg4OWRjOTRjZjZkYTE3YWU2ZWFiNWJiN2I3MTU1ZjU3NzUxOWQ=",
+                            "oid": "ecc889dc94cf6da17ae6eab5bb7b7155f577519d",
+                            "url": "https://github.com/sourcecred/example-github/commit/ecc889dc94cf6da17ae6eab5bb7b7155f577519d"
+                        },
+                        {
+                            "author": {
+                                "user": {
+                                    "__typename": "User",
+                                    "id": "MDQ6VXNlcjE0MDAwMjM=",
+                                    "login": "decentralion",
+                                    "url": "https://github.com/decentralion"
+                                }
+                            },
+                            "id": "MDY6Q29tbWl0MTIzMjU1MDA2OmVjOTFhZGI3MThhNjA0NWI0OTIzMDNmMDBkOGU4YmViOTU3ZGM3ODA=",
+                            "oid": "ec91adb718a6045b492303f00d8e8beb957dc780",
+                            "url": "https://github.com/sourcecred/example-github/commit/ec91adb718a6045b492303f00d8e8beb957dc780"
+                        }
+                    ],
+                    "pageInfo": {
+                        "endCursor": "6bd1b4c0b719c22c688a74863be07a699b7b9b34 5",
+                        "hasNextPage": false
+                    }
+                }
+            }
+        },
         "id": "MDEwOlJlcG9zaXRvcnkxMjMyNTUwMDY=",
         "issues": {
             "nodes": [


### PR DESCRIPTION
This adds logic for retrieving every commit in the default branch's
history, along with authorship information connecting that commit to a
GitHub user (when available).

This will allows us to do better cred tracking, especially for projects
that don't always use pull requests for merging code.

This results in a moderate increase in load time for the GitHub plugin.
On my machine, loading SourceCred before this change takes 30s, and
after this change it takes 34s.

Test plan:
Observe that the example-github has been updated with commits and
authorship. Also, I ran the query for a larger repository
(`sourcecred/sourcecred`) to verify that the continuation logic works.