### PR TITLE
Optimize `Graph.neighbors`

### DIFF
--- a/src/core/graph.js
+++ b/src/core/graph.js
@@ -552,8 +552,14 @@ export class Graph {
     options: NeighborsOptions,
     initialModificationCount: ModificationCount
   ): Iterator<Neighbor> {
-    const nodeFilter = (n) => NodeAddress.hasPrefix(n, options.nodePrefix);
-    const edgeFilter = (e) => EdgeAddress.hasPrefix(e, options.edgePrefix);
+    const nodeFilter =
+      options.nodePrefix === NodeAddress.empty
+        ? (_) => true
+        : (n) => NodeAddress.hasPrefix(n, options.nodePrefix);
+    const edgeFilter =
+      options.edgePrefix === EdgeAddress.empty
+        ? (_) => true
+        : (n) => EdgeAddress.hasPrefix(n, options.edgePrefix);
     const direction = options.direction;
     const adjacencies: {edges: Edge[], direction: string}[] = [];
     if (direction === Direction.IN || direction === Direction.ANY) {


### PR DESCRIPTION
Callers of `Graph.neighbors` can choose not to do any prefix filtering
(i.e. get all neighbors) by passing `NodeAddress.empty` and
`EdgeAddress.empty` as the prefix filters. This means that we call
`Address.hasPrefix`, which calls `Address.isValid` on twice. This is
redundant work for a function that we know will return true.

This commit introduces a slight optimization so that in the case where
the prefix was the empty address, we shortcut this work. The commit was
motivated by seeing `neighbors`, `hasPrefix`, and `isValid` showing up
on some perf profiling of node decomposition related functionality. In
my profiling, this commit did not actually significantly improve the
perf. However, it's a simple and principled commit that makes sense, so
I'm submitting it anyway.

Test plan: Unit tests already have good coverage of calling `neighbors`
with an empty node or edge address.