### PR TITLE
Add the `WeightedGraph` class

### DIFF
--- a/src/core/__snapshots__/weightedGraph.test.js.snap
+++ b/src/core/__snapshots__/weightedGraph.test.js.snap
@@ -1,0 +1,44 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`core/weightedGraph to/from JSON snapshots on a simple graph 1`] = `
+Array [
+  Object {
+    "type": "sourcecred/weightedGraph",
+    "version": "0.1.0",
+  },
+  Object {
+    "graph": Array [
+      Object {
+        "type": "sourcecred/graph",
+        "version": "0.4.0",
+      },
+      Object {
+        "edges": Array [
+          Object {
+            "address": Array [
+              "edge",
+            ],
+            "dstIndex": 0,
+            "srcIndex": 1,
+          },
+        ],
+        "nodes": Array [
+          Array [
+            "dst",
+          ],
+          Array [
+            "src",
+          ],
+        ],
+      },
+    ],
+    "sortedEdgeWeights": Array [
+      Object {
+        "froWeight": 4,
+        "toWeight": 3,
+      },
+    ],
+    "syntheticLoopWeight": 1,
+  },
+]
+`;

--- a/src/core/weightedGraph.js
+++ b/src/core/weightedGraph.js
@@ -1,0 +1,186 @@
+// @flow
+
+import {
+  type ReadOnlyGraph,
+  type Edge,
+  type EdgesOptions,
+  type NeighborsOptions,
+  type Neighbor,
+  Graph,
+  type GraphJSON,
+  type EdgeAddressT,
+  type NodeAddressT,
+  EdgeAddress,
+  NodeAddress,
+  edgeToString,
+} from "./graph";
+
+import deepEqual from "lodash.isequal";
+import {toCompat, fromCompat, type Compatible} from "../util/compat";
+import {type EdgeWeight} from "./attribution/graphToMarkovChain";
+import * as NullUtil from "../util/null";
+
+export type EdgeEvaluator = (Edge) => EdgeWeight;
+
+const COMPAT_INFO = {type: "sourcecred/weightedGraph", version: "0.1.0"};
+export opaque type WeightedGraphJSON = Compatible<{|
+  +graph: GraphJSON,
+  // sorted by edgeAddress
+  +sortedEdgeWeights: EdgeWeight[],
+  +syntheticLoopWeight: number,
+|}>;
+
+export class WeightedGraph implements ReadOnlyGraph {
+  _graph: Graph;
+  _edgeWeights: Map<EdgeAddressT, EdgeWeight>;
+  _syntheticLoopWeight: number;
+  _totalOutWeight: Map<NodeAddressT, number>;
+
+  constructor(
+    graph: Graph,
+    edgeWeights: Map<EdgeAddressT, EdgeWeight>,
+    syntheticLoopWeight: number
+  ): void {
+    this._graph = graph;
+    this._edgeWeights = edgeWeights;
+    this._syntheticLoopWeight = syntheticLoopWeight;
+    this._totalOutWeight = new Map();
+    for (const n of graph.nodes()) {
+      this._totalOutWeight.set(n, syntheticLoopWeight);
+    }
+    let nEdgesEncountered = 0;
+    for (const e of graph.edges()) {
+      const edgeWeight = this._edgeWeights.get(e.address);
+      if (edgeWeight == null) {
+        throw new Error(`Missing weight for edge ${edgeToString(e)}`);
+      }
+      const {toWeight, froWeight} = edgeWeight;
+      const srcOutWeight =
+        NullUtil.get(this._totalOutWeight.get(e.src)) + toWeight;
+      this._totalOutWeight.set(e.src, srcOutWeight);
+      const dstOutWeight =
+        NullUtil.get(this._totalOutWeight.get(e.dst)) + froWeight;
+      this._totalOutWeight.set(e.dst, dstOutWeight);
+      nEdgesEncountered += 1;
+    }
+    if (nEdgesEncountered !== this._edgeWeights.size) {
+      // It must be that edgeWeights.size is bigger, because we already
+      // would have errored if any edges were missing a weight
+      // (in NullUtil.get)
+      throw new Error(
+        "There are edge weights that don't correspond to any edge"
+      );
+    }
+    if (syntheticLoopWeight <= 0) {
+      throw new Error(
+        `syntheticLoopWeight must be positive, but is ${syntheticLoopWeight}`
+      );
+    }
+  }
+
+  hasNode(a: NodeAddressT): boolean {
+    return this._graph.hasNode(a);
+  }
+  nodes(options?: {|+prefix: NodeAddressT|}): Iterator<NodeAddressT> {
+    return this._graph.nodes(options);
+  }
+  hasEdge(address: EdgeAddressT): boolean {
+    return this._graph.hasEdge(address);
+  }
+  edge(address: EdgeAddressT): ?Edge {
+    return this._graph.edge(address);
+  }
+  edges(options?: EdgesOptions): Iterator<Edge> {
+    return this._graph.edges(options);
+  }
+  neighbors(node: NodeAddressT, options: NeighborsOptions): Iterator<Neighbor> {
+    return this._graph.neighbors(node, options);
+  }
+
+  totalOutWeight(n: NodeAddressT): number {
+    const w = this._totalOutWeight.get(n);
+    if (w == null) {
+      throw new Error(
+        `Tried to retrieve weight for nonexistent node ${NodeAddress.toString(
+          n
+        )}`
+      );
+    }
+    return w;
+  }
+
+  syntheticLoopWeight(): number {
+    return this._syntheticLoopWeight;
+  }
+
+  edgeWeight(address: EdgeAddressT): EdgeWeight {
+    const w = this._edgeWeights.get(address);
+    if (w == null) {
+      throw new Error(
+        `Tried to retrieve edgeWeight for nonexistent edge ${EdgeAddress.toString(
+          address
+        )}`
+      );
+    }
+    return w;
+  }
+
+  equals(that: WeightedGraph): boolean {
+    return (
+      this._graph.equals(that._graph) &&
+      this._syntheticLoopWeight === that._syntheticLoopWeight &&
+      deepEqual(this._edgeWeights, that._edgeWeights)
+    );
+  }
+
+  toJSON(): WeightedGraphJSON {
+    // TODO(perf): This is redundant with the sorting that already
+    // happens in Graph.toJSON. Find a way to deduplicate that work.
+    const sortedEdgeAddresses = Array.from(this.edges())
+      .map((x) => x.address)
+      .sort();
+    const sortedEdgeWeights = sortedEdgeAddresses.map((x) =>
+      NullUtil.get(this._edgeWeights.get(x))
+    );
+    const rawJSON = {
+      graph: this._graph.toJSON(),
+      sortedEdgeWeights,
+      syntheticLoopWeight: this._syntheticLoopWeight,
+    };
+    return toCompat(COMPAT_INFO, rawJSON);
+  }
+
+  static fromJSON(json: WeightedGraphJSON): WeightedGraph {
+    const {
+      graph: graphJSON,
+      sortedEdgeWeights,
+      syntheticLoopWeight,
+    } = fromCompat(COMPAT_INFO, json);
+    const graph = Graph.fromJSON(graphJSON);
+    // TODO(perf): This is redundant with the fact that edges are
+    // already stored in sorted order in the GraphJSON.
+    // Find a way to deduplicate that work.
+    const sortedEdgeAddresses = Array.from(graph.edges())
+      .map((x) => x.address)
+      .sort();
+    const edgeWeights = new Map();
+    for (let i = 0; i < sortedEdgeAddresses.length; i++) {
+      edgeWeights.set(sortedEdgeAddresses[i], sortedEdgeWeights[i]);
+    }
+    return new WeightedGraph(graph, edgeWeights, syntheticLoopWeight);
+  }
+
+  // Alternative API to using the constructor.
+  // (Really just a light sugar.)
+  static fromEvaluator(
+    graph: Graph,
+    evaluator: EdgeEvaluator,
+    syntheticLoopWeight: number
+  ): WeightedGraph {
+    const edgeWeights = new Map();
+    for (const e of graph.edges()) {
+      edgeWeights.set(e.address, evaluator(e));
+    }
+    return new WeightedGraph(graph, edgeWeights, syntheticLoopWeight);
+  }
+}

