### PR TITLE
homepage: add prototypes listing

### DIFF
--- a/src/homepage/PrototypesPage.js
+++ b/src/homepage/PrototypesPage.js
@@ -1,0 +1,39 @@
+// @flow
+
+import stringify from "json-stable-stringify";
+import React, {type ComponentType} from "react";
+
+import type {RepoIdRegistry} from "../explorer/repoIdRegistry";
+import Link from "../webutil/Link";
+import type {Assets} from "../webutil/assets";
+
+export default function makePrototypesPage(
+  registry: RepoIdRegistry
+): ComponentType<{|+assets: Assets|}> {
+  return class PrototypesPage extends React.Component<{|+assets: Assets|}> {
+    render() {
+      return (
+        <div
+          style={{
+            maxWidth: 900,
+            margin: "0 auto",
+            marginBottom: 200,
+            padding: "0 10px",
+            lineHeight: 1.5,
+          }}
+        >
+          <p>Select a project:</p>
+          <ul>
+            {registry.map((x) => (
+              <li key={stringify(x)}>
+                <Link to={`/prototypes/${x.owner}/${x.name}/`}>
+                  {`${x.owner}/${x.name}`}
+                </Link>
+              </li>
+            ))}
+          </ul>
+        </div>
+      );
+    }
+  };
+}

--- a/src/homepage/routeData.js
+++ b/src/homepage/routeData.js
@@ -35,6 +35,15 @@ const routeData /*: $ReadOnlyArray<RouteDatum> */ = [
     navTitle: "Home",
   },
   {
+    path: "/prototypes/",
+    contents: {
+      type: "PAGE",
+      component: () => require("./PrototypesPage").default([]),
+    },
+    title: "SourceCred prototypes",
+    navTitle: null, // for now
+  },
+  {
     path: "/prototype/",
     contents: {
       type: "PAGE",


### PR DESCRIPTION
Test Plan:
Apply the following patch:

```diff
diff --git a/src/homepage/routeData.js b/src/homepage/routeData.js
index 32d3eb65..aac7fc9a 100644
--- a/src/homepage/routeData.js
+++ b/src/homepage/routeData.js
@@ -38,7 +38,10 @@ const routeData /*: $ReadOnlyArray<RouteDatum> */ = [
     path: "/prototypes/",
     contents: {
       type: "PAGE",
-      component: () => require("./PrototypesPage").default([]),
+      component: () =>
+        require("./PrototypesPage").default([
+          {owner: "sourcecred", name: "example-github"},
+        ]),
     },
     title: "SourceCred prototypes",
     navTitle: null, // for now
```

Then, load <http://localhost:8080/prototypes/> and see that there is an
entry in the list, and that it links to
<http://localhost:8080/prototypes/sourcecred/example-github/>. Note that
clicking the link raises a console error because there is no such route.

wchargin-branch: homepage-prototypes-page