### PR TITLE
Declare the fallback plugin in analysis

### DIFF
--- a/src/analysis/fallbackAdapter.js
+++ b/src/analysis/fallbackAdapter.js
@@ -1,0 +1,21 @@
+// @flow
+
+import {Graph} from "../core/graph";
+import type {RepoId} from "../core/repoId";
+import type {PluginDeclaration} from "./pluginDeclaration";
+import type {IAnalysisAdapter} from "./analysisAdapter";
+
+import {fallbackDeclaration} from "./fallbackDeclaration";
+
+export class FallbackAdapter implements IAnalysisAdapter {
+  declaration(): PluginDeclaration {
+    return fallbackDeclaration;
+  }
+
+  load(
+    _unused_sourcecredDirectory: string,
+    _unused_repoId: RepoId
+  ): Promise<Graph> {
+    return Promise.resolve(new Graph());
+  }
+}

--- a/src/analysis/fallbackDeclaration.js
+++ b/src/analysis/fallbackDeclaration.js
@@ -1,0 +1,32 @@
+// @flow
+
+import {NodeAddress, EdgeAddress} from "../core/graph";
+
+import type {PluginDeclaration} from "./pluginDeclaration";
+
+import type {EdgeType, NodeType} from "./types";
+
+export const FALLBACK_NAME = "FALLBACK_ADAPTER";
+
+export const fallbackNodeType: NodeType = Object.freeze({
+  name: "node",
+  pluralName: "nodes",
+  prefix: NodeAddress.empty,
+  defaultWeight: 1,
+});
+
+export const fallbackEdgeType: EdgeType = Object.freeze({
+  forwardName: "points to",
+  backwardName: "is pointed to by",
+  defaultForwardWeight: 1,
+  defaultBackwardWeight: 1,
+  prefix: EdgeAddress.empty,
+});
+
+export const fallbackDeclaration: PluginDeclaration = Object.freeze({
+  name: FALLBACK_NAME,
+  nodePrefix: NodeAddress.empty,
+  edgePrefix: EdgeAddress.empty,
+  nodeTypes: Object.freeze([fallbackNodeType]),
+  edgeTypes: Object.freeze([fallbackEdgeType]),
+});

--- a/src/app/adapters/adapterSet.test.js
+++ b/src/app/adapters/adapterSet.test.js
@@ -3,12 +3,12 @@
 import {NodeAddress, EdgeAddress, Graph} from "../../core/graph";
 import {FactorioStaticAdapter} from "../../plugins/demo/appAdapter";
 import {StaticAdapterSet} from "./adapterSet";
+import {FallbackStaticAdapter} from "./fallbackAdapter";
 import {
-  FallbackStaticAdapter,
   FALLBACK_NAME,
   fallbackNodeType,
   fallbackEdgeType,
-} from "./fallbackAdapter";
+} from "../../analysis/fallbackDeclaration";
 import {Assets} from "../assets";
 import {makeRepoId} from "../../core/repoId";
 

--- a/src/app/adapters/fallbackAdapter.js
+++ b/src/app/adapters/fallbackAdapter.js
@@ -1,40 +1,13 @@
 // @flow
 
