### PR TITLE
mirror: add helper to find unused table name

### DIFF
--- a/src/graphql/mirror.js
+++ b/src/graphql/mirror.js
@@ -1215,3 +1215,48 @@ export function _makeSingleUpdateFunction<Args: BindingDictionary>(
     }
   };
 }
+
+/**
+ * Find a name for a new table (or index) that starts with the given
+ * prefix and is not used by any current table or index.
+ *
+ * This function does not actually create any tables. Consider including
+ * it in a transaction that subsequently creates the table.
+ *
+ * The provided prefix must be a SQL-safe string, or an error will be
+ * thrown.
+ *
+ * The result will be a SQL-safe string, and will not need to be quoted
+ * unless the provided prefix does.
+ *
+ * See: `isSqlSafe`.
+ */
+export function _nontransactionallyFindUnusedTableName(
+  db: Database,
+  prefix: string
+) {
+  if (!isSqlSafe(prefix)) {
+    throw new Error("Unsafe table name prefix: " + JSON.stringify(prefix));
+  }
+  const result: string = db
+    .prepare(
+      dedent`\
+        SELECT :prefix || (IFNULL(MAX(CAST(suffix AS INTEGER)), 0) + 1)
+        FROM (
+            SELECT SUBSTR(name, LENGTH(:prefix) + 1) AS suffix
+            FROM sqlite_master
+            WHERE SUBSTR(name, 1, LENGTH(:prefix)) = :prefix
+        )
+      `
+    )
+    .pluck()
+    .get({prefix});
+  // istanbul ignore if: should not be possible---it only has the
+  // prefix (which is safe as defined above) and a trailing integer.
+  if (!isSqlSafe(result)) {
+    throw new Error(
+      "Invariant violation: unsafe table name: " + JSON.stringify(result)
+    );
+  }
+  return result;
+}


### PR DESCRIPTION
Summary:
Per <https://github.com/sourcecred/sourcecred/pull/894#discussion_r220406780>.

Test Plan:
Unit tests included; run `yarn unit`.

wchargin-branch: mirror-unused-table-name