### PR TITLE
Add commits in the history to the RelationalView

### DIFF
--- a/src/plugins/github/__snapshots__/createGraph.test.js.snap
+++ b/src/plugins/github/__snapshots__/createGraph.test.js.snap
@@ -25,8 +25,8 @@ Array [
           "6",
           "417104047",
         ],
-        "dstIndex": 17,
-        "srcIndex": 35,
+        "dstIndex": 21,
+        "srcIndex": 39,
       },
       Object {
         "address": Array [
@@ -43,8 +43,8 @@ Array [
           "example-github",
           "1",
         ],
-        "dstIndex": 21,
-        "srcIndex": 36,
+        "dstIndex": 25,
+        "srcIndex": 40,
       },
       Object {
         "address": Array [
@@ -61,8 +61,8 @@ Array [
           "example-github",
           "10",
         ],
-        "dstIndex": 22,
-        "srcIndex": 36,
+        "dstIndex": 26,
+        "srcIndex": 40,
       },
       Object {
         "address": Array [
@@ -79,8 +79,8 @@ Array [
           "example-github",
           "2",
         ],
-        "dstIndex": 24,
-        "srcIndex": 36,
+        "dstIndex": 28,
+        "srcIndex": 40,
       },
       Object {
         "address": Array [
@@ -97,8 +97,8 @@ Array [
           "example-github",
           "4",
         ],
-        "dstIndex": 25,
-        "srcIndex": 36,
+        "dstIndex": 29,
+        "srcIndex": 40,
       },
       Object {
         "address": Array [
@@ -115,8 +115,8 @@ Array [
           "example-github",
           "6",
         ],
-        "dstIndex": 26,
-        "srcIndex": 36,
+        "dstIndex": 30,
+        "srcIndex": 40,
       },
       Object {
         "address": Array [
@@ -133,8 +133,8 @@ Array [
           "example-github",
           "7",
         ],
-        "dstIndex": 27,
-        "srcIndex": 36,
+        "dstIndex": 31,
+        "srcIndex": 40,
       },
       Object {
         "address": Array [
@@ -151,8 +151,8 @@ Array [
           "example-github",
           "8",
         ],
-        "dstIndex": 28,
-        "srcIndex": 36,
+        "dstIndex": 32,
+        "srcIndex": 40,
       },
       Object {
         "address": Array [
@@ -169,8 +169,8 @@ Array [
           "example-github",
           "3",
         ],
-        "dstIndex": 29,
-        "srcIndex": 36,
+        "dstIndex": 33,
+        "srcIndex": 40,
       },
       Object {
         "address": Array [
@@ -187,8 +187,8 @@ Array [
           "example-github",
           "5",
         ],
-        "dstIndex": 30,
-        "srcIndex": 36,
+        "dstIndex": 34,
+        "srcIndex": 40,
       },
       Object {
         "address": Array [
@@ -205,8 +205,8 @@ Array [
           "example-github",
           "9",
         ],
-        "dstIndex": 31,
-        "srcIndex": 36,
+        "dstIndex": 35,
+        "srcIndex": 40,
       },
       Object {
         "address": Array [
@@ -225,8 +225,8 @@ Array [
           "11",
           "420813621",
         ],
-        "dstIndex": 5,
-        "srcIndex": 36,
+        "dstIndex": 9,
+        "srcIndex": 40,
       },
       Object {
         "address": Array [
@@ -245,8 +245,8 @@ Array [
           "2",
           "373768703",
         ],
-        "dstIndex": 6,
-        "srcIndex": 36,
+        "dstIndex": 10,
+        "srcIndex": 40,
       },
       Object {
         "address": Array [
@@ -265,8 +265,8 @@ Array [
           "2",
           "373768850",
         ],
-        "dstIndex": 7,
-        "srcIndex": 36,
+        "dstIndex": 11,
+        "srcIndex": 40,
       },
       Object {
         "address": Array [
@@ -285,8 +285,8 @@ Array [
           "2",
           "385576185",
         ],
-        "dstIndex": 8,
-        "srcIndex": 36,
+        "dstIndex": 12,
+        "srcIndex": 40,
       },
       Object {
         "address": Array [
@@ -305,8 +305,8 @@ Array [
           "2",
           "385576220",
         ],
-        "dstIndex": 9,
-        "srcIndex": 36,
+        "dstIndex": 13,
+        "srcIndex": 40,
       },
       Object {
         "address": Array [
@@ -325,8 +325,8 @@ Array [
           "2",
           "385576248",
         ],
-        "dstIndex": 10,
-        "srcIndex": 36,
+        "dstIndex": 14,
+        "srcIndex": 40,
       },
       Object {
         "address": Array [
@@ -345,8 +345,8 @@ Array [
           "2",
           "385576273",
         ],
-        "dstIndex": 11,
-        "srcIndex": 36,
+        "dstIndex": 15,
+        "srcIndex": 40,
       },
       Object {
         "address": Array [
@@ -365,8 +365,8 @@ Array [
           "2",
           "385576920",
         ],
-        "dstIndex": 12,
-        "srcIndex": 36,
+        "dstIndex": 16,
+        "srcIndex": 40,
       },
       Object {
         "address": Array [
@@ -385,8 +385,8 @@ Array [
           "2",
           "385576936",
         ],
-        "dstIndex": 13,
-        "srcIndex": 36,
+        "dstIndex": 17,
+        "srcIndex": 40,
       },
       Object {
         "address": Array [
@@ -405,8 +405,8 @@ Array [
           "6",
           "373768442",
         ],
-        "dstIndex": 14,
-        "srcIndex": 36,
+        "dstIndex": 18,
+        "srcIndex": 40,
       },
       Object {
         "address": Array [
@@ -425,8 +425,8 @@ Array [
           "6",
           "373768538",
         ],
-        "dstIndex": 15,
-        "srcIndex": 36,
+        "dstIndex": 19,
+        "srcIndex": 40,
       },
       Object {
         "address": Array [
@@ -445,8 +445,8 @@ Array [
           "6",
           "385223316",
         ],
-        "dstIndex": 16,
-        "srcIndex": 36,
+        "dstIndex": 20,
+        "srcIndex": 40,
       },
       Object {
         "address": Array [
@@ -465,8 +465,8 @@ Array [
           "3",
           "369162222",
         ],
-        "dstIndex": 18,
-        "srcIndex": 36,
+        "dstIndex": 22,
+        "srcIndex": 40,
       },
       Object {
         "address": Array [
@@ -483,8 +483,8 @@ Array [
           "example-github",
           "10",
         ],
-        "dstIndex": 22,
-        "srcIndex": 37,
+        "dstIndex": 26,
+        "srcIndex": 41,
       },
       Object {
         "address": Array [
@@ -501,8 +501,8 @@ Array [
           "example-github",
           "11",
         ],
-        "dstIndex": 23,
-        "srcIndex": 37,
+        "dstIndex": 27,
+        "srcIndex": 41,
       },
       Object {
         "address": Array [
@@ -519,8 +519,8 @@ Array [
           "example-github",
           "9",
         ],
-        "dstIndex": 31,
-        "srcIndex": 37,
+        "dstIndex": 35,
+        "srcIndex": 41,
       },
       Object {
         "address": Array [
@@ -538,8 +538,8 @@ Array [
           "5",
           "100313899",
         ],
-        "dstIndex": 33,
-        "srcIndex": 37,
+        "dstIndex": 37,
+        "srcIndex": 41,
       },
       Object {
         "address": Array [
@@ -557,8 +557,8 @@ Array [
           "5",
           "100314038",
         ],
-        "dstIndex": 34,
-        "srcIndex": 37,
+        "dstIndex": 38,
+        "srcIndex": 41,
       },
       Object {
         "address": Array [
@@ -577,8 +577,8 @@ Array [
           "11",
           "420813013",
         ],
-        "dstIndex": 3,
-        "srcIndex": 37,
+        "dstIndex": 7,
+        "srcIndex": 41,
       },
       Object {
         "address": Array [
@@ -597,8 +597,8 @@ Array [
           "5",
           "396430464",
         ],
-        "dstIndex": 19,
-        "srcIndex": 37,
+        "dstIndex": 23,
+        "srcIndex": 41,
       },
       Object {
         "address": Array [
@@ -618,8 +618,8 @@ Array [
           "100313899",
           "171460198",
         ],
-        "dstIndex": 20,
-        "srcIndex": 37,
+        "dstIndex": 24,
+        "srcIndex": 41,
       },
       Object {
         "address": Array [
@@ -632,8 +632,8 @@ Array [
           "example-github",
           "1",
         ],
-        "dstIndex": 32,
-        "srcIndex": 21,
+        "dstIndex": 36,
+        "srcIndex": 25,
       },
       Object {
         "address": Array [
@@ -646,8 +646,8 @@ Array [
           "example-github",
           "10",
         ],
-        "dstIndex": 32,
-        "srcIndex": 22,
+        "dstIndex": 36,
+        "srcIndex": 26,
       },
       Object {
         "address": Array [
@@ -660,8 +660,8 @@ Array [
           "example-github",
           "11",
         ],
-        "dstIndex": 32,
-        "srcIndex": 23,
+        "dstIndex": 36,
+        "srcIndex": 27,
       },
       Object {
         "address": Array [
@@ -674,8 +674,8 @@ Array [
           "example-github",
           "2",
         ],
-        "dstIndex": 32,
-        "srcIndex": 24,
+        "dstIndex": 36,
+        "srcIndex": 28,
       },
       Object {
         "address": Array [
@@ -688,8 +688,8 @@ Array [
           "example-github",
           "4",
         ],
-        "dstIndex": 32,
-        "srcIndex": 25,
+        "dstIndex": 36,
+        "srcIndex": 29,
       },
       Object {
         "address": Array [
@@ -702,8 +702,8 @@ Array [
           "example-github",
           "6",
         ],
-        "dstIndex": 32,
-        "srcIndex": 26,
+        "dstIndex": 36,
+        "srcIndex": 30,
       },
       Object {
         "address": Array [
@@ -716,8 +716,8 @@ Array [
           "example-github",
           "7",
         ],
-        "dstIndex": 32,
-        "srcIndex": 27,
+        "dstIndex": 36,
+        "srcIndex": 31,
       },
       Object {
         "address": Array [
@@ -730,8 +730,8 @@ Array [
           "example-github",
           "8",
         ],
-        "dstIndex": 32,
-        "srcIndex": 28,
+        "dstIndex": 36,
+        "srcIndex": 32,
       },
       Object {
         "address": Array [
@@ -744,8 +744,8 @@ Array [
           "example-github",
           "3",
         ],
-        "dstIndex": 32,
-        "srcIndex": 29,
+        "dstIndex": 36,
+        "srcIndex": 33,
       },
       Object {
         "address": Array [
@@ -758,8 +758,8 @@ Array [
           "example-github",
           "5",
         ],
-        "dstIndex": 32,
-        "srcIndex": 30,
+        "dstIndex": 36,
+        "srcIndex": 34,
       },
       Object {
         "address": Array [
@@ -772,8 +772,8 @@ Array [
           "example-github",
           "9",
         ],
-        "dstIndex": 32,
-        "srcIndex": 31,
+        "dstIndex": 36,
+        "srcIndex": 35,
       },
       Object {
         "address": Array [
@@ -787,8 +787,8 @@ Array [
           "5",
           "100313899",
         ],
-        "dstIndex": 30,
-        "srcIndex": 33,
+        "dstIndex": 34,
+        "srcIndex": 37,
       },
       Object {
         "address": Array [
@@ -802,8 +802,8 @@ Array [
           "5",
           "100314038",
         ],
-        "dstIndex": 30,
-        "srcIndex": 34,
+        "dstIndex": 34,
+        "srcIndex": 38,
       },
       Object {
         "address": Array [
@@ -818,8 +818,8 @@ Array [
           "11",
           "420811872",
         ],
-        "dstIndex": 23,
-        "srcIndex": 2,
+        "dstIndex": 27,
+        "srcIndex": 6,
       },
       Object {
         "address": Array [
@@ -834,8 +834,8 @@ Array [
           "11",
           "420813013",
         ],
-        "dstIndex": 23,
-        "srcIndex": 3,
+        "dstIndex": 27,
+        "srcIndex": 7,
       },
       Object {
         "address": Array [
@@ -850,8 +850,8 @@ Array [
           "11",
           "420813206",
         ],
-        "dstIndex": 23,
-        "srcIndex": 4,
+        "dstIndex": 27,
+        "srcIndex": 8,
       },
       Object {
         "address": Array [
@@ -866,8 +866,8 @@ Array [
           "11",
           "420813621",
         ],
-        "dstIndex": 23,
-        "srcIndex": 5,
+        "dstIndex": 27,
+        "srcIndex": 9,
       },
       Object {
         "address": Array [
@@ -882,8 +882,8 @@ Array [
           "2",
           "373768703",
         ],
-        "dstIndex": 24,
-        "srcIndex": 6,
+        "dstIndex": 28,
+        "srcIndex": 10,
       },
       Object {
         "address": Array [
@@ -898,8 +898,8 @@ Array [
           "2",
           "373768850",
         ],
-        "dstIndex": 24,
-        "srcIndex": 7,
+        "dstIndex": 28,
+        "srcIndex": 11,
       },
       Object {
         "address": Array [
@@ -914,8 +914,8 @@ Array [
           "2",
           "385576185",
         ],
-        "dstIndex": 24,
-        "srcIndex": 8,
+        "dstIndex": 28,
+        "srcIndex": 12,
       },
       Object {
         "address": Array [
@@ -930,8 +930,8 @@ Array [
           "2",
           "385576220",
         ],
-        "dstIndex": 24,
-        "srcIndex": 9,
+        "dstIndex": 28,
+        "srcIndex": 13,
       },
       Object {
         "address": Array [
@@ -946,8 +946,8 @@ Array [
           "2",
           "385576248",
         ],
-        "dstIndex": 24,
-        "srcIndex": 10,
+        "dstIndex": 28,
+        "srcIndex": 14,
       },
       Object {
         "address": Array [
@@ -962,8 +962,8 @@ Array [
           "2",
           "385576273",
         ],
-        "dstIndex": 24,
-        "srcIndex": 11,
+        "dstIndex": 28,
+        "srcIndex": 15,
       },
       Object {
         "address": Array [
@@ -978,8 +978,8 @@ Array [
           "2",
           "385576920",
         ],
-        "dstIndex": 24,
-        "srcIndex": 12,
+        "dstIndex": 28,
+        "srcIndex": 16,
       },
       Object {
         "address": Array [
@@ -994,8 +994,8 @@ Array [
           "2",
           "385576936",
         ],
-        "dstIndex": 24,
-        "srcIndex": 13,
+        "dstIndex": 28,
+        "srcIndex": 17,
       },
       Object {
         "address": Array [
@@ -1010,8 +1010,8 @@ Array [
           "6",
           "373768442",
         ],
-        "dstIndex": 26,
-        "srcIndex": 14,
+        "dstIndex": 30,
+        "srcIndex": 18,
       },
       Object {
         "address": Array [
@@ -1026,8 +1026,8 @@ Array [
           "6",
           "373768538",
         ],
-        "dstIndex": 26,
-        "srcIndex": 15,
+        "dstIndex": 30,
+        "srcIndex": 19,
       },
       Object {
         "address": Array [
@@ -1042,8 +1042,8 @@ Array [
           "6",
           "385223316",
         ],
-        "dstIndex": 26,
-        "srcIndex": 16,
+        "dstIndex": 30,
+        "srcIndex": 20,
       },
       Object {
         "address": Array [
@@ -1058,8 +1058,8 @@ Array [
           "6",
           "417104047",
         ],
-        "dstIndex": 26,
-        "srcIndex": 17,
+        "dstIndex": 30,
+        "srcIndex": 21,
       },
       Object {
         "address": Array [
@@ -1074,8 +1074,8 @@ Array [
           "3",
           "369162222",
         ],
-        "dstIndex": 29,
-        "srcIndex": 18,
+        "dstIndex": 33,
+        "srcIndex": 22,
       },
       Object {
         "address": Array [
@@ -1090,8 +1090,8 @@ Array [
           "5",
           "396430464",
         ],
-        "dstIndex": 30,
-        "srcIndex": 19,
+        "dstIndex": 34,
+        "srcIndex": 23,
       },
       Object {
         "address": Array [
@@ -1107,8 +1107,8 @@ Array [
           "100313899",
           "171460198",
         ],
-        "dstIndex": 33,
-        "srcIndex": 20,
+        "dstIndex": 37,
+        "srcIndex": 24,
       },
       Object {
         "address": Array [
@@ -1132,8 +1132,8 @@ Array [
           "USER",
           "wchargin",
         ],
-        "dstIndex": 19,
-        "srcIndex": 30,
+        "dstIndex": 23,
+        "srcIndex": 34,
       },
       Object {
         "address": Array [
@@ -1147,7 +1147,7 @@ Array [
           "3",
         ],
         "dstIndex": 0,
-        "srcIndex": 29,
+        "srcIndex": 33,
       },
       Object {
         "address": Array [
@@ -1160,8 +1160,8 @@ Array [
           "example-github",
           "5",
         ],
-        "dstIndex": 1,
-        "srcIndex": 30,
+        "dstIndex": 2,
+        "srcIndex": 34,
       },
       Object {
         "address": Array [
@@ -1179,8 +1179,8 @@ Array [
           "example-github",
           "10",
         ],
-        "dstIndex": 22,
-        "srcIndex": 22,
+        "dstIndex": 26,
+        "srcIndex": 26,
       },
       Object {
         "address": Array [
@@ -1198,8 +1198,8 @@ Array [
           "example-github",
           "2",
         ],
-        "dstIndex": 24,
-        "srcIndex": 22,
+        "dstIndex": 28,
+        "srcIndex": 26,
       },
       Object {
         "address": Array [
@@ -1217,8 +1217,8 @@ Array [
           "example-github",
           "1",
         ],
-        "dstIndex": 21,
-        "srcIndex": 24,
+        "dstIndex": 25,
+        "srcIndex": 28,
       },
       Object {
         "address": Array [
@@ -1235,8 +1235,8 @@ Array [
           "USER",
           "wchargin",
         ],
-        "dstIndex": 37,
-        "srcIndex": 30,
+        "dstIndex": 41,
+        "srcIndex": 34,
       },
       Object {
         "address": Array [
@@ -1256,8 +1256,8 @@ Array [
           "example-github",
           "6",
         ],
-        "dstIndex": 26,
-        "srcIndex": 6,
+        "dstIndex": 30,
+        "srcIndex": 10,
       },
       Object {
         "address": Array [
@@ -1279,8 +1279,8 @@ Array [
           "6",
           "373768538",
         ],
-        "dstIndex": 15,
-        "srcIndex": 7,
+        "dstIndex": 19,
+        "srcIndex": 11,
       },
       Object {
         "address": Array [
@@ -1300,8 +1300,8 @@ Array [
           "example-github",
           "5",
         ],
-        "dstIndex": 30,
-        "srcIndex": 8,
+        "dstIndex": 34,
+        "srcIndex": 12,
       },
       Object {
         "address": Array [
@@ -1322,8 +1322,8 @@ Array [
           "5",
           "100313899",
         ],
-        "dstIndex": 33,
-        "srcIndex": 9,
+        "dstIndex": 37,
+        "srcIndex": 13,
       },
       Object {
         "address": Array [
@@ -1346,8 +1346,8 @@ Array [
           "100313899",
           "171460198",
         ],
-        "dstIndex": 20,
-        "srcIndex": 10,
+        "dstIndex": 24,
+        "srcIndex": 14,
       },
       Object {
         "address": Array [
@@ -1366,8 +1366,8 @@ Array [
           "USER",
           "wchargin",
         ],
-        "dstIndex": 37,
-        "srcIndex": 11,
+        "dstIndex": 41,
+        "srcIndex": 15,
       },
       Object {
         "address": Array [
@@ -1387,8 +1387,8 @@ Array [
           "example-github",
           "1",
         ],
-        "dstIndex": 21,
-        "srcIndex": 12,
+        "dstIndex": 25,
+        "srcIndex": 16,
       },
       Object {
         "address": Array [
@@ -1408,8 +1408,8 @@ Array [
           "example-github",
           "2",
         ],
-        "dstIndex": 24,
-        "srcIndex": 12,
+        "dstIndex": 28,
+        "srcIndex": 16,
       },
       Object {
         "address": Array [
@@ -1429,8 +1429,8 @@ Array [
           "example-github",
           "3",
         ],
-        "dstIndex": 29,
-        "srcIndex": 12,
+        "dstIndex": 33,
+        "srcIndex": 16,
       },
       Object {
         "address": Array [
@@ -1451,8 +1451,8 @@ Array [
           "5",
           "100313899",
         ],
-        "dstIndex": 33,
-        "srcIndex": 12,
+        "dstIndex": 37,
+        "srcIndex": 16,
       },
       Object {
         "address": Array [
@@ -1475,8 +1475,8 @@ Array [
           "100313899",
           "171460198",
         ],
-        "dstIndex": 20,
-        "srcIndex": 12,
+        "dstIndex": 24,
+        "srcIndex": 16,
       },
       Object {
         "address": Array [
@@ -1496,8 +1496,8 @@ Array [
           "example-github",
           "2",
         ],
-        "dstIndex": 24,
-        "srcIndex": 16,
+        "dstIndex": 28,
+        "srcIndex": 20,
       },
       Object {
         "address": Array [
@@ -1517,8 +1517,8 @@ Array [
           "example-github",
           "2",
         ],
-        "dstIndex": 24,
-        "srcIndex": 18,
+        "dstIndex": 28,
+        "srcIndex": 22,
       },
     ],
     "nodes": Array [
@@ -1532,7 +1532,31 @@ Array [
         "sourcecred",
         "git",
         "COMMIT",
+        "6bd1b4c0b719c22c688a74863be07a699b7b9b34",
+      ],
+      Array [
+        "sourcecred",
+        "git",
+        "COMMIT",
         "6d5b3aa31ebb68a06ceb46bbd6cf49b6ccd6f5e6",
+      ],
+      Array [
+        "sourcecred",
+        "git",
+        "COMMIT",
+        "c430bd74455105f77215ece51945094ceeee6c86",
+      ],
+      Array [
+        "sourcecred",
+        "git",
+        "COMMIT",
+        "ec91adb718a6045b492303f00d8e8beb957dc780",
+      ],
+      Array [
+        "sourcecred",
+        "git",
+        "COMMIT",
+        "ecc889dc94cf6da17ae6eab5bb7b7155f577519d",
       ],
       Array [
         "sourcecred",

--- a/src/plugins/github/__snapshots__/relationalView.test.js.snap
+++ b/src/plugins/github/__snapshots__/relationalView.test.js.snap
@@ -147,12 +147,16 @@ Array [
 ]
 `;
 
-exports[`plugins/github/relationalView RelationalView entity: commits has expected number of them 1`] = `2`;
+exports[`plugins/github/relationalView RelationalView entity: commits has expected number of them 1`] = `6`;
 
 exports[`plugins/github/relationalView RelationalView entity: commits they have expected urls 1`] = `
 Array [
   "https://github.com/sourcecred/example-github/commit/0a223346b4e6dec0127b1e6aa892c4ee0424b66a",
   "https://github.com/sourcecred/example-github/commit/6d5b3aa31ebb68a06ceb46bbd6cf49b6ccd6f5e6",
+  "https://github.com/sourcecred/example-github/commit/6bd1b4c0b719c22c688a74863be07a699b7b9b34",
+  "https://github.com/sourcecred/example-github/commit/c430bd74455105f77215ece51945094ceeee6c86",
+  "https://github.com/sourcecred/example-github/commit/ecc889dc94cf6da17ae6eab5bb7b7155f577519d",
+  "https://github.com/sourcecred/example-github/commit/ec91adb718a6045b492303f00d8e8beb957dc780",
 ]
 `;
 


### PR DESCRIPTION
This builds on #821 so that every commit in the default ref's history is
added as a Commit entity to the GitHub relational view. This means that
these commits are also added to the graph by the GitHub plugin. In
general, this will have no effect on real graphs, because these commits
were already available via the Git plugin.

Test plan:
Observe that the snapshot changes just correspond to new commits being
available to the RelationalView, and correspondingly added to the GitHub
graph. `yarn test --full` passes.