### PR TITLE
mirror: align test schema more with GitHub schema

### DIFF
--- a/src/graphql/mirror.test.js
+++ b/src/graphql/mirror.test.js
@@ -22,7 +22,7 @@ describe("graphql/mirror", () => {
         id: s.id(),
         url: s.primitive(),
         author: s.node("Actor"),
-        parent: s.node("Repository"),
+        repository: s.node("Repository"),
         title: s.primitive(),
         comments: s.connection("IssueComment"),
       }),
@@ -249,7 +249,7 @@ describe("graphql/mirror", () => {
             )
             .pluck()
             .all(issueId)
-        ).toEqual(["author", "parent"].sort());
+        ).toEqual(["author", "repository"].sort());
         expect(
           db.prepare("SELECT * FROM primitives_Issue WHERE id = ?").all(issueId)
         ).toEqual([
@@ -897,7 +897,7 @@ describe("graphql/mirror", () => {
         result.objectTypes["Issue"].primitiveFieldNames.slice().sort()
       ).toEqual(["url", "title"].sort());
       expect(result.objectTypes["Issue"].linkFieldNames.slice().sort()).toEqual(
-        ["author", "parent"].sort()
+        ["author", "repository"].sort()
       );
       expect(
         result.objectTypes["Issue"].connectionFieldNames.slice().sort()


### PR DESCRIPTION
Summary:
This commit changes the `Issue` type of the schema used in the `mirror`
tests to have fields a faithful subset of those in the actual GitHub
schema. The tests are self-contained, so this is not strictly required.
However, it is convenient, because it means that we can snapshot a query
that can actually be posted to GitHub.

Test Plan:
Running `yarn unit mirror` suffices for the code change. The GitHub
schema docs at <https://developer.github.com/v4/object/issue/> indicate
that each of `id`, `url`, `author`, `repository`, `title`, and
`comments` is a valid field.

wchargin-branch: mirror-test-schema