### PR TITLE
travis: pin Node v8.x.x

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: node_js
 node_js:
-  - "node"
+  - "8"
 script: yarn test
 notifications:
   email:


### PR DESCRIPTION
Summary:
SourceCred officially supports Node v8.x.x, so Travis should be testing
against that version of Node.

This fixes a cron-only, Travis-only failure. The test for the build
script asserts that stderr only contains some known expected messages.
On Node v10, which Travis was using, there is an additional deprecation
message due to <https://github.com/yarnpkg/yarn/issues/5477>.

Test Plan:
To see that this fixes the current cron-only build failure, add the
`--full` argument to the `test` script in `package.json`, and push the
resulting tree to Travis. Note that it runs `sharness-full`, which
passes.

wchargin-branch: travis-node-8