### PR TITLE
Add `scoredConnections`

### DIFF
--- a/src/analysis/__snapshots__/pagerankNodeDecomposition.test.js.snap
+++ b/src/analysis/__snapshots__/pagerankNodeDecomposition.test.js.snap
@@ -169,3 +169,173 @@ Map {
   },
 }
 `;
+
+exports[`analysis/pagerankNodeDecomposition scoredConnections has the expected output on a simple asymmetric chain 1`] = `
+Map {
+  "NodeAddress[\\"n1\\"]" => Object {
+    "score": 0.19117656878499834,
+    "scoredConnections": Array [
+      Object {
+        "connection": Object {
+          "adjacency": Object {
+            "edge": Object {
+              "address": "EdgeAddress[\\"e3\\"]",
+              "dst": "NodeAddress[\\"sink\\"]",
+              "src": "NodeAddress[\\"n1\\"]",
+            },
+            "type": "OUT_EDGE",
+          },
+          "weight": 0.1875,
+        },
+        "connectionScore": 0.1102941261444197,
+        "source": "NodeAddress[\\"sink\\"]",
+      },
+      Object {
+        "connection": Object {
+          "adjacency": Object {
+            "edge": Object {
+              "address": "EdgeAddress[\\"e1\\"]",
+              "dst": "NodeAddress[\\"n2\\"]",
+              "src": "NodeAddress[\\"n1\\"]",
+            },
+            "type": "OUT_EDGE",
+          },
+          "weight": 0.3,
+        },
+        "connectionScore": 0.066176427533429,
+        "source": "NodeAddress[\\"n2\\"]",
+      },
+      Object {
+        "connection": Object {
+          "adjacency": Object {
+            "type": "SYNTHETIC_LOOP",
+          },
+          "weight": 0.07692307692307693,
+        },
+        "connectionScore": 0.014705889906538334,
+        "source": "NodeAddress[\\"n1\\"]",
+      },
+    ],
+  },
+  "NodeAddress[\\"n2\\"]" => Object {
+    "score": 0.22058809177809668,
+    "scoredConnections": Array [
+      Object {
+        "connection": Object {
+          "adjacency": Object {
+            "edge": Object {
+              "address": "EdgeAddress[\\"e2\\"]",
+              "dst": "NodeAddress[\\"sink\\"]",
+              "src": "NodeAddress[\\"n2\\"]",
+            },
+            "type": "OUT_EDGE",
+          },
+          "weight": 0.1875,
+        },
+        "connectionScore": 0.1102941261444197,
+        "source": "NodeAddress[\\"sink\\"]",
+      },
+      Object {
+        "connection": Object {
+          "adjacency": Object {
+            "edge": Object {
+              "address": "EdgeAddress[\\"e1\\"]",
+              "dst": "NodeAddress[\\"n2\\"]",
+              "src": "NodeAddress[\\"n1\\"]",
+            },
+            "type": "IN_EDGE",
+          },
+          "weight": 0.46153846153846156,
+        },
+        "connectionScore": 0.08823533943923001,
+        "source": "NodeAddress[\\"n1\\"]",
+      },
+      Object {
+        "connection": Object {
+          "adjacency": Object {
+            "type": "SYNTHETIC_LOOP",
+          },
+          "weight": 0.1,
+        },
+        "connectionScore": 0.02205880917780967,
+        "source": "NodeAddress[\\"n2\\"]",
+      },
+    ],
+  },
+  "NodeAddress[\\"sink\\"]" => Object {
+    "score": 0.5882353394369051,
+    "scoredConnections": Array [
+      Object {
+        "connection": Object {
+          "adjacency": Object {
+            "edge": Object {
+              "address": "EdgeAddress[\\"e4\\"]",
+              "dst": "NodeAddress[\\"sink\\"]",
+              "src": "NodeAddress[\\"sink\\"]",
+            },
+            "type": "IN_EDGE",
+          },
+          "weight": 0.375,
+        },
+        "connectionScore": 0.2205882522888394,
+        "source": "NodeAddress[\\"sink\\"]",
+      },
+      Object {
+        "connection": Object {
+          "adjacency": Object {
+            "edge": Object {
+              "address": "EdgeAddress[\\"e2\\"]",
+              "dst": "NodeAddress[\\"sink\\"]",
+              "src": "NodeAddress[\\"n2\\"]",
+            },
+            "type": "IN_EDGE",
+          },
+          "weight": 0.6,
+        },
+        "connectionScore": 0.132352855066858,
+        "source": "NodeAddress[\\"n2\\"]",
+      },
+      Object {
+        "connection": Object {
+          "adjacency": Object {
+            "edge": Object {
+              "address": "EdgeAddress[\\"e4\\"]",
+              "dst": "NodeAddress[\\"sink\\"]",
+              "src": "NodeAddress[\\"sink\\"]",
+            },
+            "type": "OUT_EDGE",
+          },
+          "weight": 0.1875,
+        },
+        "connectionScore": 0.1102941261444197,
+        "source": "NodeAddress[\\"sink\\"]",
+      },
+      Object {
+        "connection": Object {
+          "adjacency": Object {
+            "edge": Object {
+              "address": "EdgeAddress[\\"e3\\"]",
+              "dst": "NodeAddress[\\"sink\\"]",
+              "src": "NodeAddress[\\"n1\\"]",
+            },
+            "type": "IN_EDGE",
+          },
+          "weight": 0.46153846153846156,
+        },
+        "connectionScore": 0.08823533943923001,
+        "source": "NodeAddress[\\"n1\\"]",
+      },
+      Object {
+        "connection": Object {
+          "adjacency": Object {
+            "type": "SYNTHETIC_LOOP",
+          },
+          "weight": 0.0625,
+        },
+        "connectionScore": 0.03676470871480657,
+        "source": "NodeAddress[\\"sink\\"]",
+      },
+    ],
+  },
+}
+`;

--- a/src/analysis/pagerankNodeDecomposition.js
+++ b/src/analysis/pagerankNodeDecomposition.js
@@ -7,6 +7,8 @@ import {
   type Connection,
   type NodeToConnections,
   adjacencySource,
+  type WeightedGraph,
+  singleNodeConnections,
 } from "../core/attribution/graphToMarkovChain";
 import type {NodeScore} from "./nodeScore";
 import * as MapUtil from "../util/map";
@@ -60,4 +62,48 @@ export function decompose(
     );
     return {score, scoredConnections};
   });
+}
+
+/*
+ * Given a weighted graph with associated scores, compute the scoredConnections
+ * for a particular node.
+ *
+ * `scoredConnections(wg, scores, n)`
+ * is equivalent to
+ * `decompose(scores, createConnections(wg)).get(n).scoredConnections`
+ *
+ * If you only need the decomposition for a single node, then calling
+ * this method is much more efficient.
+ */
+export function scoredConnections(
+  wg: WeightedGraph,
+  scores: NodeScore,
+  target: NodeAddressT
+): ScoredConnection[] {
+  const connections = singleNodeConnections(wg, target);
+  const scoredConnections: ScoredConnection[] = connections.map(
+    (connection) => {
+      const source = adjacencySource(target, connection.adjacency);
+      const sourceScore = NullUtil.get(scores.get(source));
+      const connectionScore = connection.weight * sourceScore;
+      return {connection, source, connectionScore};
+    }
+  );
+  return sortBy(
+    scoredConnections,
+    (x) => -x.connectionScore,
+    (x) => x.connection.adjacency.type,
+    (x) => {
+      switch (x.connection.adjacency.type) {
+        case "IN_EDGE":
+          return x.connection.adjacency.edge.address;
+        case "OUT_EDGE":
+          return x.connection.adjacency.edge.address;
+        case "SYNTHETIC_LOOP":
+          return "";
+        default:
+          throw new Error((x.connection.adjacency.type: empty));
+      }
+    }
+  );
 }


### PR DESCRIPTION
This adds `scoredConnections`, which allows you to compute the
`ScoredConnection[]` for a particular node. (The `WeightedGraph` is
required too).

This function is basically the single-node analogue of the full
`decompose` function from `pagerankNodeDecomposition`. I intend for this
function to wholly replace the `decompose` function. Once clients are no
longer calling `decompose`, I will remove that function, rename the
file, and slim down the `ScoredConnection` interface.

Test plan: I duplicated the testing for `decompose` so that we use the
same logic to test `scoredConnections`, and leave the path clear to
remove `decompose` down the line. I verified that the extra snapshot is
identical to the existing snapshot.