### PR TITLE
deps: add `better-sqlite3`

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "private": true,
   "dependencies": {
     "aphrodite": "^2.1.0",
+    "better-sqlite3": "wchargin/better-sqlite3#wchargin-private-inmemory-db",
     "chalk": "1.1.3",
     "commonmark": "^0.28.1",
     "express": "^4.16.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1076,6 +1076,13 @@ bcrypt-pbkdf@^1.0.0:
   dependencies:
     tweetnacl "^0.14.3"
 
+better-sqlite3@wchargin/better-sqlite3#wchargin-private-inmemory-db:
+  version "4.1.4"
+  resolved "https://codeload.github.com/wchargin/better-sqlite3/tar.gz/41f429eb11d020326065ab4e3da4433425e4be5c"
+  dependencies:
+    bindings "^1.3.0"
+    integer "^1.0.5"
+
 big.js@^3.1.3:
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/big.js/-/big.js-3.2.0.tgz#a5fc298b81b9e0dca2e458824784b65c52ba588e"
@@ -1083,6 +1090,10 @@ big.js@^3.1.3:
 binary-extensions@^1.0.0:
   version "1.11.0"
   resolved "https://registry.yarnpkg.com/binary-extensions/-/binary-extensions-1.11.0.tgz#46aa1751fb6a2f93ee5e689bb1087d4b14c6c205"
+
+bindings@^1.3.0:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/bindings/-/bindings-1.3.0.tgz#b346f6ecf6a95f5a815c5839fc7cdb22502f1ed7"
 
 block-stream@*:
   version "0.0.9"
@@ -3640,6 +3651,12 @@ inquirer@3.3.0, inquirer@^3.0.6:
     string-width "^2.1.0"
     strip-ansi "^4.0.0"
     through "^2.3.6"
+
+integer@^1.0.5:
+  version "1.0.5"
+  resolved "https://registry.yarnpkg.com/integer/-/integer-1.0.5.tgz#cadbf6078290389e8e4e29226e6b0044433deec1"
+  dependencies:
+    bindings "^1.3.0"
 
 internal-ip@1.2.0:
   version "1.2.0"


### PR DESCRIPTION
Summary:
I selected this over the alternatives, `sqlite` and `sqlite3`, primarily
because its README explicitly acknowledges that using asynchronous APIs
for CPU-bound or serialized work units are worse than useless. To me,
this is a sign that the maintainer has his head on straight.

The many-fold performance increase over `sqlite` and `sqlite3` is nice
to have, too.

For now, we use my fork of the project, which includes a critical patch
to support private in-memory databases via SQLite’s standard `:memory:`
filepath. When this patch is merged upstream, we can move back to
mainline.

Test Plan:
The following session demonstrates the basic API and validates that the
install has completed successfully:

```js
const Database = require("better-sqlite3");
const db = new Database("/tmp/irrelevant", {memory: true});

db.prepare("CREATE TABLE pythagorean_triples (x, y, z)").run();
const insert = db.prepare("INSERT INTO pythagorean_triples VALUES (?, ?, ?)");
const get = db.prepare(
  "SELECT rowid, x * x + y * y AS xxyy, z * z AS zz FROM pythagorean_triples"
);

function print(x) {
  console.log(JSON.stringify(x));
}

print(insert.run(3, 4, 5));
print(get.all());
print(insert.run(5, 12, 13));
print(get.all());

db.prepare("DELETE FROM pythagorean_triples").run();
print(get.all());
```

It prints:

```js
{"changes":1,"lastInsertROWID":1}
[{"rowid":1,"xxyy":25,"zz":25}]
{"changes":1,"lastInsertROWID":2}
[{"rowid":1,"xxyy":25,"zz":25},{"rowid":2,"xxyy":169,"zz":169}]
[]
```

wchargin-branch: dep-better-sqlite3