### PR TITLE
mirror: query and process connection updates

### DIFF
--- a/src/graphql/__snapshots__/mirror.test.js.snap
+++ b/src/graphql/__snapshots__/mirror.test.js.snap
@@ -1,0 +1,45 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`graphql/mirror Mirror _queryConnection snapshot test for actual GitHub queries 1`] = `
+"query TestQuery {
+  initialQuery: node(id: \\"MDEwOlJlcG9zaXRvcnkxMjMyNTUwMDY=\\") {
+    ... on Repository {
+      issues(first: 2) {
+        totalCount
+        pageInfo {
+          endCursor
+          hasNextPage
+        }
+        nodes {
+          __typename
+          id
+        }
+      }
+    }
+  }
+  updateQuery: node(id: \\"MDEwOlJlcG9zaXRvcnkxMjMyNTUwMDY=\\") {
+    ... on Repository {
+      issues(first: 2 after: \\"Y3Vyc29yOnYyOpHOEe_nRA==\\") {
+        totalCount
+        pageInfo {
+          endCursor
+          hasNextPage
+        }
+        nodes {
+          __typename
+          id
+        }
+      }
+    }
+  }
+  expectedIds: node(id: \\"MDEwOlJlcG9zaXRvcnkxMjMyNTUwMDY=\\") {
+    ... on Repository {
+      issues(first: 4) {
+        nodes {
+          id
+        }
+      }
+    }
+  }
+}"
+`;


### PR DESCRIPTION
Summary:
This commit adds internal functions to (a) emit a GraphQL query to fetch
data for a particular connection, and (b) ingest the results of said
query back into the database.

This commit makes progress toward #622.

Test Plan:
Unit tests included, with full coverage. While these tests check that
the GraphQL queries are as expected, they cannot check that they are
actually valid in production. To check this, follow the instructions in
the added snapshot test.

wchargin-branch: mirror-connection-updates