### PR TITLE
Move some files from core/attribution/ to analysis/

### DIFF
--- a/src/analysis/__snapshots__/pagerankNodeDecomposition.test.js.snap
+++ b/src/analysis/__snapshots__/pagerankNodeDecomposition.test.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`core/attribution/pagerankNodeDecomposition decompose has the expected output on a simple asymmetric chain 1`] = `
+exports[`analysis/pagerankNodeDecomposition decompose has the expected output on a simple asymmetric chain 1`] = `
 Map {
   "NodeAddress[\\"n1\\"]" => Object {
     "score": 0.19117656878499834,

--- a/src/analysis/nodeScore.js
+++ b/src/analysis/nodeScore.js
@@ -1,7 +1,7 @@
 // @flow
 
-import {NodeAddress, type NodeAddressT} from "../graph";
-import type {NodeDistribution} from "./graphToMarkovChain";
+import {NodeAddress, type NodeAddressT} from "../core/graph";
+import type {NodeDistribution} from "../core/attribution/graphToMarkovChain";
 
 export type NodeScore = Map<NodeAddressT, number>;
 

--- a/src/analysis/nodeScore.test.js
+++ b/src/analysis/nodeScore.test.js
@@ -1,8 +1,9 @@
 // @flow
 
-import {NodeAddress} from "../graph";
+import {NodeAddress} from "../core/graph";
 import {scoreByMaximumProbability, scoreByConstantTotal} from "./nodeScore";
-describe("core/attribution/nodeScore", () => {
+
+describe("analysis/nodeScore", () => {
   const foo = NodeAddress.fromParts(["foo"]);
   const bar = NodeAddress.fromParts(["bar"]);
   const zod = NodeAddress.fromParts(["zod"]);

--- a/src/analysis/pagerank.js
+++ b/src/analysis/pagerank.js
@@ -1,12 +1,12 @@
 // @flow
 
-import {type Edge, Graph, NodeAddress, type NodeAddressT} from "../graph";
+import {type Edge, Graph, NodeAddress, type NodeAddressT} from "../core/graph";
 import {
   distributionToNodeDistribution,
   createConnections,
   createOrderedSparseMarkovChain,
   type EdgeWeight,
-} from "./graphToMarkovChain";
+} from "../core/attribution/graphToMarkovChain";
 import {
   decompose,
   type PagerankNodeDecomposition,
@@ -14,9 +14,9 @@ import {
 
 import {scoreByConstantTotal} from "./nodeScore";
 
-import {findStationaryDistribution} from "./markovChain";
+import {findStationaryDistribution} from "../core/attribution/markovChain";
 
-export type {NodeDistribution} from "./graphToMarkovChain";
+export type {NodeDistribution} from "../core/attribution/graphToMarkovChain";
 export type {PagerankNodeDecomposition} from "./pagerankNodeDecomposition";
 export type PagerankOptions = {|
   +selfLoopWeight?: number,
@@ -29,7 +29,7 @@ export type PagerankOptions = {|
   +totalScoreNodePrefix?: NodeAddressT,
 |};
 
-export type {EdgeWeight} from "./graphToMarkovChain";
+export type {EdgeWeight} from "../core/attribution/graphToMarkovChain";
 export type EdgeEvaluator = (Edge) => EdgeWeight;
 
 function defaultOptions(): PagerankOptions {

--- a/src/analysis/pagerankNodeDecomposition.js
+++ b/src/analysis/pagerankNodeDecomposition.js
@@ -2,15 +2,15 @@
 
 import sortBy from "lodash.sortby";
 
-import type {NodeAddressT} from "../graph";
+import type {NodeAddressT} from "../core/graph";
 import {
   type Connection,
   type NodeToConnections,
   adjacencySource,
-} from "./graphToMarkovChain";
+} from "../core/attribution/graphToMarkovChain";
 import type {NodeScore} from "./nodeScore";
-import * as MapUtil from "../../util/map";
-import * as NullUtil from "../../util/null";
+import * as MapUtil from "../util/map";
+import * as NullUtil from "../util/null";
 
 export type ScoredConnection = {|
   +connection: Connection,

--- a/src/analysis/pagerankNodeDecomposition.test.js
+++ b/src/analysis/pagerankNodeDecomposition.test.js
@@ -1,16 +1,16 @@
 // @flow
 
-import {EdgeAddress, Graph, NodeAddress, edgeToStrings} from "../graph";
+import {EdgeAddress, Graph, NodeAddress, edgeToStrings} from "../core/graph";
 import {
   distributionToNodeDistribution,
   createConnections,
   createOrderedSparseMarkovChain,
-} from "./graphToMarkovChain";
-import {findStationaryDistribution} from "./markovChain";
+} from "../core/attribution/graphToMarkovChain";
+import {findStationaryDistribution} from "../core/attribution/markovChain";
 import {decompose} from "./pagerankNodeDecomposition";
-import * as MapUtil from "../../util/map";
+import * as MapUtil from "../util/map";
 
-import {advancedGraph} from "../graphTestUtil";
+import {advancedGraph} from "../core/graphTestUtil";
 
 /**
  * Format a decomposition to be shown in a snapshot. This converts
@@ -108,7 +108,7 @@ function validateDecomposition(decomposition) {
   }
 }
 
-describe("core/attribution/pagerankNodeDecomposition", () => {
+describe("analysis/pagerankNodeDecomposition", () => {
   describe("decompose", () => {
     it("has the expected output on a simple asymmetric chain", async () => {
       const n1 = NodeAddress.fromParts(["n1"]);

--- a/src/app/credExplorer/pagerankTable/Connection.js
+++ b/src/app/credExplorer/pagerankTable/Connection.js
@@ -5,7 +5,7 @@ import * as NullUtil from "../../../util/null";
 
 import type {NodeAddressT} from "../../../core/graph";
 import type {Connection} from "../../../core/attribution/graphToMarkovChain";
-import type {ScoredConnection} from "../../../core/attribution/pagerankNodeDecomposition";
+import type {ScoredConnection} from "../../../analysis/pagerankNodeDecomposition";
 import {DynamicAdapterSet} from "../../adapters/adapterSet";
 import {TableRow} from "./TableRow";
 import {NodeRow} from "./Node";

--- a/src/app/credExplorer/pagerankTable/Table.js
+++ b/src/app/credExplorer/pagerankTable/Table.js
@@ -5,7 +5,7 @@ import sortBy from "lodash.sortby";
 import * as NullUtil from "../../../util/null";
 
 import {type NodeAddressT, NodeAddress} from "../../../core/graph";
-import type {PagerankNodeDecomposition} from "../../../core/attribution/pagerankNodeDecomposition";
+import type {PagerankNodeDecomposition} from "../../../analysis/pagerankNodeDecomposition";
 import {DynamicAdapterSet} from "../../adapters/adapterSet";
 import type {DynamicPluginAdapter} from "../../adapters/pluginAdapter";
 import {FALLBACK_NAME} from "../../adapters/fallbackAdapter";

--- a/src/app/credExplorer/pagerankTable/aggregate.js
+++ b/src/app/credExplorer/pagerankTable/aggregate.js
@@ -5,7 +5,7 @@ import stringify from "json-stable-stringify";
 import * as MapUtil from "../../../util/map";
 import {NodeTrie, EdgeTrie} from "../../../core/trie";
 import type {NodeType, EdgeType} from "../../adapters/pluginAdapter";
-import type {ScoredConnection} from "../../../core/attribution/pagerankNodeDecomposition";
+import type {ScoredConnection} from "../../../analysis/pagerankNodeDecomposition";
 
 // Sorted by descending `summary.score`
 export type FlatAggregations = $ReadOnlyArray<FlatAggregation>;

--- a/src/app/credExplorer/pagerankTable/shared.js
+++ b/src/app/credExplorer/pagerankTable/shared.js
@@ -9,7 +9,7 @@ import {
 
 import {DynamicAdapterSet} from "../../adapters/adapterSet";
 
-import type {PagerankNodeDecomposition} from "../../../core/attribution/pagerankNodeDecomposition";
+import type {PagerankNodeDecomposition} from "../../../analysis/pagerankNodeDecomposition";
 
 export function nodeDescription(
   address: NodeAddressT,

--- a/src/app/credExplorer/pagerankTable/sharedTestUtils.js
+++ b/src/app/credExplorer/pagerankTable/sharedTestUtils.js
@@ -1,7 +1,7 @@
 // @flow
 
 import {dynamicAdapterSet} from "../../adapters/demoAdapters";
-import {pagerank} from "../../../core/attribution/pagerank";
+import {pagerank} from "../../../analysis/pagerank";
 import {defaultWeightsForAdapterSet} from "../weights/weights";
 
 export const COLUMNS = () => ["Description", "", "Cred"];

--- a/src/app/credExplorer/state.js
+++ b/src/app/credExplorer/state.js
@@ -5,12 +5,12 @@ import deepEqual from "lodash.isequal";
 import {Graph, type NodeAddressT} from "../../core/graph";
 import type {Assets} from "../../app/assets";
 import type {RepoId} from "../../core/repoId";
-import {type EdgeEvaluator} from "../../core/attribution/pagerank";
+import {type EdgeEvaluator} from "../../analysis/pagerank";
 import {
   type PagerankNodeDecomposition,
   type PagerankOptions,
   pagerank,
-} from "../../core/attribution/pagerank";
+} from "../../analysis/pagerank";
 
 import {StaticAdapterSet, DynamicAdapterSet} from "../adapters/adapterSet";
 import type {WeightedTypes} from "./weights/weights";

--- a/src/app/credExplorer/state.test.js
+++ b/src/app/credExplorer/state.test.js
@@ -10,7 +10,7 @@ import {
 import {Graph, NodeAddress} from "../../core/graph";
 import {Assets} from "../assets";
 import {makeRepoId, type RepoId} from "../../core/repoId";
-import {type EdgeEvaluator} from "../../core/attribution/pagerank";
+import {type EdgeEvaluator} from "../../analysis/pagerank";
 import {
   type WeightedTypes,
   defaultWeightsForAdapterSet,
@@ -19,7 +19,7 @@ import {StaticAdapterSet, DynamicAdapterSet} from "../adapters/adapterSet";
 import type {
   PagerankNodeDecomposition,
   PagerankOptions,
-} from "../../core/attribution/pagerank";
+} from "../../analysis/pagerank";
 import {staticAdapterSet} from "../adapters/demoAdapters";
 
 describe("app/credExplorer/state", () => {

--- a/src/app/credExplorer/weights/weightsToEdgeEvaluator.js
+++ b/src/app/credExplorer/weights/weightsToEdgeEvaluator.js
@@ -2,7 +2,7 @@
 
 import type {Edge} from "../../../core/graph";
 import type {WeightedTypes} from "./weights";
-import type {EdgeEvaluator} from "../../../core/attribution/pagerank";
+import type {EdgeEvaluator} from "../../../analysis/pagerank";
 import {NodeTrie, EdgeTrie} from "../../../core/trie";
 
 export function weightsToEdgeEvaluator(weights: WeightedTypes): EdgeEvaluator {


### PR DESCRIPTION
The `core/attribution/` folder has some code that really is "core" in
that it deals with very basic concepts around converting graphs to
markov chains and running PageRank on them, and some code that is less
"core", like for normalizing scores and doing analysis on them.

To make progresson #704, we need an intermediary directory that has
analysis-related code that is e.g. aware of Node and Edge types, and
weights on those types, and can use them to run weight-informed
PageRank. That code shouldn't live in the app directory (since it is not
coupled to the frontend rendering), but also shouldn't live in core
(since "core" is basically finalized code with fully baked abstractions,
and per #710, this is not true of the node/edge type system).

Thus, I've decided to create the `analysis` directory. To get that
directory started, I've moved the non-core code in `core/attribution/`
to `analysis/`.

Test plan: `yarn test` passes, which is all we need, since this is a
straightforward file rename.