### PR TITLE
ui: remove `:visited` color change for nav links

### DIFF
--- a/src/app/Colors.js
+++ b/src/app/Colors.js
@@ -1,0 +1,21 @@
+// @flow
+
+export type HexColor = string;
+
+export default (Object.freeze({
+  brand: Object.freeze({
+    medium: "#0872A2",
+    dark: "#3A066A",
+  }),
+  accent: Object.freeze({
+    medium: "#FF3201",
+  }),
+}): {|
+  +brand: {|
+    +medium: HexColor,
+    +dark: HexColor,
+  |},
+  +accent: {|
+    +medium: HexColor,
+  |},
+|});

--- a/src/app/Link.js
+++ b/src/app/Link.js
@@ -4,6 +4,8 @@ import React, {Component} from "react";
 import {Link as RouterLink} from "react-router";
 import {StyleSheet, css} from "aphrodite/no-important";
 
+import Colors from "./Colors";
+
 /**
  * A styled link component for both client-side router links and normal
  * external links.
@@ -47,12 +49,12 @@ const colorAttributes = (color) => ({
 });
 const styles = StyleSheet.create({
   link: {
-    ...colorAttributes("#0872A2"),
+    ...colorAttributes(Colors.brand.medium),
     ":visited": {
-      ...colorAttributes("#3A066A"),
+      ...colorAttributes(Colors.brand.dark),
     },
     ":active": {
-      ...colorAttributes("#FF3201"),
+      ...colorAttributes(Colors.accent.medium),
     },
   },
 });

--- a/src/app/Page.js
+++ b/src/app/Page.js
@@ -4,6 +4,7 @@ import React, {type Node} from "react";
 import {StyleSheet, css} from "aphrodite/no-important";
 
 import type {Assets} from "./assets";
+import Colors from "./Colors";
 import Link from "./Link";
 import GithubLogo from "./GithubLogo";
 import TwitterLogo from "./TwitterLogo";
@@ -133,6 +134,10 @@ const style = StyleSheet.create({
     textDecoration: "none",
     ":hover": {
       textDecoration: "underline",
+    },
+    ":visited:not(:active)": {
+      color: Colors.brand.medium,
+      fill: Colors.brand.medium, // for SVG icons
     },
   },
   navItemLeft: {


### PR DESCRIPTION
Test Plan:
Note that the nav links are now a lighter color, except when `:active`
(e.g., when you’re holding down the mouse button).

Suggested by @decentralion . :-)

wchargin-branch: remove-visited