### PR TITLE
ci: run `test_full` on all merges to master

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -45,6 +45,11 @@ workflows:
   commit:
     jobs:
       - test
+      - test_full:
+          filters:
+            branches:
+              only:
+                - master
   nightly:
     triggers:
       - schedule:


### PR DESCRIPTION
Summary:
We currently run quicktest on pull requests, quicktest again on commits
_after_ they are merged into `master`, and fulltest nightly. This commit
retains quicktest on pull requests, but switches to fulltest once a
commit is merged into master. We still run fulltest nightly as well, to
detect any changes in remote APIs that we hit.

Test Plan:
Push this commit. Check that Circle CI runs its workflow normally (as
quicktest), verifying that the config parses correctly. Then, merge this
commit, and verify that the full tests have run.

wchargin-branch: ci-test-full-on-master