### PR TITLE
flow: mark bound parameters as covariant

### DIFF
--- a/flow-typed/npm/better-sqlite3_vx.x.x.js
+++ b/flow-typed/npm/better-sqlite3_vx.x.x.js
@@ -53,7 +53,7 @@ declare type bettersqlite3$Database$RegisterOptions = {
 // now, `number` is a good approximation.
 declare type bettersqlite3$BoundValue = number | string | Buffer | null;
 declare type bettersqlite3$BindingDictionary = {
-  [string]: bettersqlite3$BoundValue
+  +[string]: bettersqlite3$BoundValue
 };
 
 declare class bettersqlite3$Statement {


### PR DESCRIPTION
Summary:
Before this patch, an object whose type has read-only attributes cannot
be passed to `stmt.run`/etc., because the libdef does not promise not to
mutate its argument. This patch fixes that oversight.

Test Plan:
Create the following test file, and note that it fails to typecheck
before this change but passes after:

```js
// @flow
import Database from "better-sqlite3";
const db = new Database("/tmp/foo");
const args: {|+id: number|} = {id: 1};
db.prepare("INSERT INTO foo (id) VALUES (?)").run(args);
```

wchargin-branch: flow-better-sqlite3-bound-parameters-covariant