### PR TITLE
changelog: add Mirror module entry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## [Unreleased]
+- Cache GitHub data, allowing for incremental and resumable loading (#622)
 - Hyperlink Git commits to GitHub (#887)
 - Relicense from MIT to MIT + Apache-2 (#812)
 - Display short hash + summary for commits (#879)


### PR DESCRIPTION
Summary:
This points to #622 as the blanket issue, though really there was a long
series of pull requests worth of implementation.

Test Plan:
None.

wchargin-branch: changelog-mirror