### PR TITLE
relationalView: use new data format

### DIFF
--- a/config/paths.js
+++ b/config/paths.js
@@ -29,6 +29,9 @@ module.exports = {
   backendEntryPoints: {
     sourcecred: resolveApp("src/cli/main.js"),
     //
+    testContinuations: resolveApp(
+      "src/plugins/github/bin/testContinuations.js"
+    ),
     generateGithubGraphqlFlowTypes: resolveApp(
       "src/plugins/github/bin/generateGraphqlFlowTypes.js"
     ),

--- a/src/plugins/github/bin/testContinuations.js
+++ b/src/plugins/github/bin/testContinuations.js
@@ -1,0 +1,106 @@
+// @flow
+// Ad hoc testing script for RelationalView input format consistency.
+
+import Database from "better-sqlite3";
+import fs from "fs-extra";
+import stringify from "json-stable-stringify";
+import deepEqual from "lodash.isequal";
+
+import {makeRepoId} from "../../../core/repoId";
+import {Mirror} from "../../../graphql/mirror";
+import fetchGithubRepo, {postQuery} from "../fetchGithubRepo";
+import type {Repository} from "../graphqlTypes";
+import {RelationalView, type RelationalViewJSON} from "../relationalView";
+import githubSchema from "../schema";
+
+async function test(options: {|
+  +token: string,
+  +owner: string,
+  +name: string,
+  +graphqlId: string,
+  +outputFilepaths: {|
+    +continuations: string,
+    +mirror: string,
+  |},
+|}) {
+  async function fetchViaContinuations(): Promise<RelationalViewJSON> {
+    const raw = await fetchGithubRepo(
+      makeRepoId(options.owner, options.name),
+      options.token
+    );
+    const rv = new RelationalView();
+    rv.addData(raw);
+    return rv.toJSON();
+  }
+
+  async function fetchViaMirror(): Promise<RelationalViewJSON> {
+    const mirror = new Mirror(new Database(":memory:"), githubSchema());
+    mirror.registerObject({typename: "Repository", id: options.graphqlId});
+    await mirror.update((payload) => postQuery(payload, options.token), {
+      nodesLimit: 100,
+      nodesOfTypeLimit: 100,
+      connectionPageSize: 100,
+      connectionLimit: 100,
+      since: new Date(0),
+      now: () => new Date(),
+    });
+    const repository = ((mirror.extract(options.graphqlId): any): Repository);
+    const rv = new RelationalView();
+    rv.addRepository(repository);
+    return rv.toJSON();
+  }
+
+  function saveTo(filename: string, repo: RelationalViewJSON): Promise<void> {
+    return fs.writeFile(filename, stringify(repo));
+  }
+
+  const [viaContinuations, viaMirror] = await Promise.all([
+    fetchViaContinuations(),
+    fetchViaMirror(),
+  ]);
+
+  if (deepEqual(viaContinuations, viaMirror)) {
+    console.log("Identical. Saving to disk...");
+  } else {
+    console.log("Different. Saving to disk...");
+  }
+
+  await Promise.all([
+    saveTo(options.outputFilepaths.continuations, viaContinuations),
+    saveTo(options.outputFilepaths.mirror, viaMirror),
+  ]);
+}
+
+async function main() {
+  const args = process.argv.slice(2);
+  const token = process.env.SOURCECRED_GITHUB_TOKEN;
+  if (args.length !== 5 || token == null) {
+    const invocation = [
+      "SOURCECRED_GITHUB_TOKEN=<token>",
+      "node",
+      "test.js",
+      "REPO_OWNER",
+      "REPO_NAME",
+      "GRAPHQL_ID",
+      "CONTINUATIONS_OUTPUT_FILENAME",
+      "MIRROR_OUTPUT_FILENAME",
+    ];
+    console.error("usage: " + invocation.join(" "));
+    process.exitCode = 1;
+    return;
+  }
+  const [owner, name, graphqlId, continuations, mirror] = args;
+  const options = {
+    token,
+    owner,
+    name,
+    graphqlId,
+    outputFilepaths: {
+      continuations,
+      mirror,
+    },
+  };
+  await test(options);
+}
+
+main();

--- a/src/plugins/github/relationalView.test.js
+++ b/src/plugins/github/relationalView.test.js
@@ -355,4 +355,29 @@ describe("plugins/github/relationalView", () => {
       expect(json1).toEqual(json2);
     });
   });
+
+  describe("expectAllNonNull", () => {
+    it("returns non-null elements unscathed, with no warnings", () => {
+      jest.spyOn(console, "warn").mockImplementation(() => {});
+      jest.spyOn(console, "error").mockImplementation(() => {});
+
+      const o = {__typename: "X", id: "x", xs: [1, 2]};
+      expect(R.expectAllNonNull(o, "xs", o.xs)).toEqual([1, 2]);
+      expect(console.warn).not.toHaveBeenCalled();
+      expect(console.error).not.toHaveBeenCalled();
+    });
+
+    it("filters out nulls, issuing a warning", () => {
+      jest.spyOn(console, "warn").mockImplementation(() => {});
+      jest.spyOn(console, "error").mockImplementation(() => {});
+
+      const o = {__typename: "X", id: "x", xs: [1, null, 3, null]};
+      expect(R.expectAllNonNull(o, "xs", o.xs)).toEqual([1, 3]);
+      expect(console.warn).toHaveBeenCalledTimes(2);
+      expect(console.warn).toHaveBeenCalledWith(
+        "X[x].xs: unexpected null value"
+      );
+      expect(console.error).not.toHaveBeenCalled();
+    });
+  });
 });


### PR DESCRIPTION
Summary:
This makes significant progress toward #923. As of this commit, it is
possible to use the Mirror module for the whole loading pipeline. This
process may be slow for repositories that do not use pull requests at
all (more precisely, that have large connected commit subgraphs none of
whose nodes is the merge commit of a pull request; see #920 for details)
so it is not yet the default codepath.

Test Plan:
Existing unit tests should suffice. For extra testing, I’ve added a
script that fetches a repository both via the old continuations logic
and the new Mirror logic, then constructs relational views and checks
whether the data is the same. For `example-github`, the views are
identical. For `sourcecred`, they are not: the old continuations logic
erroneously omits two commits, which the Mirror logic includes.

You can run the test like this:

```
$ node ./bin/testContinuations.js \
> sourcecred sourcecred MDEwOlJlcG9zaXRvcnkxMjAxNDU1NzA= \
> /tmp/continuations.json /tmp/mirror.json \
> 2> >(jq . >&2)
{
  "child": "0d38dde23a6de831315f3643a7d2bc15e8df7678",
  "parent": "cb8ba0eaa1abc1f921e7165bb19e29b40723ce65",
  "type": "UNKNOWN_PARENT_OID"
}
{
  "child": "d152f48ce4c2ed1d046bf6ed4f139e7e393ea660",
  "parent": "de7a8723963d9cd0437ef34f5942a071b850c0e7",
  "type": "UNKNOWN_PARENT_OID"
}
Different. Saving to disk...
```

Use `diff -u <(jq . /tmp/continuations.json) <(jq . /tmp/mirror.json)`
to inspect the differences, and note that exactly the two missing
commits have been added and that there are no other changes. (The diff
is small: just 51 lines of nicely formatted JSON.) The full log is here:
<https://gist.github.com/wchargin/e159cac9dcf3cc3b1efbd54f59e24e0b>

I also generated the `sourcecred/sourcecred` cred attribution and viewed
it with `yarn start`, which seems to work fine.

wchargin-branch: relationalview-new-data-format