### PR TITLE
test: run Sharness verbosely on nightly jobs

### DIFF
--- a/package.json
+++ b/package.json
@@ -70,7 +70,7 @@
     "test": "node ./config/test.js",
     "unit": "BABEL_ENV=test NODE_ENV=test jest --env=jsdom",
     "sharness": "make -sC ./sharness prove PROVE_OPTS=-f TEST_OPTS='--chain-lint'",
-    "sharness-full": "make -sC ./sharness prove PROVE_OPTS=-f TEST_OPTS='--chain-lint --long'",
+    "sharness-full": "make -sC ./sharness prove PROVE_OPTS=-vf TEST_OPTS='-v --chain-lint --long'",
     "coverage": "npm run unit -- --coverage",
     "flow": "flow",
     "lint": "eslint src config --max-warnings 0"


### PR DESCRIPTION
Summary:
Tests that run only on nightly builds (`yarn test --full`) and fail only
on CI (not locally) are a bit more inconvenient to debug when they fail.
This patch makes the `yarn test --full` script print all the
intermediate output in Sharness tests, which can be helpful. We don’t do
this for `yarn test` simply because it generates a ton of spam even on
successful tests.

Test Plan:

    $ yarn test --full 2>&1 | wc -l
    1173

wchargin-branch: test-full-verbose