### PR TITLE
github: fix misc. errors in old GraphQL system

### DIFF
--- a/src/plugins/github/__snapshots__/graphql.test.js.snap
+++ b/src/plugins/github/__snapshots__/graphql.test.js.snap
@@ -217,12 +217,25 @@ exports[`plugins/github/graphql creates a query 1`] = `
       ...pulls
     }
     defaultBranchRef {
+      id
       target {
         __typename
         ... on Commit {
           history(first: 100) {
             ...commitHistory
           }
+        }
+        ... on Blob {
+          id
+          oid
+        }
+        ... on Tag {
+          id
+          oid
+        }
+        ... on Tree {
+          id
+          oid
         }
       }
     }

--- a/src/plugins/github/example/example-github.json
+++ b/src/plugins/github/example/example-github.json
@@ -1,6 +1,7 @@
 {
     "repository": {
         "defaultBranchRef": {
+            "id": "MDM6UmVmMTIzMjU1MDA2Om1hc3Rlcg==",
             "target": {
                 "__typename": "Commit",
                 "history": {


### PR DESCRIPTION
Summary:
This fixes the following issues:

  - Pull request reviews actually do not have reactions.
  - We must fetch the `id` of a `Ref`.
  - We must fetch the `id` of a `Commit`, `Tree`, `Blob`, or `Tag`, and
    should also fetch its `oid`.
  - Repository owners cannot be bots.
  - Commit and reaction authors cannot be bots, organizations, or
    `undefined`.

Test Plan:
Running `yarn test --full` passes, and the snapshot diff is clearly
correct.

wchargin-branch: github-fix-up-continuations