### PR TITLE
env: pass parent PATH to Git invocations

### DIFF
--- a/config/env.js
+++ b/config/env.js
@@ -69,11 +69,12 @@ process.env.NODE_PATH = (process.env.NODE_PATH || "")
 // should not need this dependency.
 function getGitState() /*: GitState */ {
   const env = {
+    GIT_ATTR_NOSYSTEM: "1",
+    GIT_CONFIG_NOSYSTEM: "1",
     LANG: "C",
     LC_ALL: "C",
+    PATH: process.env.PATH,
     TZ: "UTC",
-    GIT_CONFIG_NOSYSTEM: "1",
-    GIT_ATTR_NOSYSTEM: "1",
   };
 
   const diffIndex = spawnSync(


### PR DESCRIPTION
Summary:
Our environment-stripping logic used in `config/env.js` to read the
current Git state included stripping the `PATH` environment variable.
This had the effect that the system Git executable would always be used
in preference to a user-installed version.

Test Plan:
Run `/usr/bin/git --version`, and then install a different version of
Git. (For instance, check out an old tag, then `make && make install`
from the `git/git` repository.) Then, add

```js
  console.log(execFileSync("git", ["--version"], {env}).toString());
```

to `getGitState` in `config/env.js`, and run

    NODE_ENV=development node ./config/env.js

Note that this prints the version of the system Git before this change,
and the user Git after this change.

Alternately, local-install a version of Git earlier than 2.6.0, and note
that `yarn unit` now _fails_ because the `--date=format:…` syntax is not
known to such versions of Git. Prior to this commit, the tests would
pass as long as the system Git were more recent.

wchargin-branch: env-git-path