### PR TITLE
schema: make `fields` and `clauses` exact

### DIFF
--- a/src/graphql/schema.js
+++ b/src/graphql/schema.js
@@ -33,8 +33,8 @@ export type ObjectId = string;
 //     are not.
 export type Schema = {+[Typename]: NodeType};
 export type NodeType =
-  | {|+type: "OBJECT", +fields: {+[Fieldname]: FieldType}|}
-  | {|+type: "UNION", +clauses: {+[Typename]: true}|};
+  | {|+type: "OBJECT", +fields: {|+[Fieldname]: FieldType|}|}
+  | {|+type: "UNION", +clauses: {|+[Typename]: true|}|};
 export type FieldType =
   | {|+type: "ID"|}
   | {|+type: "PRIMITIVE"|}
@@ -101,7 +101,7 @@ export function object(fields: {[Fieldname]: FieldType}): NodeType {
 }
 
 export function union(clauses: $ReadOnlyArray<Typename>): NodeType {
-  const clausesMap = {};
+  const clausesMap: {|[Typename]: true|} = ({}: any);
   for (const clause of clauses) {
     if (clausesMap[clause] != null) {
       throw new Error(`duplicate union clause: "${clause}"`);


### PR DESCRIPTION
Summary:
This affords more flexibility to clients, because an exact value can be
used in place of an inexact value, but not vice versa.

Test Plan:
Running `yarn flow` suffices.

wchargin-branch: schema-exact-type-fields