### PR TITLE
webpack: remove dynamic import

### DIFF
--- a/config/paths.js
+++ b/config/paths.js
@@ -15,7 +15,6 @@ module.exports = {
   appBuild: resolveApp("build"),
   appIndexJs: resolveApp("src/homepage/index.js"),
   appServerSideRenderingIndexJs: resolveApp("src/homepage/server.js"),
-  appRouteData: resolveApp("src/homepage/routeData.js"),
   appPackageJson: resolveApp("package.json"),
   appSrc: resolveApp("src"),
   yarnLockFile: resolveApp("yarn.lock"),

--- a/config/webpack.config.web.js
+++ b/config/webpack.config.web.js
@@ -221,8 +221,9 @@ function plugins(mode /*: "development" | "production" */) {
   const basePlugins = [
     new StaticSiteGeneratorPlugin({
       entry: "ssr",
-      // $ExpectFlowError(dynamic require)
-      paths: require(paths.appRouteData).routeData.map(({path}) => path),
+      paths: require("../src/homepage/routeData").routeData.map(
+        ({path}) => path
+      ),
       locals: {},
     }),
     new CopyPlugin([{from: paths.favicon, to: "favicon.png"}]),


### PR DESCRIPTION
Summary:
This import does not need to be dynamic; the fact that it is loses us
safety for no benefit. (When I originally wrote it, it was less
obviously bad, but the surrounding code has changed over time.)

Test Plan:
Running `yarn flow` suffices, and now actually checks this module
instead of typing it as `any`. Running `yarn test --full` is nice, too.

wchargin-branch: webpack-remove-dynamic-import