### PR TITLE
flow-typed: update prettier libdef metadata

### DIFF
--- a/flow-typed/npm/prettier_v1.x.x.js
+++ b/flow-typed/npm/prettier_v1.x.x.js
@@ -1,5 +1,5 @@
-// flow-typed signature: 4eed8da2dc730dc33e7710b465eaa44b
-// flow-typed version: cc7a557b34/prettier_v1.x.x/flow_>=v0.56.x
+// flow-typed signature: 066c92e9ccb5f0711df8d73cbca837d6
+// flow-typed version: 9e32affdbd/prettier_v1.x.x/flow_>=v0.56.x
 
 declare module "prettier" {
   declare export type AST = Object;


### PR DESCRIPTION
Summary:
Generated with `flow-typed install prettier@1.13.4 --overwrite`. The
changes in #925 have been merged upstream; this pulls in the updated
signature and version.

Test Plan:
`yarn flow` passes.

wchargin-branch: flow-typed-update-prettier