### PR TITLE
env: drop `--date=format:...` to support Git 2.1.4

### DIFF
--- a/config/env.js
+++ b/config/env.js
@@ -95,7 +95,7 @@ function getGitState() /*: GitState */ {
     .toString()
     .trim();
 
-  const commitTimestamp = execFileSync(
+  const iso8601Timestamp = execFileSync(
     "git",
     [
       "-C",
@@ -103,13 +103,25 @@ function getGitState() /*: GitState */ {
       "show",
       "--no-patch",
       "--format=%cd",
-      "--date=format:%Y%m%d-%H%M",
+      "--date=iso8601",
       commitHash,
     ],
     {env}
   )
     .toString()
     .trim();
+  const commitDate = new Date(iso8601Timestamp);
+  function zeroPad(number /*: number */, length /*: number */) /*: string */ {
+    return String(number).padStart(length, "0");
+  }
+  const commitTimestamp = [
+    zeroPad(commitDate.getFullYear(), 4),
+    zeroPad(commitDate.getMonth(), 2),
+    zeroPad(commitDate.getDay(), 2),
+    "-",
+    zeroPad(commitDate.getHours(), 2),
+    zeroPad(commitDate.getMinutes(), 2),
+  ].join("");
 
   return {commitHash, commitTimestamp, dirty};
 }


### PR DESCRIPTION
Summary:
Git only learned `--date=format:...` in Git 2.6.0. Some old Docker
images have older versions of Git. It’s not too much work to reimplement
this particular bit of functionality, so this commit does so.

Test Plan:
Install Git 2.1.4 (as used on Circle CI): from the Git repository for
Git itself, run:

    git checkout v2.1.4
    make
    make install

Watch `yarn test --full` pass. Before this commit, `yarn unit` failed.

wchargin-branch: env-support-git-2.1.4