### PR TITLE
markdown: ignore references in HTML code elements

### DIFF
--- a/src/plugins/github/parseReferences.test.js
+++ b/src/plugins/github/parseReferences.test.js
@@ -38,6 +38,16 @@ describe("plugins/github/parseReferences", () => {
     expect(parseReferences(input)).toHaveLength(0);
   });
 
+  it("finds references in normal HTML elements", () => {
+    const input = "see <em>#1, #2, and #3</em> for context";
+    expect(parseReferences(input)).toHaveLength(3);
+  });
+
+  it('does not find references in HTML "code" elements', () => {
+    const input = "see <code>#1, #2, and #3</code> for context";
+    expect(parseReferences(input)).toHaveLength(0);
+  });
+
   it("does not find references in inline code with lots of backticks", () => {
     // An attempt to evade inline code with regular expressions might
     // well fail here, because an even number of backticks appears on


### PR DESCRIPTION
Summary:
Fixes #903. We already ignore Markdown code syntax (backticks), but
prior to this commit we treated the contents of all HTML elements,
including `<code>`, as normal text. As of this commit, `<code>` elements
are stripped entirely. Other HTML elements, like `<em>`, are unaffected.

Test Plan:
Unit tests added. Also, load data for `ipfs/js-ipfs-block-service`, and
observe in the UI that PR `#36` (Update aegir to version 9.0.0) no
longer has any outward references.

wchargin-branch: markdown-html-code