### PR TITLE
prettier: ignore sharness/

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -2,3 +2,4 @@
 /build
 /coverage
 /flow-typed
+/sharness


### PR DESCRIPTION
Summary:
Sharness tests use temporary directories under the `sharness/`
directory, which sometimes contain build output, which includes
JavaScript files. This creates a flaky failure in `yarn test`: if
`sharness` creates a file then `check-pretty` can complain about it.

Test Plan:
None.

wchargin-branch: prettier-ignore-sharness