### PR TITLE
env: fix commit date formatting

### DIFF
--- a/config/env.js
+++ b/config/env.js
@@ -116,8 +116,8 @@ function getGitState() /*: GitState */ {
   }
   const commitTimestamp = [
     zeroPad(commitDate.getFullYear(), 4),
-    zeroPad(commitDate.getMonth(), 2),
-    zeroPad(commitDate.getDay(), 2),
+    zeroPad(commitDate.getMonth() + 1, 2),
+    zeroPad(commitDate.getDate(), 2),
     "-",
     zeroPad(commitDate.getHours(), 2),
     zeroPad(commitDate.getMinutes(), 2),


### PR DESCRIPTION
Summary:
Fun facts:

  - `new Date().getDay()` does not return the day of the month. It
    returns the day of the _week_ as an integer `0 ≤ n ≤ 6`.
  - `new Date().getDate()` returns the day of the month from 1 to 31.
  - `new Date().getMonth()` really does return the month, but _this_ one
    is zero-based!

All this to say, my implementation in #901 was a bit flawed.
Why didn’t I notice at the time? I wrote and tested the change on
2018-10-01, which was a Monday, so both `getDay()` and `getDate()` were
in fact `1`. As for me failing to notice that `getMonth()` was off by
one—well, sometimes I’m very dumb.

Test Plan:

```shell
$ NODE_ENV=development node -e '
>     require("./config/env");
>     console.log(process.env.SOURCECRED_GIT_STATE);
> '
{"commitHash":"f9bb75ef71c5","commitTimestamp":"20181030-1518","dirty":true}
$ date -I
2018-10-30
```

wchargin-branch: env-fix-date-formatting