### PR TITLE
Remove git adresses for trees, blobs, and entries

### DIFF
--- a/src/plugins/git/__snapshots__/edges.test.js.snap
+++ b/src/plugins/git/__snapshots__/edges.test.js.snap
@@ -1,64 +1,5 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`plugins/git/edges createEdge works for "becomes" 1`] = `
-Object {
-  "addressParts": Array [
-    "sourcecred",
-    "git",
-    "BECOMES",
-    "3",
-    "TREE_ENTRY",
-    "de07d6d2b2977734cf39d2b9aff4135eefce3eb7",
-    "old_science.txt",
-    "3",
-    "TREE_ENTRY",
-    "7be3ecfee5314ffa9b2d93fc4377792b2d6d70ed",
-    "science.txt",
-  ],
-  "dstParts": Array [
-    "sourcecred",
-    "git",
-    "TREE_ENTRY",
-    "7be3ecfee5314ffa9b2d93fc4377792b2d6d70ed",
-    "science.txt",
-  ],
-  "srcParts": Array [
-    "sourcecred",
-    "git",
-    "TREE_ENTRY",
-    "de07d6d2b2977734cf39d2b9aff4135eefce3eb7",
-    "old_science.txt",
-  ],
-}
-`;
-
-exports[`plugins/git/edges createEdge works for "hasContents" 1`] = `
-Object {
-  "addressParts": Array [
-    "sourcecred",
-    "git",
-    "HAS_CONTENTS",
-    "3",
-    "TREE_ENTRY",
-    "7be3ecfee5314ffa9b2d93fc4377792b2d6d70ed",
-    "science.txt",
-  ],
-  "dstParts": Array [
-    "sourcecred",
-    "git",
-    "BLOB",
-    "f1f2514ca6d7a6a1a0511957021b1995bf9ace1c",
-  ],
-  "srcParts": Array [
-    "sourcecred",
-    "git",
-    "TREE_ENTRY",
-    "7be3ecfee5314ffa9b2d93fc4377792b2d6d70ed",
-    "science.txt",
-  ],
-}
-`;
-
 exports[`plugins/git/edges createEdge works for "hasParent" 1`] = `
 Object {
   "addressParts": Array [
@@ -83,58 +24,6 @@ Object {
     "git",
     "COMMIT",
     "3715ddfb8d4c4fd2a6f6af75488c82f84c92ec2f",
-  ],
-}
-`;
-
-exports[`plugins/git/edges createEdge works for "hasTree" 1`] = `
-Object {
-  "addressParts": Array [
-    "sourcecred",
-    "git",
-    "HAS_TREE",
-    "2",
-    "COMMIT",
-    "3715ddfb8d4c4fd2a6f6af75488c82f84c92ec2f",
-  ],
-  "dstParts": Array [
-    "sourcecred",
-    "git",
-    "TREE",
-    "7be3ecfee5314ffa9b2d93fc4377792b2d6d70ed",
-  ],
-  "srcParts": Array [
-    "sourcecred",
-    "git",
-    "COMMIT",
-    "3715ddfb8d4c4fd2a6f6af75488c82f84c92ec2f",
-  ],
-}
-`;
-
-exports[`plugins/git/edges createEdge works for "includes" 1`] = `
-Object {
-  "addressParts": Array [
-    "sourcecred",
-    "git",
-    "INCLUDES",
-    "3",
-    "TREE_ENTRY",
-    "7be3ecfee5314ffa9b2d93fc4377792b2d6d70ed",
-    "science.txt",
-  ],
-  "dstParts": Array [
-    "sourcecred",
-    "git",
-    "TREE_ENTRY",
-    "7be3ecfee5314ffa9b2d93fc4377792b2d6d70ed",
-    "science.txt",
-  ],
-  "srcParts": Array [
-    "sourcecred",
-    "git",
-    "TREE",
-    "7be3ecfee5314ffa9b2d93fc4377792b2d6d70ed",
   ],
 }
 `;

