### PR TITLE
release: v0.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Changelog
 
 ## [Unreleased]
+<!-- Please add new entries to the _top_ of this section. -->
+
+## [0.2.0]
 - Cache GitHub data, allowing for incremental and resumable loading (#622)
 - Hyperlink Git commits to GitHub (#887)
 - Relicense from MIT to MIT + Apache-2 (#812)
@@ -11,7 +14,6 @@
 - Detect references in commit messages (#829)
 - Add commit authorship to the graph (#826)
 - Add `MentionsAuthor` edges to the graph (#808)
-<!-- Please add new entries to the _top_ of this section. -->
 
 ## [0.1.0]
 - Organize weight config by plugin (#773)

--- a/src/app/version.js
+++ b/src/app/version.js
@@ -58,7 +58,7 @@ const environment = parseEnvironment(process.env.NODE_ENV);
 
 export const VERSION_INFO: VersionInfo = Object.freeze({
   major: 0,
-  minor: 1,
+  minor: 2,
   patch: 0,
   gitState,
   environment,


### PR DESCRIPTION
Test Plan:
Remove the SourceCred output directory, run `yarn backend`, and load
data for `sourcecred/example-github` and `sourcecred/sourcecred`. Then,
run `yarn start` and note that the cred explorer still works. Finally,
note that `yarn test --full` passes.

wchargin-branch: release-v0.2.0