### PR TITLE
Add the `RepoIdString` type

### DIFF
--- a/src/core/repoId.js
+++ b/src/core/repoId.js
@@ -10,6 +10,8 @@ export opaque type RepoId: {|
   +owner: string,
 |};
 
+export opaque type RepoIdString: string = string;
+
 export const githubOwnerPattern = "[A-Za-z0-9-]+";
 export const githubRepoPattern = "[A-Za-z0-9-._]+";
 
@@ -33,6 +35,6 @@ export function stringToRepoId(x: string): RepoId {
   return makeRepoId(pieces[0], pieces[1]);
 }
 
-export function repoIdToString(x: RepoId): string {
+export function repoIdToString(x: RepoId): RepoIdString {
   return `${x.owner}/${x.name}`;
 }

--- a/src/core/repoId.test.js
+++ b/src/core/repoId.test.js
@@ -5,6 +5,7 @@ import {
   stringToRepoId,
   repoIdToString,
   type RepoId,
+  type RepoIdString,
 } from "./repoId";
 
 describe("core/repoId", () => {
@@ -20,6 +21,12 @@ describe("core/repoId", () => {
       const repoId: RepoId = makeRepoId("foo", "bar");
       const _unused_owner: string = repoId.owner;
       const _unused_name: string = repoId.name;
+    });
+  });
+  describe("RepoIdString type", () => {
+    it("manually constructing a RepoIdString is illegal", () => {
+      // $ExpectFlowError
+      const _unused_repoIdString: RepoIdString = "foobar";
     });
   });
   describe("makeRepoId", () => {


### PR DESCRIPTION
This modifies `core/repoId` so that `repoIdToString` returns not a
`string`, but an opaque subtype of `string` called `RepoIdString`.

This allows us to store stringified `RepoId`s (which is useful whenever
we want value-not-reference semantics, like for use as a map key)
while still maintaining a type assertion that the strings, in fact,
represent valid `RepoId`s.

Test plan: A unit test verifies that it's a flow error to cast a string
to a `RepoIdString`.