### PR TITLE
test: skip `test_load_example_github` on CircleCI

### DIFF
--- a/sharness/test_load_example_github.t
+++ b/sharness/test_load_example_github.t
@@ -15,13 +15,18 @@ export GIT_ATTR_NOSYSTEM=1
 # shellcheck disable=SC1091
 . ./sharness.sh
 
+# TODO(#955): Investigate why this test fails on CircleCI.
+if [ -n "${CIRCLECI:-}" ]; then
+    test_set_prereq CIRCLECI
+fi
+
 toplevel="$(git -C "$(dirname "$0")" rev-parse --show-toplevel)"
 
 if [ -n "${SOURCECRED_GITHUB_TOKEN:-}" ]; then
     test_set_prereq HAVE_GITHUB_TOKEN
 fi
 
-test_expect_success EXPENSIVE,HAVE_GITHUB_TOKEN \
+test_expect_success !CIRCLECI,EXPENSIVE,HAVE_GITHUB_TOKEN \
     "should load sourcecred/example-github" '
     SOURCECRED_DIRECTORY=. node "$toplevel/bin/sourcecred.js" \
         load sourcecred/example-github &&
@@ -35,13 +40,13 @@ fi
 
 snapshot_directory="$toplevel/sharness/__snapshots__/example-github-load"
 
-test_expect_success LOADED_GITHUB,UPDATE_SNAPSHOT \
+test_expect_success !CIRCLECI,LOADED_GITHUB,UPDATE_SNAPSHOT \
     "should update the snapshot" '
     rm -rf "$snapshot_directory" &&
     cp -r . "$snapshot_directory"
 '
 
-test_expect_success LOADED_GITHUB "should be identical to the snapshot" '
+test_expect_success !CIRCLECI,LOADED_GITHUB "should be identical to the snapshot" '
     diff -qr . "$snapshot_directory"
 '
 


### PR DESCRIPTION
Summary:
This is a quick patch for #955, pending investigation and fix.

Test Plan:

```shell
$ cd sharness/
$ ./test_load_example_github.t --long
ok 1 - should load sourcecred/example-github
ok 2 # skip should update the snapshot (missing UPDATE_SNAPSHOT of !CIRCLECI,LOADED_GITHUB,UPDATE_SNA
PSHOT)
ok 3 - should be identical to the snapshot
# passed all 3 test(s)
1..3
$ CIRCLECI=true ./test_load_example_github.t --long
ok 1 # skip should load sourcecred/example-github (missing !CIRCLECI of !CIRCLECI,EXPENSIVE,HAVE_GITH
UB_TOKEN)
ok 2 # skip should update the snapshot (missing UPDATE_SNAPSHOT,LOADED_GITHUB,!CIRCLECI of !CIRCLECI,
LOADED_GITHUB,UPDATE_SNAPSHOT)
ok 3 # skip should be identical to the snapshot (missing LOADED_GITHUB,!CIRCLECI of !CIRCLECI,LOADED_
GITHUB)
# passed all 3 test(s)
1..3
```

Ref.: <https://circleci.com/docs/2.0/env-vars/#built-in-environment-variables>

wchargin-branch: test-skip-failing-circleci