### PR TITLE
mirror: query and process own-data updates

### DIFF
--- a/src/graphql/__snapshots__/mirror.test.js.snap
+++ b/src/graphql/__snapshots__/mirror.test.js.snap
@@ -232,3 +232,32 @@ exports[`graphql/mirror Mirror _queryConnection snapshot test for actual GitHub 
   }
 }"
 `;
+
+exports[`graphql/mirror Mirror _updateOwnData snapshot test for actual GitHub queries 1`] = `
+"query TestQuery {
+  node(id: \\"MDU6SXNzdWUzNDg1NDA0NjE=\\") {
+    ... on Issue {
+      __typename
+      id
+      url
+      author {
+        __typename
+        ... on User {
+          id
+        }
+        ... on Bot {
+          id
+        }
+        ... on Organization {
+          id
+        }
+      }
+      repository {
+        __typename
+        id
+      }
+      title
+    }
+  }
+}"
+`;


### PR DESCRIPTION
Summary:
This commit adds internal functions to (a) emit a GraphQL query to fetch
data for own-data of an object, and (b) ingest the results of said query
back into the database.

The API and implementation differ from the connection-updating analogues
introduced in #878 in that the query for own data is independent of an
object’s ID: it depends only on the object’s type. This affords us more
flexibility in composing queries.

As described in a internal documentation comment, values are stored in
the database in JSON-stringified form: we cannot use the obvious raw SQL
values, because there is no native encoding of booleans (`0`/`1` is
conventional), and we need to distinguish them from other data types.
There are other ways to solve this problem. Notably:

 1. We could take inspiration from OCaml: encode stronger static types
    and a simpler runtime representation. That is, we could change the
    schema field types from simply “primitive” to the various specific
    primitive types. Then, when reading data out from the database, we
    could reinterpret the values appropriately.

 2. We could take advantage of the fact that we are not using all of
    SQLite’s data types. In particular, we do not store anything as a
    binary blob, so we could encode `false` as a length-0 zeroblob and
    `true` as a length-1 zeroblob, for instance. Again, when reading
    data out from the database, we would reinterpret the values—but in
    this approach we would not need an explicit schema from the user.

For now, we take the easiest and simplest approach just to get ourselves
off the ground. We can easily move to the second option described above
later.

This commit makes progress toward #622.

Test Plan:
Unit tests included, with full coverage. While these tests check that
the GraphQL queries are as expected, they cannot check that they are
actually valid in production. To check this, follow the instructions in
the added snapshot test.

wchargin-branch: mirror-own-data-updates