### PR TITLE
Use `WeightedGraph` in `createConnections`

### DIFF
--- a/src/analysis/pagerank.js
+++ b/src/analysis/pagerank.js
@@ -6,6 +6,7 @@ import {
   createConnections,
   createOrderedSparseMarkovChain,
   type EdgeWeight,
+  createWeightedGraph,
 } from "../core/attribution/graphToMarkovChain";
 import {
   decompose,
@@ -52,11 +53,12 @@ export async function pagerank(
     ...defaultOptions(),
     ...(options || {}),
   };
-  const connections = createConnections(
+  const weightedGraph = createWeightedGraph(
     graph,
     edgeWeight,
     fullOptions.selfLoopWeight
   );
+  const connections = createConnections(weightedGraph);
   const osmc = createOrderedSparseMarkovChain(connections);
   const distribution = await findStationaryDistribution(osmc.chain, {
     verbose: fullOptions.verbose,

--- a/src/analysis/pagerankNodeDecomposition.test.js
+++ b/src/analysis/pagerankNodeDecomposition.test.js
@@ -5,6 +5,7 @@ import {
   distributionToNodeDistribution,
   createConnections,
   createOrderedSparseMarkovChain,
+  createWeightedGraph,
 } from "../core/attribution/graphToMarkovChain";
 import {findStationaryDistribution} from "../core/attribution/markovChain";
 import {decompose} from "./pagerankNodeDecomposition";
@@ -126,7 +127,8 @@ describe("analysis/pagerankNodeDecomposition", () => {
         .addEdge(e3)
         .addEdge(e4);
       const edgeWeight = () => ({toWeight: 6.0, froWeight: 3.0});
-      const connections = createConnections(g, edgeWeight, 1.0);
+      const weightedGraph = createWeightedGraph(g, edgeWeight, 1.0);
+      const connections = createConnections(weightedGraph);
       const osmc = createOrderedSparseMarkovChain(connections);
       const pi = await findStationaryDistribution(osmc.chain, {
         verbose: false,
@@ -143,7 +145,8 @@ describe("analysis/pagerankNodeDecomposition", () => {
     it("is valid on the example graph", async () => {
       const g = advancedGraph().graph1();
       const edgeWeight = () => ({toWeight: 6.0, froWeight: 3.0});
-      const connections = createConnections(g, edgeWeight, 1.0);
+      const weightedGraph = createWeightedGraph(g, edgeWeight, 1.0);
+      const connections = createConnections(weightedGraph);
       const osmc = createOrderedSparseMarkovChain(connections);
       const pi = await findStationaryDistribution(osmc.chain, {
         verbose: false,

--- a/src/core/attribution/graphToMarkovChain.test.js
+++ b/src/core/attribution/graphToMarkovChain.test.js
@@ -165,7 +165,7 @@ describe("core/attribution/graphToMarkovChain", () => {
         .addEdge(e3)
         .addEdge(e4);
       const edgeWeight = () => ({toWeight: 6.0, froWeight: 3.0});
-      const actual = createConnections(g, edgeWeight, 1.0);
+      const actual = createConnections(createWeightedGraph(g, edgeWeight, 1.0));
       // Total out-weights (for normalization factors):
       //   - for `n1`: 2 out, 0 in, 1 synthetic: 12 + 0 + 1 = 13
       //   - for `n2`: 1 out, 1 in, 1 synthetic: 6 + 3 + 1 = 10
@@ -202,7 +202,7 @@ describe("core/attribution/graphToMarkovChain", () => {
         throw new Error("Don't even look at me");
       };
       const osmc = createOrderedSparseMarkovChain(
-        createConnections(g, edgeWeight, 1e-3)
+        createConnections(createWeightedGraph(g, edgeWeight, 1e-3))
       );
       const expected = {
         nodeOrder: [n],
@@ -231,7 +231,7 @@ describe("core/attribution/graphToMarkovChain", () => {
         .addEdge(e4);
       const edgeWeight = () => ({toWeight: 1, froWeight: 0});
       const osmc = createOrderedSparseMarkovChain(
-        createConnections(g, edgeWeight, 0.0)
+        createConnections(createWeightedGraph(g, edgeWeight, 0.0))
       );
       const expected = {
         nodeOrder: [n1, n2, n3],
@@ -269,7 +269,7 @@ describe("core/attribution/graphToMarkovChain", () => {
         .addEdge(e3);
       const edgeWeight = () => ({toWeight: 1, froWeight: 1});
       const osmc = createOrderedSparseMarkovChain(
-        createConnections(g, edgeWeight, 0.0)
+        createConnections(createWeightedGraph(g, edgeWeight, 0.0))
       );
       const expected = {
         nodeOrder: [n1, n2, n3],
@@ -301,7 +301,7 @@ describe("core/attribution/graphToMarkovChain", () => {
         return {toWeight: 4 - epsilon / 2, froWeight: 1 - epsilon / 2};
       }
       const osmc = createOrderedSparseMarkovChain(
-        createConnections(g, edgeWeight, epsilon)
+        createConnections(createWeightedGraph(g, edgeWeight, epsilon))
       );
       // Edges from `src`:
       //   - to `src` with weight `epsilon`


### PR DESCRIPTION
This commit takes the `WeightedGraph` type added in #1008, and uses it
in `createConnections`.

`createConnections` now has a simplified signature (it just takes a
`WeightedGraph`), and a simplified implementation (it no longer needs to
calculate totalOutWeights).

Test plan: `createConnections` already has thorough unit testing (both
direct and indirect tests). Run `yarn test`.

Part of the #967 work group.