### PR TITLE
Hyperlink Git commits to GitHub

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## [Unreleased]
+- Hyperlink Git commits to GitHub (#887)
 - Relicense from MIT to MIT + Apache-2 (#812)
 - Display short hash + summary for commits (#879)
 - Hyperlink to GitHub entities (#860)

--- a/src/app/adapters/defaultPlugins.js
+++ b/src/app/adapters/defaultPlugins.js
@@ -3,7 +3,11 @@
 import {StaticAdapterSet} from "./adapterSet";
 import {StaticPluginAdapter as GithubAdapter} from "../../plugins/github/pluginAdapter";
 import {StaticPluginAdapter as GitAdapter} from "../../plugins/git/pluginAdapter";
+import {GithubGitGateway} from "../../plugins/github/githubGitGateway";
 
 export function defaultStaticAdapters(): StaticAdapterSet {
-  return new StaticAdapterSet([new GithubAdapter(), new GitAdapter()]);
+  return new StaticAdapterSet([
+    new GithubAdapter(),
+    new GitAdapter(new GithubGitGateway()),
+  ]);
 }

--- a/src/plugins/git/__snapshots__/render.test.js.snap
+++ b/src/plugins/git/__snapshots__/render.test.js.snap
@@ -1,3 +1,0 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
-
-exports[`plugins/git/render commit snapshots as expected 1`] = `"3715ddf: This is an example commit"`;

--- a/src/plugins/git/gitGateway.js
+++ b/src/plugins/git/gitGateway.js
@@ -1,0 +1,12 @@
+// @flow
+
+import type {RepoId} from "../../core/repoId";
+import type {Hash} from "./types";
+
+export type URL = string;
+
+// Interface for adapting to a Git hosting provider, e.g. GitHub
+export interface GitGateway {
+  // URL to permalink to an individual commit
+  commitUrl(repo: RepoId, hash: Hash): URL;
+}

--- a/src/plugins/git/pluginAdapter.js
+++ b/src/plugins/git/pluginAdapter.js
@@ -10,8 +10,14 @@ import {description} from "./render";
 import type {Assets} from "../../app/assets";
 import type {RepoId} from "../../core/repoId";
 import type {Repository} from "./types";
+import type {GitGateway} from "./gitGateway";
 
 export class StaticPluginAdapter implements IStaticPluginAdapter {
+  _gitGateway: GitGateway;
+
+  constructor(gg: GitGateway): void {
+    this._gitGateway = gg;
+  }
   name() {
     return "Git";
   }
@@ -65,16 +71,22 @@ export class StaticPluginAdapter implements IStaticPluginAdapter {
       loadGraph(),
       loadRepository(),
     ]);
-    return new DynamicPluginAdapter(graph, repository);
+    return new DynamicPluginAdapter(this._gitGateway, graph, repository);
   }
 }
 
 class DynamicPluginAdapter implements IDynamicPluginAdapter {
   +_graph: Graph;
   +_repository: Repository;
-  constructor(graph: Graph, repository: Repository) {
+  +_gitGateway: GitGateway;
+  constructor(
+    gitGateway: GitGateway,
+    graph: Graph,
+    repository: Repository
+  ): void {
     this._graph = graph;
     this._repository = repository;
+    this._gitGateway = gitGateway;
   }
   graph() {
     return this._graph;
@@ -83,9 +95,9 @@ class DynamicPluginAdapter implements IDynamicPluginAdapter {
     // This cast is unsound, and might throw at runtime, but won't have
     // silent failures or cause problems down the road.
     const address = N.fromRaw((node: any));
-    return description(address, this._repository);
+    return description(address, this._repository, this._gitGateway);
   }
   static() {
-    return new StaticPluginAdapter();
+    return new StaticPluginAdapter(this._gitGateway);
   }
 }

--- a/src/plugins/github/githubGitGateway.js
+++ b/src/plugins/github/githubGitGateway.js
@@ -1,0 +1,11 @@
+// @flow
+
+import {type RepoId} from "../../core/repoId";
+import type {Hash} from "../git/types";
+import type {GitGateway, URL} from "../git/gitGateway";
+
+export class GithubGitGateway implements GitGateway {
+  commitUrl(repoId: RepoId, hash: Hash): URL {
+    return `https://github.com/${repoId.owner}/${repoId.name}/commit/${hash}`;
+  }
+}

--- a/src/plugins/github/githubGitGateway.test.js
+++ b/src/plugins/github/githubGitGateway.test.js
@@ -1,0 +1,17 @@
+// @flow
+
+import {makeRepoId} from "../../core/repoId";
+import {GithubGitGateway} from "./githubGitGateway";
+
+describe("src/plugins/github/githubGitGateway", () => {
+  describe("commitUrl", () => {
+    it("works for a simple example", () => {
+      const repoId = makeRepoId("sourcecred", "example-github");
+      const hash = "ec91adb718a6";
+      const url = new GithubGitGateway().commitUrl(repoId, hash);
+      expect(url).toMatchInlineSnapshot(
+        `"https://github.com/sourcecred/example-github/commit/ec91adb718a6"`
+      );
+    });
+  });
+});

--- a/src/plugins/github/pluginAdapter.js
+++ b/src/plugins/github/pluginAdapter.js
@@ -154,7 +154,7 @@ export class StaticPluginAdapter implements IStaticPluginAdapter {
 class DynamicPluginAdapter implements IDynamicPluginAdapater {
   +_view: RelationalView;
   +_graph: Graph;
-  constructor(view: RelationalView, graph: Graph) {
+  constructor(view: RelationalView, graph: Graph): void {
     this._view = view;
     this._graph = graph;
   }

--- a/src/plugins/github/render.js
+++ b/src/plugins/github/render.js
@@ -75,7 +75,6 @@ function userlike(x: R.Userlike) {
 // because the commit has a Git plugin prefix and will therefore by
 // handled by the git plugin adapter
 function commit(x: R.Commit) {
-  // TODO(@wchargin): Ensure this hash is unambiguous
   const shortHash = x.address().hash.slice(0, 7);
   return (
     <span>


### PR DESCRIPTION
This modifies the `nodeDescription` code for the Git plugin so that when
given a Git commit, it will hyperlink to that commit on GitHub. It does
this by looking up the corresponding `RepoId`s from the newly-added
`commitToRepoId` field in the `Repository` (#884).

Per a [suggestion in review], rather than hardcoding the GitHub url
logic in the Git plugin, we provide them via a `GitGateway`.

[suggestion in review]: https://github.com/sourcecred/sourcecred/pull/887#issuecomment-424059649

When no `RepoId` is found, it errors to console and does not include a
hyperlink. When multiple `RepoId`s are available, it chooses to link to
one arbitrarily. (In the future, we could amend this behavior to add
links to every valid repo). This behavior is tested.

Test plan:
I ran the application on newly-generated data and verified that it sets
up commit hyperlinks appropriately. Also, see unit tests.