### PR TITLE
schema: allow annotating primitive field types

### DIFF
--- a/src/graphql/mirror.js
+++ b/src/graphql/mirror.js
@@ -808,6 +808,15 @@ export class Mirror {
     }
     const b = Queries.build;
     switch (type.type) {
+      case "SCALAR":
+        throw new Error(
+          "Cannot create selections for scalar type: " +
+            JSON.stringify(typename)
+        );
+      case "ENUM":
+        throw new Error(
+          "Cannot create selections for enum type: " + JSON.stringify(typename)
+        );
       case "OBJECT":
         return [b.field("__typename"), b.field("id")];
       case "UNION":
@@ -1831,6 +1840,12 @@ export function _buildSchemaInfo(schema: Schema.Schema): SchemaInfo {
   for (const typename of Object.keys(schema)) {
     const type = schema[typename];
     switch (type.type) {
+      case "SCALAR":
+        // Nothing to do.
+        break;
+      case "ENUM":
+        // Nothing to do.
+        break;
       case "OBJECT": {
         const entry: {|
           +fields: {|+[Schema.Fieldname]: Schema.FieldType|},


### PR DESCRIPTION
Summary:
Prior to this change, primitive fields were un\[i\]typed. This commit
allows adding type annotations. Such annotations do not change the
semantics at all, but we will be able to use them to generate Flow types
corresponding to a schema.

This commit also strengthens the validation on schemata to catch some
errors that would previously have gone unnoticed at schema construction
time: e.g., a node reference to a type that does not exist.

Test Plan:
Unit tests updated, retaining full coverage. The demo script continues
to work when loading `example-github` or `sourcecred`.

wchargin-branch: schema-annotated-primitives