### PR TITLE
github: fetch dates from commits

### DIFF
--- a/src/plugins/github/__snapshots__/graphql.test.js.snap
+++ b/src/plugins/github/__snapshots__/graphql.test.js.snap
@@ -361,6 +361,7 @@ fragment commit on Commit {
   oid
   message
   author {
+    date
     user {
       ...whoami
     }

--- a/src/plugins/github/example/example-github.json
+++ b/src/plugins/github/example/example-github.json
@@ -7,6 +7,7 @@
                     "nodes": [
                         {
                             "author": {
+                                "date": "2018-09-12T19:48:21-07:00",
                                 "user": null
                             },
                             "id": "MDY6Q29tbWl0MTIzMjU1MDA2OjZiZDFiNGMwYjcxOWMyMmM2ODhhNzQ4NjNiZTA3YTY5OWI3YjliMzQ=",
@@ -16,6 +17,7 @@
                         },
                         {
                             "author": {
+                                "date": "2018-09-12T14:43:54-07:00",
                                 "user": {
                                     "__typename": "User",
                                     "id": "MDQ6VXNlcjQyODE5Mzgy",
@@ -30,6 +32,7 @@
                         },
                         {
                             "author": {
+                                "date": "2018-02-28T20:25:54-08:00",
                                 "user": {
                                     "__typename": "User",
                                     "id": "MDQ6VXNlcjE0MDAwMjM=",
@@ -44,6 +47,7 @@
                         },
                         {
                             "author": {
+                                "date": "2018-02-28T00:43:47-08:00",
                                 "user": {
                                     "__typename": "User",
                                     "id": "MDQ6VXNlcjE0MDAwMjM=",
@@ -58,6 +62,7 @@
                         },
                         {
                             "author": {
+                                "date": "2018-02-28T00:42:09-08:00",
                                 "user": {
                                     "__typename": "User",
                                     "id": "MDQ6VXNlcjE0MDAwMjM=",
@@ -72,6 +77,7 @@
                         },
                         {
                             "author": {
+                                "date": "2018-02-28T00:41:11-08:00",
                                 "user": {
                                     "__typename": "User",
                                     "id": "MDQ6VXNlcjE0MDAwMjM=",
@@ -864,6 +870,7 @@
                     "id": "MDExOlB1bGxSZXF1ZXN0MTcxODg3NzQx",
                     "mergeCommit": {
                         "author": {
+                            "date": "2018-02-28T00:43:47-08:00",
                             "user": {
                                 "__typename": "User",
                                 "id": "MDQ6VXNlcjE0MDAwMjM=",
@@ -956,6 +963,7 @@
                     "id": "MDExOlB1bGxSZXF1ZXN0MTcxODg4NTIy",
                     "mergeCommit": {
                         "author": {
+                            "date": "2018-02-28T20:25:54-08:00",
                             "user": {
                                 "__typename": "User",
                                 "id": "MDQ6VXNlcjE0MDAwMjM=",

--- a/src/plugins/github/graphql.js
+++ b/src/plugins/github/graphql.js
@@ -1002,7 +1002,10 @@ export type CommitJSON = {|
   +id: string,
   +url: string,
   +oid: string, // the hash
-  +author: ?{|+user: NullableAuthorJSON|},
+  +author: ?{|
+    +date: /* ISO 8601 */ string,
+    +user: NullableAuthorJSON,
+  |},
   +message: string,
 |};
 
@@ -1013,7 +1016,10 @@ function commitFragment(): FragmentDefinition {
     b.field("url"),
     b.field("oid"),
     b.field("message"),
-    b.field("author", {}, [b.field("user", {}, [b.fragmentSpread("whoami")])]),
+    b.field("author", {}, [
+      b.field("date"),
+      b.field("user", {}, [b.fragmentSpread("whoami")]),
+    ]),
   ]);
 }
 


### PR DESCRIPTION
Summary:
This has two benefits:

  - The dates on commits are data that we will probably want when we add
    timestamps to authorship edges to accommodate time-weighted cred.

  - Once the mirror module is integrated with the GitHub plugin, we’ll
    want to fetch dates on commits, because this is the only real-world
    test case for a nested field that contains a primitive field (as
    opposed to a node reference), so it’ll be nice to be continually
    exercising that somewhat-edge case.

Date strings are in commit-local time and do not depend on the time zone
of the requester (in contrast to [cursors]). For example, on SourceCred:

```shell
$ time node ./bin/fetchAndPrintGithubRepo.js \
> sourcecred sourcecred "${GITHUB_TOKEN}" |
> jq -rc '
>     .repository.defaultBranchRef.target.history.nodes[]
>     .author?.date[-6:]
> ' | sort | uniq -c
      1 +03:00
      6 -04:00
    717 -07:00
     58 -08:00
```

[cursors]: <https://github.com/sourcecred/sourcecred/pull/129#issuecomment-382970474>

Test Plan:
The snapshot contains 8 instances of `oid` and 8 instances of `date`,
which is good (each of these properties appears exactly once on each
commit, and nowhere else). Running `yarn test --full` passes.

wchargin-branch: github-commit-dates