### PR TITLE
Prepare to enable flow-type eslint rules

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,5 +1,7 @@
 // @flow
 module.exports = {
+  parser: "babel-eslint",
+  plugins: ["flowtype"],
   extends: "react-app",
   rules: {
     "no-unused-vars": [
@@ -12,5 +14,9 @@ module.exports = {
     ],
     "no-use-before-define": ["off"],
     "no-useless-constructor": ["off"],
+    // TODO(@decentralion): Enable this rule.
+    //    "flowtype/no-mutable-array": [2],
+    // TODO(@decentralion): Enable this rule.
+    //    "flowtype/require-exact-type": [2, "always"],
   },
 };

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "enzyme-to-json": "^3.3.3",
     "eslint": "4.10.0",
     "eslint-config-react-app": "^2.1.0",
-    "eslint-plugin-flowtype": "2.39.1",
+    "eslint-plugin-flowtype": "2.50.0",
     "eslint-plugin-import": "2.8.0",
     "eslint-plugin-jsx-a11y": "5.1.1",
     "eslint-plugin-react": "7.4.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2479,11 +2479,11 @@ eslint-module-utils@^2.1.1:
     debug "^2.6.8"
     pkg-dir "^1.0.0"
 
-eslint-plugin-flowtype@2.39.1:
-  version "2.39.1"
-  resolved "https://registry.yarnpkg.com/eslint-plugin-flowtype/-/eslint-plugin-flowtype-2.39.1.tgz#b5624622a0388bcd969f4351131232dcb9649cd5"
+eslint-plugin-flowtype@2.50.0:
+  version "2.50.0"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-flowtype/-/eslint-plugin-flowtype-2.50.0.tgz#953e262fa9b5d0fa76e178604892cf60dfb916da"
   dependencies:
-    lodash "^4.15.0"
+    lodash "^4.17.10"
 
 eslint-plugin-import@2.8.0:
   version "2.8.0"
@@ -4673,6 +4673,10 @@ lodash.uniq@^4.5.0:
 lodash@^4.13.1:
   version "4.17.10"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.10.tgz#1b7793cf7259ea38fb3661d4d38b3260af8ae4e7"
+
+lodash@^4.17.10:
+  version "4.17.11"
+  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.11.tgz#b39ea6229ef607ecd89e2c8df12536891cac9b8d"
 
 loglevel@^1.4.1:
   version "1.6.1"


### PR DESCRIPTION
This commit upgrades the flow-type eslint plugin to latest, and writes
new rules into the eslintrc. To keep the diff clean, the rules are
disabled: I will turn them on individually (fixing errors) in followon
commits.

Test plan: `yarn test`.
Uncommenting the lines produces many lint errors (but the linter still operates as expected).