--- a/src/plugins/git/__snapshots__/nodes.test.js.snap
+++ b/src/plugins/git/__snapshots__/nodes.test.js.snap
@@ -1,20 +1,5 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`plugins/git/nodes snapshots as expected: blob 1`] = `
-Object {
-  "address": Array [
-    "sourcecred",
-    "git",
-    "BLOB",
-    "f1f2514ca6d7a6a1a0511957021b1995bf9ace1c",
-  ],
-  "structured": Object {
-    "hash": "f1f2514ca6d7a6a1a0511957021b1995bf9ace1c",
-    "type": "BLOB",
-  },
-}
-`;
-
 exports[`plugins/git/nodes snapshots as expected: commit 1`] = `
 Object {
   "address": Array [
@@ -26,38 +11,6 @@ Object {
   "structured": Object {
     "hash": "3715ddfb8d4c4fd2a6f6af75488c82f84c92ec2f",
     "type": "COMMIT",
-  },
-}
-`;
-
-exports[`plugins/git/nodes snapshots as expected: tree 1`] = `
-Object {
-  "address": Array [
-    "sourcecred",
-    "git",
-    "TREE",
-    "7be3ecfee5314ffa9b2d93fc4377792b2d6d70ed",
-  ],
-  "structured": Object {
-    "hash": "7be3ecfee5314ffa9b2d93fc4377792b2d6d70ed",
-    "type": "TREE",
-  },
-}
-`;
-
-exports[`plugins/git/nodes snapshots as expected: treeEntry 1`] = `
-Object {
-  "address": Array [
-    "sourcecred",
-    "git",
-    "TREE_ENTRY",
-    "7be3ecfee5314ffa9b2d93fc4377792b2d6d70ed",
-    "science.txt",
-  ],
-  "structured": Object {
-    "name": "science.txt",
-    "treeHash": "7be3ecfee5314ffa9b2d93fc4377792b2d6d70ed",
-    "type": "TREE_ENTRY",
   },
 }
 `;

--- a/src/plugins/git/__snapshots__/render.test.js.snap
+++ b/src/plugins/git/__snapshots__/render.test.js.snap
@@ -1,9 +1,3 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`plugins/git/render blob snapshots as expected 1`] = `"blob f1f2514ca6d7a6a1a0511957021b1995bf9ace1c"`;
-
 exports[`plugins/git/render commit snapshots as expected 1`] = `"commit 3715ddfb8d4c4fd2a6f6af75488c82f84c92ec2f"`;
-
-exports[`plugins/git/render tree snapshots as expected 1`] = `"tree 7be3ecfee5314ffa9b2d93fc4377792b2d6d70ed"`;
-
-exports[`plugins/git/render treeEntry snapshots as expected 1`] = `"entry \\"science.txt\\" in tree 7be3ecfee5314ffa9b2d93fc4377792b2d6d70ed"`;

