### PR TITLE
deps: upgrade `flow-bin@^0.86.0`

### DIFF
--- a/config/webpack.config.web.js
+++ b/config/webpack.config.web.js
@@ -56,7 +56,7 @@ const repoRegistry = loadRepoRegistry();
 // Get environment variables to inject into our app.
 const env = getClientEnvironment(repoRegistry);
 
-function makeConfig(mode /*: "production" | "development" */) {
+function makeConfig(mode /*: "production" | "development" */) /*: mixed */ {
   return {
     // Don't attempt to continue if there are any errors.
     bail: true,

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "eslint-plugin-jsx-a11y": "5.1.1",
     "eslint-plugin-react": "7.4.0",
     "file-loader": "1.1.5",
-    "flow-bin": "^0.80.0",
+    "flow-bin": "^0.86.0",
     "jest": "^23.6.0",
     "jest-fetch-mock": "^1.6.5",
     "prettier": "^1.13.4",

--- a/src/explorer/weights/PluginWeightConfig.js
+++ b/src/explorer/weights/PluginWeightConfig.js
@@ -1,6 +1,6 @@
 // @flow
 
-import React from "react";
+import React, {type Node as ReactNode} from "react";
 import deepEqual from "lodash.isequal";
 import * as MapUtil from "../../util/map";
 import {NodeTypeConfig} from "./NodeTypeConfig";
@@ -24,7 +24,7 @@ export class PluginWeightConfig extends React.Component<Props> {
     super(props);
   }
 
-  _renderNodeWeightControls() {
+  _renderNodeWeightControls(): ReactNode {
     return Array.from(this.props.weightedTypes.nodes.values()).map(
       (wnt: WeightedNodeType) => {
         const onChange = (newType: WeightedNodeType) => {
@@ -44,7 +44,7 @@ export class PluginWeightConfig extends React.Component<Props> {
     );
   }
 
-  _renderEdgeWeightControls() {
+  _renderEdgeWeightControls(): ReactNode {
     return Array.from(this.props.weightedTypes.edges.values()).map(
       (wnt: WeightedEdgeType) => {
         const onChange = (newType: WeightedEdgeType) => {

--- a/src/explorer/weights/WeightConfig.js
+++ b/src/explorer/weights/WeightConfig.js
@@ -1,6 +1,6 @@
 // @flow
 
-import React from "react";
+import React, {type Node as ReactNode} from "react";
 import * as NullUtil from "../../util/null";
 import * as MapUtil from "../../util/map";
 
@@ -36,7 +36,7 @@ export class WeightConfig extends React.Component<Props> {
     );
   }
 
-  _renderPluginWeightConfigs() {
+  _renderPluginWeightConfigs(): ReactNode {
     return this.props.adapters
       .adapters()
       .filter((x) => x.declaration().name !== FALLBACK_NAME)

--- a/yarn.lock
+++ b/yarn.lock
@@ -3440,10 +3440,10 @@ flatten@^1.0.2:
   resolved "https://registry.yarnpkg.com/flatten/-/flatten-1.0.2.tgz#dae46a9d78fbe25292258cc1e780a41d95c03782"
   integrity sha1-2uRqnXj74lKSJYzB54CkHZXAN4I=
 
-flow-bin@^0.80.0:
-  version "0.80.0"
-  resolved "https://registry.yarnpkg.com/flow-bin/-/flow-bin-0.80.0.tgz#04cc1ee626a6f50786f78170c92ebe1745235403"
-  integrity sha512-0wRnqvXErQRPrx6GBLB5swgndfWkotd9MgfePgT7Z+VsE046c8Apzl7KKTCypB/pzn0pZF2g5Jurxxb2umET8g==
+flow-bin@^0.86.0:
+  version "0.86.0"
+  resolved "https://registry.yarnpkg.com/flow-bin/-/flow-bin-0.86.0.tgz#153a28722b4dc13b7200c74b644dd4d9f4969a11"
+  integrity sha512-ulRvFH3ewGIYwg+qPk/OJXoe3Nhqi0RyR0wqgK0b1NzUDEC6O99zU39MBTickXvlrr6iwRO6Wm4lVGeDmnzbew==
 
 flush-write-stream@^1.0.0:
   version "1.0.3"


### PR DESCRIPTION
Summary:
There have been some breaking changes that require new type annotations,
which is a good thing: these prevent `any`-leakage.

Test Plan:
Run `yarn flow`.

wchargin-branch: flow-v0.86.0