### PR TITLE
git: don’t warn when rendering unknown commits

### DIFF
--- a/src/plugins/git/render.js
+++ b/src/plugins/git/render.js
@@ -17,7 +17,6 @@ export function description(
       const hash = address.hash;
       const commit = repository.commits[hash];
       if (commit == null) {
-        console.error(`Unable to find data for commit ${hash}`);
         return <code>{hash}</code>;
       }
       // This `any`-cast courtesy of facebook/flow#6927.

--- a/src/plugins/git/render.test.js
+++ b/src/plugins/git/render.test.js
@@ -115,14 +115,13 @@ describe("plugins/git/render", () => {
       expect(el.text()).toContain(commit.summary);
     }
   });
-  it("logs an error for a commit not in the repository", () => {
+  it("renders just the hash for a commit not in the repository", () => {
+    // This can happen if, for instance, the GitHub plugin picks up a
+    // commit object that was not known to the Git plugin. (Via, say, a
+    // pull request that was merged but not into master, or a reference
+    // to a commit in a different repository.)
+    //
     const el = renderExample(unregisteredCommit);
-    expect(console.error).toHaveBeenCalledWith(
-      `Unable to find data for commit ${unregisteredCommit.hash}`
-    );
-    // $ExpectFlowError
-    console.error = jest.fn();
-
     expect(el.find(Link)).toHaveLength(0);
     // Has the full hash, b.c. short hash couldn't be found
     expect(el.find("code").text()).toEqual(unregisteredCommit.hash);


### PR DESCRIPTION
Summary:
Fixes #953. See that issue for context.

Test Plan:
Unit tests updated. To see the change in action, load the SourceCred
data and expand @decentralion’s commits-authored to find commits that
were merged into non-`master` branches. Note that these commits are
rendered correctly (in the same way that they were before this patch),
and that there is no console error (new as of this patch).

![Screenshot](https://user-images.githubusercontent.com/4317806/47805669-1f98b580-dcf5-11e8-8683-8ee91f7f478a.png)

wchargin-branch: git-no-warn-on-unknown-commit