### PR TITLE
Add `ReadOnlyGraph` interface

### DIFF
--- a/src/core/graph.js
+++ b/src/core/graph.js
@@ -68,7 +68,24 @@ export opaque type GraphJSON = Compatible<{|
 
 type ModificationCount = number;
 
-export class Graph {
+// For clients that need to be able to read the state of a graph,
+// without ever mutating it.
+export interface ReadOnlyGraph {
+  hasNode(a: NodeAddressT): boolean;
+  nodes(options?: {|+prefix: NodeAddressT|}): Iterator<NodeAddressT>;
+  hasEdge(address: EdgeAddressT): boolean;
+  edge(address: EdgeAddressT): ?Edge;
+  edges(options?: EdgesOptions): Iterator<Edge>;
+  neighbors(node: NodeAddressT, options: NeighborsOptions): Iterator<Neighbor>;
+  // TODO(@decentralion): Consider adding `equals` to this interface
+  // (caveat: Need to consider how this works if the other Graph is a
+  // different implementation)
+  // TODO(@decentralion): Consider adding `toJSON` to this interface
+  // (caveat: need to consider how this works if the other Graph has a
+  // richer JSON representation)
+}
+
+export class Graph implements ReadOnlyGraph {
   _nodes: Set<NodeAddressT>;
   _edges: Map<EdgeAddressT, Edge>;
   _inEdges: Map<NodeAddressT, Edge[]>;


### PR DESCRIPTION
The `ReadOnlyGraph` is an interface for a graph that cannot be mutated.
As such, it only presents its read methods, e.g. `nodes`.

This change is motivated by my desire to create "enriched" graph
classes, e.g. `WeightedGraph`, which wrap the graph along with
additional metadata. For those enriched graphs to maintain integrity,
independently modifying the underlying graph must be disallowed, so this
is the interface they should implement.

In principle, I'd like to add `toJSON` and `equals` to this interface,
but it's not clear how to do that properly.

Test plan: `yarn flow` suffices.