### PR TITLE
travis: fix notification email config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,6 @@ script: yarn test
 notifications:
   email:
     recipients:
-      wchargin+travis-sourcecred@gmail.com
-      decentralion+travis-sourcecred@dandelion.io
+      - wchargin+travis-sourcecred@gmail.com
+      - decentralion+travis-sourcecred@dandelion.io
     on_failure: always


### PR DESCRIPTION
Summary:
In #339, we attempted to configure Travis to email us on build failure.
But we misread [the docs]: the emails need to be preceded by a hyphen.

[the docs]: https://docs.travis-ci.com/user/notifications#configuring-email-notifications

This is understandable because the Travis documentation renders the
critical hyphen with `#999` against a background of `#f5f2f0` at 12px,
which has a contrast ratio of only 2.55, failing WCAG 2.0 categorically.

Test Plan:
Fingers crossed.

wchargin-branch: travis-email-config