### PR TITLE
graphql: improve coverage of `queries` module

### DIFF
--- a/src/graphql/__snapshots__/queries.test.js.snap
+++ b/src/graphql/__snapshots__/queries.test.js.snap
@@ -322,6 +322,26 @@ Array [
             "type": "INLINE_FRAGMENT",
             "typeCondition": "Gizmo",
           },
+          Object {
+            "selections": Array [
+              Object {
+                "alias": null,
+                "args": Object {},
+                "name": "__typename",
+                "selections": Array [],
+                "type": "FIELD",
+              },
+              Object {
+                "alias": null,
+                "args": Object {},
+                "name": "id",
+                "selections": Array [],
+                "type": "FIELD",
+              },
+            ],
+            "type": "INLINE_FRAGMENT",
+            "typeCondition": null,
+          },
         ],
         "type": "FIELD",
       },
@@ -374,7 +394,7 @@ Array [
 ]
 `;
 
-exports[`graphql/queries end-to-end-test cases for a query using lots of features should stringify as inline 1`] = `"query QueryWithParameters($qp1: String! $qp2: String!) { thing(id: 12345 name: $qp1) { fruit(type: APPLE tasty: true) ...otherThings } more { ... on Widget { mcguffins { quantity } goo: slime(state: SLIMY) { availability } } ... on Gizmo { cogs(attributes: { teeth: [ 12 14 16 ] shaft: null }) } } } query QueryWithoutParameters { rateLimit { remaining } } fragment otherThings on Thing { __typename quality }"`;
+exports[`graphql/queries end-to-end-test cases for a query using lots of features should stringify as inline 1`] = `"query QueryWithParameters($qp1: String! $qp2: String!) { thing(id: 12345 name: $qp1) { fruit(type: APPLE tasty: true) ...otherThings } more { ... on Widget { mcguffins { quantity } goo: slime(state: SLIMY) { availability } } ... on Gizmo { cogs(attributes: { teeth: [ 12 14 16 ] shaft: null }) } ... { __typename id } } } query QueryWithoutParameters { rateLimit { remaining } } fragment otherThings on Thing { __typename quality }"`;
 
 exports[`graphql/queries end-to-end-test cases for a query using lots of features should stringify as multiline 1`] = `
 "query QueryWithParameters($qp1: String! $qp2: String!) {
@@ -393,6 +413,10 @@ exports[`graphql/queries end-to-end-test cases for a query using lots of feature
     }
     ... on Gizmo {
       cogs(attributes: { teeth: [ 12 14 16 ] shaft: null })
+    }
+    ... {
+      __typename
+      id
     }
   }
 }

--- a/src/graphql/queries.js
+++ b/src/graphql/queries.js
@@ -259,8 +259,9 @@ export const stringify = {
         return stringify.queryDefinition(definition, ls);
       case "FRAGMENT":
         return stringify.fragmentDefinition(definition, ls);
+      // istanbul ignore next: unreachable per Flow
       default:
-        throw new Error(`Unknown definition type: ${definition.type}`);
+        throw new Error(`Unknown definition type: ${(definition.type: empty)}`);
     }
   },
 
@@ -314,8 +315,9 @@ export const stringify = {
         return stringify.fragmentSpread(selection, ls);
       case "INLINE_FRAGMENT":
         return stringify.inlineFragment(selection, ls);
+      // istanbul ignore next: unreachable per Flow
       default:
-        throw new Error(`Unknown selection type: ${selection.type}`);
+        throw new Error(`Unknown selection type: ${(selection.type: empty)}`);
     }
   },
 
@@ -382,8 +384,9 @@ export const stringify = {
         return stringify.listValue(value, ls);
       case "OBJECT":
         return stringify.objectValue(value, ls);
+      // istanbul ignore next: unreachable per Flow
       default:
-        throw new Error(`Unknown value type: ${value.type}`);
+        throw new Error(`Unknown value type: ${(value.type: empty)}`);
     }
   },
 

--- a/src/graphql/queries.test.js
+++ b/src/graphql/queries.test.js
@@ -103,6 +103,7 @@ function featurefulQuery(): Body {
               }),
             }),
           ]),
+          b.inlineFragment(null, [b.field("__typename"), b.field("id")]),
         ]),
       ]
     ),


### PR DESCRIPTION
Summary:
Each change provides real value, by either testing a plausible happy
path that simply was not tested previously, or by adding an
`empty`-assertion to a switch against a discriminated union type.

Test Plan:
For the snapshot change relating to the query formatter, note that
Prettier formats the changed portion of the snapshot in the same way, by
visiting <https://prettier.io/playground> and setting the parser to
"graphql". (Prettier in general agrees with the stringification defined
by this module, except for commas and spacing, for which we don’t bother
to generate impeccably pretty output.)

Run `yarn coverage` and note that the coverage of the whole `graphql`
package is 100% on all axes.

wchargin-branch: graphql-coverage