### PR TITLE
mirror: add internal method `_createUpdate`

### DIFF
--- a/src/graphql/mirror.js
+++ b/src/graphql/mirror.js
@@ -247,6 +247,16 @@ export class Mirror {
       }
     });
   }
+
+  /**
+   * Register a new update, representing one communication with the
+   * remote server. A unique ID will be created and returned.
+   */
+  _createUpdate(updateTimestamp: Date): UpdateId {
+    return this._db
+      .prepare("INSERT INTO updates (time_epoch_millis) VALUES (?)")
+      .run(+updateTimestamp).lastInsertROWID;
+  }
 }
 
 /**
@@ -340,6 +350,8 @@ export function _buildSchemaInfo(schema: Schema.Schema): SchemaInfo {
   }
   return result;
 }
+
+type UpdateId = number;
 
 /**
  * Execute a function inside a database transaction.


### PR DESCRIPTION
Summary:
It’s useful to add this simple function now because the rest of the
commits required to implement #622 will want to use it extensively in
test code. Actual clients of the API will not need to use it, because
the concept of “updates” is an implementation detail: clients will
always provide simple timestamps.

Test Plan:
Unit tests included, with full coverage; run `yarn unit`.

wchargin-branch: mirror-createupdate