### PR TITLE
Move `weightsToEdgeEvaluator` to `analysis`

### DIFF
--- a/src/analysis/weightsToEdgeEvaluator.js
+++ b/src/analysis/weightsToEdgeEvaluator.js
@@ -1,9 +1,9 @@
 // @flow
 
-import type {Edge} from "../../../core/graph";
-import type {WeightedTypes} from "../../../analysis/weights";
-import type {EdgeEvaluator} from "../../../analysis/pagerank";
-import {NodeTrie, EdgeTrie} from "../../../core/trie";
+import type {Edge} from "../core/graph";
+import type {WeightedTypes} from "./weights";
+import type {EdgeEvaluator} from "./pagerank";
+import {NodeTrie, EdgeTrie} from "../core/trie";
 
 export function weightsToEdgeEvaluator(weights: WeightedTypes): EdgeEvaluator {
   const nodeTrie = new NodeTrie();

--- a/src/analysis/weightsToEdgeEvaluator.test.js
+++ b/src/analysis/weightsToEdgeEvaluator.test.js
@@ -1,19 +1,16 @@
 // @flow
 
-import * as NullUtil from "../../../util/null";
-import {
-  fallbackNodeType,
-  fallbackEdgeType,
-} from "../../../analysis/fallbackDeclaration";
+import * as NullUtil from "../util/null";
+import {fallbackNodeType, fallbackEdgeType} from "./fallbackDeclaration";
 import {
   inserterNodeType,
   machineNodeType,
   assemblesEdgeType,
-} from "../../../plugins/demo/declaration";
-import {edges as factorioEdges} from "../../../plugins/demo/graph";
+} from "../plugins/demo/declaration";
+import {edges as factorioEdges} from "../plugins/demo/graph";
 import {weightsToEdgeEvaluator} from "./weightsToEdgeEvaluator";
 
-describe("app/credExplorer/weights/weightsToEdgeEvaluator", () => {
+describe("analysis/weightsToEdgeEvaluator", () => {
   describe("weightsToEdgeEvaluator", () => {
     type WeightArgs = {|
       +assemblesForward?: number,

--- a/src/app/credExplorer/state.js
+++ b/src/app/credExplorer/state.js
@@ -14,7 +14,7 @@ import {
 
 import {StaticAdapterSet, DynamicAdapterSet} from "../adapters/adapterSet";
 import type {WeightedTypes} from "../../analysis/weights";
-import {weightsToEdgeEvaluator} from "./weights/weightsToEdgeEvaluator";
+import {weightsToEdgeEvaluator} from "../../analysis/weightsToEdgeEvaluator";
 
 /*
   This models the UI states of the credExplorer/App as a state machine.


### PR DESCRIPTION
The logic for converting weights into an edge evaluator should not be
coupled to the frontend application.

Progress towards #967.

Test plan: Very straightforward rename; `yarn test` suffices.