### PR TITLE
mirror: add connection object types to query plan

### DIFF
--- a/src/graphql/mirror.js
+++ b/src/graphql/mirror.js
@@ -428,12 +428,16 @@ export class Mirror {
         .prepare(
           dedent`\
             SELECT
+                objects.typename AS objectTypename,
                 connections.object_id AS objectId,
                 connections.fieldname AS fieldname,
                 connections.last_update IS NULL AS neverUpdated,
                 connections.end_cursor AS endCursor
             FROM connections
-            LEFT OUTER JOIN updates ON connections.last_update = updates.rowid
+            LEFT OUTER JOIN updates
+                ON connections.last_update = updates.rowid
+            JOIN objects
+                ON connections.object_id = objects.id
             WHERE connections.has_next_page
             OR connections.last_update IS NULL
             OR updates.time_epoch_millis < :timeEpochMillisThreshold
@@ -1046,6 +1050,7 @@ type QueryPlan = {|
     +id: Schema.ObjectId,
   |}>,
   +connections: $ReadOnlyArray<{|
+    +objectTypename: Schema.Typename,
     +objectId: Schema.ObjectId,
     +fieldname: Schema.Fieldname,
     +endCursor: EndCursor | void, // `undefined` if never fetched

--- a/src/graphql/mirror.test.js
+++ b/src/graphql/mirror.test.js
@@ -494,18 +494,21 @@ describe("graphql/mirror", () => {
           connections: [
             {
               // loaded before cutoff
+              objectTypename: "Repository",
               objectId: "repo:ab/cd",
               fieldname: "issues",
               endCursor: "cursor:repo.issues",
             },
             {
               // never loaded
+              objectTypename: "Issue",
               objectId: "issue:ab/cd#1",
               fieldname: "comments",
               endCursor: undefined,
             },
             {
               // loaded, but has more data available
+              objectTypename: "Issue",
               objectId: "issue:ab/cd#2",
               fieldname: "comments",
               endCursor: null,


### PR DESCRIPTION
Summary:
This reestablishes harmony in light of #882.

Test Plan:
Existing unit tests suffice; run `yarn unit`.

wchargin-branch: mirror-query-plan-connection-object-typename