### PR TITLE
Use read only arrays by default

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -14,8 +14,7 @@ module.exports = {
     ],
     "no-use-before-define": ["off"],
     "no-useless-constructor": ["off"],
-    // TODO(@decentralion): Enable this rule.
-    //    "flowtype/no-mutable-array": [2],
+    "flowtype/no-mutable-array": [2],
     // TODO(@decentralion): Enable this rule.
     //    "flowtype/require-exact-type": [2, "always"],
   },

--- a/src/app/adapters/adapterSet.js
+++ b/src/app/adapters/adapterSet.js
@@ -45,11 +45,11 @@ export class StaticAdapterSet {
     return this._adapters;
   }
 
-  nodeTypes(): NodeType[] {
+  nodeTypes(): $ReadOnlyArray<NodeType> {
     return [].concat(...this._adapters.map((x) => x.nodeTypes()));
   }
 
-  edgeTypes(): EdgeType[] {
+  edgeTypes(): $ReadOnlyArray<EdgeType> {
     return [].concat(...this._adapters.map((x) => x.edgeTypes()));
   }
 

--- a/src/app/adapters/pluginAdapter.js
+++ b/src/app/adapters/pluginAdapter.js
@@ -23,8 +23,8 @@ export interface StaticPluginAdapter {
   name(): string;
   nodePrefix(): NodeAddressT;
   edgePrefix(): EdgeAddressT;
-  nodeTypes(): NodeType[];
-  edgeTypes(): EdgeType[];
+  nodeTypes(): $ReadOnlyArray<NodeType>;
+  edgeTypes(): $ReadOnlyArray<EdgeType>;
   load(assets: Assets, repo: Repo): Promise<DynamicPluginAdapter>;
 }
 

--- a/src/app/credExplorer/pagerankTable/aggregate.js
+++ b/src/app/credExplorer/pagerankTable/aggregate.js
@@ -59,7 +59,7 @@ export function aggregateByNodeType(
   const aggregations: NodeAggregation[] = [];
   for (const [
     nodeType: NodeType,
-    connections: ScoredConnection[],
+    connections: $ReadOnlyArray<ScoredConnection>,
   ] of nodeTypeToConnections) {
     const connectionScores = connections.map((x) => x.connectionScore);
     const aggregation = {
@@ -75,6 +75,7 @@ export function aggregateByNodeType(
   return sortBy(aggregations, (x) => -x.summary.score);
 }
 
+// eslint-disable-next-line flowtype/no-mutable-array
 type EdgeTypeToConnection = Map<EdgeType, ScoredConnection[]>;
 export function aggregateByConnectionType(
   xs: $ReadOnlyArray<ScoredConnection>,

--- a/src/cli/common.js
+++ b/src/cli/common.js
@@ -8,7 +8,7 @@ import * as NullUtil from "../util/null";
 
 export type PluginName = "git" | "github";
 
-export function defaultPlugins(): PluginName[] {
+export function defaultPlugins(): $ReadOnlyArray<PluginName> {
   return ["git", "github"];
 }
 

--- a/src/core/address.js
+++ b/src/core/address.js
@@ -37,7 +37,7 @@ export interface AddressModule<Address> {
    * Convert an address to the array of parts that it represents. This
    * is the inverse of `fromParts`.
    */
-  toParts(address: Address): string[];
+  toParts(address: Address): $ReadOnlyArray<string>;
 
   /**
    * Pretty-print an address. The result will be human-readable and
@@ -54,7 +54,7 @@ export interface AddressModule<Address> {
    *
    * but may be more efficient.
    */
-  append(address: Address, ...components: string[]): Address;
+  append(address: Address, ...components: $ReadOnlyArray<string>): Address;
 
   /**
    * Test whether the given address has the given prefix. This function
@@ -196,7 +196,7 @@ export function makeAddressModule(options: Options): AddressModule<string> {
 
   const empty = fromParts([]);
 
-  function toParts(address: Address): string[] {
+  function toParts(address: Address): $ReadOnlyArray<string> {
     assertValid(address);
     const parts = address.split(separator);
     return parts.slice(1, parts.length - 1);
@@ -207,7 +207,7 @@ export function makeAddressModule(options: Options): AddressModule<string> {
     return `${name}${stringify(parts)}`;
   }
 
-  function append(address: Address, ...parts: string[]): Address {
+  function append(address: Address, ...parts: $ReadOnlyArray<string>): Address {
     assertValid(address);
     assertValidParts(parts);
     return address + nullDelimited(parts);

--- a/src/core/attribution/graphToMarkovChain.js
+++ b/src/core/attribution/graphToMarkovChain.js
@@ -64,6 +64,7 @@ export function createConnections(
 
   function processConnection(target: NodeAddressT, connection: Connection) {
     const connections = NullUtil.get(result.get(target));
+    // eslint-disable-next-line flowtype/no-mutable-array
     (((connections: $ReadOnlyArray<Connection>): any): Connection[]).push(
       connection
     );

--- a/src/core/graph.js
+++ b/src/core/graph.js
@@ -53,7 +53,7 @@ export type EdgesOptions = {|
   +dstPrefix: NodeAddressT,
 |};
 
-type AddressJSON = string[]; // Result of calling {Node,Edge}Address.toParts
+type AddressJSON = $ReadOnlyArray<string>; // Result of calling {Node,Edge}Address.toParts
 type Integer = number;
 type IndexedEdgeJSON = {|
   +address: AddressJSON,
@@ -62,8 +62,8 @@ type IndexedEdgeJSON = {|
 |};
 
 export opaque type GraphJSON = Compatible<{|
-  +nodes: AddressJSON[],
-  +edges: IndexedEdgeJSON[],
+  +nodes: $ReadOnlyArray<AddressJSON>,
+  +edges: $ReadOnlyArray<IndexedEdgeJSON>,
 |}>;
 
 type ModificationCount = number;
@@ -71,7 +71,9 @@ type ModificationCount = number;
 export class Graph {
   _nodes: Set<NodeAddressT>;
   _edges: Map<EdgeAddressT, Edge>;
+  // eslint-disable-next-line flowtype/no-mutable-array
   _inEdges: Map<NodeAddressT, Edge[]>;
+  // eslint-disable-next-line flowtype/no-mutable-array
   _outEdges: Map<NodeAddressT, Edge[]>;
 
   checkInvariants() {
@@ -495,7 +497,7 @@ export class Graph {
     const nodeFilter = (n) => NodeAddress.hasPrefix(n, options.nodePrefix);
     const edgeFilter = (e) => EdgeAddress.hasPrefix(e, options.edgePrefix);
     const direction = options.direction;
-    const adjacencies: {edges: Edge[], direction: string}[] = [];
+    const adjacencies: {edges: $ReadOnlyArray<Edge>, direction: string}[] = [];
     if (direction === Direction.IN || direction === Direction.ANY) {
       const inEdges = NullUtil.get(this._inEdges.get(node));
       adjacencies.push({edges: inEdges, direction: "IN"});
@@ -617,7 +619,11 @@ export function edgeToStrings(
 
 export function edgeToParts(
   edge: Edge
-): {|+addressParts: string[], +srcParts: string[], +dstParts: string[]|} {
+): {|
+  +addressParts: $ReadOnlyArray<string>,
+  +srcParts: $ReadOnlyArray<string>,
+  +dstParts: $ReadOnlyArray<string>,
+|} {
   const addressParts = EdgeAddress.toParts(edge.address);
   const srcParts = NodeAddress.toParts(edge.src);
   const dstParts = NodeAddress.toParts(edge.dst);

--- a/src/core/graph.test.js
+++ b/src/core/graph.test.js
@@ -341,7 +341,7 @@ describe("core/graph", () => {
             .addNode(n4);
         function expectSortedNodes(
           options: {|+prefix: NodeAddressT|} | void,
-          expected: NodeAddressT[]
+          expected: $ReadOnlyArray<NodeAddressT>
         ) {
           const actual = graph().nodes(options);
           expect(Array.from(actual).sort()).toEqual(expected.slice().sort());
@@ -828,7 +828,7 @@ describe("core/graph", () => {
       function expectNeighbors(
         node: NodeAddressT,
         options: NeighborsOptions,
-        expected: Neighbor[]
+        expected: $ReadOnlyArray<Neighbor>
       ) {
         const g = quiver();
         const actual = Array.from(g.neighbors(node, options));

--- a/src/core/trie.js
+++ b/src/core/trie.js
@@ -58,7 +58,7 @@ class BaseTrie<K, V> {
    * was added to this trie with value `v`, then append `v` to
    * `result`. Return `result`.
    */
-  get(k: K): V[] {
+  get(k: K): $ReadOnlyArray<V> {
     const parts = this.addressModule.toParts(k);
     const result: V[] = [];
     let entry: Entry<V> = this.entry;

--- a/src/graphql/queries.js
+++ b/src/graphql/queries.js
@@ -10,7 +10,7 @@
  *   - the two layout strategies `multilineLayout` and `inlineLayout`
  */
 
-export type Body = Definition[];
+export type Body = $ReadOnlyArray<Definition>;
 
 export type Definition = QueryDefinition | FragmentDefinition;
 
@@ -21,8 +21,8 @@ export type GraphQLType = string;
 export type QueryDefinition = {|
   +type: "QUERY",
   +name: string,
-  +params: Parameter[],
-  +selections: Selection[],
+  +params: $ReadOnlyArray<Parameter>,
+  +selections: $ReadOnlyArray<Selection>,
 |};
 export type Parameter = {|+name: string, +type: GraphQLType|};
 
@@ -30,7 +30,7 @@ export type FragmentDefinition = {|
   +type: "FRAGMENT",
   +name: string,
   +typeCondition: GraphQLType,
-  +selections: Selection[],
+  +selections: $ReadOnlyArray<Selection>,
 |};
 
 export type Selection = Field | FragmentSpread | InlineFragment;
@@ -39,7 +39,7 @@ export type Field = {|
   +alias: ?string,
   +name: string,
   +args: Arguments,
-  +selections: Selection[],
+  +selections: $ReadOnlyArray<Selection>,
 |};
 export type FragmentSpread = {|
   +type: "FRAGMENT_SPREAD",
@@ -48,7 +48,7 @@ export type FragmentSpread = {|
 export type InlineFragment = {|
   +type: "INLINE_FRAGMENT",
   +typeCondition: ?GraphQLType,
-  +selections: Selection[],
+  +selections: $ReadOnlyArray<Selection>,
 |};
 
 export type Arguments = {[string]: Value};
@@ -64,14 +64,14 @@ export type LiteralValue = {|
   +data: number | string | boolean | null,
 |};
 export type EnumValue = {|+type: "ENUM", +data: string|};
-export type ListValue = {|+type: "LIST", +data: Value[]|};
+export type ListValue = {|+type: "LIST", +data: $ReadOnlyArray<Value>|};
 export type ObjectValue = {|+type: "OBJECT", +data: {[string]: Value}|};
 
 export const build = {
   query(
     name: string,
-    params: Parameter[],
-    selections: Selection[]
+    params: $ReadOnlyArray<Parameter>,
+    selections: $ReadOnlyArray<Selection>
   ): QueryDefinition {
     return {
       type: "QUERY",
@@ -88,7 +88,7 @@ export const build = {
   fragment(
     name: string,
     typeCondition: GraphQLType,
-    selections: Selection[]
+    selections: $ReadOnlyArray<Selection>
   ): FragmentDefinition {
     return {
       type: "FRAGMENT",
@@ -98,7 +98,11 @@ export const build = {
     };
   },
 
-  field(name: string, args: ?Arguments, selections: ?(Selection[])): Field {
+  field(
+    name: string,
+    args: ?Arguments,
+    selections: ?$ReadOnlyArray<Selection>
+  ): Field {
     return {
       type: "FIELD",
       alias: null,
@@ -127,7 +131,7 @@ export const build = {
 
   inlineFragment(
     typeCondition: ?GraphQLType,
-    selections: Selection[]
+    selections: $ReadOnlyArray<Selection>
   ): InlineFragment {
     return {
       type: "INLINE_FRAGMENT",
@@ -157,7 +161,7 @@ export const build = {
     };
   },
 
-  list(data: Value[]): ListValue {
+  list(data: $ReadOnlyArray<Value>): ListValue {
     return {
       type: "LIST",
       data: data,
@@ -181,7 +185,7 @@ export interface LayoutStrategy {
 
   // Join groups of tokens. The elements should be the results of calls
   // to `atom` (or other `join`s).
-  join(lines: string[]): string;
+  join(lines: $ReadOnlyArray<string>): string;
 
   // Get a strategy for the next level of nesting. For instance, if this
   // object lays out its result over multiple lines, then this method
@@ -202,7 +206,7 @@ export function multilineLayout(tab: string): LayoutStrategy {
           .join("");
         return indentation + line;
       },
-      join: (xs: string[]) => xs.join("\n"),
+      join: (xs: $ReadOnlyArray<string>) => xs.join("\n"),
       next: () => strategy(indentLevel + 1),
     };
   }
@@ -226,7 +230,7 @@ export function inlineLayout(): LayoutStrategy {
  * with a formatter.
  */
 function formatList<T>(
-  values: T[],
+  values: $ReadOnlyArray<T>,
   subformatter: (value: T, ls: LayoutStrategy) => string,
   ls: LayoutStrategy
 ): string {

--- a/src/plugins/git/createGraph.test.js
+++ b/src/plugins/git/createGraph.test.js
@@ -30,7 +30,7 @@ describe("plugins/git/createGraph", () => {
       beforeTree: Hash,
       afterTree: Hash,
       trees: {[Hash]: Tree}
-    ): BecomesEdge[] {
+    ): $ReadOnlyArray<BecomesEdge> {
       const repo = {
         commits: {
           commit1: {

--- a/src/plugins/git/edges.js
+++ b/src/plugins/git/edges.js
@@ -17,7 +17,7 @@ export const BECOMES_TYPE: "BECOMES" = "BECOMES";
 export const HAS_CONTENTS_TYPE: "HAS_CONTENTS" = "HAS_CONTENTS";
 
 const GIT_PREFIX = EdgeAddress.fromParts(["sourcecred", "git"]);
-function gitEdgeAddress(...parts: string[]): RawAddress {
+function gitEdgeAddress(...parts: $ReadOnlyArray<string>): RawAddress {
   return EdgeAddress.append(GIT_PREFIX, ...parts);
 }
 

--- a/src/plugins/git/gitUtils.js
+++ b/src/plugins/git/gitUtils.js
@@ -12,10 +12,16 @@ export interface Utils {
   deterministicCommit(message: string): void;
 }
 
-export type GitDriver = (args: string[], env?: {[string]: string}) => string;
+export type GitDriver = (
+  args: $ReadOnlyArray<string>,
+  env?: {[string]: string}
+) => string;
 
 export function localGit(repositoryPath: string): GitDriver {
-  return function git(args: string[], env?: {[string]: string}): string {
+  return function git(
+    args: $ReadOnlyArray<string>,
+    env?: {[string]: string}
+  ): string {
     // We standardize the environment variables shown to Git, using
     // Git's test suite [1] as inspiration. It is particularly important
     // that `GIT_DIR` be unset from the parent process environment.

--- a/src/plugins/git/loadRepository.js
+++ b/src/plugins/git/loadRepository.js
@@ -47,7 +47,7 @@ function objectMap<T: {+hash: Hash}>(ts: $ReadOnlyArray<T>): {[Hash]: T} {
   return result;
 }
 
-function findCommits(git: GitDriver, rootRef: string): Commit[] {
+function findCommits(git: GitDriver, rootRef: string): $ReadOnlyArray<Commit> {
   return git(["log", "--oneline", "--pretty=%H %T %P", rootRef])
     .split("\n")
     .filter((line) => line.length > 0)
@@ -57,7 +57,7 @@ function findCommits(git: GitDriver, rootRef: string): Commit[] {
     });
 }
 
-function findTrees(git: GitDriver, rootTrees: Set<Hash>): Tree[] {
+function findTrees(git: GitDriver, rootTrees: Set<Hash>): $ReadOnlyArray<Tree> {
   const result: Tree[] = [];
   const visited: Set<Hash> = new Set();
   const frontier: Set<Hash> = new Set(rootTrees);

--- a/src/plugins/git/nodes.js
+++ b/src/plugins/git/nodes.js
@@ -6,7 +6,7 @@ import type {Hash} from "./types";
 export opaque type RawAddress: NodeAddressT = NodeAddressT;
 
 const GIT_PREFIX = NodeAddress.fromParts(["sourcecred", "git"]);
-export function _gitAddress(...parts: string[]): RawAddress {
+export function _gitAddress(...parts: $ReadOnlyArray<string>): RawAddress {
   return NodeAddress.append(GIT_PREFIX, ...parts);
 }
 

--- a/src/plugins/github/edges.js
+++ b/src/plugins/github/edges.js
@@ -22,7 +22,7 @@ export const MENTIONS_AUTHOR_TYPE = "MENTIONS_AUTHOR";
 export const REACTS_TYPE = "REACTS";
 
 const GITHUB_PREFIX = EdgeAddress.fromParts(["sourcecred", "github"]);
-function githubEdgeAddress(...parts: string[]): RawAddress {
+function githubEdgeAddress(...parts: $ReadOnlyArray<string>): RawAddress {
   return EdgeAddress.append(GITHUB_PREFIX, ...parts);
 }
 

--- a/src/plugins/github/graphView.js
+++ b/src/plugins/github/graphView.js
@@ -97,7 +97,7 @@ export class GraphView {
       edgePrefix: GE.Prefix.hasParent,
       nodePrefix: GN.Prefix.base,
     };
-    const parents: GN.ParentAddress[] = Array.from(
+    const parents: $ReadOnlyArray<GN.ParentAddress> = Array.from(
       this._neighbors(child, options)
     );
     if (parents.length !== 1) {
@@ -166,9 +166,9 @@ export class GraphView {
       +dstPrefix: NodeAddressT,
     |};
     function homProduct(
-      srcPrefixes: NodeAddressT[],
-      dstPrefixes: NodeAddressT[]
-    ): Hom[] {
+      srcPrefixes: $ReadOnlyArray<NodeAddressT>,
+      dstPrefixes: $ReadOnlyArray<NodeAddressT>
+    ): $ReadOnlyArray<Hom> {
       const result = [];
       for (const srcPrefix of srcPrefixes) {
         for (const dstPrefix of dstPrefixes) {
@@ -178,7 +178,7 @@ export class GraphView {
       return result;
     }
     type EdgeInvariant = {|
-      +homs: Hom[],
+      +homs: $ReadOnlyArray<Hom>,
       +srcAccessor?: (GE.StructuredAddress) => NodeAddressT,
       +dstAccessor?: (GE.StructuredAddress) => NodeAddressT,
     |};

--- a/src/plugins/github/graphql.js
+++ b/src/plugins/github/graphql.js
@@ -596,7 +596,7 @@ async function resolveContinuations(
  */
 export function requiredFragments(
   query: QueryDefinition
-): FragmentDefinition[] {
+): $ReadOnlyArray<FragmentDefinition> {
   const fragmentsByName = {};
   createFragments().forEach((fd) => {
     fragmentsByName[fd.name] = fd;
@@ -684,7 +684,10 @@ export function merge<T>(
   function isObject(x) {
     return !Array.isArray(x) && typeof x === "object" && x != null;
   }
-  function checkKey(key: string | number, destination: Object | Array<any>) {
+  function checkKey(
+    key: string | number,
+    destination: Object | $ReadOnlyArray<any>
+  ) {
     if (!(key in destination)) {
       const keyText = JSON.stringify(key);
       const destinationText = JSON.stringify(destination);
@@ -1029,7 +1032,7 @@ function reactionsFragment(): FragmentDefinition {
  * These fragments are used to construct the root query, and also to
  * fetch more pages of specific entity types.
  */
-export function createFragments(): FragmentDefinition[] {
+export function createFragments(): $ReadOnlyArray<FragmentDefinition> {
   return [
     whoamiFragment(),
     issuesFragment(),

--- a/src/plugins/github/graphql.test.js
+++ b/src/plugins/github/graphql.test.js
@@ -251,7 +251,7 @@ describe("plugins/github/graphql", () => {
         reviewComments: true,
       });
       const result = Array.from(continuationsFromQuery(data));
-      const expectedContinuations: Continuation[] = (() => {
+      const expectedContinuations: $ReadOnlyArray<Continuation> = (() => {
         const continuations = makeContinuations();
         return [
           continuations.issues,
@@ -281,7 +281,7 @@ describe("plugins/github/graphql", () => {
         reviewComments: true,
       });
       const result = Array.from(continuationsFromQuery(data));
-      const expectedContinuations: Continuation[] = (() => {
+      const expectedContinuations: $ReadOnlyArray<Continuation> = (() => {
         const continuations = makeContinuations();
         return [
           continuations.issues,

--- a/src/plugins/github/heuristics/mentionsAuthorReference.js
+++ b/src/plugins/github/heuristics/mentionsAuthorReference.js
@@ -80,6 +80,7 @@ function createThread(root: RV.Issue | RV.Pull): Thread {
           (((userlikeToPostsReferencingThem: Map<
             N.RawAddress,
             $ReadOnlyArray<number>
+            // eslint-disable-next-line flowtype/no-mutable-array
           >): any): Map<N.RawAddress, number[]>),
           referencedAddress,
           posts.length - 1

--- a/src/plugins/github/nodes.js
+++ b/src/plugins/github/nodes.js
@@ -6,7 +6,7 @@ import * as GitNode from "../git/nodes";
 export opaque type RawAddress: NodeAddressT = NodeAddressT;
 
 const GITHUB_PREFIX = NodeAddress.fromParts(["sourcecred", "github"]);
-export function _githubAddress(...parts: string[]): RawAddress {
+export function _githubAddress(...parts: $ReadOnlyArray<string>): RawAddress {
   return NodeAddress.append(GITHUB_PREFIX, ...parts);
 }
 

--- a/src/plugins/github/parseMarkdown.js
+++ b/src/plugins/github/parseMarkdown.js
@@ -24,7 +24,7 @@ import {Node, Parser} from "commonmark";
  *
  * See test cases for examples.
  */
-export function textBlocks(string: string): string[] {
+export function textBlocks(string: string): $ReadOnlyArray<string> {
   const ast = new Parser().parse(string);
   deformat(ast);
   coalesceText(ast);

--- a/src/plugins/github/parseReferences.js
+++ b/src/plugins/github/parseReferences.js
@@ -15,7 +15,7 @@ export type ParsedReference = {|
  * (across softbreaks), and exclude references that occur within code
  * blocks.
  */
-export function parseReferences(body: string): ParsedReference[] {
+export function parseReferences(body: string): $ReadOnlyArray<ParsedReference> {
   // Note to maintainer: If it becomes necessary to encode references in a
   // richer format, consider implementing the type signature described in
   // https://github.com/sourcecred/sourcecred/pull/130#pullrequestreview-113849998
@@ -23,7 +23,9 @@ export function parseReferences(body: string): ParsedReference[] {
   return [].concat.apply([], blocks.map(parseReferencesFromRawString));
 }
 
-function parseReferencesFromRawString(textBlock: string): ParsedReference[] {
+function parseReferencesFromRawString(
+  textBlock: string
+): $ReadOnlyArray<ParsedReference> {
   return [
     ...findNumericReferences(textBlock),
     ...findRepoNumericReferences(textBlock),
@@ -33,7 +35,9 @@ function parseReferencesFromRawString(textBlock: string): ParsedReference[] {
   ];
 }
 
-function findRepoNumericReferences(textBlock: string): ParsedReference[] {
+function findRepoNumericReferences(
+  textBlock: string
+): $ReadOnlyArray<ParsedReference> {
   const re = new RegExp(
     `(?:\\W|^)((?:${githubOwnerPattern})/(?:${githubRepoPattern})#\\d+)(?=\\W|$)`,
     "gm"
@@ -44,14 +48,18 @@ function findRepoNumericReferences(textBlock: string): ParsedReference[] {
   }));
 }
 
-function findNumericReferences(textBlock: string): ParsedReference[] {
+function findNumericReferences(
+  textBlock: string
+): $ReadOnlyArray<ParsedReference> {
   return findAllMatches(/(?:\W|^)(#\d+)(?=\W|$)/gm, textBlock).map((x) => ({
     refType: "BASIC",
     ref: x[1],
   }));
 }
 
-function findUsernameReferences(textBlock: string): ParsedReference[] {
+function findUsernameReferences(
+  textBlock: string
+): $ReadOnlyArray<ParsedReference> {
   const pairedWithPattern =
     "(?:\\W|^)(?:P|p)aired(?:-| )(?:w|W)ith:? " +
     `(@(?:${githubOwnerPattern}))(?=\\W|$)`;
@@ -74,7 +82,9 @@ function findUsernameReferences(textBlock: string): ParsedReference[] {
   return [...pairedWithRefs, ...basicRefs];
 }
 
-function findGithubUrlReferences(textBlock: string): ParsedReference[] {
+function findGithubUrlReferences(
+  textBlock: string
+): $ReadOnlyArray<ParsedReference> {
   const urlRegex = new RegExp(
     "" +
       /(?:\W|^)/.source +
@@ -99,7 +109,9 @@ function findGithubUrlReferences(textBlock: string): ParsedReference[] {
   }));
 }
 
-function findCommitReferences(textBlock: string): ParsedReference[] {
+function findCommitReferences(
+  textBlock: string
+): $ReadOnlyArray<ParsedReference> {
   const hashReferences = findAllMatches(
     /(?:\W|^)([a-fA-F0-9]{40,})(?=\W|$)/gm,
     textBlock
@@ -140,7 +152,7 @@ function findCommitReferences(textBlock: string): ParsedReference[] {
   return [...hashReferences, ...urlReferences];
 }
 
-function findAllMatches(re: RegExp, s: string): any[] {
+function findAllMatches(re: RegExp, s: string): $ReadOnlyArray<any> {
   // modified from: https://stackoverflow.com/a/6323598
   let m;
   const matches = [];

--- a/src/plugins/github/relationalView.js
+++ b/src/plugins/github/relationalView.js
@@ -52,7 +52,9 @@ export class RelationalView {
   _commits: Map<N.RawAddress, CommitEntry>;
   _reviews: Map<N.RawAddress, ReviewEntry>;
   _userlikes: Map<N.RawAddress, UserlikeEntry>;
+  // eslint-disable-next-line flowtype/no-mutable-array
   _mapReferences: Map<N.RawAddress, N.ReferentAddress[]>;
+  // eslint-disable-next-line flowtype/no-mutable-array
   _mapReferencedBy: Map<N.RawAddress, N.TextContentAddress[]>;
 
   constructor(): void {
@@ -444,7 +446,9 @@ export class RelationalView {
     return {content: json.content, user: authorAddresses[0]};
   }
 
-  _addNullableAuthor(json: NullableAuthorJSON): UserlikeAddress[] {
+  _addNullableAuthor(
+    json: NullableAuthorJSON
+  ): $ReadOnlyArray<UserlikeAddress> {
     if (json == null) {
       return [];
     } else {
@@ -548,7 +552,11 @@ export class RelationalView {
         return; // user can't author the same thing twice
       }
     }
-    e._entry.authors.push(extraAuthor.address());
+    // eslint-disable-next-line flowtype/no-mutable-array
+    const entryAuthors: UserlikeAddress[] = ((e._entry.authors: $ReadOnlyArray<
+      UserlikeAddress
+    >): any);
+    entryAuthors.push(extraAuthor.address());
   }
 
   *_referencedBy(e: ReferentEntity): Iterator<TextContentEntity> {
@@ -673,8 +681,8 @@ export class _Entity<+T: Entry> {
 type RepoEntry = {|
   +address: RepoAddress,
   +url: string,
-  +issues: IssueAddress[],
-  +pulls: PullAddress[],
+  +issues: $ReadOnlyArray<IssueAddress>,
+  +pulls: $ReadOnlyArray<PullAddress>,
 |};
 
 export class Repo extends _Entity<RepoEntry> {
@@ -709,9 +717,9 @@ type IssueEntry = {|
   +title: string,
   +body: string,
   +url: string,
-  +comments: CommentAddress[],
-  +authors: UserlikeAddress[],
-  +reactions: ReactionRecord[],
+  +comments: $ReadOnlyArray<CommentAddress>,
+  +authors: $ReadOnlyArray<UserlikeAddress>,
+  +reactions: $ReadOnlyArray<ReactionRecord>,
 |};
 
 export class Issue extends _Entity<IssueEntry> {
@@ -757,13 +765,13 @@ type PullEntry = {|
   +title: string,
   +body: string,
   +url: string,
-  +comments: CommentAddress[],
-  +reviews: ReviewAddress[],
+  +comments: $ReadOnlyArray<CommentAddress>,
+  +reviews: $ReadOnlyArray<ReviewAddress>,
   +mergedAs: ?GitNode.CommitAddress,
   +additions: number,
   +deletions: number,
-  +authors: UserlikeAddress[],
-  +reactions: ReactionRecord[],
+  +authors: $ReadOnlyArray<UserlikeAddress>,
+  +reactions: $ReadOnlyArray<ReactionRecord>,
 |};
 
 export class Pull extends _Entity<PullEntry> {
@@ -823,9 +831,9 @@ type ReviewEntry = {|
   +address: ReviewAddress,
   +body: string,
   +url: string,
-  +comments: CommentAddress[],
+  +comments: $ReadOnlyArray<CommentAddress>,
   +state: ReviewState,
-  +authors: UserlikeAddress[],
+  +authors: $ReadOnlyArray<UserlikeAddress>,
 |};
 
 export class Review extends _Entity<ReviewEntry> {
@@ -864,8 +872,8 @@ type CommentEntry = {|
   +address: CommentAddress,
   +body: string,
   +url: string,
-  +authors: UserlikeAddress[],
-  +reactions: ReactionRecord[],
+  +authors: $ReadOnlyArray<UserlikeAddress>,
+  +reactions: $ReadOnlyArray<ReactionRecord>,
 |};
 
 export class Comment extends _Entity<CommentEntry> {
@@ -910,7 +918,7 @@ export class Comment extends _Entity<CommentEntry> {
 type CommitEntry = {|
   +address: GitNode.CommitAddress,
   +url: string,
-  +authors: UserlikeAddress[],
+  +authors: $ReadOnlyArray<UserlikeAddress>,
   +message: string,
 |};
 
@@ -1026,6 +1034,6 @@ export opaque type RelationalViewJSON = Compatible<{|
   +comments: AddressEntryMapJSON<CommentEntry>,
   +commits: AddressEntryMapJSON<CommitEntry>,
   +userlikes: AddressEntryMapJSON<UserlikeEntry>,
-  +references: AddressEntryMapJSON<N.ReferentAddress[]>,
-  +referencedBy: AddressEntryMapJSON<N.TextContentAddress[]>,
+  +references: AddressEntryMapJSON<$ReadOnlyArray<N.ReferentAddress>>,
+  +referencedBy: AddressEntryMapJSON<$ReadOnlyArray<N.TextContentAddress>>,
 |}>;

--- a/src/util/dedent.js
+++ b/src/util/dedent.js
@@ -18,7 +18,10 @@
  *
  * Lines that contain only whitespace are not used for measuring.
  */
-export default function dedent(strings: string[], ...values: string[]) {
+export default function dedent(
+  strings: $ReadOnlyArray<string>,
+  ...values: $ReadOnlyArray<string>
+) {
   const lineLengths = strings
     .join("")
     .split("\n")

--- a/src/util/map.js
+++ b/src/util/map.js
@@ -24,7 +24,9 @@ export function fromObject<K, V, InK: K & string, InV: V>(object: {
   [InK]: InV,
 }): Map<K, V> {
   const result = new Map();
-  const keys = (((Object.keys(object): string[]): any): InK[]);
+  const keys = (((Object.keys(object): $ReadOnlyArray<
+    string
+  >): any): $ReadOnlyArray<InK>);
   for (const key of keys) {
     result.set(key, object[key]);
   }
@@ -155,6 +157,7 @@ export function merge<K, V>(
  * If the key is already in the map, its value will be mutated, not
  * replaced.
  */
+// eslint-disable-next-line flowtype/no-mutable-array
 export function pushValue<K, V>(map: Map<K, V[]>, key: K, value: V): void {
   let arr = map.get(key);
   if (arr == null) {

--- a/src/util/map.test.js
+++ b/src/util/map.test.js
@@ -180,8 +180,9 @@ describe("util/map", () => {
     });
     it("allows mapping to a different value type", () => {
       const input: Map<number, string> = new Map().set(1, "one").set(2, "two");
-      const output: Map<number, string[]> = MapUtil.mapValues(input, (_, s) =>
-        s.split("")
+      const output: Map<number, $ReadOnlyArray<string>> = MapUtil.mapValues(
+        input,
+        (_, s) => s.split("")
       );
       expect(input).toEqual(new Map().set(1, "one").set(2, "two"));
       expect(output).toEqual(


### PR DESCRIPTION
This enables an eslint rule disallowing the use of mutable arrays in
favor of read only arrays. There are a few cases where we genuinely need
mutable arrays, so we added a lint exception. Note that in the future,
you can still write `[]` for convenience and then call `yarn lint --fix`
to fix them all up before committing.

There are a few cases where we have now marked function outputs as
readonly when returning a mutable instance would be totally fine. We
could mark them all as exceptions, but I like adopting a policy of "read
only unless actually required mutable" because it is simpler to
enforce/maintain. A caller who needs to mutate their copy can always
just call  `.slice()`.

Test plan: `yarn test`