### PR TITLE
Git: track the repositories containing each commit

### DIFF
--- a/src/plugins/git/cloneAndLoadRepository.js
+++ b/src/plugins/git/cloneAndLoadRepository.js
@@ -20,7 +20,7 @@ export default function cloneAndLoadRepository(repoId: RepoId): Repository {
   const tmpdir = tmp.dirSync({unsafeCleanup: true});
   const git = localGit(tmpdir.name);
   git(["clone", cloneUrl, ".", "--quiet"]);
-  const result = loadRepository(tmpdir.name, "HEAD");
+  const result = loadRepository(tmpdir.name, "HEAD", repoId);
   tmpdir.removeCallback();
   return result;
 }

--- a/src/plugins/git/example/example-git.json
+++ b/src/plugins/git/example/example-git.json
@@ -1,4 +1,30 @@
 {
+    "commitToRepoId": {
+        "3715ddfb8d4c4fd2a6f6af75488c82f84c92ec2f": {
+            "sourcecred/example-git": true
+        },
+        "69c5aad50eec8f2a0a07c988c3b283a6490eb45b": {
+            "sourcecred/example-git": true
+        },
+        "8d287c3bfbf8455ef30187bf5153ffc1b6eef268": {
+            "sourcecred/example-git": true
+        },
+        "c08ee3a4edea384d5291ffcbf06724a13ed72325": {
+            "sourcecred/example-git": true
+        },
+        "c2b51945e7457546912a8ce158ed9d294558d294": {
+            "sourcecred/example-git": true
+        },
+        "c90f6424017f787bbbaf22e4082a01355546f7e3": {
+            "sourcecred/example-git": true
+        },
+        "d160cca97611e9dfed642522ad44408d0292e8ea": {
+            "sourcecred/example-git": true
+        },
+        "e8b7a8f19701cd5a25e4a097d513ead60e5f8bcc": {
+            "sourcecred/example-git": true
+        }
+    },
     "commits": {
         "3715ddfb8d4c4fd2a6f6af75488c82f84c92ec2f": {
             "hash": "3715ddfb8d4c4fd2a6f6af75488c82f84c92ec2f",

--- a/src/plugins/git/mergeRepository.js
+++ b/src/plugins/git/mergeRepository.js
@@ -6,18 +6,23 @@ import type {Repository} from "./types";
 export function mergeRepository(
   repositories: $ReadOnlyArray<Repository>
 ): Repository {
-  const newRepository = {commits: {}};
-  for (const {commits} of repositories) {
+  const newCommits = {};
+  const newCommitToRepoId = {};
+  for (const {commits, commitToRepoId} of repositories) {
     for (const commitHash of Object.keys(commits)) {
-      const existingCommit = newRepository.commits[commitHash];
+      const existingCommit = newCommits[commitHash];
       if (
         existingCommit != null &&
         !deepEqual(existingCommit, commits[commitHash])
       ) {
         throw new Error(`Conflict between commits at ${commitHash}`);
       }
-      newRepository.commits[commitHash] = commits[commitHash];
+      newCommits[commitHash] = commits[commitHash];
+      const newRepos = commitToRepoId[commitHash];
+      const existingRepos = newCommitToRepoId[commitHash] || {};
+      const combinedRepoIdsForCommit = {...newRepos, ...existingRepos};
+      newCommitToRepoId[commitHash] = combinedRepoIdsForCommit;
     }
   }
-  return newRepository;
+  return {commits: newCommits, commitToRepoId: newCommitToRepoId};
 }

--- a/src/plugins/git/render.test.js
+++ b/src/plugins/git/render.test.js
@@ -1,5 +1,6 @@
 // @flow
 
+import {makeRepoId} from "../../core/repoId";
 import * as GN from "./nodes";
 import {description} from "./render";
 import type {Repository} from "./types";
@@ -18,6 +19,9 @@ describe("plugins/git/render", () => {
         summary: "This is an example commit",
         parentHashes: [],
       },
+    },
+    commitToRepoId: {
+      [exampleHash]: {[(makeRepoId("sourcecred", "example-git"): any)]: true},
     },
   });
 

--- a/src/plugins/git/types.js
+++ b/src/plugins/git/types.js
@@ -1,7 +1,12 @@
 // @flow
 
+import type {RepoIdString} from "../../core/repoId";
+
 export type Repository = {|
   +commits: {[Hash]: Commit},
+  // For every commit, track all the RepoIds of repos
+  // containing this commit.
+  +commitToRepoId: {[Hash]: {+[RepoIdString]: true}},
 |};
 export type Hash = string;
 export type Commit = {|


### PR DESCRIPTION
This modifies the Git `Repository` data structure so that for every
commit, we track the `RepoId`s of repos containing that commit. This way
we will be able to do things like hyperlink to the right url for that
commit.

`loadRepository` has been modified to set the initial `repoId`.
`mergeRepository` has been updated to ensure that it concatenates the
`repoId`s properly.
Tests were added for both cases.

The example-git snapshot has been updated accordingly.

Test plan: `yarn test --full`