### PR TITLE
Rename `PluginAdapter` to `AppAdapter`

### DIFF
--- a/src/app/adapters/adapterSet.js
+++ b/src/app/adapters/adapterSet.js
@@ -5,19 +5,19 @@ import {NodeTrie, EdgeTrie} from "../../core/trie";
 import type {Assets} from "../assets";
 import type {RepoId} from "../../core/repoId";
 
-import type {StaticPluginAdapter, DynamicPluginAdapter} from "./pluginAdapter";
+import type {StaticAppAdapter, DynamicAppAdapter} from "./appAdapter";
 import type {EdgeType, NodeType} from "../../analysis/types";
 
 import {FallbackStaticAdapter} from "./fallbackAdapter";
 
 export class StaticAdapterSet {
-  _adapters: $ReadOnlyArray<StaticPluginAdapter>;
-  _adapterNodeTrie: NodeTrie<StaticPluginAdapter>;
-  _adapterEdgeTrie: EdgeTrie<StaticPluginAdapter>;
+  _adapters: $ReadOnlyArray<StaticAppAdapter>;
+  _adapterNodeTrie: NodeTrie<StaticAppAdapter>;
+  _adapterEdgeTrie: EdgeTrie<StaticAppAdapter>;
   _typeNodeTrie: NodeTrie<NodeType>;
   _typeEdgeTrie: EdgeTrie<EdgeType>;
 
-  constructor(adapters: $ReadOnlyArray<StaticPluginAdapter>): void {
+  constructor(adapters: $ReadOnlyArray<StaticAppAdapter>): void {
     this._adapters = [new FallbackStaticAdapter(), ...adapters];
     this._adapterNodeTrie = new NodeTrie();
     this._adapterEdgeTrie = new EdgeTrie();
@@ -37,7 +37,7 @@ export class StaticAdapterSet {
     this.edgeTypes().forEach((t) => this._typeEdgeTrie.add(t.prefix, t));
   }
 
-  adapters(): $ReadOnlyArray<StaticPluginAdapter> {
+  adapters(): $ReadOnlyArray<StaticAppAdapter> {
     return this._adapters;
   }
 
@@ -49,11 +49,11 @@ export class StaticAdapterSet {
     return [].concat(...this._adapters.map((x) => x.declaration().edgeTypes));
   }
 
-  adapterMatchingNode(x: NodeAddressT): StaticPluginAdapter {
+  adapterMatchingNode(x: NodeAddressT): StaticAppAdapter {
     return this._adapterNodeTrie.getLast(x);
   }
 
-  adapterMatchingEdge(x: EdgeAddressT): StaticPluginAdapter {
+  adapterMatchingEdge(x: EdgeAddressT): StaticAppAdapter {
     return this._adapterEdgeTrie.getLast(x);
   }
 
@@ -73,14 +73,14 @@ export class StaticAdapterSet {
 }
 
 export class DynamicAdapterSet {
-  _adapters: $ReadOnlyArray<DynamicPluginAdapter>;
+  _adapters: $ReadOnlyArray<DynamicAppAdapter>;
   _staticAdapterSet: StaticAdapterSet;
-  _adapterNodeTrie: NodeTrie<DynamicPluginAdapter>;
-  _adapterEdgeTrie: EdgeTrie<DynamicPluginAdapter>;
+  _adapterNodeTrie: NodeTrie<DynamicAppAdapter>;
+  _adapterEdgeTrie: EdgeTrie<DynamicAppAdapter>;
 
   constructor(
     staticAdapterSet: StaticAdapterSet,
-    adapters: $ReadOnlyArray<DynamicPluginAdapter>
+    adapters: $ReadOnlyArray<DynamicAppAdapter>
   ): void {
     this._staticAdapterSet = staticAdapterSet;
     this._adapters = adapters;
@@ -92,15 +92,15 @@ export class DynamicAdapterSet {
     });
   }
 
-  adapterMatchingNode(x: NodeAddressT): DynamicPluginAdapter {
+  adapterMatchingNode(x: NodeAddressT): DynamicAppAdapter {
     return this._adapterNodeTrie.getLast(x);
   }
 
-  adapterMatchingEdge(x: EdgeAddressT): DynamicPluginAdapter {
+  adapterMatchingEdge(x: EdgeAddressT): DynamicAppAdapter {
     return this._adapterEdgeTrie.getLast(x);
   }
 
-  adapters(): $ReadOnlyArray<DynamicPluginAdapter> {
+  adapters(): $ReadOnlyArray<DynamicAppAdapter> {
     return this._adapters;
   }
 

--- a/src/app/adapters/appAdapter.js
+++ b/src/app/adapters/appAdapter.js
@@ -6,13 +6,13 @@ import type {Assets} from "../assets";
 import type {RepoId} from "../../core/repoId";
 import type {PluginDeclaration} from "../../analysis/pluginDeclaration";
 
-export interface StaticPluginAdapter {
+export interface StaticAppAdapter {
   declaration(): PluginDeclaration;
-  load(assets: Assets, repoId: RepoId): Promise<DynamicPluginAdapter>;
+  load(assets: Assets, repoId: RepoId): Promise<DynamicAppAdapter>;
 }
 
-export interface DynamicPluginAdapter {
+export interface DynamicAppAdapter {
   graph(): Graph;
   nodeDescription(NodeAddressT): ReactNode;
-  static (): StaticPluginAdapter;
+  static (): StaticAppAdapter;
 }

--- a/src/app/adapters/defaultPlugins.js
+++ b/src/app/adapters/defaultPlugins.js
@@ -1,8 +1,8 @@
 // @flow
 
 import {StaticAdapterSet} from "./adapterSet";
-import {StaticPluginAdapter as GithubAdapter} from "../../plugins/github/pluginAdapter";
-import {StaticPluginAdapter as GitAdapter} from "../../plugins/git/pluginAdapter";
+import {StaticAppAdapter as GithubAdapter} from "../../plugins/github/appAdapter";
+import {StaticAppAdapter as GitAdapter} from "../../plugins/git/appAdapter";
 import {GithubGitGateway} from "../../plugins/github/githubGitGateway";
 
 export function defaultStaticAdapters(): StaticAdapterSet {

--- a/src/app/adapters/demoAdapters.js
+++ b/src/app/adapters/demoAdapters.js
@@ -7,7 +7,7 @@ import {
   type NodeAddressT,
   EdgeAddress,
 } from "../../core/graph";
-import type {StaticPluginAdapter, DynamicPluginAdapter} from "./pluginAdapter";
+import type {StaticAppAdapter, DynamicAppAdapter} from "./appAdapter";
 import type {EdgeType, NodeType} from "../../analysis/types";
 import type {PluginDeclaration} from "../../analysis/pluginDeclaration";
 
@@ -52,12 +52,12 @@ export const declaration: PluginDeclaration = Object.freeze({
   edgeTypes: [assemblesEdgeType, transportsEdgeType],
 });
 
-export class FactorioStaticAdapter implements StaticPluginAdapter {
+export class FactorioStaticAdapter implements StaticAppAdapter {
   loadingMock: Function;
   declaration() {
     return declaration;
   }
-  async load(assets: Assets, repoId: RepoId): Promise<DynamicPluginAdapter> {
+  async load(assets: Assets, repoId: RepoId): Promise<DynamicAppAdapter> {
     if (this.loadingMock) {
       return this.loadingMock(assets, repoId).then(
         () => new FactorioDynamicAdapter()
@@ -102,7 +102,7 @@ export function factorioGraph() {
     .addEdge(factorioEdges.assembles1);
 }
 
-export class FactorioDynamicAdapter implements DynamicPluginAdapter {
+export class FactorioDynamicAdapter implements DynamicAppAdapter {
   graph() {
     return factorioGraph();
   }

--- a/src/app/adapters/fallbackAdapter.js
+++ b/src/app/adapters/fallbackAdapter.js
@@ -9,7 +9,7 @@ import {
 import type {Assets} from "../assets";
 import type {RepoId} from "../../core/repoId";
 
-import type {StaticPluginAdapter, DynamicPluginAdapter} from "./pluginAdapter";
+import type {StaticAppAdapter, DynamicAppAdapter} from "./appAdapter";
 
 export const FALLBACK_NAME = "FALLBACK_ADAPTER";
 
@@ -36,7 +36,7 @@ export const fallbackDeclaration = Object.freeze({
   edgeTypes: [fallbackEdgeType],
 });
 
-export class FallbackStaticAdapter implements StaticPluginAdapter {
+export class FallbackStaticAdapter implements StaticAppAdapter {
   declaration() {
     return fallbackDeclaration;
   }
@@ -46,7 +46,7 @@ export class FallbackStaticAdapter implements StaticPluginAdapter {
   }
 }
 
-export class FallbackDynamicAdapter implements DynamicPluginAdapter {
+export class FallbackDynamicAdapter implements DynamicAppAdapter {
   graph() {
     return new Graph();
   }

--- a/src/app/credExplorer/pagerankTable/Table.js
+++ b/src/app/credExplorer/pagerankTable/Table.js
@@ -7,7 +7,7 @@ import * as NullUtil from "../../../util/null";
 import {type NodeAddressT, NodeAddress} from "../../../core/graph";
 import type {PagerankNodeDecomposition} from "../../../analysis/pagerankNodeDecomposition";
 import {DynamicAdapterSet} from "../../adapters/adapterSet";
-import type {DynamicPluginAdapter} from "../../adapters/pluginAdapter";
+import type {DynamicAppAdapter} from "../../adapters/appAdapter";
 import {FALLBACK_NAME} from "../../adapters/fallbackAdapter";
 import {type WeightedTypes} from "../weights/weights";
 import {WeightConfig} from "../weights/WeightConfig";
@@ -92,7 +92,7 @@ export class PagerankTable extends React.PureComponent<
       throw new Error("Impossible.");
     }
 
-    function optionGroup(adapter: DynamicPluginAdapter) {
+    function optionGroup(adapter: DynamicAppAdapter) {
       const header = (
         <option
           key={adapter.static().declaration().nodePrefix}
@@ -124,7 +124,7 @@ export class PagerankTable extends React.PureComponent<
           <option value={NodeAddress.empty}>Show all</option>
           {sortBy(
             adapters.adapters(),
-            (a: DynamicPluginAdapter) => a.static().declaration().name
+            (a: DynamicAppAdapter) => a.static().declaration().name
           )
             .filter((a) => a.static().declaration().name !== FALLBACK_NAME)
             .map(optionGroup)}

--- a/src/app/credExplorer/weights/PluginWeightConfig.js
+++ b/src/app/credExplorer/weights/PluginWeightConfig.js
@@ -5,7 +5,7 @@ import deepEqual from "lodash.isequal";
 import * as MapUtil from "../../../util/map";
 import {NodeTypeConfig} from "./NodeTypeConfig";
 import {EdgeTypeConfig} from "./EdgeTypeConfig";
-import {StaticPluginAdapter} from "../../adapters/pluginAdapter";
+import {StaticAppAdapter} from "../../adapters/appAdapter";
 import {styledVariable} from "./EdgeTypeConfig";
 import {
   type WeightedTypes,
@@ -14,7 +14,7 @@ import {
 } from "./weights";
 
 export type Props = {|
-  +adapter: StaticPluginAdapter,
+  +adapter: StaticAppAdapter,
   +onChange: (WeightedTypes) => void,
   +weightedTypes: WeightedTypes,
 |};

--- a/src/app/credExplorer/weights/weights.js
+++ b/src/app/credExplorer/weights/weights.js
@@ -3,7 +3,7 @@
 import * as MapUtil from "../../../util/map";
 import {type NodeAddressT, type EdgeAddressT} from "../../../core/graph";
 import type {EdgeType, NodeType} from "../../../analysis/types";
-import type {StaticPluginAdapter} from "../../adapters/pluginAdapter";
+import type {StaticAppAdapter} from "../../adapters/appAdapter";
 import type {StaticAdapterSet} from "../../adapters/adapterSet";
 
 export type WeightedNodeType = {|+type: NodeType, +weight: number|};
@@ -36,7 +36,7 @@ export function defaultWeightedEdgeType(type: EdgeType): WeightedEdgeType {
 }
 
 export function defaultWeightsForAdapter(
-  adapter: StaticPluginAdapter
+  adapter: StaticAppAdapter
 ): WeightedTypes {
   return {
     nodes: new Map(

--- a/src/plugins/git/appAdapter.js
+++ b/src/plugins/git/appAdapter.js
@@ -1,8 +1,8 @@
 // @flow
 import type {
-  StaticPluginAdapter as IStaticPluginAdapter,
-  DynamicPluginAdapter as IDynamicPluginAdapter,
-} from "../../app/adapters/pluginAdapter";
+  StaticAppAdapter as IStaticAppAdapter,
+  DynamicAppAdapter as IDynamicAppAdapter,
+} from "../../app/adapters/appAdapter";
 import {Graph} from "../../core/graph";
 import * as N from "./nodes";
 import {description} from "./render";
@@ -13,7 +13,7 @@ import type {GitGateway} from "./gitGateway";
 import type {PluginDeclaration} from "../../analysis/pluginDeclaration";
 import {declaration} from "./declaration";
 
-export class StaticPluginAdapter implements IStaticPluginAdapter {
+export class StaticAppAdapter implements IStaticAppAdapter {
   _gitGateway: GitGateway;
 
   constructor(gg: GitGateway): void {
@@ -22,7 +22,7 @@ export class StaticPluginAdapter implements IStaticPluginAdapter {
   declaration(): PluginDeclaration {
     return declaration;
   }
-  async load(assets: Assets, repoId: RepoId): Promise<IDynamicPluginAdapter> {
+  async load(assets: Assets, repoId: RepoId): Promise<IDynamicAppAdapter> {
     const baseUrl = `/api/v1/data/data/${repoId.owner}/${repoId.name}/git/`;
     async function loadGraph() {
       const url = assets.resolve(baseUrl + "graph.json");
@@ -45,11 +45,11 @@ export class StaticPluginAdapter implements IStaticPluginAdapter {
       loadGraph(),
       loadRepository(),
     ]);
-    return new DynamicPluginAdapter(this._gitGateway, graph, repository);
+    return new DynamicAppAdapter(this._gitGateway, graph, repository);
   }
 }
 
-class DynamicPluginAdapter implements IDynamicPluginAdapter {
+class DynamicAppAdapter implements IDynamicAppAdapter {
   +_graph: Graph;
   +_repository: Repository;
   +_gitGateway: GitGateway;
@@ -72,6 +72,6 @@ class DynamicPluginAdapter implements IDynamicPluginAdapter {
     return description(address, this._repository, this._gitGateway);
   }
   static() {
-    return new StaticPluginAdapter(this._gitGateway);
+    return new StaticAppAdapter(this._gitGateway);
   }
 }

--- a/src/plugins/github/appAdapter.js
+++ b/src/plugins/github/appAdapter.js
@@ -2,9 +2,9 @@
 import pako from "pako";
 
 import type {
-  StaticPluginAdapter as IStaticPluginAdapter,
-  DynamicPluginAdapter as IDynamicPluginAdapater,
-} from "../../app/adapters/pluginAdapter";
+  StaticAppAdapter as IStaticAppAdapter,
+  DynamicAppAdapter as IDynamicAppAdapter,
+} from "../../app/adapters/appAdapter";
 import {type Graph, NodeAddress} from "../../core/graph";
 import {createGraph} from "./createGraph";
 import * as N from "./nodes";
@@ -15,11 +15,11 @@ import type {RepoId} from "../../core/repoId";
 import type {PluginDeclaration} from "../../analysis/pluginDeclaration";
 import {declaration} from "./declaration";
 
-export class StaticPluginAdapter implements IStaticPluginAdapter {
+export class StaticAppAdapter implements IStaticAppAdapter {
   declaration(): PluginDeclaration {
     return declaration;
   }
-  async load(assets: Assets, repoId: RepoId): Promise<IDynamicPluginAdapater> {
+  async load(assets: Assets, repoId: RepoId): Promise<IDynamicAppAdapter> {
     const url = assets.resolve(
       `/api/v1/data/data/${repoId.owner}/${repoId.name}/github/view.json.gz`
     );
@@ -32,11 +32,11 @@ export class StaticPluginAdapter implements IStaticPluginAdapter {
     const json = JSON.parse(pako.ungzip(blob, {to: "string"}));
     const view = RelationalView.fromJSON(json);
     const graph = createGraph(view);
-    return new DynamicPluginAdapter(view, graph);
+    return new DynamicAppAdapter(view, graph);
   }
 }
 
-class DynamicPluginAdapter implements IDynamicPluginAdapater {
+class DynamicAppAdapter implements IDynamicAppAdapter {
   +_view: RelationalView;
   +_graph: Graph;
   constructor(view: RelationalView, graph: Graph): void {
@@ -57,6 +57,6 @@ class DynamicPluginAdapter implements IDynamicPluginAdapater {
     return this._graph;
   }
   static() {
-    return new StaticPluginAdapter();
+    return new StaticAppAdapter();
   }
 }


### PR DESCRIPTION
Now that we're planning to add adapters for the `analysis` module, we
should rename the `PluginAdapter` to make it clear that it's scoped for
`app`.

Test plan: `yarn test` suffices