### PR TITLE
Remove obsolete eslint TODOs

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -14,9 +14,5 @@ module.exports = {
     ],
     "no-use-before-define": ["off"],
     "no-useless-constructor": ["off"],
-    // TODO(@decentralion): Enable this rule.
-    //    "flowtype/no-mutable-array": [2],
-    // TODO(@decentralion): Enable this rule.
-    //    "flowtype/require-exact-type": [2, "always"],
   },
 };


### PR DESCRIPTION
I wanted to add two new flowtype lint rules. However, as seen in #853
and #854, these rules don't work very well. As such, I'm giving up on
those two and removing the TODOs.

Test plan: n/a