### PR TITLE
homepage: render project-specific prototype pages

### DIFF
--- a/config/webpack.config.web.js
+++ b/config/webpack.config.web.js
@@ -51,9 +51,10 @@ function loadRepoRegistry() /*: RepoIdRegistry */ {
   }
   return json[1];
 }
+const repoRegistry = loadRepoRegistry();
 
 // Get environment variables to inject into our app.
-const env = getClientEnvironment(loadRepoRegistry());
+const env = getClientEnvironment(repoRegistry);
 
 function makeConfig(mode /*: "production" | "development" */) {
   return {
@@ -221,9 +222,9 @@ function plugins(mode /*: "development" | "production" */) {
   const basePlugins = [
     new StaticSiteGeneratorPlugin({
       entry: "ssr",
-      paths: require("../src/homepage/routeData").routeData.map(
-        ({path}) => path
-      ),
+      paths: require("../src/homepage/routeData")
+        .makeRouteData(repoRegistry)
+        .map(({path}) => path),
       locals: {},
     }),
     new CopyPlugin([{from: paths.favicon, to: "favicon.png"}]),

--- a/src/homepage/App.js
+++ b/src/homepage/App.js
@@ -5,18 +5,22 @@ import {Router} from "react-router";
 import type {History /* actually `any` */} from "history";
 
 import {createRoutes} from "./createRoutes";
-import {resolveTitleFromPath} from "./routeData";
+import {type RouteData, resolveTitleFromPath} from "./routeData";
 
-export default class App extends React.Component<{|+history: History|}> {
+export default class App extends React.Component<{|
+  +routeData: RouteData,
+  +history: History,
+|}> {
   render() {
+    const {routeData, history} = this.props;
     return (
       <Router
-        history={this.props.history}
-        routes={createRoutes()}
+        history={history}
+        routes={createRoutes(routeData)}
         onUpdate={function() {
           const router = this;
           const path: string = router.state.location.pathname;
-          document.title = resolveTitleFromPath(path);
+          document.title = resolveTitleFromPath(routeData, path);
         }}
       />
     );

--- a/src/homepage/Page.js
+++ b/src/homepage/Page.js
@@ -9,12 +9,13 @@ import Link from "../webutil/Link";
 import GithubLogo from "./GithubLogo";
 import TwitterLogo from "./TwitterLogo";
 import DiscordLogo from "./DiscordLogo";
-import {routeData} from "./routeData";
+import type {RouteData} from "./routeData";
 import * as NullUtil from "../util/null";
 import {VERSION_SHORT, VERSION_FULL} from "../core/version";
 
 export default class Page extends React.Component<{|
   +assets: Assets,
+  +routeData: RouteData,
   +children: Node,
 |}> {
   render() {
@@ -29,7 +30,7 @@ export default class Page extends React.Component<{|
                     SourceCred
                   </Link>
                 </li>
-                {routeData.map(({navTitle, path}) =>
+                {this.props.routeData.map(({navTitle, path}) =>
                   NullUtil.map(navTitle, (navTitle) => (
                     <li
                       key={path}

--- a/src/homepage/ProjectPage.js
+++ b/src/homepage/ProjectPage.js
@@ -1,0 +1,31 @@
+// @flow
+
+import React, {type ComponentType} from "react";
+
+import type {RepoId} from "../core/repoId";
+import type {Assets} from "../webutil/assets";
+
+export default function makeProjectPage(
+  repoId: RepoId
+): ComponentType<{|+assets: Assets|}> {
+  return class ProjectPage extends React.Component<{|+assets: Assets|}> {
+    render() {
+      return (
+        <div
+          style={{
+            maxWidth: 900,
+            margin: "0 auto",
+            marginBottom: 200,
+            padding: "0 10px",
+            lineHeight: 1.5,
+          }}
+        >
+          <p>
+            <strong>TODO:</strong> Render an explorer for{" "}
+            {`${repoId.owner}/${repoId.name}`}
+          </p>.
+        </div>
+      );
+    }
+  };
+}

--- a/src/homepage/createRouteDataFromEnvironment.js
+++ b/src/homepage/createRouteDataFromEnvironment.js
@@ -1,0 +1,13 @@
+// @flow
+
+import type {RepoIdRegistry} from "../explorer/repoIdRegistry";
+import {type RouteData, makeRouteData} from "./routeData";
+
+export default function createRouteDataFromEnvironment(): RouteData {
+  const raw = process.env.REPO_REGISTRY;
+  if (raw == null) {
+    throw new Error("fatal: repo ID registry unset");
+  }
+  const registry: RepoIdRegistry = JSON.parse(raw);
+  return makeRouteData(registry);
+}

--- a/src/homepage/createRoutes.js
+++ b/src/homepage/createRoutes.js
@@ -3,14 +3,18 @@
 import React from "react";
 import {IndexRoute, Route} from "react-router";
 
-import Page from "./Page";
-import ExternalRedirect from "./ExternalRedirect";
 import withAssets from "../webutil/withAssets";
-import {routeData} from "./routeData";
+import ExternalRedirect from "./ExternalRedirect";
+import Page from "./Page";
+import type {RouteData} from "./routeData";
 
-export function createRoutes() {
+export function createRoutes(routeData: RouteData) {
+  const PageWithAssets = withAssets(Page);
+  const PageWithRoutes = (props) => (
+    <PageWithAssets routeData={routeData} {...props} />
+  );
   return (
-    <Route path="/" component={withAssets(Page)}>
+    <Route path="/" component={PageWithRoutes}>
       {routeData.map(({path, contents}) => {
         switch (contents.type) {
           case "PAGE":

--- a/src/homepage/index.js
+++ b/src/homepage/index.js
@@ -3,9 +3,10 @@ import React from "react";
 import ReactDOM from "react-dom";
 import createBrowserHistory from "history/lib/createBrowserHistory";
 
-import createRelativeHistory from "../webutil/createRelativeHistory";
 import normalize from "../util/pathNormalize";
+import createRelativeHistory from "../webutil/createRelativeHistory";
 import App from "./App";
+import createRouteDataFromEnvironment from "./createRouteDataFromEnvironment";
 
 import "./index.css";
 
@@ -25,7 +26,8 @@ if (initialRoot == null) {
 const basename = normalize(`${window.location.pathname}/${initialRoot}/`);
 const history = createRelativeHistory(createBrowserHistory(), basename);
 
-ReactDOM.hydrate(<App history={history} />, target);
+const routeData = createRouteDataFromEnvironment();
+ReactDOM.hydrate(<App routeData={routeData} history={history} />, target);
 
 // In Chrome, relative favicon URLs are recomputed at every pushState,
 // although other assets (like the `src` of an `img`) are not. We don't

--- a/src/homepage/routeData.test.js
+++ b/src/homepage/routeData.test.js
@@ -1,15 +1,23 @@
 // @flow
 
-import {routeData} from "./routeData";
+import {stringToRepoId} from "../core/repoId";
+import {makeRouteData} from "./routeData";
 
 describe("homepage/routeData", () => {
+  function routeData() {
+    return makeRouteData([
+      stringToRepoId("sourcecred/example-github"),
+      stringToRepoId("sourcecred/sourcecred"),
+    ]);
+  }
+
   /*
    * React Router doesn't support relative paths. I'm not sure exactly
    * what a path without a leading slash would do; it's asking for
    * trouble. If we need them, we can reconsider this test.
    */
   it("every path has a leading slash", () => {
-    for (const route of routeData) {
+    for (const route of routeData()) {
       if (!route.path.startsWith("/")) {
         expect(route.path).toEqual("/" + route.path);
       }
@@ -35,7 +43,7 @@ describe("homepage/routeData", () => {
    * handled by a different pipeline (e.g., `copy-webpack-plugin`).
    */
   it("every path has a trailing slash", () => {
-    for (const route of routeData) {
+    for (const route of routeData()) {
       if (!route.path.endsWith("/")) {
         expect(route.path).toEqual(route.path + "/");
       }


### PR DESCRIPTION
Summary:
Currently, we render simply render a placeholder. Soon, we’ll remove the
repository selector dropdown from the cred explorer, and render
project-specific cred attributions.

Test Plan:
Run `yarn start`. Navigate to `/prototypes/` and observe:

![Screenshot of `/prototypes/`](https://user-images.githubusercontent.com/4317806/47877810-03227900-ddda-11e8-9a17-28398d83059f.png)

Note that the links point to URLs like
`/prototypes/sourcecred/example-github`:

![Screenshot of a project page](https://user-images.githubusercontent.com/4317806/47877888-35cc7180-ddda-11e8-95db-9f5099e146a8.png)

Then, check that `yarn test --full` passes.

wchargin-branch: homepage-project-pages