### PR TITLE
Define Reaction edges

### DIFF
--- a/src/plugins/github/__snapshots__/edges.test.js.snap
+++ b/src/plugins/github/__snapshots__/edges.test.js.snap
@@ -155,6 +155,127 @@ Object {
 }
 `;
 
+exports[`plugins/github/edges createEdge works for "reactsHeart" 1`] = `
+Object {
+  "addressParts": Array [
+    "sourcecred",
+    "github",
+    "REACTS",
+    "HEART",
+    "5",
+    "sourcecred",
+    "github",
+    "USERLIKE",
+    "USER",
+    "decentralion",
+    "6",
+    "sourcecred",
+    "github",
+    "PULL",
+    "sourcecred",
+    "example-github",
+    "5",
+  ],
+  "dstParts": Array [
+    "sourcecred",
+    "github",
+    "PULL",
+    "sourcecred",
+    "example-github",
+    "5",
+  ],
+  "srcParts": Array [
+    "sourcecred",
+    "github",
+    "USERLIKE",
+    "USER",
+    "decentralion",
+  ],
+}
+`;
+
+exports[`plugins/github/edges createEdge works for "reactsHooray" 1`] = `
+Object {
+  "addressParts": Array [
+    "sourcecred",
+    "github",
+    "REACTS",
+    "HOORAY",
+    "5",
+    "sourcecred",
+    "github",
+    "USERLIKE",
+    "USER",
+    "decentralion",
+    "8",
+    "sourcecred",
+    "github",
+    "COMMENT",
+    "ISSUE",
+    "sourcecred",
+    "example-github",
+    "2",
+    "373768703",
+  ],
+  "dstParts": Array [
+    "sourcecred",
+    "github",
+    "COMMENT",
+    "ISSUE",
+    "sourcecred",
+    "example-github",
+    "2",
+    "373768703",
+  ],
+  "srcParts": Array [
+    "sourcecred",
+    "github",
+    "USERLIKE",
+    "USER",
+    "decentralion",
+  ],
+}
+`;
+
+exports[`plugins/github/edges createEdge works for "reactsThumbsUp" 1`] = `
+Object {
+  "addressParts": Array [
+    "sourcecred",
+    "github",
+    "REACTS",
+    "THUMBS_UP",
+    "5",
+    "sourcecred",
+    "github",
+    "USERLIKE",
+    "USER",
+    "decentralion",
+    "6",
+    "sourcecred",
+    "github",
+    "ISSUE",
+    "sourcecred",
+    "example-github",
+    "2",
+  ],
+  "dstParts": Array [
+    "sourcecred",
+    "github",
+    "ISSUE",
+    "sourcecred",
+    "example-github",
+    "2",
+  ],
+  "srcParts": Array [
+    "sourcecred",
+    "github",
+    "USERLIKE",
+    "USER",
+    "decentralion",
+  ],
+}
+`;
+
 exports[`plugins/github/edges createEdge works for "references" 1`] = `
 Object {
   "addressParts": Array [

--- a/src/plugins/github/edges.test.js
+++ b/src/plugins/github/edges.test.js
@@ -5,6 +5,7 @@ import {createEdge, fromRaw, toRaw} from "./edges";
 import * as GE from "./edges";
 import * as GN from "./nodes";
 import {COMMIT_TYPE} from "../git/nodes";
+import {Reactions} from "./graphql";
 
 describe("plugins/github/edges", () => {
   const nodeExamples = {
@@ -63,6 +64,24 @@ describe("plugins/github/edges", () => {
         dst: nodeExamples.issue(),
         who: nodeExamples.user(),
       }),
+    reactsHeart: () =>
+      createEdge.reacts(
+        Reactions.HEART,
+        nodeExamples.user(),
+        nodeExamples.pull()
+      ),
+    reactsThumbsUp: () =>
+      createEdge.reacts(
+        Reactions.THUMBS_UP,
+        nodeExamples.user(),
+        nodeExamples.issue()
+      ),
+    reactsHooray: () =>
+      createEdge.reacts(
+        Reactions.HOORAY,
+        nodeExamples.user(),
+        nodeExamples.issueComment()
+      ),
   };
 
   describe("createEdge", () => {

--- a/src/plugins/github/nodes.js
+++ b/src/plugins/github/nodes.js
@@ -120,6 +120,9 @@ export type ParentAddress =
   | PullAddress
   | ReviewAddress;
 
+// GitHub allows you to react to these types
+export type ReactableAddress = IssueAddress | PullAddress | CommentAddress;
+
 // Each of these types may have Comments as children
 export type CommentableAddress = IssueAddress | PullAddress | ReviewAddress;
 


### PR DESCRIPTION
This adds support to `github/edges` for creating edges representing
GitHub reactions. These edges are not actually added to the graph.

Test plan: Unit tests