### PR TITLE
Require exact types by default

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -16,7 +16,6 @@ module.exports = {
     "no-useless-constructor": ["off"],
     // TODO(@decentralion): Enable this rule.
     //    "flowtype/no-mutable-array": [2],
-    // TODO(@decentralion): Enable this rule.
-    //    "flowtype/require-exact-type": [2, "always"],
+    "flowtype/require-exact-type": [2, "always"],
   },
 };

--- a/src/graphql/queries.js
+++ b/src/graphql/queries.js
@@ -51,7 +51,10 @@ export type InlineFragment = {|
   +selections: Selection[],
 |};
 
-export type Arguments = {[string]: Value};
+// The next line should be exact, but flow's support isn't great
+// and doing so is a miserable change
+// eslint-disable-next-line flowtype/require-exact-type
+export type Arguments = {+[string]: Value};
 export type Value =
   | VariableValue
   | LiteralValue
@@ -238,7 +241,7 @@ function formatList<T>(
  * join the keys and their corresponding results with a formatter.
  */
 function formatObject<T>(
-  object: {[string]: T},
+  object: {+[string]: T},
   subformatter: (value: T, ls: LayoutStrategy) => string,
   ls: LayoutStrategy
 ): string {

--- a/src/graphql/schema.js
+++ b/src/graphql/schema.js
@@ -31,7 +31,7 @@ export type ObjectId = string;
 //     represented as `PRIMITIVE`s (except for `ID`s).
 //   - Connections are supported as object fields, but arbitrary lists
 //     are not.
-export type Schema = {+[Typename]: NodeType};
+export type Schema = {|+[Typename]: NodeType|};
 export type NodeType =
   | {|+type: "OBJECT", +fields: {|+[Fieldname]: FieldType|}|}
   | {|+type: "UNION", +clauses: {|+[Typename]: true|}|};
@@ -46,7 +46,7 @@ export type FieldType =
 const ID_FIELD_NAME = "id";
 
 export function schema(types: {[Typename]: NodeType}): Schema {
-  const result = {};
+  const result: {|[Typename]: NodeType|} = ({}: any);
   for (const typename of Object.keys(types)) {
     const type = types[typename];
     switch (type.type) {

--- a/src/util/compat.test.js
+++ b/src/util/compat.test.js
@@ -4,8 +4,8 @@ import {toCompat, fromCompat} from "./compat";
 import type {Compatible} from "./compat";
 
 describe("util/compat", () => {
-  type FooV1 = {foo: number};
-  type FooV2 = {bar: {foo: number}};
+  type FooV1 = {|foo: number|};
+  type FooV2 = {|bar: {|foo: number|}|};
   const type = "Foo Plugin's Experiment";
   const v1 = "v1";
   const v2 = "v2";


### PR DESCRIPTION
This enables the flowtype lint rule for requiring exact object types. I
added an exception in queries.js because it was a huge mess to properly
label it as exact. I also added a flyby fix to mark some objects as
readonly at @wchargin's suggestion.

Test plan: `yarn test`