### PR TITLE
Implement to/fromJSON for PagerankNodeDecomp

### DIFF
--- a/src/analysis/pagerankNodeDecomposition.js
+++ b/src/analysis/pagerankNodeDecomposition.js
@@ -11,6 +11,7 @@ import {
 import type {NodeScore} from "./nodeScore";
 import * as MapUtil from "../util/map";
 import * as NullUtil from "../util/null";
+import {toCompat, fromCompat, type Compatible} from "../util/compat";
 
 export type ScoredConnection = {|
   +connection: Connection,
@@ -18,15 +19,35 @@ export type ScoredConnection = {|
   +connectionScore: number,
 |};
 
-export type PagerankNodeDecomposition = Map<
-  NodeAddressT,
-  {|
-    +score: number,
-    // Connections are sorted by `adjacencyScore` descending,
-    // breaking ties in a deterministic (but unspecified) order.
-    +scoredConnections: $ReadOnlyArray<ScoredConnection>,
-  |}
->;
+export type DecomposedNode = {|
+  +score: number,
+  // Connections are sorted by `adjacencyScore` descending,
+  // breaking ties in a deterministic (but unspecified) order.
+  +scoredConnections: $ReadOnlyArray<ScoredConnection>,
+|};
+
+export type PagerankNodeDecomposition = Map<NodeAddressT, DecomposedNode>;
+
+export opaque type PagerankNodeDecompositionJSON = Compatible<{|
+  [NodeAddressT]: DecomposedNode,
+|}>;
+
+const COMPAT_INFO = {
+  type: "sourcecred/pagerankNodeDecomposition",
+  version: "0.1.0",
+};
+
+export function toJSON(
+  x: PagerankNodeDecomposition
+): PagerankNodeDecompositionJSON {
+  return toCompat(COMPAT_INFO, MapUtil.toObject(x));
+}
+
+export function fromJSON(
+  x: PagerankNodeDecompositionJSON
+): PagerankNodeDecomposition {
+  return MapUtil.fromObject(fromCompat(COMPAT_INFO, x));
+}
 
 export function decompose(
   pr: NodeScore,


### PR DESCRIPTION
For #967, we need to actually serialize the results from running
PageRank so that others can consume it. This commit adds toJSON and
fromJSON methods for PagerankNodeDecomposition so that we can do just
that.

Test plan: Unit tests to verify round trip stability of the JSON have
been added. Run `yarn test`.