### PR TITLE
Request commit messages from GitHub

### DIFF
--- a/src/plugins/github/__snapshots__/graphql.test.js.snap
+++ b/src/plugins/github/__snapshots__/graphql.test.js.snap
@@ -347,6 +347,7 @@ fragment commit on Commit {
   id
   url
   oid
+  message
   author {
     user {
       ...whoami

--- a/src/plugins/github/__snapshots__/relationalView.test.js.snap
+++ b/src/plugins/github/__snapshots__/relationalView.test.js.snap
@@ -26,6 +26,12 @@ Array [
 ]
 `;
 
+exports[`plugins/github/relationalView Commit has message 1`] = `
+"Merge pull request #3 from sourcecred/add-readme
+
+Add README, merge via PR."
+`;
+
 exports[`plugins/github/relationalView Commit has url 1`] = `"https://github.com/sourcecred/example-github/commit/0a223346b4e6dec0127b1e6aa892c4ee0424b66a"`;
 
 exports[`plugins/github/relationalView Issue authors has expected number of authors 1`] = `1`;

--- a/src/plugins/github/example/example-github.json
+++ b/src/plugins/github/example/example-github.json
@@ -10,6 +10,7 @@
                                 "user": null
                             },
                             "id": "MDY6Q29tbWl0MTIzMjU1MDA2OjZiZDFiNGMwYjcxOWMyMmM2ODhhNzQ4NjNiZTA3YTY5OWI3YjliMzQ=",
+                            "message": "A commit from someone with no GitHub account\n\nSummary:\nThis is a commit to master by a user with email at `example.com`, which\nshould not be linked to any GitHub account.\n\nGenerated with:\n\n    git -c user.name='Mysterious Stranger' \\\n        -c user.email='mysterious-stranger@example.com' \\\n        commit -S\n\nActually committed and signed by William Chargin <wchargin@gmail.com>.\nVerify public key at either of:\n  - <https://github.com/wchargin.gpg>\n  - <https://wchargin.github.io/> (click link to \"My PGP key\")",
                             "oid": "6bd1b4c0b719c22c688a74863be07a699b7b9b34",
                             "url": "https://github.com/sourcecred/example-github/commit/6bd1b4c0b719c22c688a74863be07a699b7b9b34"
                         },
@@ -23,6 +24,7 @@
                                 }
                             },
                             "id": "MDY6Q29tbWl0MTIzMjU1MDA2OmM0MzBiZDc0NDU1MTA1Zjc3MjE1ZWNlNTE5NDUwOTRjZWVlZTZjODY=",
+                            "message": "Hello from credbot!\n\nSummary:\nThis is a commit to master under the name and email of credbot, who has\nno other contributions to the repository. This is intended to test that\nwe can still pull the correct GitHub user off of the commit.\n\nGenerated with:\n\n    git -c user.name='credbot' \\\n        -c user.email='42819382+credbot@users.noreply.github.com' \\\n        commit\n\nActually committed and signed by William Chargin <wchargin@gmail.com>.\nVerify public key at either of:\n  - <https://github.com/wchargin.gpg>\n  - <https://wchargin.github.io/> (click link to \"My PGP key\")",
                             "oid": "c430bd74455105f77215ece51945094ceeee6c86",
                             "url": "https://github.com/sourcecred/example-github/commit/c430bd74455105f77215ece51945094ceeee6c86"
                         },
@@ -36,6 +38,7 @@
                                 }
                             },
                             "id": "MDY6Q29tbWl0MTIzMjU1MDA2OjZkNWIzYWEzMWViYjY4YTA2Y2ViNDZiYmQ2Y2Y0OWI2Y2NkNmY1ZTY=",
+                            "message": "This pull request will be more contentious. I can feel it... (#5)\n\n* This pull request will be more contentious. I can feel it...\r\n\r\n* Address wchargin's unreasonable complaints",
                             "oid": "6d5b3aa31ebb68a06ceb46bbd6cf49b6ccd6f5e6",
                             "url": "https://github.com/sourcecred/example-github/commit/6d5b3aa31ebb68a06ceb46bbd6cf49b6ccd6f5e6"
                         },
@@ -49,6 +52,7 @@
                                 }
                             },
                             "id": "MDY6Q29tbWl0MTIzMjU1MDA2OjBhMjIzMzQ2YjRlNmRlYzAxMjdiMWU2YWE4OTJjNGVlMDQyNGI2NmE=",
+                            "message": "Merge pull request #3 from sourcecred/add-readme\n\nAdd README, merge via PR.",
                             "oid": "0a223346b4e6dec0127b1e6aa892c4ee0424b66a",
                             "url": "https://github.com/sourcecred/example-github/commit/0a223346b4e6dec0127b1e6aa892c4ee0424b66a"
                         },
@@ -62,6 +66,7 @@
                                 }
                             },
                             "id": "MDY6Q29tbWl0MTIzMjU1MDA2OmVjYzg4OWRjOTRjZjZkYTE3YWU2ZWFiNWJiN2I3MTU1ZjU3NzUxOWQ=",
+                            "message": "Add README, merge via PR.",
                             "oid": "ecc889dc94cf6da17ae6eab5bb7b7155f577519d",
                             "url": "https://github.com/sourcecred/example-github/commit/ecc889dc94cf6da17ae6eab5bb7b7155f577519d"
                         },
@@ -75,6 +80,7 @@
                                 }
                             },
                             "id": "MDY6Q29tbWl0MTIzMjU1MDA2OmVjOTFhZGI3MThhNjA0NWI0OTIzMDNmMDBkOGU4YmViOTU3ZGM3ODA=",
+                            "message": "Commit without pull request.",
                             "oid": "ec91adb718a6045b492303f00d8e8beb957dc780",
                             "url": "https://github.com/sourcecred/example-github/commit/ec91adb718a6045b492303f00d8e8beb957dc780"
                         }
@@ -478,6 +484,7 @@
                             }
                         },
                         "id": "MDY6Q29tbWl0MTIzMjU1MDA2OjBhMjIzMzQ2YjRlNmRlYzAxMjdiMWU2YWE4OTJjNGVlMDQyNGI2NmE=",
+                        "message": "Merge pull request #3 from sourcecred/add-readme\n\nAdd README, merge via PR.",
                         "oid": "0a223346b4e6dec0127b1e6aa892c4ee0424b66a",
                         "url": "https://github.com/sourcecred/example-github/commit/0a223346b4e6dec0127b1e6aa892c4ee0424b66a"
                     },
@@ -533,6 +540,7 @@
                             }
                         },
                         "id": "MDY6Q29tbWl0MTIzMjU1MDA2OjZkNWIzYWEzMWViYjY4YTA2Y2ViNDZiYmQ2Y2Y0OWI2Y2NkNmY1ZTY=",
+                        "message": "This pull request will be more contentious. I can feel it... (#5)\n\n* This pull request will be more contentious. I can feel it...\r\n\r\n* Address wchargin's unreasonable complaints",
                         "oid": "6d5b3aa31ebb68a06ceb46bbd6cf49b6ccd6f5e6",
                         "url": "https://github.com/sourcecred/example-github/commit/6d5b3aa31ebb68a06ceb46bbd6cf49b6ccd6f5e6"
                     },

--- a/src/plugins/github/graphql.js
+++ b/src/plugins/github/graphql.js
@@ -863,6 +863,7 @@ export type CommitJSON = {|
   +url: string,
   +oid: string, // the hash
   +author: ?{|+user: NullableAuthorJSON|},
+  +message: string,
 |};
 
 function commitFragment(): FragmentDefinition {
@@ -871,6 +872,7 @@ function commitFragment(): FragmentDefinition {
     b.field("id"),
     b.field("url"),
     b.field("oid"),
+    b.field("message"),
     b.field("author", {}, [b.field("user", {}, [b.fragmentSpread("whoami")])]),
   ]);
 }

--- a/src/plugins/github/relationalView.js
+++ b/src/plugins/github/relationalView.js
@@ -78,6 +78,7 @@ export class RelationalView {
    * Mutate the RelationalView, by replacing all of the post bodies with
    * empty strings. Usage of this method is a convenient hack to save space,
    * as we don't currently use the bodies after the _addReferences step.
+   * Also removes commit messages.
    */
   compressByRemovingBody() {
     for (const [address, post] of this._issues.entries()) {
@@ -98,6 +99,11 @@ export class RelationalView {
     for (const [address, post] of this._reviews.entries()) {
       const compressedPost = {...post, body: ""};
       this._reviews.set(address, compressedPost);
+    }
+
+    for (const [address, post] of this._commits.entries()) {
+      const compressedPost = {...post, message: ""};
+      this._commits.set(address, compressedPost);
     }
   }
 
@@ -336,6 +342,7 @@ export class RelationalView {
       address,
       url: json.url,
       authors,
+      message: json.message,
     };
     this._commits.set(N.toRaw(address), entry);
     return address;
@@ -853,6 +860,7 @@ type CommitEntry = {|
   +address: GitNode.CommitAddress,
   +url: string,
   +authors: UserlikeAddress[],
+  +message: string,
 |};
 
 export class Commit extends _Entity<CommitEntry> {
@@ -861,6 +869,9 @@ export class Commit extends _Entity<CommitEntry> {
   }
   authors(): Iterator<Userlike> {
     return getAuthors(this._view, this._entry);
+  }
+  message(): string {
+    return this._entry.message;
   }
 }
 

--- a/src/plugins/github/relationalView.test.js
+++ b/src/plugins/github/relationalView.test.js
@@ -138,6 +138,7 @@ describe("plugins/github/relationalView", () => {
   describe("Commit", () => {
     const entity = commit;
     has("url", () => entity.url());
+    has("message", () => entity.message());
     hasEntities("authors", () => entity.authors());
   });
 
@@ -309,6 +310,21 @@ describe("plugins/github/relationalView", () => {
       expect(somePostsHaveBodies()).toBe(true);
       rv.compressByRemovingBody();
       expect(somePostsHaveBodies()).toBe(false);
+    });
+    it("removes messages from all commits", () => {
+      const rv = new R.RelationalView();
+      rv.addData(exampleData());
+      function someCommitsHaveMessages() {
+        for (const commit of rv.commits()) {
+          if (commit.message() !== "") {
+            return true;
+          }
+        }
+        return false;
+      }
+      expect(someCommitsHaveMessages()).toBe(true);
+      rv.compressByRemovingBody();
+      expect(someCommitsHaveMessages()).toBe(false);
     });
   });
 


### PR DESCRIPTION
We could get this information from the Git plugin, but since we want to
use this for reference detection, it's much easier to have this follow
the same pipeline as all the other GitHub reference detection code.

I've updated the relational view to also remove the commit messages when
compressing by removing bodies. A unit test was added to check this
works as intended.

See #815 for tracking.

Test plan:
`yarn test --full` passes.
Snapshot changes are appropriate.