### PR TITLE
Add `analysisAdapter`

### DIFF
--- a/src/analysis/analysisAdapter.js
+++ b/src/analysis/analysisAdapter.js
@@ -1,0 +1,10 @@
+// @flow
+
+import {Graph} from "../core/graph";
+import type {RepoId} from "../core/repoId";
+import type {PluginDeclaration} from "./pluginDeclaration";
+
+export interface IAnalysisAdapter {
+  declaration(): PluginDeclaration;
+  load(sourcecredDirectory: string, repoId: RepoId): Promise<Graph>;
+}

--- a/src/plugins/git/analysisAdapter.js
+++ b/src/plugins/git/analysisAdapter.js
@@ -1,0 +1,26 @@
+// @flow
+
+import fs from "fs-extra";
+import path from "path";
+import {Graph} from "../../core/graph";
+import type {IAnalysisAdapter} from "../../analysis/analysisAdapter";
+import {type RepoId, repoIdToString} from "../../core/repoId";
+import {declaration} from "./declaration";
+
+export class AnalysisAdapter implements IAnalysisAdapter {
+  declaration() {
+    return declaration;
+  }
+  async load(sourcecredDirectory: string, repoId: RepoId): Promise<Graph> {
+    const file = path.join(
+      sourcecredDirectory,
+      "data",
+      repoIdToString(repoId),
+      "git",
+      "graph.json"
+    );
+    const rawData = await fs.readFile(file);
+    const json = JSON.parse(rawData.toString());
+    return Graph.fromJSON(json);
+  }
+}

--- a/src/plugins/git/analysisAdapter.test.js
+++ b/src/plugins/git/analysisAdapter.test.js
@@ -1,0 +1,39 @@
+// @flow
+
+import fs from "fs-extra";
+import path from "path";
+import {AnalysisAdapter} from "./analysisAdapter";
+import {stringToRepoId} from "../../core/repoId";
+import {declaration} from "./declaration";
+import {Graph} from "../../core/graph";
+
+describe("plugins/git/analysisAdapter", () => {
+  it("provides the declaration", () => {
+    const aa = new AnalysisAdapter();
+    expect(aa.declaration()).toEqual(declaration);
+  });
+  it("loads the Git graph", async () => {
+    const sourcecredDirectory = path.join(
+      "sharness",
+      "__snapshots__",
+      "example-github-load"
+    );
+    const expectedPath = path.join(
+      sourcecredDirectory,
+      "data",
+      "sourcecred",
+      "example-github",
+      "git",
+      "graph.json"
+    );
+    const expectedGraphBuffer: Buffer = await fs.readFile(expectedPath);
+    const expectedGraphJSON = JSON.parse(expectedGraphBuffer.toString());
+    const expectedGraph = Graph.fromJSON(expectedGraphJSON);
+    const aa = new AnalysisAdapter();
+    const actualGraph = await aa.load(
+      sourcecredDirectory,
+      stringToRepoId("sourcecred/example-github")
+    );
+    expect(actualGraph.equals(expectedGraph)).toBe(true);
+  });
+});

--- a/src/plugins/github/analysisAdapter.js
+++ b/src/plugins/github/analysisAdapter.js
@@ -1,0 +1,30 @@
+// @flow
+
+import fs from "fs-extra";
+import path from "path";
+import pako from "pako";
+import {type RepoId, repoIdToString} from "../../core/repoId";
+import {Graph} from "../../core/graph";
+import type {IAnalysisAdapter} from "../../analysis/analysisAdapter";
+import {declaration} from "./declaration";
+import {RelationalView} from "./relationalView";
+import {createGraph} from "./createGraph";
+
+export class AnalysisAdapter implements IAnalysisAdapter {
+  declaration() {
+    return declaration;
+  }
+  async load(sourcecredDirectory: string, repoId: RepoId): Promise<Graph> {
+    const file = path.join(
+      sourcecredDirectory,
+      "data",
+      repoIdToString(repoId),
+      "github",
+      "view.json.gz"
+    );
+    const compressedData = await fs.readFile(file);
+    const json = JSON.parse(pako.ungzip(compressedData, {to: "string"}));
+    const view = RelationalView.fromJSON(json);
+    return createGraph(view);
+  }
+}

--- a/src/plugins/github/analysisAdapter.test.js
+++ b/src/plugins/github/analysisAdapter.test.js
@@ -1,0 +1,42 @@
+// @flow
+
+import fs from "fs-extra";
+import path from "path";
+import pako from "pako";
+import {AnalysisAdapter} from "./analysisAdapter";
+import {stringToRepoId} from "../../core/repoId";
+import {declaration} from "./declaration";
+import {RelationalView} from "./relationalView";
+import {createGraph} from "./createGraph";
+
+describe("plugins/github/analysisAdapter", () => {
+  it("provides the declaration", () => {
+    const aa = new AnalysisAdapter();
+    expect(aa.declaration()).toEqual(declaration);
+  });
+  it("loads the GitHub graph", async () => {
+    const sourcecredDirectory = path.join(
+      "sharness",
+      "__snapshots__",
+      "example-github-load"
+    );
+    const expectedPath = path.join(
+      sourcecredDirectory,
+      "data",
+      "sourcecred",
+      "example-github",
+      "github",
+      "view.json.gz"
+    );
+    const blob = await fs.readFile(expectedPath);
+    const json = JSON.parse(pako.ungzip(blob, {to: "string"}));
+    const view = RelationalView.fromJSON(json);
+    const graph = createGraph(view);
+    const aa = new AnalysisAdapter();
+    const actualGraph = await aa.load(
+      sourcecredDirectory,
+      stringToRepoId("sourcecred/example-github")
+    );
+    expect(actualGraph.equals(graph)).toBe(true);
+  });
+});


### PR DESCRIPTION
For #704, we're adding plugin adapters that are specific to the needs of
the analysis module. They have a simple scope: they just provide a way
to get the declaration, and to load the corresponding graph.

Adapters for the `git` and `github` plugins have been implemented, along
with unit tests.

Test plan: `yarn test` suffices.