### PR TITLE
mirror: add public method `registerObject`

### DIFF
--- a/src/graphql/mirror.test.js
+++ b/src/graphql/mirror.test.js
@@ -213,6 +213,141 @@ describe("graphql/mirror", () => {
         ).toEqual(3);
       });
     });
+
+    describe("registerObject", () => {
+      it("adds an object and its connections, links, and primitives", () => {
+        const db = new Database(":memory:");
+        const schema = buildGithubSchema();
+        const mirror = new Mirror(db, schema);
+        mirror.registerObject({
+          typename: "Issue",
+          id: "issue:sourcecred/example-github#1",
+        });
+
+        const issueId = "issue:sourcecred/example-github#1";
+        expect(
+          db
+            .prepare("SELECT * FROM objects WHERE typename = ? AND id = ?")
+            .all("Issue", issueId)
+        ).toHaveLength(1);
+        expect(
+          db
+            .prepare(
+              "SELECT fieldname FROM connections WHERE object_id = ? " +
+                "ORDER BY fieldname ASC"
+            )
+            .pluck()
+            .all(issueId)
+        ).toEqual(["comments"]);
+        expect(
+          db
+            .prepare(
+              "SELECT fieldname FROM links WHERE parent_id = ? " +
+                "ORDER BY fieldname ASC"
+            )
+            .pluck()
+            .all(issueId)
+        ).toEqual(["author", "parent"].sort());
+        expect(
+          db.prepare("SELECT * FROM primitives_Issue WHERE id = ?").all(issueId)
+        ).toEqual([
+          {
+            id: issueId,
+            url: null,
+            title: null,
+          },
+        ]);
+
+        expect(
+          db
+            .prepare(
+              "SELECT COUNT(1) FROM connections WHERE last_update IS NOT NULL"
+            )
+            .pluck()
+            .get()
+        ).toBe(0);
+        expect(
+          db
+            .prepare("SELECT COUNT(1) FROM links WHERE child_id IS NOT NULL")
+            .pluck()
+            .get()
+        ).toBe(0);
+        expect(
+          db
+            .prepare(
+              "SELECT COUNT(1) FROM primitives_Issue WHERE " +
+                "url IS NOT NULL OR title IS NOT NULL"
+            )
+            .pluck()
+            .get()
+        ).toBe(0);
+      });
+      it("doesn't touch an existing object with the same typename", () => {
+        const db = new Database(":memory:");
+        const schema = buildGithubSchema();
+        const mirror = new Mirror(db, schema);
+        const objectId = "issue:sourcecred/example-github#1";
+        mirror.registerObject({
+          typename: "Issue",
+          id: objectId,
+        });
+
+        const updateId = mirror._createUpdate(new Date(123));
+        db.prepare(
+          "UPDATE objects SET last_update = :updateId WHERE id = :objectId"
+        ).run({updateId, objectId});
+
+        mirror.registerObject({
+          typename: "Issue",
+          id: objectId,
+        });
+        expect(
+          db.prepare("SELECT * FROM objects WHERE id = ?").get(objectId)
+        ).toEqual({
+          typename: "Issue",
+          id: objectId,
+          last_update: updateId,
+        });
+      });
+      it("rejects if an existing object's typename were to change", () => {
+        const db = new Database(":memory:");
+        const schema = buildGithubSchema();
+        const mirror = new Mirror(db, schema);
+        mirror.registerObject({typename: "Issue", id: "my-favorite-id"});
+        expect(() => {
+          mirror.registerObject({typename: "User", id: "my-favorite-id"});
+        }).toThrow(
+          'Inconsistent type for ID "my-favorite-id": ' +
+            'expected "Issue", got "User"'
+        );
+      });
+      it("rejects an unknown type", () => {
+        const db = new Database(":memory:");
+        const schema = buildGithubSchema();
+        const mirror = new Mirror(db, schema);
+        expect(() =>
+          mirror.registerObject({
+            typename: "Wat",
+            id: "repo:sourcecred/example-github",
+          })
+        ).toThrow('Unknown type: "Wat"');
+        expect(db.prepare("SELECT * FROM objects").all()).toHaveLength(0);
+        expect(db.prepare("SELECT * FROM connections").all()).toHaveLength(0);
+      });
+      it("rejects a union type", () => {
+        const db = new Database(":memory:");
+        const schema = buildGithubSchema();
+        const mirror = new Mirror(db, schema);
+        expect(() =>
+          mirror.registerObject({
+            typename: "Actor",
+            id: "user:credbot",
+          })
+        ).toThrow('Cannot add object of non-object type: "Actor" (UNION)');
+        expect(db.prepare("SELECT * FROM objects").all()).toHaveLength(0);
+        expect(db.prepare("SELECT * FROM connections").all()).toHaveLength(0);
+      });
+    });
   });
 
   describe("_buildSchemaInfo", () => {


### PR DESCRIPTION
Summary:
This function informs the GraphQL mirror of the existence of an object,
specified by its global ID and its concrete typename (“concrete” meaning
“object type”—like `User`, not `Actor`).

The function will be called extensively internally as more objects are
discovered while traversing the graph, but also needs to be exposed as a
public entry point: a client needs to call this function at least once
to register the root node of interest. A typical client workflow, once
all of #622 is implemented, might be:

 1. Issue a standalone GraphQL query to find the ID of a root node, like
    a GitHub repository: `repository(owner: "foo", name: "bar") { id }`.
 2. Call `registerObject` with the ID found in the previous step.
 3. Instruct the mirror to recursively update all dependencies.
 4. Extract data from the mirror.

As of this commit, steps (1) and (2) are possible.

This commit makes progress toward #622.

Test Plan:
Unit tests included, with full coverage; run `yarn unit`.

wchargin-branch: mirror-registerobject