### PR TITLE
site: fix prototypes page dimensions

### DIFF
--- a/src/homepage/PrototypesPage.js
+++ b/src/homepage/PrototypesPage.js
@@ -17,9 +17,9 @@ export default function makePrototypesPage(
           style={{
             maxWidth: 900,
             margin: "0 auto",
-            marginBottom: 200,
             padding: "0 10px",
             lineHeight: 1.5,
+            height: "100%",
           }}
         >
           <p>Select a project:</p>


### PR DESCRIPTION
Summary:
Prior to this commit, the prototypes page, which lists just a handful of
repositories, was rendered with a vertical scrollbar: you had to scroll
200px to see the version info. This is silly.

The `height: 100%` is necessary not to get it to fill up the whole page,
but to get it to _not_ fill up ~30 extra pixels. I have no idea why.

Test Plan:
Run `yarn start` and note that `/prototypes/` now renders without a
scrollbar, and with the version info in the bottom-right corner.

wchargin-branch: site-fix-prototypes-page-dimensions