### PR TITLE
Load commits' short hash and summary

### DIFF
--- a/src/plugins/git/__snapshots__/createGraph.test.js.snap
+++ b/src/plugins/git/__snapshots__/createGraph.test.js.snap
@@ -35,7 +35,7 @@ Array [
           "COMMIT",
           "e8b7a8f19701cd5a25e4a097d513ead60e5f8bcc",
         ],
-        "dstIndex": 6,
+        "dstIndex": 7,
         "srcIndex": 1,
       },
       Object {
@@ -75,13 +75,28 @@ Array [
           "HAS_PARENT",
           "2",
           "COMMIT",
+          "c90f6424017f787bbbaf22e4082a01355546f7e3",
+          "2",
+          "COMMIT",
+          "3715ddfb8d4c4fd2a6f6af75488c82f84c92ec2f",
+        ],
+        "dstIndex": 0,
+        "srcIndex": 5,
+      },
+      Object {
+        "address": Array [
+          "sourcecred",
+          "git",
+          "HAS_PARENT",
+          "2",
+          "COMMIT",
           "d160cca97611e9dfed642522ad44408d0292e8ea",
           "2",
           "COMMIT",
           "8d287c3bfbf8455ef30187bf5153ffc1b6eef268",
         ],
         "dstIndex": 2,
-        "srcIndex": 5,
+        "srcIndex": 6,
       },
       Object {
         "address": Array [
@@ -95,8 +110,8 @@ Array [
           "COMMIT",
           "d160cca97611e9dfed642522ad44408d0292e8ea",
         ],
-        "dstIndex": 5,
-        "srcIndex": 6,
+        "dstIndex": 6,
+        "srcIndex": 7,
       },
     ],
     "nodes": Array [
@@ -129,6 +144,12 @@ Array [
         "git",
         "COMMIT",
         "c2b51945e7457546912a8ce158ed9d294558d294",
+      ],
+      Array [
+        "sourcecred",
+        "git",
+        "COMMIT",
+        "c90f6424017f787bbbaf22e4082a01355546f7e3",
       ],
       Array [
         "sourcecred",

--- a/src/plugins/git/example/__snapshots__/exampleRepo.test.js.snap
+++ b/src/plugins/git/example/__snapshots__/exampleRepo.test.js.snap
@@ -9,6 +9,7 @@ Array [
   "e8b7a8f19701cd5a25e4a097d513ead60e5f8bcc",
   "69c5aad50eec8f2a0a07c988c3b283a6490eb45b",
   "3715ddfb8d4c4fd2a6f6af75488c82f84c92ec2f",
+  "c90f6424017f787bbbaf22e4082a01355546f7e3",
 ]
 `;
 

--- a/src/plugins/git/example/example-git.json
+++ b/src/plugins/git/example/example-git.json
@@ -4,41 +4,63 @@
             "hash": "3715ddfb8d4c4fd2a6f6af75488c82f84c92ec2f",
             "parentHashes": [
                 "69c5aad50eec8f2a0a07c988c3b283a6490eb45b"
-            ]
+            ],
+            "shortHash": "3715ddf",
+            "summary": "Clean up TODOS"
         },
         "69c5aad50eec8f2a0a07c988c3b283a6490eb45b": {
             "hash": "69c5aad50eec8f2a0a07c988c3b283a6490eb45b",
             "parentHashes": [
                 "e8b7a8f19701cd5a25e4a097d513ead60e5f8bcc"
-            ]
+            ],
+            "shortHash": "69c5aad",
+            "summary": "Solve quantum gravity"
         },
         "8d287c3bfbf8455ef30187bf5153ffc1b6eef268": {
             "hash": "8d287c3bfbf8455ef30187bf5153ffc1b6eef268",
             "parentHashes": [
                 "c08ee3a4edea384d5291ffcbf06724a13ed72325"
-            ]
+            ],
+            "shortHash": "8d287c3",
+            "summary": "Add gravity defiance module"
         },
         "c08ee3a4edea384d5291ffcbf06724a13ed72325": {
             "hash": "c08ee3a4edea384d5291ffcbf06724a13ed72325",
             "parentHashes": [
                 "c2b51945e7457546912a8ce158ed9d294558d294"
-            ]
+            ],
+            "shortHash": "c08ee3a",
+            "summary": "Add repository description"
         },
         "c2b51945e7457546912a8ce158ed9d294558d294": {
             "hash": "c2b51945e7457546912a8ce158ed9d294558d294",
-            "parentHashes": []
+            "parentHashes": [],
+            "shortHash": "c2b5194",
+            "summary": "Initial commit"
+        },
+        "c90f6424017f787bbbaf22e4082a01355546f7e3": {
+            "hash": "c90f6424017f787bbbaf22e4082a01355546f7e3",
+            "parentHashes": [
+                "3715ddfb8d4c4fd2a6f6af75488c82f84c92ec2f"
+            ],
+            "shortHash": "c90f642",
+            "summary": "  This | has leading whitespace."
         },
         "d160cca97611e9dfed642522ad44408d0292e8ea": {
             "hash": "d160cca97611e9dfed642522ad44408d0292e8ea",
             "parentHashes": [
                 "8d287c3bfbf8455ef30187bf5153ffc1b6eef268"
-            ]
+            ],
+            "shortHash": "d160cca",
+            "summary": "Discover gravity"
         },
         "e8b7a8f19701cd5a25e4a097d513ead60e5f8bcc": {
             "hash": "e8b7a8f19701cd5a25e4a097d513ead60e5f8bcc",
             "parentHashes": [
                 "d160cca97611e9dfed642522ad44408d0292e8ea"
-            ]
+            ],
+            "shortHash": "e8b7a8f",
+            "summary": "Pull quantum gravity defiance from upstream"
         }
     }
 }

--- a/src/plugins/git/example/exampleRepo.js
+++ b/src/plugins/git/example/exampleRepo.js
@@ -97,6 +97,9 @@ export function createExampleRepo(intoDirectory: string): RepositoryInfo {
   git.exec(["rm", "TODOS.txt"]);
   commit("Clean up TODOS");
 
+  git.writeAndStage("src/whatever.py", "import json\nprint('hello world')\n");
+  commit("  This | has leading whitespace.");
+
   return {path: repositoryPath, commits};
 }
 

--- a/src/plugins/git/loadRepository.js
+++ b/src/plugins/git/loadRepository.js
@@ -47,11 +47,14 @@ function objectMap<T: {+hash: Hash}>(ts: $ReadOnlyArray<T>): {[Hash]: T} {
 }
 
 function findCommits(git: GitDriver, rootRef: string): Commit[] {
-  return git(["log", "--oneline", "--pretty=%H %P", rootRef])
+  return git(["log", "--format=%H %h %P|%s", rootRef])
     .split("\n")
     .filter((line) => line.length > 0)
     .map((line) => {
-      const [hash, ...parentHashes] = line.trim().split(" ");
-      return {hash, parentHashes};
+      const pipeLocation = line.indexOf("|");
+      const first = line.slice(0, pipeLocation).trim();
+      const summary = line.slice(pipeLocation + 1);
+      const [hash, shortHash, ...parentHashes] = first.split(" ");
+      return {hash, shortHash, summary, parentHashes};
     });
 }

--- a/src/plugins/git/mergeRepository.test.js
+++ b/src/plugins/git/mergeRepository.test.js
@@ -10,10 +10,14 @@ describe("plugins/git/mergeRepository", () => {
       commits: {
         commit1: {
           hash: "commit1",
+          shortHash: "commit1",
+          summary: "a commit",
           parentHashes: [],
         },
         commit2: {
           hash: "commit2",
+          shortHash: "commit2",
+          summary: "another commit",
           parentHashes: ["commit1"],
         },
       },
@@ -22,10 +26,14 @@ describe("plugins/git/mergeRepository", () => {
       commits: {
         commit1: {
           hash: "commit1",
+          shortHash: "commit1",
+          summary: "a commit",
           parentHashes: [],
         },
         commit3: {
           hash: "commit3",
+          shortHash: "commit3",
+          summary: "a third commit",
           parentHashes: ["commit1"],
         },
       },
@@ -56,6 +64,8 @@ describe("plugins/git/mergeRepository", () => {
         commits: {
           commit1: {
             hash: "commit1",
+            shortHash: "commit1",
+            summary: "a conflicting commit",
             parentHashes: ["commit0"],
           },
         },

--- a/src/plugins/git/types.js
+++ b/src/plugins/git/types.js
@@ -7,4 +7,8 @@ export type Hash = string;
 export type Commit = {|
   +hash: Hash,
   +parentHashes: $ReadOnlyArray<Hash>,
+  // a shorter version of the hash;
+  // shortHash is not guaranteed unique.
+  +shortHash: string,
+  +summary: string, // Oneline commit summary
 |};


### PR DESCRIPTION
This modifies the Git Commit type to includea short hash and a oneline
summary, and modifies `loadRepository` so that we actually get that
data.

Test plan: Observe that the snapshot is updated, and the updates are
correct. `yarn test --full` passes.