--- a/src/plugins/git/edges.test.js
+++ b/src/plugins/git/edges.test.js
@@ -7,10 +7,6 @@ import * as GN from "./nodes";
 
 describe("plugins/git/edges", () => {
   const nodeExamples = {
-    blob: (): GN.BlobAddress => ({
-      type: GN.BLOB_TYPE,
-      hash: "f1f2514ca6d7a6a1a0511957021b1995bf9ace1c",
-    }),
     commit: (): GN.CommitAddress => ({
       type: GN.COMMIT_TYPE,
       hash: "3715ddfb8d4c4fd2a6f6af75488c82f84c92ec2f",
@@ -19,33 +15,11 @@ describe("plugins/git/edges", () => {
       type: GN.COMMIT_TYPE,
       hash: "69c5aad50eec8f2a0a07c988c3b283a6490eb45b",
     }),
-    tree: (): GN.TreeAddress => ({
-      type: GN.TREE_TYPE,
-      hash: "7be3ecfee5314ffa9b2d93fc4377792b2d6d70ed",
-    }),
-    treeEntry: (): GN.TreeEntryAddress => ({
-      type: GN.TREE_ENTRY_TYPE,
-      treeHash: "7be3ecfee5314ffa9b2d93fc4377792b2d6d70ed",
-      name: "science.txt",
-    }),
-    oldTreeEntry: (): GN.TreeEntryAddress => ({
-      type: GN.TREE_ENTRY_TYPE,
-      treeHash: "de07d6d2b2977734cf39d2b9aff4135eefce3eb7",
-      name: "old_science.txt",
-    }),
   };
 
   const edgeExamples = {
-    hasTree: () =>
-      createEdge.hasTree(nodeExamples.commit(), nodeExamples.tree()),
     hasParent: () =>
       createEdge.hasParent(nodeExamples.commit(), nodeExamples.parentCommit()),
-    includes: () =>
-      createEdge.includes(nodeExamples.tree(), nodeExamples.treeEntry()),
-    becomes: () =>
-      createEdge.becomes(nodeExamples.oldTreeEntry(), nodeExamples.treeEntry()),
-    hasContents: () =>
-      createEdge.hasContents(nodeExamples.treeEntry(), nodeExamples.blob()),
   };
 
   describe("createEdge", () => {

--- a/src/plugins/git/graphView.test.js
+++ b/src/plugins/git/graphView.test.js
@@ -78,18 +78,13 @@ describe("plugins/git/graphView", () => {
         const c3: GN.CommitAddress = {type: GN.COMMIT_TYPE, hash: "c3"};
         const e2 = GE.createEdge.hasParent(c1, c2);
         const e3 = GE.createEdge.hasParent(c1, c3);
-        const tree: GN.TreeAddress = {type: GN.TREE_TYPE, hash: "t1"};
         const foreignNode = NodeAddress.fromParts(["who", "are", "you"]);
         const baseGraph = () =>
           new Graph()
             .addNode(foreignNode)
             .addNode(GN.toRaw(c1))
             .addNode(GN.toRaw(c2))
-            .addNode(GN.toRaw(c3))
-            .addNode(GN.toRaw(tree))
-            .addEdge(GE.createEdge.hasTree(c1, tree))
-            .addEdge(GE.createEdge.hasTree(c2, tree))
-            .addEdge(GE.createEdge.hasTree(c3, tree));
+            .addNode(GN.toRaw(c3));
         it("for proper src", () => {
           const badEdge = {...e2, src: foreignNode};
           const g = baseGraph().addEdge(badEdge);

--- a/src/plugins/git/nodes.js
+++ b/src/plugins/git/nodes.js
@@ -10,49 +10,19 @@ export function _gitAddress(...parts: string[]): RawAddress {
   return NodeAddress.append(GIT_PREFIX, ...parts);
 }
 
-export const BLOB_TYPE: "BLOB" = "BLOB";
 export const COMMIT_TYPE: "COMMIT" = "COMMIT";
-export const TREE_TYPE: "TREE" = "TREE";
-export const TREE_ENTRY_TYPE: "TREE_ENTRY" = "TREE_ENTRY";
 
 export const Prefix = Object.freeze({
   base: GIT_PREFIX,
-  blob: _gitAddress(BLOB_TYPE),
   commit: _gitAddress(COMMIT_TYPE),
-  tree: _gitAddress(TREE_TYPE),
-  treeEntry: _gitAddress(TREE_ENTRY_TYPE),
 });
 
-export type BlobAddress = {|
-  +type: typeof BLOB_TYPE,
-  +hash: Hash,
-|};
 export type CommitAddress = {|
   +type: typeof COMMIT_TYPE,
   +hash: Hash,
 |};
-export type TreeAddress = {|
-  +type: typeof TREE_TYPE,
-  +hash: Hash,
-|};
-export type TreeEntryAddress = {|
-  +type: typeof TREE_ENTRY_TYPE,
-  +treeHash: Hash,
-  +name: string,
-|};
 
-// A tree entry has contents with one of the following types of
-// addresses.
-export type TreeEntryContentsAddress =
-  | BlobAddress
-  | CommitAddress
-  | TreeAddress;
-
-export type StructuredAddress =
-  | BlobAddress
-  | CommitAddress
-  | TreeAddress
-  | TreeEntryAddress;
+export type StructuredAddress = CommitAddress;
 
 export function fromRaw(x: RawAddress): StructuredAddress {
   function fail() {
@@ -64,25 +34,10 @@ export function fromRaw(x: RawAddress): StructuredAddress {
   const [_unused_sc, _unused_git, _type, ...rest] = NodeAddress.toParts(x);
   const type: $ElementType<StructuredAddress, "type"> = (_type: any);
   switch (type) {
-    case "BLOB": {
-      if (rest.length !== 1) throw fail();
-      const [hash] = rest;
-      return {type: BLOB_TYPE, hash};
-    }
     case "COMMIT": {
       if (rest.length !== 1) throw fail();
       const [hash] = rest;
       return {type: COMMIT_TYPE, hash};
-    }
-    case "TREE": {
-      if (rest.length !== 1) throw fail();
-      const [hash] = rest;
-      return {type: TREE_TYPE, hash};
-    }
-    case "TREE_ENTRY": {
-      if (rest.length !== 2) throw fail();
-      const [treeHash, name] = rest;
-      return {type: TREE_ENTRY_TYPE, treeHash, name};
     }
     default:
       // eslint-disable-next-line no-unused-expressions
@@ -93,14 +48,8 @@ export function fromRaw(x: RawAddress): StructuredAddress {
 
 export function toRaw(x: StructuredAddress): RawAddress {
   switch (x.type) {
-    case BLOB_TYPE:
-      return NodeAddress.append(Prefix.blob, x.hash);
     case COMMIT_TYPE:
       return NodeAddress.append(Prefix.commit, x.hash);
-    case TREE_TYPE:
-      return NodeAddress.append(Prefix.tree, x.hash);
-    case TREE_ENTRY_TYPE:
-      return NodeAddress.append(Prefix.treeEntry, x.treeHash, x.name);
     default:
       throw new Error(`Unexpected type ${(x.type: empty)}`);
   }

--- a/src/plugins/git/nodes.test.js
+++ b/src/plugins/git/nodes.test.js
@@ -6,36 +6,18 @@ import {fromRaw, toRaw} from "./nodes";
 
 describe("plugins/git/nodes", () => {
   const examples = {
-    blob: (): GN.BlobAddress => ({
-      type: GN.BLOB_TYPE,
-      hash: "f1f2514ca6d7a6a1a0511957021b1995bf9ace1c",
-    }),
     commit: (): GN.CommitAddress => ({
       type: GN.COMMIT_TYPE,
       hash: "3715ddfb8d4c4fd2a6f6af75488c82f84c92ec2f",
     }),
-    tree: (): GN.TreeAddress => ({
-      type: GN.TREE_TYPE,
-      hash: "7be3ecfee5314ffa9b2d93fc4377792b2d6d70ed",
-    }),
-    treeEntry: (): GN.TreeEntryAddress => ({
-      type: GN.TREE_ENTRY_TYPE,
-      treeHash: "7be3ecfee5314ffa9b2d93fc4377792b2d6d70ed",
-      name: "science.txt",
-    }),
   };
 
-  // Incorrect types should be caught statically, either due to being
-  // totally invalid...
+  // Incorrect types should be caught statically
   // $ExpectFlowError
   const _unused_badTree: GN.RepoAddress = {
     type: "TREEEEE",
     hash: "browns",
   };
-  // ...or due to being annotated with the type of a distinct structured
-  // address:
-  // $ExpectFlowError
-  const _unused_badCommit: GN.CommitAddress = {...examples.tree()};
 
   describe("`fromRaw` after `toRaw` is identity", () => {
     Object.keys(examples).forEach((example) => {
@@ -92,37 +74,11 @@ describe("plugins/git/nodes", () => {
       expectBadAddress("no type", []);
       expectBadAddress("bad type", ["wat"]);
 
-      expectBadAddress("blob with no hash", [GN.BLOB_TYPE]);
-      expectBadAddress("blob with extra field", [
-        GN.BLOB_TYPE,
-        examples.blob().hash,
-        examples.blob().hash,
-      ]);
-
       expectBadAddress("commit with no hash", [GN.COMMIT_TYPE]);
       expectBadAddress("commit with extra field", [
         GN.COMMIT_TYPE,
         examples.commit().hash,
         examples.commit().hash,
-      ]);
-
-      expectBadAddress("tree with no hash", [GN.TREE_TYPE]);
-      expectBadAddress("tree with extra field", [
-        GN.TREE_TYPE,
-        examples.tree().hash,
-        examples.tree().hash,
-      ]);
-
-      expectBadAddress("tree entry with no fields", [GN.TREE_ENTRY_TYPE]);
-      expectBadAddress("tree entry with only tree hash", [
-        GN.TREE_ENTRY_TYPE,
-        examples.treeEntry().treeHash,
-      ]);
-      expectBadAddress("tree entry with extra field", [
-        GN.TREE_ENTRY_TYPE,
-        examples.treeEntry().treeHash,
-        examples.treeEntry().name,
-        "wat",
       ]);
     });
 

--- a/src/plugins/git/render.test.js
+++ b/src/plugins/git/render.test.js
@@ -5,34 +5,12 @@ import {description} from "./render";
 
 describe("plugins/git/render", () => {
   const examples = {
-    blob: (): GN.BlobAddress => ({
-      type: GN.BLOB_TYPE,
-      hash: "f1f2514ca6d7a6a1a0511957021b1995bf9ace1c",
-    }),
     commit: (): GN.CommitAddress => ({
       type: GN.COMMIT_TYPE,
       hash: "3715ddfb8d4c4fd2a6f6af75488c82f84c92ec2f",
     }),
-    tree: (): GN.TreeAddress => ({
-      type: GN.TREE_TYPE,
-      hash: "7be3ecfee5314ffa9b2d93fc4377792b2d6d70ed",
-    }),
-    treeEntry: (): GN.TreeEntryAddress => ({
-      type: GN.TREE_ENTRY_TYPE,
-      treeHash: "7be3ecfee5314ffa9b2d93fc4377792b2d6d70ed",
-      name: "science.txt",
-    }),
   };
-  it("blob snapshots as expected", () => {
-    expect(description(examples.blob())).toMatchSnapshot();
-  });
   it("commit snapshots as expected", () => {
     expect(description(examples.commit())).toMatchSnapshot();
-  });
-  it("tree snapshots as expected", () => {
-    expect(description(examples.tree())).toMatchSnapshot();
-  });
-  it("treeEntry snapshots as expected", () => {
-    expect(description(examples.treeEntry())).toMatchSnapshot();
   });
 });

--- a/src/plugins/github/graphView.test.js
+++ b/src/plugins/github/graphView.test.js
@@ -4,7 +4,7 @@ import {Graph, type Edge, EdgeAddress} from "../../core/graph";
 import {GraphView} from "./graphView";
 import * as GE from "./edges";
 import * as GN from "./nodes";
-import {COMMIT_TYPE, toRaw as gitToRaw, TREE_TYPE} from "../git/nodes";
+import {COMMIT_TYPE, toRaw as gitToRaw} from "../git/nodes";
 import {exampleGraph} from "./example/example";
 
 function exampleView() {
@@ -263,12 +263,6 @@ describe("plugins/github/graphView", () => {
         it("src must be a pull", () => {
           // $ExpectFlowError
           const badEdge = GE.createEdge.mergedAs(issue, commit);
-          failsForEdge(badEdge);
-        });
-        it("dst must be commit address", () => {
-          const tree = {type: TREE_TYPE, hash: "hash"};
-          // $ExpectFlowError
-          const badEdge = GE.createEdge.mergedAs(pull, tree);
           failsForEdge(badEdge);
         });
         it("src must be pull in edge address", () => {

--- a/src/plugins/github/nodes.test.js
+++ b/src/plugins/github/nodes.test.js
@@ -50,10 +50,6 @@ describe("plugins/github/nodes", () => {
     type: GitNode.COMMIT_TYPE,
     hash: "0000000000000000000000000000000000000000",
   });
-  const tree = (): GitNode.TreeAddress => ({
-    type: GitNode.TREE_TYPE,
-    hash: "0000000000000000000000000000000000000000",
-  });
 
   const examples = {
     repo,
@@ -150,10 +146,6 @@ describe("plugins/github/nodes", () => {
         );
       });
       expectBadAddress("no kind", []);
-      expectBadAddress(
-        "Git node that isn't a commit",
-        NodeAddress.toParts(GitNode.toRaw(tree()))
-      );
       describe("repository with", () => {
         checkBadCases([
           {name: "no owner", parts: [GN.REPO_TYPE]},
@@ -249,12 +241,6 @@ describe("plugins/github/nodes", () => {
           // $ExpectFlowError
           toRaw({type: "COMMENT", parent: {type: "ICE_CREAM"}});
         }).toThrow("Bad comment parent type");
-      });
-      it("a git address that isn't a commit", () => {
-        expect(() => {
-          // $ExpectFlowError
-          toRaw(tree());
-        }).toThrow("Unexpected type");
       });
     });
   });


### PR DESCRIPTION
In #873 I removed the data types for trees, blobs, and entries, but
neglected to remove the address related code. This commit corrects that
mistake. Some test cases in other modules have been removed because the
failure is now structurally impossible, e.g. it is not possible that we
would provide a non-commit address to the GitHub plugin, because
non-commit addresses do not exist.

Test plan: `yarn test --full` passes.