### PR TITLE
flow: change better-sqlite3 `each` to `iterator`

### DIFF
--- a/flow-typed/npm/better-sqlite3_vx.x.x.js
+++ b/flow-typed/npm/better-sqlite3_vx.x.x.js
@@ -78,13 +78,11 @@ declare class bettersqlite3$Statement {
     namedParams: bettersqlite3$BindingDictionary,
     ...params: bettersqlite3$BoundValue[]
   ): any[];
-  each(params: any, cb: (row: any) => void): void;
-  each(cb: (row: any) => void): void;
-  each(...params: bettersqlite3$BoundValue[]): void;
-  each(
+  iterate(...params: bettersqlite3$BoundValue[]): Iterator<any>;
+  iterate(
     namedParams: bettersqlite3$BindingDictionary,
     ...params: bettersqlite3$BoundValue[]
-  ): void;
+  ): Iterator<any>;
   pluck(toggleState?: boolean): this;
   bind(...params: bettersqlite3$BoundValue[]): this;
   bind(


### PR DESCRIPTION
Summary:
This was changed in the v4.0.0 release of `better-sqlite3`:
<https://github.com/JoshuaWise/better-sqlite3/pull/61>

Test Plan:
Create the following test file, and note that it fails to typecheck
before this change (on two counts) but passes after:

```js
// @flow
import Database from "better-sqlite3";
const db = new Database(":memory:");
db.prepare("CREATE TABLE foo (id)").run();
const insert = db.prepare("INSERT INTO foo (id) VALUES (?)");
insert.run(1);
insert.run(2);
const retrieve = db.prepare("SELECT id FROM foo").pluck();

console.log("Old way:");
try {
  // $ExpectFlowError
  retrieve.each((x) => void console.log(x));
} catch (e) {
  console.log("Failed (good):", String(e));
}
console.log();

console.log("New way:");
for (const value of retrieve.iterate()) {
  console.log(value);
}
```

Also, run the test with `NODE_ENV=development babel-node src/test.js`,
and note that it outputs:

```
$ NODE_ENV=development babel-node src/test.js
Old way:
Failed (good): TypeError: retrieve.each is not a function

New way:
1
2
```

wchargin-branch: flow-better-sqlite3-iterator