### PR TITLE
test: fix `test_load_example_github`

### DIFF
--- a/sharness/test_load_example_github.t
+++ b/sharness/test_load_example_github.t
@@ -15,20 +15,25 @@ export GIT_ATTR_NOSYSTEM=1
 # shellcheck disable=SC1091
 . ./sharness.sh
 
-# TODO(#955): Investigate why this test fails on CircleCI.
-if [ -n "${CIRCLECI:-}" ]; then
-    test_set_prereq CIRCLECI
-fi
-
-toplevel="$(git -C "$(dirname "$0")" rev-parse --show-toplevel)"
+test_expect_success "environment and Node linking setup" '
+    toplevel="$(git -C "$(dirname "$0")" rev-parse --show-toplevel)" &&
+    snapshot_directory="${toplevel}/sharness/__snapshots__/example-github-load" &&
+    if [ -z "${SOURCECRED_BIN}" ]; then
+        printf >&2 "warn: missing environment variable SOURCECRED_BIN\n" &&
+        printf >&2 "warn: using repository bin directory as fallback\n" &&
+        export SOURCECRED_BIN="${toplevel}/bin"
+    fi &&
+    export NODE_PATH="${toplevel}/node_modules${NODE_PATH:+:${NODE_PATH}}" &&
+    test_set_prereq SETUP
+'
 
 if [ -n "${SOURCECRED_GITHUB_TOKEN:-}" ]; then
     test_set_prereq HAVE_GITHUB_TOKEN
 fi
 
-test_expect_success !CIRCLECI,EXPENSIVE,HAVE_GITHUB_TOKEN \
+test_expect_success EXPENSIVE,SETUP,HAVE_GITHUB_TOKEN \
     "should load sourcecred/example-github" '
-    SOURCECRED_DIRECTORY=. node "$toplevel/bin/sourcecred.js" \
+    SOURCECRED_DIRECTORY=. node "${SOURCECRED_BIN}/sourcecred.js" \
         load sourcecred/example-github &&
     rm -rf cache &&
     test_set_prereq LOADED_GITHUB
@@ -38,15 +43,13 @@ if [ -n "${UPDATE_SNAPSHOT}" ]; then
     test_set_prereq UPDATE_SNAPSHOT
 fi
 
-snapshot_directory="$toplevel/sharness/__snapshots__/example-github-load"
-
-test_expect_success !CIRCLECI,LOADED_GITHUB,UPDATE_SNAPSHOT \
+test_expect_success LOADED_GITHUB,UPDATE_SNAPSHOT \
     "should update the snapshot" '
     rm -rf "$snapshot_directory" &&
     cp -r . "$snapshot_directory"
 '
 
-test_expect_success !CIRCLECI,LOADED_GITHUB "should be identical to the snapshot" '
+test_expect_success LOADED_GITHUB "should be identical to the snapshot" '
     diff -qr . "$snapshot_directory"
 '
 


### PR DESCRIPTION
Summary:
Fixes #955. Our test runner does run `yarn backend` before Sharness
tests, but it builds the backend applications into a temporary directory
rather than squashing the repository backend (which is good!). The test
script has learned about this directory.

Test Plan:
Run `rm -rf ./bin && yarn test --full`, which fails before this commit
and passes after it.

wchargin-branch: fix-test-load-example-github