### PR TITLE
mirror: add support for shallow-nested fields

### DIFF
--- a/src/graphql/__snapshots__/mirror.test.js.snap
+++ b/src/graphql/__snapshots__/mirror.test.js.snap
@@ -234,8 +234,8 @@ exports[`graphql/mirror Mirror _queryConnection snapshot test for actual GitHub 
 `;
 
 exports[`graphql/mirror Mirror _updateOwnData snapshot test for actual GitHub queries 1`] = `
-"query TestQuery {
-  node(id: \\"MDU6SXNzdWUzNDg1NDA0NjE=\\") {
+"query TestUpdate {
+  issue: node(id: \\"MDU6SXNzdWUzNDg1NDA0NjE=\\") {
     ... on Issue {
       __typename
       id
@@ -257,6 +257,20 @@ exports[`graphql/mirror Mirror _updateOwnData snapshot test for actual GitHub qu
         id
       }
       title
+    }
+  }
+  commit: node(id: \\"MDY6Q29tbWl0MTIwMTQ1NTcwOjU1OTUwZjUzNTQ1NTEwOWJhNDhhYmYyYjk3N2U2NmFhMWNjMzVlNjk=\\") {
+    ... on Commit {
+      __typename
+      id
+      oid
+      author {
+        date
+        user {
+          __typename
+          id
+        }
+      }
     }
   }
 }"

--- a/src/graphql/demo.js
+++ b/src/graphql/demo.js
@@ -158,8 +158,10 @@ function schema(): Schema.Schema {
       url: s.primitive(),
       oid: s.primitive(),
       message: s.primitive(),
-      // author omitted for now: GitActor has no `id`; see:
-      // https://github.com/sourcecred/sourcecred/issues/622#issuecomment-425220132
+      author: /* GitActor */ s.nested({
+        date: s.primitive(),
+        user: s.node("User"),
+      }),
     }),
     Tag: s.object({
       id: s.id(),


### PR DESCRIPTION
Summary:
This commit follows up on the previous two pull requests by drawing the
rest of the owl.

Resolves #915.

Test Plan:
Unit tests included.

To verify the snapshot change, open the snapshot file, and copy
everything from `query TestUpdate {` through the matching `}`, not
including the enclosing quotes. Strip all backslashes (Jest adds them).
Post the resulting query to GitHub and verify that it completes
successfully and that the result contains a commit with an `author`.

In other words, `xsel -ob | tr -d '\\' | ghquery | jq .` with [ghquery].

[ghquery]: https://gist.github.com/wchargin/630e03e66fa084b7b2297189615326d1

The demo entry point has also been updated. For an end-to-end test, you
can run the following command to see a commit with a `null` author (with
the current state of the repository) and a commit with a non-`null`
author:

```
$ node bin/mirror.js /tmp/mirror-example.db \
>     Repository MDEwOlJlcG9zaXRvcnkxMjMyNTUwMDY= \
>     3600 2>/dev/null |
> jq '(.defaultBranchRef.target, .pullRequests[0].mergeCommit) | {url, author}'
{
  "url": "https://github.com/sourcecred/example-github/commit/6bd1b4c0b719c22c688a74863be07a699b7b9b34",
  "author": {
    "date": "2018-09-12T19:48:21-07:00",
    "user": null
  }
}
{
  "url": "https://github.com/sourcecred/example-github/commit/0a223346b4e6dec0127b1e6aa892c4ee0424b66a",
  "author": {
    "date": "2018-02-28T00:43:47-08:00",
    "user": {
      "id": "MDQ6VXNlcjE0MDAwMjM=",
      "__typename": "User",
      "url": "https://github.com/decentralion",
      "login": "decentralion"
    }
  }
}
```

You can also check that it is possible to fetch the whole SourceCred
repository (ID: `MDEwOlJlcG9zaXRvcnkxMjAxNDU1NzA=`).

wchargin-branch: mirror-shallow