--- a/src/core/weightedGraph.test.js
+++ b/src/core/weightedGraph.test.js
@@ -1,0 +1,257 @@
+// @flow
+
+import {EdgeAddress, Graph, NodeAddress} from "./graph";
+import {WeightedGraph} from "./weightedGraph";
+import {advancedGraph} from "./graphTestUtil";
+
+describe("core/weightedGraph", () => {
+  const src = NodeAddress.fromParts(["src"]);
+  const dst = NodeAddress.fromParts(["dst"]);
+  const edge = {address: EdgeAddress.fromParts(["edge"]), src, dst};
+
+  describe("constructor", () => {
+    it("errors if there are missing edge weights", () => {
+      const g = new Graph();
+      g.addNode(src);
+      g.addNode(dst);
+      g.addEdge(edge);
+      const edgeWeights = new Map();
+      expect(() => new WeightedGraph(g, edgeWeights, 0.01)).toThrowError(
+        "Missing weight"
+      );
+    });
+    it("errors if there are extra edge weights", () => {
+      const g = new Graph();
+      g.addNode(src);
+      g.addNode(dst);
+      g.addEdge(edge);
+      const edgeWeights = new Map();
+      edgeWeights.set(edge.address, {toWeight: 3, froWeight: 4});
+      edgeWeights.set(EdgeAddress.empty, {toWeight: 4, froWeight: 7});
+      expect(() => new WeightedGraph(g, edgeWeights, 0.01)).toThrowError(
+        "edge weights that don't correspond to any edge"
+      );
+    });
+    it("errors if syntheticLoopWeight is 0", () => {
+      expect(() => new WeightedGraph(new Graph(), new Map(), 0)).toThrowError(
+        "syntheticLoopWeight must be positive"
+      );
+    });
+    it("errors if syntheticLoopWeight is negative", () => {
+      expect(() => new WeightedGraph(new Graph(), new Map(), -3)).toThrowError(
+        "syntheticLoopWeight must be positive"
+      );
+    });
+    it("returns a WeightedGraph", () => {
+      // Sadly, this check would have prevented very confusing
+      // type errors in similar cases.
+      // $ExpectFlowError
+      const _: Graph = new WeightedGraph(new Graph(), new Map(), 1);
+    });
+  });
+
+  it("syntheticLoopWeight() returns that weight", () => {
+    const slw = 1.337;
+    const wg = new WeightedGraph(new Graph(), new Map(), slw);
+    expect(wg.syntheticLoopWeight()).toBe(slw);
+  });
+
+  describe("edgeWeight", () => {
+    it("throws an error for non-existent edge", () => {
+      const wg = new WeightedGraph(new Graph(), new Map(), 1);
+      expect(() => wg.edgeWeight(edge.address)).toThrowError(
+        "nonexistent edge"
+      );
+    });
+    it("returns the correct edge weight", () => {
+      const g = new Graph();
+      g.addNode(src);
+      g.addNode(dst);
+      g.addEdge(edge);
+      const edgeWeights = new Map();
+      const w = {toWeight: 1, froWeight: 2};
+      edgeWeights.set(edge.address, w);
+      const wg = new WeightedGraph(g, edgeWeights, 1);
+      expect(wg.edgeWeight(edge.address)).toBe(w);
+    });
+  });
+
+  describe("totalOutWeight", () => {
+    it("throws an error for non-existent edge", () => {
+      const wg = new WeightedGraph(new Graph(), new Map(), 1);
+      expect(() => wg.totalOutWeight(src)).toThrowError("nonexistent node");
+    });
+
+    it("returns the syntheticLoopWeight for an isolated node", () => {
+      const slw = 0.653;
+      const g = new Graph().addNode(src);
+      const wg = new WeightedGraph(g, new Map(), slw);
+      expect(wg.totalOutWeight(src)).toBe(slw);
+    });
+
+    it("correctly handles the toWeight and froWeight on an edge", () => {
+      const slw = 0.653;
+      const g = new Graph()
+        .addNode(src)
+        .addNode(dst)
+        .addEdge(edge);
+      const ee = () => ({toWeight: 3, froWeight: 0});
+      const wg = WeightedGraph.fromEvaluator(g, ee, slw);
+      expect(wg.totalOutWeight(src)).toBe(slw + 3);
+      expect(wg.totalOutWeight(dst)).toBe(slw);
+    });
+
+    it("correctly handles a loop edge", () => {
+      const g = new Graph()
+        .addNode(src)
+        .addEdge({address: edge.address, src: src, dst: src});
+      const ee = () => ({toWeight: 1, froWeight: 2});
+      const wg = WeightedGraph.fromEvaluator(g, ee, 0.1);
+      expect(wg.totalOutWeight(src)).toBe(1 + 2 + 0.1);
+    });
+
+    it("correctly handles a node with multiple incident edges", () => {
+      const g = new Graph()
+        .addNode(src)
+        .addNode(dst)
+        .addEdge({address: EdgeAddress.fromParts(["1"]), src, dst})
+        .addEdge({address: EdgeAddress.fromParts(["2"]), src, dst});
+      const ee = () => ({toWeight: 1, froWeight: 2});
+      const wg = WeightedGraph.fromEvaluator(g, ee, 0.1);
+      expect(wg.totalOutWeight(src)).toBe(1 + 1 + 0.1);
+    });
+  });
+
+  describe("delegated Graph methods", () => {
+    it("hasNode is delegated properly", () => {
+      const wg = new WeightedGraph(new Graph(), new Map(), 0.1);
+      const ret = Symbol();
+      const arg: any = Symbol();
+      // $ExpectFlowError
+      wg._graph.hasNode = jest.fn().mockReturnValue(ret);
+      expect(wg.hasNode(arg)).toBe(ret);
+      expect(wg._graph.hasNode).toHaveBeenCalledWith(arg);
+    });
+    it("nodes is delegated properly", () => {
+      const wg = new WeightedGraph(new Graph(), new Map(), 0.1);
+      const ret = Symbol();
+      const arg: any = Symbol();
+      // $ExpectFlowError
+      wg._graph.nodes = jest.fn().mockReturnValue(ret);
+      expect(wg.nodes(arg)).toBe(ret);
+      expect(wg._graph.nodes).toHaveBeenCalledWith(arg);
+    });
+    it("hasEdge is delegated properly", () => {
+      const wg = new WeightedGraph(new Graph(), new Map(), 0.1);
+      const ret = Symbol();
+      const arg: any = Symbol();
+      // $ExpectFlowError
+      wg._graph.hasEdge = jest.fn().mockReturnValue(ret);
+      expect(wg.hasEdge(arg)).toBe(ret);
+      expect(wg._graph.hasEdge).toHaveBeenCalledWith(arg);
+    });
+    it("edge is delegated properly", () => {
+      const wg = new WeightedGraph(new Graph(), new Map(), 0.1);
+      const ret = Symbol();
+      const arg: any = Symbol();
+      // $ExpectFlowError
+      wg._graph.edge = jest.fn().mockReturnValue(ret);
+      expect(wg.edge(arg)).toBe(ret);
+      expect(wg._graph.edge).toHaveBeenCalledWith(arg);
+    });
+    it("edges is delegated properly", () => {
+      const wg = new WeightedGraph(new Graph(), new Map(), 0.1);
+      const ret = Symbol();
+      const arg: any = Symbol();
+      // $ExpectFlowError
+      wg._graph.edges = jest.fn().mockReturnValue(ret);
+      expect(wg.edges(arg)).toBe(ret);
+      expect(wg._graph.edges).toHaveBeenCalledWith(arg);
+    });
+    it("neighbors is delegated properly", () => {
+      const wg = new WeightedGraph(new Graph(), new Map(), 0.1);
+      const ret = Symbol();
+      const arg1: any = Symbol();
+      const arg2: any = Symbol();
+      // $ExpectFlowError
+      wg._graph.neighbors = jest.fn().mockReturnValue(ret);
+      expect(wg.neighbors(arg1, arg2)).toBe(ret);
+      expect(wg._graph.neighbors).toHaveBeenCalledWith(arg1, arg2);
+    });
+  });
+
+  describe("equals", () => {
+    it("is invariant to the history of the graph", () => {
+      const {graph1, graph2} = advancedGraph();
+      const edgeEvaluator = (_) => ({toWeight: 3, froWeight: 4});
+      const wg1 = WeightedGraph.fromEvaluator(graph1(), edgeEvaluator, 1);
+      const wg2 = WeightedGraph.fromEvaluator(graph2(), edgeEvaluator, 1);
+      expect(wg1.equals(wg2)).toBe(true);
+    });
+    it("checks that the graphs are equal", () => {
+      const g1 = new Graph()
+        .addNode(src)
+        .addNode(dst)
+        .addEdge(edge)
+        .addNode(NodeAddress.fromParts(["isolated"]));
+      const g2 = new Graph()
+        .addNode(src)
+        .addNode(dst)
+        .addEdge(edge);
+      const edgeEvaluator = () => ({toWeight: 1, froWeight: 2});
+      const wg1 = WeightedGraph.fromEvaluator(g1, edgeEvaluator, 1);
+      const wg2 = WeightedGraph.fromEvaluator(g2, edgeEvaluator, 1);
+      expect(wg1.equals(wg2)).toBe(false);
+    });
+    it("checks that the synthetic loop weights are equal", () => {
+      const wg1 = new WeightedGraph(new Graph(), new Map(), 1);
+      const wg2 = new WeightedGraph(new Graph(), new Map(), 2);
+      expect(wg1.equals(wg2)).toBe(false);
+    });
+    it("checks that the edge weights are equal", () => {
+      const g = new Graph()
+        .addNode(src)
+        .addNode(dst)
+        .addEdge(edge);
+      const ee1 = () => ({toWeight: 1, froWeight: 2});
+      const ee2 = () => ({toWeight: 2, froWeight: 3});
+      const wg1 = WeightedGraph.fromEvaluator(g, ee1, 1);
+      const wg2 = WeightedGraph.fromEvaluator(g, ee2, 1);
+      expect(wg1.equals(wg2)).toBe(false);
+    });
+  });
+
+  describe("to/from JSON", () => {
+    function checkRoundTrip(wg: WeightedGraph) {
+      const wgJSON = wg.toJSON();
+      const wg_ = WeightedGraph.fromJSON(wgJSON);
+      const wgJSON_ = wg_.toJSON();
+      expect(wg_.equals(wg)).toBe(true);
+      expect(wgJSON).toEqual(wgJSON_);
+    }
+    it("is round-trip consistent on the advanced graph", () => {
+      const {graph1} = advancedGraph();
+      const edgeEvaluator = (_) => ({toWeight: 3, froWeight: 4});
+      const wg = WeightedGraph.fromEvaluator(graph1(), edgeEvaluator, 0.1);
+      checkRoundTrip(wg);
+    });
+    it("is round-trip consistent on a simple graph", () => {
+      const g = new Graph()
+        .addNode(src)
+        .addNode(dst)
+        .addEdge(edge);
+      const edgeEvaluator = (_) => ({toWeight: 3, froWeight: 4});
+      const wg = WeightedGraph.fromEvaluator(g, edgeEvaluator, 1);
+      checkRoundTrip(wg);
+    });
+    it("snapshots on a simple graph", () => {
+      const g = new Graph()
+        .addNode(src)
+        .addNode(dst)
+        .addEdge(edge);
+      const edgeEvaluator = (_) => ({toWeight: 3, froWeight: 4});
+      const wg = WeightedGraph.fromEvaluator(g, edgeEvaluator, 1);
+      expect(wg.toJSON()).toMatchSnapshot();
+    });
+  });
+});


