### PR TITLE
Cleanup some minor mistakes

### DIFF
--- a/src/plugins/github/graphql.js
+++ b/src/plugins/github/graphql.js
@@ -116,10 +116,10 @@ export type RepositoryJSON = {|
 
 export type RefJSON = {|+target: GitObjectJSON|};
 export type GitObjectJSON =
-  | {|+__typename: "COMMIT", +history: ConnectionJSON<CommitJSON>|}
-  | {|+__typename: "TREE"|}
-  | {|+__typename: "BLOB"|}
-  | {|+__typename: "TAG"|};
+  | {|+__typename: "Commit", +history: ConnectionJSON<CommitJSON>|}
+  | {|+__typename: "Tree"|}
+  | {|+__typename: "Blob"|}
+  | {|+__typename: "Tag"|};
 
 /**
  * The top-level GitHub query to request data about a repository.

--- a/src/plugins/github/relationalView.js
+++ b/src/plugins/github/relationalView.js
@@ -327,8 +327,6 @@ export class RelationalView {
       number: String(json.number),
       repo,
     };
-    // TODO(@decentralion): Rewrite so that pulls actually have
-    // the commit attached (not just oid)
     const mergedAs =
       json.mergeCommit == null ? null : this._addCommit(json.mergeCommit);
 


### PR DESCRIPTION
Pull #821 had a few minor mistakes:
- the capitalization of the GitObject types was incorrect
- a test that manually creates a GitHub query had not been updated to
include the new field

Also, #819 added an inaccurate TODO (the TODO was fixed in the commit
itself).

These minor mistakes have been corrected.

Test plan: `yarn test --full` passes.