### PR TITLE
Update WeightSlider.js to allow 0 weights

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## [Unreleased]
+- Enable setting type weights to 0 in the UI (#1005)
 - Add support for 🚀 and 👀 reaction types (#1068)
 - Create one page per project, rather than having a selector (#988)
 <!-- Please add new entries to the _top_ of this section. -->

--- a/src/explorer/weights/WeightSlider.js
+++ b/src/explorer/weights/WeightSlider.js
@@ -2,6 +2,9 @@
 
 import React from "react";
 
+export const WEIGHT_SLIDER_MIN = -5;
+export const WEIGHT_SLIDER_MAX = 5;
+
 export type Props = {|
   +weight: number,
   +name: React$Node,
@@ -14,13 +17,15 @@ export class WeightSlider extends React.Component<Props> {
         <span style={{flexGrow: 1}}>{this.props.name}</span>
         <input
           type="range"
-          min={-5}
-          max={5}
+          min={WEIGHT_SLIDER_MIN}
+          max={WEIGHT_SLIDER_MAX}
           step={1}
-          value={Math.log2(this.props.weight)}
+          value={convertWeightToSliderValue(this.props.weight)}
           onChange={(e) => {
-            const logValue = e.target.valueAsNumber;
-            this.props.onChange(2 ** logValue);
+            const sliderValue = convertSliderValueToWeight(
+              e.target.valueAsNumber
+            );
+            this.props.onChange(sliderValue);
           }}
         />{" "}
         <span
@@ -33,11 +38,19 @@ export class WeightSlider extends React.Component<Props> {
   }
 }
 
+function convertWeightToSliderValue(weight: number): number {
+  return weight === 0 ? WEIGHT_SLIDER_MIN : Math.log2(weight);
+}
+
+function convertSliderValueToWeight(sliderValue: number): number {
+  return sliderValue === WEIGHT_SLIDER_MIN ? 0 : 2 ** sliderValue;
+}
+
 export function formatWeight(n: number) {
-  if (n <= 0 || !isFinite(n)) {
+  if (n < 0 || !isFinite(n)) {
     throw new Error(`Invalid weight: ${n}`);
   }
-  if (n >= 1) {
+  if (n >= 1 || n === 0) {
     return n.toFixed(0) + "×";
   } else {
     return `1/${(1 / n).toFixed(0)}×`;

--- a/src/explorer/weights/WeightSlider.js
+++ b/src/explorer/weights/WeightSlider.js
@@ -2,14 +2,47 @@
 
 import React from "react";
 
-export const WEIGHT_SLIDER_MIN = -5;
-export const WEIGHT_SLIDER_MAX = 5;
+/**
+ * The Weight is the number that the WeightSlider actually provides to the
+ * instantiating component. The Weight varies in the range
+ * [0, 2**MAX_SLIDER_VALUE].
+ */
+export type Weight = number;
+
+/**
+ * The SliderPosition is the current position of the [range input] that the
+ * WeightSlider instantiates. It varies in the range [MIN_SLIDER, MAX_SLIDER].
+ *
+ * [range input]: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/range
+ *
+ * The returned Weight is exponential in the SliderPosition, so that e.g. if
+ * the SliderPosition is 2 then the Weight is 4, if the SliderPosition is 3
+ * then the Weight is 8, and so forth. The exception is when the
+ * SliderPosition==MIN_SLIDER_VALUE. In this case, the Weight will be 0.
+ */
+export type SliderPosition = number;
+
+export const MIN_SLIDER: SliderPosition = -5;
+export const MAX_SLIDER: SliderPosition = 5;
 
 export type Props = {|
-  +weight: number,
+  // The current Weight the WeightSlider is set to
+  +weight: Weight,
+  // The name associated with the slider.
+  // Will be displayed adjacent to the slider.
   +name: React$Node,
-  +onChange: (number) => void,
+  // onChange handler so the parent can recieve (and then set) the new weight
+  +onChange: (Weight) => void,
 |};
+
+/**
+ * The WeightSlider is a React component for letting the user input
+ * a numeric weight that varies over an exponential range.
+ * The WeightSlider instantiates a slider that lets the user change
+ * the weight, displays the current weight value, and displays
+ * a "name" for the slider (which may be an arbitrary inline React
+ * component).
+ */
 export class WeightSlider extends React.Component<Props> {
   render() {
     return (
@@ -17,15 +50,13 @@ export class WeightSlider extends React.Component<Props> {
         <span style={{flexGrow: 1}}>{this.props.name}</span>
         <input
           type="range"
-          min={WEIGHT_SLIDER_MIN}
-          max={WEIGHT_SLIDER_MAX}
+          min={MIN_SLIDER}
+          max={MAX_SLIDER}
           step={1}
-          value={convertWeightToSliderValue(this.props.weight)}
+          value={weightToSlider(this.props.weight)}
           onChange={(e) => {
-            const sliderValue = convertSliderValueToWeight(
-              e.target.valueAsNumber
-            );
-            this.props.onChange(sliderValue);
+            const weight: Weight = sliderToWeight(e.target.valueAsNumber);
+            this.props.onChange(weight);
           }}
         />{" "}
         <span
@@ -38,12 +69,43 @@ export class WeightSlider extends React.Component<Props> {
   }
 }
 
-function convertWeightToSliderValue(weight: number): number {
-  return weight === 0 ? WEIGHT_SLIDER_MIN : Math.log2(weight);
+/**
+ * Converts a Weight into a SliderPosition.
+ *
+ * If the Weight corresponds to an illegal slider value (i.e. weight < 0 or
+ * weight > 2**MAX_SLIDER), then an error will be thrown.
+ * be thrown.
+ *
+ * Over the domain of legal weights, `weightToSlider` and `sliderToWeight`
+ * compose to form the identity function.
+ */
+export function weightToSlider(weight: Weight): SliderPosition {
+  if (weight < 0 || weight > 2 ** MAX_SLIDER) {
+    throw new Error(`Weight out of range: ${weight}`);
+  }
+  if (isNaN(weight)) {
+    throw new Error("illegal value: NaN");
+  }
+  return Math.max(MIN_SLIDER, Math.log2(weight));
 }
 
-function convertSliderValueToWeight(sliderValue: number): number {
-  return sliderValue === WEIGHT_SLIDER_MIN ? 0 : 2 ** sliderValue;
+/**
+ * Converts a SliderPosition into a Weight.
+ *
+ * If the SliderPosition is illegal (ie. not in the range [MIN_SLIDER,
+ * MAX_SLIDER]), then an error will be thrown.
+ *
+ * Over the domain of legal slider positions, `sliderToWeight` and
+ * `weightToSlider` compose to form the identity function.
+ */
+export function sliderToWeight(sliderPosition: SliderPosition): Weight {
+  if (sliderPosition < MIN_SLIDER || sliderPosition > MAX_SLIDER) {
+    throw new Error(`Slider position out of range: ${sliderPosition}`);
+  }
+  if (isNaN(sliderPosition)) {
+    throw new Error("illegal value: NaN");
+  }
+  return sliderPosition === MIN_SLIDER ? 0 : 2 ** sliderPosition;
 }
 
 export function formatWeight(n: number) {

--- a/src/explorer/weights/WeightSlider.js
+++ b/src/explorer/weights/WeightSlider.js
@@ -96,7 +96,7 @@ export class WeightSlider extends React.Component<Props> {
  * having the application error.
  */
 export function weightToSlider(weight: Weight): SliderPosition {
-  if (isNaN(weight) || !isFinite(weight) || weight < 0) {
+  if (!isFinite(weight) || weight < 0) {
     throw new Error(`illegal weight: ${weight}`);
   }
   const tentativePosition = Math.log2(weight);

--- a/src/explorer/weights/WeightSlider.js
+++ b/src/explorer/weights/WeightSlider.js
@@ -3,22 +3,16 @@
 import React from "react";
 
 /**
- * The Weight is the number that the WeightSlider actually provides to the
- * instantiating component. The Weight varies in the range
- * [0, 2**MAX_SLIDER_VALUE].
+ * The Weight that the user supplies via a WeightSlider.
+ * Weights are finite and non-negative. The vast majority of weights cannot
+ * be selected via the WeightSlider, which is only capable of choosing a few
+ * specific weights.
  */
 export type Weight = number;
 
 /**
- * The SliderPosition is the current position of the [range input] that the
- * WeightSlider instantiates. It varies in the range [MIN_SLIDER, MAX_SLIDER].
- *
- * [range input]: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/range
- *
- * The returned Weight is exponential in the SliderPosition, so that e.g. if
- * the SliderPosition is 2 then the Weight is 4, if the SliderPosition is 3
- * then the Weight is 8, and so forth. The exception is when the
- * SliderPosition==MIN_SLIDER_VALUE. In this case, the Weight will be 0.
+ * SliderPosition is an integer in the range `[MIN_SLIDER, MAX_SLIDER]` which
+ * describes the current position of the WeightSlider's slider.
  */
 export type SliderPosition = number;
 
@@ -27,21 +21,35 @@ export const MAX_SLIDER: SliderPosition = 5;
 
 export type Props = {|
   // The current Weight the WeightSlider is set to
+  // Note: It is acceptable to pass the WeightSlider a weight which the slider
+  // is incapable of picking (e.g. 1/3).
   +weight: Weight,
-  // The name associated with the slider.
-  // Will be displayed adjacent to the slider.
+  // The name associated with the slider; displayed adjacent to the slider.
   +name: React$Node,
-  // onChange handler so the parent can recieve (and then set) the new weight
+  // Callback invoked with the new weight after the user adjusts the slider.
   +onChange: (Weight) => void,
 |};
 
 /**
- * The WeightSlider is a React component for letting the user input
- * a numeric weight that varies over an exponential range.
- * The WeightSlider instantiates a slider that lets the user change
- * the weight, displays the current weight value, and displays
- * a "name" for the slider (which may be an arbitrary inline React
- * component).
+ * The WeightSlider is a [controlled component] which lets the user choose a
+ * numeric weight by dragging a slider.
+ *
+ * The weight varies exponentially in the slider position, so that moving the
+ * slider by one notch changes the weight by a power of two. The exception is
+ * when the user drags the slider to its minimum value, in which case the
+ * weight is set to 0.
+ *
+ * In addition to rendering a slider (instantiated as a [range input]), it also renders
+ * a description of the slider, and the weight associated with the current slider position.
+ *
+ * Note that it is possible to configure the WeightSlider with a weight that
+ * that is impossible to select via the slider; for example, 1/3. In such cases,
+ * the WeightSlider's slider will be set to the closest possible position, and after
+ * the user adjusts the weight via the slider, it will always correspond exactly to
+ * the slider position.
+ *
+ * [controlled component]: https://reactjs.org/docs/forms.html#controlled-components
+ * [range input]: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/range
  */
 export class WeightSlider extends React.Component<Props> {
   render() {
@@ -72,31 +80,43 @@ export class WeightSlider extends React.Component<Props> {
 /**
  * Converts a Weight into a SliderPosition.
  *
- * If the Weight corresponds to an illegal slider value (i.e. weight < 0 or
- * weight > 2**MAX_SLIDER), then an error will be thrown.
- * be thrown.
+ * If the Weight is an illegal value (negative, NaN, or infinite), an error
+ * will be thrown.
  *
- * Over the domain of legal weights, `weightToSlider` and `sliderToWeight`
- * compose to form the identity function.
+ * It is possible that the Weight will be a legal value, but will not
+ * correspond to any SliderPosition (as SliderPositions are always integers, in
+ * the range `[MIN_SLIDER, MAX_SLIDER]`). In such cases, it may seem principled
+ * to throw a conversion error. However, initial weights are provided by
+ * plugins, and plugin authors might reasonably choose weights like 1/3 that do
+ * not correspond to a slider value. We choose to make the WeightSlider robust
+ * to such decisions by rounding to the closest appropriate slider position. In
+ * such cases, the WeightSlider's weight will be inconsistent with the slider
+ * position, and moving the Slider away from and back to its initial position
+ * will actually change the weight. This is unfortunate, but is preferable to
+ * having the application error.
  */
 export function weightToSlider(weight: Weight): SliderPosition {
-  if (weight < 0 || weight > 2 ** MAX_SLIDER) {
-    throw new Error(`Weight out of range: ${weight}`);
+  if (isNaN(weight) || !isFinite(weight) || weight < 0) {
+    throw new Error(`illegal weight: ${weight}`);
   }
-  if (isNaN(weight)) {
-    throw new Error("illegal value: NaN");
+  const tentativePosition = Math.log2(weight);
+  if (tentativePosition < MIN_SLIDER) {
+    return MIN_SLIDER;
   }
-  return Math.max(MIN_SLIDER, Math.log2(weight));
+  if (tentativePosition > MAX_SLIDER) {
+    return MAX_SLIDER;
+  }
+  return Math.round(tentativePosition);
 }
 
 /**
  * Converts a SliderPosition into a Weight.
  *
- * If the SliderPosition is illegal (ie. not in the range [MIN_SLIDER,
- * MAX_SLIDER]), then an error will be thrown.
+ * SliderPosition must be an integer in the range `[MIN_SLIDER, MAX_SLIDER]`.
+ * If it is not, then an error will be thrown.
  *
- * Over the domain of legal slider positions, `sliderToWeight` and
- * `weightToSlider` compose to form the identity function.
+ * Over the domain of legal slider positions `p`, `weightToSlider(sliderToWeight(p))`
+ * is the identity function.
  */
 export function sliderToWeight(sliderPosition: SliderPosition): Weight {
   if (sliderPosition < MIN_SLIDER || sliderPosition > MAX_SLIDER) {
@@ -104,6 +124,9 @@ export function sliderToWeight(sliderPosition: SliderPosition): Weight {
   }
   if (isNaN(sliderPosition)) {
     throw new Error("illegal value: NaN");
+  }
+  if (Math.round(sliderPosition) !== sliderPosition) {
+    throw new Error(`slider position not integer: ${sliderPosition}`);
   }
   return sliderPosition === MIN_SLIDER ? 0 : 2 ** sliderPosition;
 }

--- a/src/explorer/weights/WeightSlider.test.js
+++ b/src/explorer/weights/WeightSlider.test.js
@@ -3,7 +3,7 @@
 import React from "react";
 import {shallow} from "enzyme";
 
-import {WeightSlider, formatWeight} from "./WeightSlider";
+import {WeightSlider, formatWeight, WEIGHT_SLIDER_MIN} from "./WeightSlider";
 
 require("../../webutil/testUtil").configureEnzyme();
 
@@ -19,6 +19,19 @@ describe("explorer/weights/WeightSlider", () => {
     it("sets slider to the log of provided weight", () => {
       const {element} = example();
       expect(element.find("input").props().value).toBe(Math.log2(3));
+    });
+    it("sets slider value to the minimum value when the provided weight equals zero", () => {
+      const element = shallow(
+        <WeightSlider weight={0} name="foo" onChange={jest.fn()} />
+      );
+      expect(element.find("input").props().value).toBe(WEIGHT_SLIDER_MIN);
+    });
+    it("sets weight to zero when the slider value equals the minimum value", () => {
+      const {element, onChange} = example();
+      const input = element.find("input");
+      input.simulate("change", {target: {valueAsNumber: WEIGHT_SLIDER_MIN}});
+      expect(onChange).toHaveBeenCalledTimes(1);
+      expect(onChange).toHaveBeenCalledWith(0);
     });
     it("prints the provided weight", () => {
       const {element} = example();
@@ -54,8 +67,11 @@ describe("explorer/weights/WeightSlider", () => {
     it("shows numbers less than 1 (but not 0) as integer-rounded fractions", () => {
       expect(formatWeight(0.249)).toBe("1/4×");
     });
+    it("shows numbers equal to 0 as 0x", () => {
+      expect(formatWeight(0)).toBe("0×");
+    });
     it("throws on bad values", () => {
-      const bads = [NaN, Infinity, -Infinity, -3, 0];
+      const bads = [NaN, Infinity, -Infinity, -3];
       for (const bad of bads) {
         expect(() => formatWeight(bad)).toThrowError("Invalid weight");
       }

--- a/src/plugins/github/declaration.js
+++ b/src/plugins/github/declaration.js
@@ -110,8 +110,7 @@ const mentionsAuthorEdgeType = Object.freeze({
   forwardName: "mentions author of",
   backwardName: "has author mentioned by",
   defaultForwardWeight: 1,
-  // TODO(#811): Probably change this to 0
-  defaultBackwardWeight: 1 / 32,
+  defaultBackwardWeight: 0,
   prefix: E.Prefix.mentionsAuthor,
   description: "TODO: Add a description for this EdgeType",
 });
@@ -120,8 +119,7 @@ const reactsHeartEdgeType = Object.freeze({
   forwardName: "reacted ❤️ to",
   backwardName: "got ❤️ from",
   defaultForwardWeight: 2,
-  // TODO(#811): Probably change this to 0
-  defaultBackwardWeight: 1 / 32,
+  defaultBackwardWeight: 0,
   prefix: E.Prefix.reactsHeart,
   description: "TODO: Add a description for this EdgeType",
 });
@@ -130,8 +128,7 @@ const reactsThumbsUpEdgeType = Object.freeze({
   forwardName: "reacted 👍 to",
   backwardName: "got 👍 from",
   defaultForwardWeight: 1,
-  // TODO(#811): Probably change this to 0
-  defaultBackwardWeight: 1 / 32,
+  defaultBackwardWeight: 0,
   prefix: E.Prefix.reactsThumbsUp,
   description: "TODO: Add a description for this EdgeType",
 });
@@ -140,8 +137,7 @@ const reactsHoorayEdgeType = Object.freeze({
   forwardName: "reacted 🎉 to",
   backwardName: "got 🎉 from",
   defaultForwardWeight: 4,
-  // TODO(#811): Probably change this to 0
-  defaultBackwardWeight: 1 / 32,
+  defaultBackwardWeight: 0,
   prefix: E.Prefix.reactsHooray,
   description: "TODO: Add a description for this EdgeType",
 });

--- a/src/plugins/github/declaration.js
+++ b/src/plugins/github/declaration.js
@@ -101,7 +101,7 @@ const referencesEdgeType = Object.freeze({
   forwardName: "references",
   backwardName: "is referenced by",
   defaultForwardWeight: 1,
-  defaultBackwardWeight: 1 / 16,
+  defaultBackwardWeight: 0,
   prefix: E.Prefix.references,
   description: "TODO: Add a description for this EdgeType",
 });

--- a/src/plugins/github/declaration.js
+++ b/src/plugins/github/declaration.js
@@ -146,8 +146,7 @@ const reactsRocketEdgeType = Object.freeze({
   forwardName: "reacted 🚀 to",
   backwardName: "got 🚀 from",
   defaultForwardWeight: 1,
-  // TODO(#811): Probably change this to 0
-  defaultBackwardWeight: 1 / 32,
+  defaultBackwardWeight: 0,
   prefix: E.Prefix.reactsRocket,
   description: "TODO: Add a description for this EdgeType",
 });


### PR DESCRIPTION
We changed the weight slider so the minimum value maps to zero instead
of a power of two. Also changed declarations to default at zero when
appropriate to keep UI state consistent.

test plan: Tested UI, confirmed ability to move weights to 0, added unit
tests