### PR TITLE
Ensure that `RelationalView` is not typed as `any`

### DIFF
--- a/src/plugins/github/heuristics/mentionsAuthorReference.test.js
+++ b/src/plugins/github/heuristics/mentionsAuthorReference.test.js
@@ -121,6 +121,8 @@ describe("plugins/github/heuristics/mentionsAuthorReference", () => {
             url: "https://github.com/my-owner/my-repo/pulls/3",
             number: 3,
             body: "Self referentially yours: @steven",
+            title: "a pull request, just because",
+            mergeCommit: null,
             additions: 0,
             deletions: 0,
             comments: connection([]),
@@ -136,6 +138,7 @@ describe("plugins/github/heuristics/mentionsAuthorReference", () => {
           login: "my-owner",
           url: "https://github.com/my-owner",
         },
+        defaultBranchRef: null,
       },
     };
     view.addData(data);

--- a/src/plugins/github/relationalView.js
+++ b/src/plugins/github/relationalView.js
@@ -51,7 +51,7 @@ export class RelationalView {
   _mapReferences: Map<N.RawAddress, N.ReferentAddress[]>;
   _mapReferencedBy: Map<N.RawAddress, N.TextContentAddress[]>;
 
-  constructor() {
+  constructor(): void {
     this._repos = new Map();
     this._issues = new Map();
     this._pulls = new Map();


### PR DESCRIPTION
This fixes another instance of the notorious [facebook/flow#6400]. We
also fix some type errors that were being masked as a consequence.

Test plan: `yarn test` passes.

[facebook/flow#6400]: https://github.com/facebook/flow/issues/6400