### PR TITLE
mirror: add an end-to-end `update` function

### DIFF
--- a/config/paths.js
+++ b/config/paths.js
@@ -33,5 +33,6 @@ module.exports = {
       "src/plugins/github/bin/fetchAndPrintGithubRepo.js"
     ),
     createExampleRepo: resolveApp("src/plugins/git/bin/createExampleRepo.js"),
+    mirror: resolveApp("src/graphql/demo.js"),
   },
 };

--- a/src/graphql/demo.js
+++ b/src/graphql/demo.js
@@ -1,0 +1,192 @@
+// @flow
+//
+// Command-line entry point for src/graphql/mirror.js, mostly for
+// testing purposes. Downloads and prints all nodes reachable from an
+// arbitrary root node. To use this module, first obtain the typename
+// and ID of a GraphQL object to query. Here are some repository IDs
+// (typename "Repository"):
+//
+//   - sourcecred/sourcecred: MDEwOlJlcG9zaXRvcnkxMjAxNDU1NzA=
+//   - sourcecred/example-github: id: MDEwOlJlcG9zaXRvcnkxMjMyNTUwMDY=
+//
+// Then, invoke this program, passing the name of a persistent database
+// file, the typename and ID from above, and a TTL in seconds. The
+// provided object and all its transitive dependencies will be updated
+// if absent or older than the TTL, then printed in structured form.
+//
+import Database from "better-sqlite3";
+
+import {postQuery} from "../plugins/github/fetchGithubRepo";
+
+import {Mirror} from "./mirror";
+import * as Queries from "./queries";
+import * as Schema from "./schema";
+
+require("../tools/entry");
+
+main();
+
+async function main() {
+  const [_unused_node, scriptName, ...args] = process.argv;
+  const token = process.env.SOURCECRED_GITHUB_TOKEN;
+  if (args.length !== 4 || token == null) {
+    console.error(`usage: node ${scriptName} DB_FILE TYPENAME ID TTL_SECONDS`);
+    console.error("Required arguments:");
+    console.error("  DB_FILE: filepath in which to store a database");
+    console.error("  TYPENAME: GraphQL typename of the root object");
+    console.error("  ID: GraphQL ID for an object to fetch");
+    console.error("  TTL_SECONDS: Fetch updates if more than this old");
+    console.error("Required environment variables:");
+    const url = "https://github.com/settings/tokens";
+    console.error(`  SOURCECRED_GITHUB_TOKEN: ${url}`);
+    console.error("Optional environment variables:");
+    console.error("  NODES_LIMIT: positive integer (default 100)");
+    console.error("  CONNECTION_PAGE_SIZE: integer 1..100 (default) inclusive");
+    console.error("  CONNECTION_LIMIT: positive integer (default 100)");
+    process.exitCode = 1;
+    return;
+  }
+  const [dbFilename, typename, id, ttlSecondsString] = args;
+
+  const db = new Database(dbFilename);
+  const mirror = new Mirror(db, schema());
+  console.warn("Registering...");
+  mirror.registerObject({typename, id});
+  console.warn("Updating...");
+  await mirror.update(
+    async (payload) => {
+      console.warn("[Posting query...]");
+      console.warn(
+        JSON.stringify({
+          type: "REQUEST",
+          graphql: Queries.stringify.body(payload.body, Queries.inlineLayout()),
+        })
+      );
+      const result = await postQuery(payload, token);
+      console.warn("[Processing result...]");
+      console.warn(JSON.stringify({type: "RESPONSE", result}));
+      return result;
+    },
+    {
+      nodesLimit: +(process.env.NODES_LIMIT || 100),
+      nodesOfTypeLimit: 100,
+      connectionPageSize: +(process.env.CONNECTION_PAGE_SIZE || 100),
+      connectionLimit: +(process.env.CONNECTION_LIMIT || 100),
+      since: new Date(new Date() - +ttlSecondsString * 1000),
+      now: () => new Date(),
+    }
+  );
+  console.warn("Extracting...");
+  const result = mirror.extract(id);
+  console.log(JSON.stringify(result, null, 4));
+}
+
+function schema(): Schema.Schema {
+  const s = Schema;
+  const types: {[Schema.Typename]: Schema.NodeType} = {
+    Repository: s.object({
+      id: s.id(),
+      url: s.primitive(),
+      name: s.primitive(),
+      owner: s.node("RepositoryOwner"),
+      issues: s.connection("Issue"),
+      pullRequests: s.connection("PullRequest"),
+      defaultBranchRef: s.node("Ref"),
+    }),
+    Issue: s.object({
+      id: s.id(),
+      url: s.primitive(),
+      title: s.primitive(),
+      body: s.primitive(),
+      number: s.primitive(),
+      author: s.node("Actor"),
+      comments: s.connection("IssueComment"),
+      reactions: s.connection("Reaction"),
+    }),
+    PullRequest: s.object({
+      id: s.id(),
+      url: s.primitive(),
+      title: s.primitive(),
+      body: s.primitive(),
+      number: s.primitive(),
+      mergeCommit: s.node("Commit"),
+      additions: s.primitive(),
+      deletions: s.primitive(),
+      author: s.node("Actor"),
+      comments: s.connection("IssueComment"), // yes, PRs have IssueComments
+      reviews: s.connection("PullRequestReview"),
+      reactions: s.connection("Reaction"),
+    }),
+    IssueComment: s.object({
+      id: s.id(),
+      url: s.primitive(),
+      body: s.primitive(),
+      author: s.node("Actor"),
+      reactions: s.connection("Reaction"),
+    }),
+    PullRequestReview: s.object({
+      id: s.id(),
+      url: s.primitive(),
+      body: s.primitive(),
+      author: s.node("Actor"),
+      state: s.primitive(),
+      comments: s.connection("PullRequestReviewComment"),
+    }),
+    PullRequestReviewComment: s.object({
+      id: s.id(),
+      url: s.primitive(),
+      body: s.primitive(),
+      author: s.node("Actor"),
+      reactions: s.connection("Reaction"),
+    }),
+    Reaction: s.object({
+      id: s.id(),
+      content: s.primitive(),
+      user: s.node("User"),
+    }),
+    Ref: s.object({
+      id: s.id(),
+      target: s.node("GitObject"),
+    }),
+    GitObject: s.union(["Blob", "Commit", "Tag", "Tree"]),
+    Blob: s.object({
+      id: s.id(),
+      oid: s.primitive(),
+    }),
+    Commit: s.object({
+      id: s.id(),
+      url: s.primitive(),
+      oid: s.primitive(),
+      message: s.primitive(),
+      // author omitted for now: GitActor has no `id`; see:
+      // https://github.com/sourcecred/sourcecred/issues/622#issuecomment-425220132
+    }),
+    Tag: s.object({
+      id: s.id(),
+      oid: s.primitive(),
+    }),
+    Tree: s.object({
+      id: s.id(),
+      oid: s.primitive(),
+      name: s.primitive(),
+    }),
+    Actor: s.union(["User", "Bot", "Organization"]), // actually an interface
+    RepositoryOwner: s.union(["User", "Organization"]), // actually an interface
+    User: s.object({
+      id: s.id(),
+      url: s.primitive(),
+      login: s.primitive(),
+    }),
+    Bot: s.object({
+      id: s.id(),
+      url: s.primitive(),
+      login: s.primitive(),
+    }),
+    Organization: s.object({
+      id: s.id(),
+      url: s.primitive(),
+      login: s.primitive(),
+    }),
+  };
+  return s.schema(types);
+}