### PR DESCRIPTION
As discussed in depth in #1004, it makes sense to package a Graph along
with the metadata needed to run Pagerank on it: hence, the
WeightedGraph, which is basically a Graph bundled with weights for every
edge, and a synthetic self loop weight.

In #1008, I created WeightedGraph as a simple struct. This commit
explores a different approach: WeightedGraph is reified as a full class
(a sibling to Graph) with a constructor that validates its invariants,
JSON (de)serialization, equality testing, and functions that implement
basic behaviors on top of it. The potential benefits of this approach
are discussed in [this comment](https://github.com/sourcecred/sourcecred/issues/1004#issuecomment-439641568)

The intention is that consumers that need read-only access to a Graph
should be able to use a WeightedGraph as well. To that end, the
WeightedGraph implements the ReadOnlyGraph interface.

One possible improvement: we could add `addNode` and `addEdge` to the
WeightedGraph, but with semantics that weights must be present. So,
`addEdge` requires an edge and a weight to both be provided. It wouldn't
be hard to implement. This is not needed by any existing client, but
having it could make it much easier to directly create PageRank-able
graphs. (If you don't need the decoupling offered by providing an edge
evaulator separately from specifiying the graph, it is really annoying.
I learned this while trying to create WeightedGraph test cases.)

Test plan: New, thorough unit tests have been added. Run `yarn test`.