-import {
-  Graph,
-  NodeAddress,
-  type NodeAddressT,
-  EdgeAddress,
-} from "../../core/graph";
-import type {Assets} from "../assets";
-import type {RepoId} from "../../core/repoId";
-
-import type {StaticAppAdapter, DynamicAppAdapter} from "./appAdapter";
-
-export const FALLBACK_NAME = "FALLBACK_ADAPTER";
-
-export const fallbackNodeType = Object.freeze({
-  name: "node",
-  pluralName: "nodes",
-  prefix: NodeAddress.empty,
-  defaultWeight: 1,
-});
-
-export const fallbackEdgeType = Object.freeze({
-  forwardName: "forward edge",
-  backwardName: "backward edge",
-  defaultForwardWeight: 1,
-  defaultBackwardWeight: 1,
-  prefix: EdgeAddress.empty,
-});
-
-export const fallbackDeclaration = Object.freeze({
-  name: FALLBACK_NAME,
-  nodePrefix: NodeAddress.empty,
-  edgePrefix: EdgeAddress.empty,
-  nodeTypes: [fallbackNodeType],
-  edgeTypes: [fallbackEdgeType],
-});
+import {fallbackDeclaration} from "../../analysis/fallbackDeclaration";
+import type {
+  StaticAppAdapter,
+  DynamicAppAdapter,
+} from "../../app/adapters/appAdapter";
+import {Assets} from "../../app/assets";
+import {type RepoId} from "../../core/repoId";
+import {Graph, NodeAddress, type NodeAddressT} from "../../core/graph";
 
 export class FallbackStaticAdapter implements StaticAppAdapter {
   declaration() {
@@ -52,7 +25,7 @@ export class FallbackDynamicAdapter implements DynamicAppAdapter {
   }
 
   nodeDescription(x: NodeAddressT) {
-    return NodeAddress.toString(x);
+    return `[fallback]: ${NodeAddress.toString(x)}`;
   }
 
   static() {

--- a/src/app/credExplorer/pagerankTable/Table.js
+++ b/src/app/credExplorer/pagerankTable/Table.js
@@ -8,7 +8,7 @@ import {type NodeAddressT, NodeAddress} from "../../../core/graph";
 import type {PagerankNodeDecomposition} from "../../../analysis/pagerankNodeDecomposition";
 import {DynamicAdapterSet} from "../../adapters/adapterSet";
 import type {DynamicAppAdapter} from "../../adapters/appAdapter";
-import {FALLBACK_NAME} from "../../adapters/fallbackAdapter";
+import {FALLBACK_NAME} from "../../../analysis/fallbackDeclaration";
 import type {WeightedTypes} from "../../../analysis/weights";
 import {WeightConfig} from "../weights/WeightConfig";
 

--- a/src/app/credExplorer/weights/PluginWeightConfig.test.js
+++ b/src/app/credExplorer/weights/PluginWeightConfig.test.js
@@ -11,7 +11,7 @@ import {FactorioStaticAdapter} from "../../../plugins/demo/appAdapter";
 import {
   fallbackNodeType,
   fallbackEdgeType,
-} from "../../adapters/fallbackAdapter";
+} from "../../../analysis/fallbackDeclaration";
 import {NodeTypeConfig} from "./NodeTypeConfig";
 import {EdgeTypeConfig} from "./EdgeTypeConfig";
 import {

--- a/src/app/credExplorer/weights/WeightConfig.js
+++ b/src/app/credExplorer/weights/WeightConfig.js
@@ -7,7 +7,7 @@ import * as MapUtil from "../../../util/map";
 import type {StaticAdapterSet} from "../../adapters/adapterSet";
 import type {WeightedTypes} from "../../../analysis/weights";
 import {PluginWeightConfig} from "./PluginWeightConfig";
-import {FALLBACK_NAME} from "../../adapters/fallbackAdapter";
+import {FALLBACK_NAME} from "../../../analysis/fallbackDeclaration";
 
 type Props = {|
   +adapters: StaticAdapterSet,

--- a/src/app/credExplorer/weights/WeightConfig.test.js
+++ b/src/app/credExplorer/weights/WeightConfig.test.js
@@ -8,7 +8,7 @@ import {
   staticAdapterSet,
 } from "../../../plugins/demo/appAdapter";
 import {inserterNodeType} from "../../../plugins/demo/declaration";
-import {FALLBACK_NAME} from "../../adapters/fallbackAdapter";
+import {FALLBACK_NAME} from "../../../analysis/fallbackDeclaration";
 import {defaultWeightsForAdapterSet, defaultWeightsForAdapter} from "./weights";
 import {WeightConfig} from "./WeightConfig";
 

--- a/src/app/credExplorer/weights/weightsToEdgeEvaluator.test.js
+++ b/src/app/credExplorer/weights/weightsToEdgeEvaluator.test.js
@@ -4,7 +4,7 @@ import * as NullUtil from "../../../util/null";
 import {
   fallbackNodeType,
   fallbackEdgeType,
-} from "../../adapters/fallbackAdapter";
+} from "../../../analysis/fallbackDeclaration";
 import {
   inserterNodeType,
   machineNodeType,


### PR DESCRIPTION
Now that the `analysis` module owns the Node and Edge types, it should
own the "fallback plugin" too. (Note that it's not actually a plugin,
though it somewhat acts like one.)

We now declare the fallback type in `analysis`, along with a fallback
analysis adapter. `app/adapters` then declares a fallback app adapter.

Test plan: `yarn test`

Progress towards #967.
