### PR TITLE
flow: fix `Statement` properties

### DIFF
--- a/flow-typed/npm/better-sqlite3_vx.x.x.js
+++ b/flow-typed/npm/better-sqlite3_vx.x.x.js
@@ -61,11 +61,9 @@ declare type bettersqlite3$BoundParameter =
   | bettersqlite3$BindingDictionary;
 
 declare class bettersqlite3$Statement {
-  +memory: boolean;
-  +readonly: boolean;
-  +name: string;
-  +open: boolean;
-  +inTransaction: boolean;
+  +database: bettersqlite3$Database;
+  +source: string;
+  +returnsData: boolean;
 
   run(...params: bettersqlite3$BoundParameter[]): bettersqlite3$RunResult;
   get(...params: bettersqlite3$BoundParameter[]): any;


### PR DESCRIPTION
Summary:
These were completely wrong; my bad.

[The docs][1] list `source` and `returnsData` but not `database`.
I include the latter only for consistency with `Transaction`, and will
consider removing them both as they are technically undocumented (though
not underscore-named, so it’s not clear-cut).

[1]: https://wchargin.github.io/better-sqlite3/api.html#properties-1

Test Plan:
At a Node console:

```js
> require("better-sqlite3")(":memory:").prepare("BEGIN")
Statement {
  returnsData: false,
  source: 'BEGIN',
  database:
   Database {
     inTransaction: false,
     open: true,
     memory: false,
     readonly: false,
     name: ':memory:' } }
```

wchargin-branch: flow-better-sqlite3-statement-properties