### PR TITLE
site: fix homepage link to prototypes page

### DIFF
--- a/src/homepage/HomePage.js
+++ b/src/homepage/HomePage.js
@@ -147,7 +147,7 @@ export default class HomePage extends React.Component<{|+assets: Assets|}> {
         <h2>Roadmap</h2>
         <p>
           SourceCred is under active development.{" "}
-          <Link to="/prototype">We have a prototype</Link> that ingests data
+          <Link to="/prototype/">We have a prototype</Link> that ingests data
           from Git and GitHub, computes cred, and allows the user to explore and
           experiment on the results. We have a long way to go to realize
           SourceCred’s full vision, but the prototype can already surface some


### PR DESCRIPTION
Summary:
Prior to this commit, clicking the in-copy link to the prototypes page
would raise a console error:

> Warning: [react-router] Location "/prototype" did not match any routes

Test Plan:
Run `yarn start` and click the link.

wchargin-branch: site-fix-homepage-prototype-link