--- a/src/plugins/github/fetchGithubRepo.js
+++ b/src/plugins/github/fetchGithubRepo.js
@@ -7,7 +7,7 @@
 import fetch from "isomorphic-fetch";
 import retry from "retry";
 
-import {stringify, inlineLayout} from "../../graphql/queries";
+import {stringify, inlineLayout, type Body} from "../../graphql/queries";
 import {createQuery, createVariables, postQueryExhaustive} from "./graphql";
 import type {GithubResponseJSON} from "./graphql";
 import type {RepoId} from "../../core/repoId";
@@ -131,7 +131,10 @@ function retryGithubFetch(fetch, fetchOptions) {
   });
 }
 
-async function postQuery({body, variables}, token): Promise<any> {
+export async function postQuery(
+  {body, variables}: {+body: Body, +variables: mixed},
+  token: string
+): Promise<any> {
   const postBody = JSON.stringify({
     query: stringify.body(body, inlineLayout()),
     variables: variables,


### PR DESCRIPTION
Summary:
This completes the minimum viable public API for the `Mirror` class. As
described on the docstring, the typical workflow for a client is:

  - Invoke the constructor to acquire a `Mirror` instance.
  - Invoke `registerObject` to register a root object of interest.
  - Invoke `update` to update all transitive dependencies.
  - Invoke `extract` to retrieve the data in structured form.

It is the third step that is added in this commit.

In this commit, we also include a command-line demo of the Mirror
module, which exercises exactly the workflow above with a hard-coded
GitHub schema. This can be used to test the module’s behavior with
real-world data. I plan to remove this entry point once we integrate
this module into SourceCred.

This commit makes progress toward #622.

Test Plan:
Unit tests included for the core functionality. The imperative shell
does not have automated tests. You can test it as follows.

First, run `yarn backend` to build `bin/mirror.js`. Then, run:

```shell
$ node bin/mirror.js /tmp/mirror-demo.db \
> Repository MDEwOlJlcG9zaXRvcnkxMjMyNTUwMDY= \
> 60
```

Here, the big base64 string is the ID for the sourcecred/example-github
repository. (This is listed in `graphql/demo.js`, alongside the ID for
the SourceCred repository itself.) The value 60 is a TTL in seconds. The
database filename is arbitrary.

This will print out a ton of output to stderr (all intermediate queries
and responses, for debugging purposes), and then the full contents of
the example repository to stdout.

Run the command again, and it should finish instantly. On my machine,
the main function runs faster than the Node startup time (50ms vs 60ms).

Then, re-run the command, changing the TTL from `60` to `1`. Note that
it sends off some queries and then prints the same repository.

It is safe to kill the program at any time, either while waiting for a
response from GitHub or while processing the results, because the mirror
module takes advantage of SQLite’s transaction-safety. Intermediate
updates will be persisted, so you’ll lose just a few seconds of
progress.

You can also of course dive into the generated database yourself to
explore the data. It’s good fun.

wchargin-branch: mirror-e2e-update