### PR TITLE
cleanup: remove unused field on ScoredConnection

### DIFF
--- a/src/analysis/__snapshots__/pagerankNodeDecomposition.test.js.snap
+++ b/src/analysis/__snapshots__/pagerankNodeDecomposition.test.js.snap
@@ -19,7 +19,6 @@ Map {
         },
         "connectionScore": 0.1102941261444197,
         "source": "NodeAddress[\\"sink\\"]",
-        "sourceScore": 0.5882353394369051,
       },
       Object {
         "connection": Object {
@@ -35,7 +34,6 @@ Map {
         },
         "connectionScore": 0.066176427533429,
         "source": "NodeAddress[\\"n2\\"]",
-        "sourceScore": 0.22058809177809668,
       },
       Object {
         "connection": Object {
@@ -46,7 +44,6 @@ Map {
         },
         "connectionScore": 0.014705889906538334,
         "source": "NodeAddress[\\"n1\\"]",
-        "sourceScore": 0.19117656878499834,
       },
     ],
   },
@@ -67,7 +64,6 @@ Map {
         },
         "connectionScore": 0.1102941261444197,
         "source": "NodeAddress[\\"sink\\"]",
-        "sourceScore": 0.5882353394369051,
       },
       Object {
         "connection": Object {
@@ -83,7 +79,6 @@ Map {
         },
         "connectionScore": 0.08823533943923001,
         "source": "NodeAddress[\\"n1\\"]",
-        "sourceScore": 0.19117656878499834,
       },
       Object {
         "connection": Object {
@@ -94,7 +89,6 @@ Map {
         },
         "connectionScore": 0.02205880917780967,
         "source": "NodeAddress[\\"n2\\"]",
-        "sourceScore": 0.22058809177809668,
       },
     ],
   },
@@ -115,7 +109,6 @@ Map {
         },
         "connectionScore": 0.2205882522888394,
         "source": "NodeAddress[\\"sink\\"]",
-        "sourceScore": 0.5882353394369051,
       },
       Object {
         "connection": Object {
@@ -131,7 +124,6 @@ Map {
         },
         "connectionScore": 0.132352855066858,
         "source": "NodeAddress[\\"n2\\"]",
-        "sourceScore": 0.22058809177809668,
       },
       Object {
         "connection": Object {
@@ -147,7 +139,6 @@ Map {
         },
         "connectionScore": 0.1102941261444197,
         "source": "NodeAddress[\\"sink\\"]",
-        "sourceScore": 0.5882353394369051,
       },
       Object {
         "connection": Object {
@@ -163,7 +154,6 @@ Map {
         },
         "connectionScore": 0.08823533943923001,
         "source": "NodeAddress[\\"n1\\"]",
-        "sourceScore": 0.19117656878499834,
       },
       Object {
         "connection": Object {
@@ -174,7 +164,6 @@ Map {
         },
         "connectionScore": 0.03676470871480657,
         "source": "NodeAddress[\\"sink\\"]",
-        "sourceScore": 0.5882353394369051,
       },
     ],
   },

--- a/src/analysis/pagerankNodeDecomposition.js
+++ b/src/analysis/pagerankNodeDecomposition.js
@@ -15,8 +15,6 @@ import * as NullUtil from "../util/null";
 export type ScoredConnection = {|
   +connection: Connection,
   +source: NodeAddressT,
-  // TODO(@decentralion): Consider removing this unused field
-  +sourceScore: number,
   +connectionScore: number,
 |};
 
@@ -42,7 +40,7 @@ export function decompose(
           const source = adjacencySource(target, connection.adjacency);
           const sourceScore = NullUtil.get(pr.get(source));
           const connectionScore = connection.weight * sourceScore;
-          return {connection, source, sourceScore, connectionScore};
+          return {connection, source, connectionScore};
         }
       ),
       (x) => -x.connectionScore,

--- a/src/analysis/pagerankNodeDecomposition.test.js
+++ b/src/analysis/pagerankNodeDecomposition.test.js
@@ -22,13 +22,12 @@ function formatDecomposition(d) {
     {
       score,
       scoredConnections: scoredConnections.map(
-        ({connection, source, sourceScore, connectionScore}) => ({
+        ({connection, source, connectionScore}) => ({
           connection: {
             adjacency: formatAdjacency(connection.adjacency),
             weight: connection.weight,
           },
           source: NodeAddress.toString(source),
-          sourceScore,
           connectionScore,
         })
       ),

--- a/src/explorer/pagerankTable/aggregate.test.js
+++ b/src/explorer/pagerankTable/aggregate.test.js
@@ -117,31 +117,26 @@ describe("explorer/pagerankTable/aggregate", () => {
       loop5: {
         connection: connections.loop5,
         source: nodes.root,
-        sourceScore: 0.2,
         connectionScore: 5,
       },
       rfz4: {
         connection: connections.rfz4,
         source: nodes.zap,
-        sourceScore: 0.2,
         connectionScore: 4,
       },
       kfr3: {
         connection: connections.kfr3,
         source: nodes.kif,
-        sourceScore: 0.2,
         connectionScore: 3,
       },
       rbk2: {
         connection: connections.rbk2,
         source: nodes.kif,
-        sourceScore: 0.2,
         connectionScore: 2,
       },
       rfk1: {
         connection: connections.rfk1,
         source: nodes.kif,
-        sourceScore: 0.2,
         connectionScore: 1,
       },
     };


### PR DESCRIPTION
This resolves an outstanding TODO in pagerankNodeDecomposition to remove
the unused sourceScore field.

I have removed it, and it was indeed unused.

Test plan: `yarn test` passes.