### PR TITLE
schema: support shallow-nested object fields

### DIFF
--- a/src/graphql/mirror.js
+++ b/src/graphql/mirror.js
@@ -1056,6 +1056,8 @@ export class Mirror {
             case "CONNECTION":
               // Not handled by this function.
               return null;
+            case "NESTED":
+              throw new Error("Nested fields not supported.");
             // istanbul ignore next
             default:
               throw new Error((field.type: empty));
@@ -1563,6 +1565,8 @@ export function _buildSchemaInfo(schema: Schema.Schema): SchemaInfo {
             case "CONNECTION":
               entry.connectionFieldNames.push(fieldname);
               break;
+            case "NESTED":
+              throw new Error("Nested fields not supported.");
             // istanbul ignore next
             default:
               throw new Error((field.type: empty));

--- a/src/graphql/schema.test.js
+++ b/src/graphql/schema.test.js
@@ -19,6 +19,14 @@ describe("graphql/schema", () => {
         title: s.primitive(),
         comments: s.connection("IssueComment"),
       }),
+      Commit: s.object({
+        id: s.id(),
+        oid: s.primitive(),
+        author: /* GitActor */ s.nested({
+          date: s.primitive(),
+          user: s.node("User"),
+        }),
+      }),
       IssueComment: s.object({
         id: s.id(),
         body: s.primitive(),


### PR DESCRIPTION
Summary:
See #915 for context. This commit changes the `schema` module only.

I had a hard time picking names that clearly distinguish the top-level
field on the object and the subfields that it contains. @decentralion
and I independently came up with “nest” and “egg”. It’s a bit colorful,
but it’s certainly easy to remember which one is which, and it doesn’t
conflict with existing notions like “parent”/“child”.

Test Plan:
Unit tests expanded slightly, retaining full coverage.

wchargin-branch: schema-shallow