### PR TITLE
Add the `WeightedGraph` class

### DIFF
--- a/src/core/__snapshots__/weightedGraph.test.js.snap
+++ b/src/core/__snapshots__/weightedGraph.test.js.snap
@@ -1,0 +1,44 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`core/weightedGraph to/from JSON snapshots on a simple graph 1`] = `
+Array [
+  Object {
+    "type": "sourcecred/weightedGraph",
+    "version": "0.1.0",
+  },
+  Object {
+    "graph": Array [
+      Object {
+        "type": "sourcecred/graph",
+        "version": "0.4.0",
+      },
+      Object {
+        "edges": Array [
+          Object {
+            "address": Array [
+              "edge",
+            ],
+            "dstIndex": 0,
+            "srcIndex": 1,
+          },
+        ],
+        "nodes": Array [
+          Array [
+            "dst",
+          ],
+          Array [
+            "src",
+          ],
+        ],
+      },
+    ],
+    "sortedEdgeWeights": Array [
+      Object {
+        "froWeight": 4,
+        "toWeight": 3,
+      },
+    ],
+    "syntheticLoopWeight": 1,
+  },
+]
+`;

--- a/src/core/weightedGraph.js
+++ b/src/core/weightedGraph.js
@@ -1,0 +1,198 @@
+// @flow
+
+import {
+  type Edge,
+  type EdgesOptions,
+  type NeighborsOptions,
+  Graph,
+  type GraphJSON,
+  type EdgeAddressT,
+  type NodeAddressT,
+  NodeAddress,
+  edgeToString,
+  sortedEdgeAddressesFromJSON,
+} from "./graph";
+
+import deepEqual from "lodash.isequal";
+import {toCompat, fromCompat, type Compatible} from "../util/compat";
+import type {EdgeWeight} from "./attribution/graphToMarkovChain";
+import * as NullUtil from "../util/null";
+
+export type {EdgeWeight} from "./attribution/graphToMarkovChain";
+export type WeightedEdge = {|+edge: Edge, +weight: EdgeWeight|};
+export type WeightedNeighbor = {|
+  +edge: Edge,
+  +node: NodeAddressT,
+  +weight: EdgeWeight,
+|};
+export type EdgeEvaluator = (Edge) => EdgeWeight;
+
+const COMPAT_INFO = {type: "sourcecred/weightedGraph", version: "0.1.0"};
+export opaque type WeightedGraphJSON = Compatible<{|
+  +graph: GraphJSON,
+  // sorted by edgeAddress
+  +sortedEdgeWeights: EdgeWeight[],
+  +syntheticLoopWeight: number,
+|}>;
+
+export class WeightedGraph {
+  _graph: Graph;
+  _edgeWeights: Map<EdgeAddressT, EdgeWeight>;
+  _syntheticLoopWeight: number;
+  _totalOutWeight: Map<NodeAddressT, number>;
+
+  constructor(
+    graph: Graph,
+    edgeWeights: Map<EdgeAddressT, EdgeWeight>,
+    syntheticLoopWeight: number
+  ): void {
+    this._graph = graph;
+    this._edgeWeights = edgeWeights;
+    this._syntheticLoopWeight = syntheticLoopWeight;
+    this._totalOutWeight = new Map();
+    for (const n of graph.nodes()) {
+      this._totalOutWeight.set(n, syntheticLoopWeight);
+    }
+    let nEdgesEncountered = 0;
+    for (const e of graph.edges()) {
+      const edgeWeight = this._edgeWeights.get(e.address);
+      if (edgeWeight == null) {
+        throw new Error(`Missing weight for edge ${edgeToString(e)}`);
+      }
+      const {toWeight, froWeight} = edgeWeight;
+      const srcOutWeight =
+        NullUtil.get(this._totalOutWeight.get(e.src)) + toWeight;
+      this._totalOutWeight.set(e.src, srcOutWeight);
+      const dstOutWeight =
+        NullUtil.get(this._totalOutWeight.get(e.dst)) + froWeight;
+      this._totalOutWeight.set(e.dst, dstOutWeight);
+      nEdgesEncountered += 1;
+    }
+    if (nEdgesEncountered !== this._edgeWeights.size) {
+      // It must be that edgeWeights.size is bigger, because we already
+      // would have errored if any edges were missing a weight
+      // (in NullUtil.get)
+      throw new Error(
+        "There are edge weights that don't correspond to any edge"
+      );
+    }
+    if (syntheticLoopWeight <= 0) {
+      throw new Error(
+        `syntheticLoopWeight must be positive, but is ${syntheticLoopWeight}`
+      );
+    }
+  }
+
+  hasNode(a: NodeAddressT): boolean {
+    return this._graph.hasNode(a);
+  }
+  nodes(options?: {|+prefix: NodeAddressT|}): Iterator<NodeAddressT> {
+    return this._graph.nodes(options);
+  }
+  hasEdge(address: EdgeAddressT): boolean {
+    return this._graph.hasEdge(address);
+  }
+
+  edge(address: EdgeAddressT): ?WeightedEdge {
+    const edge = this._graph.edge(address);
+    if (edge == null) {
+      return null;
+    }
+    const weight = NullUtil.get(this._edgeWeights.get(edge.address));
+    return {edge, weight};
+  }
+
+  *edges(options?: EdgesOptions): Iterator<WeightedEdge> {
+    for (const edge of this._graph.edges(options)) {
+      const weight = NullUtil.get(this._edgeWeights.get(edge.address));
+      yield {edge, weight};
+    }
+  }
+
+  *neighbors(
+    node: NodeAddressT,
+    options: NeighborsOptions
+  ): Iterator<WeightedNeighbor> {
+    for (const {node, edge} of this._graph.neighbors(node, options)) {
+      const weight = NullUtil.get(this._edgeWeights.get(edge.address));
+      yield {node, edge, weight};
+    }
+  }
+
+  totalOutWeight(n: NodeAddressT): number {
+    const w = this._totalOutWeight.get(n);
+    if (w == null) {
+      throw new Error(
+        `Tried to retrieve weight for nonexistent node ${NodeAddress.toString(
+          n
+        )}`
+      );
+    }
+    return w;
+  }
+
+  syntheticLoopWeight(): number {
+    return this._syntheticLoopWeight;
+  }
+
+  equals(that: WeightedGraph): boolean {
+    return (
+      this._graph.equals(that._graph) &&
+      this._syntheticLoopWeight === that._syntheticLoopWeight &&
+      deepEqual(this._edgeWeights, that._edgeWeights)
+    );
+  }
+
+  toJSON(): WeightedGraphJSON {
+    const graphJSON = this._graph.toJSON();
+    const sortedEdgeAddresses = sortedEdgeAddressesFromJSON(graphJSON);
+    const sortedEdgeWeights = sortedEdgeAddresses.map((x) =>
+      NullUtil.get(this._edgeWeights.get(x))
+    );
+    const rawJSON = {
+      graph: graphJSON,
+      sortedEdgeWeights,
+      syntheticLoopWeight: this._syntheticLoopWeight,
+    };
+    return toCompat(COMPAT_INFO, rawJSON);
+  }
+
+  static fromJSON(json: WeightedGraphJSON): WeightedGraph {
+    const {
+      graph: graphJSON,
+      sortedEdgeWeights,
+      syntheticLoopWeight,
+    } = fromCompat(COMPAT_INFO, json);
+    const graph = Graph.fromJSON(graphJSON);
+    const sortedEdgeAddresses = sortedEdgeAddressesFromJSON(graphJSON);
+    const edgeWeights = new Map();
+    for (let i = 0; i < sortedEdgeAddresses.length; i++) {
+      edgeWeights.set(sortedEdgeAddresses[i], sortedEdgeWeights[i]);
+    }
+    return new WeightedGraph(graph, edgeWeights, syntheticLoopWeight);
+  }
+
+  // Alternative API to using the constructor.
+  // (Really just a light sugar.)
+  static fromEvaluator(
+    graph: Graph,
+    evaluator: EdgeEvaluator,
+    syntheticLoopWeight: number
+  ): WeightedGraph {
+    const edgeWeights = new Map();
+    for (const e of graph.edges()) {
+      edgeWeights.set(e.address, evaluator(e));
+    }
+    return new WeightedGraph(graph, edgeWeights, syntheticLoopWeight);
+  }
+}
+
+/**
+ * Extract a GraphJSON from a WeightedGraphJSON. This is made available
+ * so that clients of WeightedGraph can retrieve the sorted Node/Edge addresses
+ * from the WeightedGraph's contained GraphJSON.
+ */
+export function extractGraphJSON(j: WeightedGraphJSON): GraphJSON {
+  const {graph: graphJSON} = fromCompat(COMPAT_INFO, j);
+  return graphJSON;
+}

--- a/src/core/weightedGraph.test.js
+++ b/src/core/weightedGraph.test.js
@@ -1,0 +1,254 @@
+// @flow
+
+import {EdgeAddress, Graph, NodeAddress, Direction} from "./graph";
+import {WeightedGraph, extractGraphJSON} from "./weightedGraph";
+import {advancedGraph} from "./graphTestUtil";
+
+describe("core/weightedGraph", () => {
+  const src = NodeAddress.fromParts(["src"]);
+  const dst = NodeAddress.fromParts(["dst"]);
+  const edge = Object.freeze({
+    address: EdgeAddress.fromParts(["edge"]),
+    src,
+    dst,
+  });
+  const backwardsEdge = Object.freeze({
+    address: EdgeAddress.fromParts(["backwards"]),
+    src: dst,
+    dst: src,
+  });
+
+  describe("constructor", () => {
+    it("errors if there are missing edge weights", () => {
+      const g = new Graph();
+      g.addNode(src);
+      g.addNode(dst);
+      g.addEdge(edge);
+      const edgeWeights = new Map();
+      expect(() => new WeightedGraph(g, edgeWeights, 0.01)).toThrowError(
+        "Missing weight"
+      );
+    });
+    it("errors if there are extra edge weights", () => {
+      const g = new Graph();
+      g.addNode(src);
+      g.addNode(dst);
+      g.addEdge(edge);
+      const edgeWeights = new Map();
+      edgeWeights.set(edge.address, {toWeight: 3, froWeight: 4});
+      edgeWeights.set(EdgeAddress.empty, {toWeight: 4, froWeight: 7});
+      expect(() => new WeightedGraph(g, edgeWeights, 0.01)).toThrowError(
+        "edge weights that don't correspond to any edge"
+      );
+    });
+    it("errors if syntheticLoopWeight is 0", () => {
+      expect(() => new WeightedGraph(new Graph(), new Map(), 0)).toThrowError(
+        "syntheticLoopWeight must be positive"
+      );
+    });
+    it("errors if syntheticLoopWeight is negative", () => {
+      expect(() => new WeightedGraph(new Graph(), new Map(), -3)).toThrowError(
+        "syntheticLoopWeight must be positive"
+      );
+    });
+    it("returns a WeightedGraph", () => {
+      // Sadly, this check would have prevented very confusing
+      // type errors in similar cases.
+      // $ExpectFlowError
+      const _: Graph = new WeightedGraph(new Graph(), new Map(), 1);
+    });
+  });
+
+  it("syntheticLoopWeight() returns that weight", () => {
+    const slw = 1.337;
+    const wg = new WeightedGraph(new Graph(), new Map(), slw);
+    expect(wg.syntheticLoopWeight()).toBe(slw);
+  });
+
+  describe("totalOutWeight", () => {
+    it("throws an error for non-existent edge", () => {
+      const wg = new WeightedGraph(new Graph(), new Map(), 1);
+      expect(() => wg.totalOutWeight(src)).toThrowError("nonexistent node");
+    });
+
+    it("returns the syntheticLoopWeight for an isolated node", () => {
+      const slw = 0.653;
+      const g = new Graph().addNode(src);
+      const wg = new WeightedGraph(g, new Map(), slw);
+      expect(wg.totalOutWeight(src)).toBe(slw);
+    });
+
+    it("correctly handles the toWeight and froWeight on an edge", () => {
+      const slw = 0.653;
+      const g = new Graph()
+        .addNode(src)
+        .addNode(dst)
+        .addEdge(edge);
+      const ee = () => ({toWeight: 3, froWeight: 0});
+      const wg = WeightedGraph.fromEvaluator(g, ee, slw);
+      expect(wg.totalOutWeight(src)).toBe(slw + 3);
+      expect(wg.totalOutWeight(dst)).toBe(slw);
+    });
+
+    it("correctly handles a loop edge", () => {
+      const g = new Graph()
+        .addNode(src)
+        .addEdge({address: edge.address, src: src, dst: src});
+      const ee = () => ({toWeight: 1, froWeight: 2});
+      const wg = WeightedGraph.fromEvaluator(g, ee, 0.1);
+      expect(wg.totalOutWeight(src)).toBe(1 + 2 + 0.1);
+    });
+
+    it("correctly handles a node with multiple incident edges", () => {
+      const g = new Graph()
+        .addNode(src)
+        .addNode(dst)
+        .addEdge({address: EdgeAddress.fromParts(["1"]), src, dst})
+        .addEdge({address: EdgeAddress.fromParts(["2"]), src, dst});
+      const ee = () => ({toWeight: 1, froWeight: 2});
+      const wg = WeightedGraph.fromEvaluator(g, ee, 0.1);
+      expect(wg.totalOutWeight(src)).toBe(1 + 1 + 0.1);
+    });
+  });
+
+  describe("wrapped Graph methods", () => {
+    const weight = Object.freeze({toWeight: 1, froWeight: 2});
+    const exampleGraph = () => {
+      const g = new Graph()
+        .addNode(src)
+        .addNode(dst)
+        .addEdge(edge)
+        .addEdge(backwardsEdge);
+      const ee = () => weight;
+      return WeightedGraph.fromEvaluator(g, ee, 0.1);
+    };
+    it("hasNode works", () => {
+      const eg = exampleGraph();
+      expect(eg.hasNode(src)).toBe(true);
+      expect(eg.hasNode(NodeAddress.fromParts(["nope"]))).toBe(false);
+    });
+    it("nodes works", () => {
+      const eg = exampleGraph();
+      expect(Array.from(eg.nodes({prefix: src}))).toEqual([src]);
+    });
+    it("hasEdge works", () => {
+      const eg = exampleGraph();
+      expect(eg.hasEdge(edge.address)).toBe(true);
+      expect(eg.hasEdge(EdgeAddress.fromParts(["nope"]))).toBe(false);
+    });
+    it("edge works", () => {
+      const eg = exampleGraph();
+      expect(eg.edge(edge.address)).toEqual({edge, weight});
+      expect(eg.edge(EdgeAddress.fromParts(["nope"]))).toEqual(null);
+    });
+    it("edges works", () => {
+      const eg = exampleGraph();
+      const edges = Array.from(
+        eg.edges({
+          addressPrefix: backwardsEdge.address,
+          dstPrefix: NodeAddress.empty,
+          srcPrefix: NodeAddress.empty,
+        })
+      );
+      expect(edges).toEqual([{edge: backwardsEdge, weight}]);
+    });
+    it("neighbors works", () => {
+      const eg = exampleGraph();
+      const neighbors = Array.from(
+        eg.neighbors(src, {
+          edgePrefix: EdgeAddress.empty,
+          nodePrefix: NodeAddress.empty,
+          direction: Direction.OUT,
+        })
+      );
+      expect(neighbors).toEqual([{edge, weight, node: dst}]);
+    });
+  });
+
+  describe("equals", () => {
+    it("doesn't depend on the graph's history", () => {
+      const {graph1, graph2} = advancedGraph();
+      const edgeEvaluator = (_) => ({toWeight: 3, froWeight: 4});
+      const wg1 = WeightedGraph.fromEvaluator(graph1(), edgeEvaluator, 1);
+      const wg2 = WeightedGraph.fromEvaluator(graph2(), edgeEvaluator, 1);
+      expect(wg1.equals(wg2)).toBe(true);
+    });
+    it("checks that the graphs are equal", () => {
+      const g1 = new Graph()
+        .addNode(src)
+        .addNode(dst)
+        .addEdge(edge)
+        .addNode(NodeAddress.fromParts(["isolated"]));
+      const g2 = new Graph()
+        .addNode(src)
+        .addNode(dst)
+        .addEdge(edge);
+      const edgeEvaluator = () => ({toWeight: 1, froWeight: 2});
+      const wg1 = WeightedGraph.fromEvaluator(g1, edgeEvaluator, 1);
+      const wg2 = WeightedGraph.fromEvaluator(g2, edgeEvaluator, 1);
+      expect(wg1.equals(wg2)).toBe(false);
+    });
+    it("checks that the synthetic loop weights are equal", () => {
+      const wg1 = new WeightedGraph(new Graph(), new Map(), 1);
+      const wg2 = new WeightedGraph(new Graph(), new Map(), 2);
+      expect(wg1.equals(wg2)).toBe(false);
+    });
+    it("checks that the edge weights are equal", () => {
+      const g = new Graph()
+        .addNode(src)
+        .addNode(dst)
+        .addEdge(edge);
+      const ee1 = () => ({toWeight: 1, froWeight: 2});
+      const ee2 = () => ({toWeight: 2, froWeight: 3});
+      const wg1 = WeightedGraph.fromEvaluator(g, ee1, 1);
+      const wg2 = WeightedGraph.fromEvaluator(g, ee2, 1);
+      expect(wg1.equals(wg2)).toBe(false);
+    });
+  });
+
+  describe("to/from JSON", () => {
+    function checkRoundTrip(wg: WeightedGraph) {
+      const wgJSON = wg.toJSON();
+      const wg_ = WeightedGraph.fromJSON(wgJSON);
+      const wgJSON_ = wg_.toJSON();
+      expect(wg_.equals(wg)).toBe(true);
+      expect(wgJSON).toEqual(wgJSON_);
+    }
+    it("is round-trip consistent on the advanced graph", () => {
+      const {graph1} = advancedGraph();
+      const edgeEvaluator = (_) => ({toWeight: 3, froWeight: 4});
+      const wg = WeightedGraph.fromEvaluator(graph1(), edgeEvaluator, 0.1);
+      checkRoundTrip(wg);
+    });
+    it("is round-trip consistent on a simple graph", () => {
+      const g = new Graph()
+        .addNode(src)
+        .addNode(dst)
+        .addEdge(edge);
+      const edgeEvaluator = (_) => ({toWeight: 3, froWeight: 4});
+      const wg = WeightedGraph.fromEvaluator(g, edgeEvaluator, 1);
+      checkRoundTrip(wg);
+    });
+    it("snapshots on a simple graph", () => {
+      const g = new Graph()
+        .addNode(src)
+        .addNode(dst)
+        .addEdge(edge);
+      const edgeEvaluator = (_) => ({toWeight: 3, froWeight: 4});
+      const wg = WeightedGraph.fromEvaluator(g, edgeEvaluator, 1);
+      expect(wg.toJSON()).toMatchSnapshot();
+    });
+  });
+
+  it("extractGraphJSON", () => {
+    const g = new Graph()
+      .addNode(src)
+      .addNode(dst)
+      .addEdge(edge);
+    const edgeEvaluator = (_) => ({toWeight: 3, froWeight: 4});
+    const wg = WeightedGraph.fromEvaluator(g, edgeEvaluator, 1);
+    const wgJSON = wg.toJSON();
+    const gJSON = g.toJSON();
+    expect(extractGraphJSON(wgJSON)).toEqual(gJSON);
+  });
+});


### PR DESCRIPTION
As discussed in depth in #1004, it makes sense to package a Graph along
with the metadata needed to run Pagerank on it: hence, the
WeightedGraph, which is basically a Graph bundled with weights for every
edge, and a synthetic self loop weight.

In #1008, I created WeightedGraph as a simple struct. This commit
explores a different approach: WeightedGraph is reified as a full class
(a sibling to Graph) with a constructor that validates its invariants,
JSON (de)serialization, equality testing, and functions that implement
basic behaviors on top of it. The potential benefits of this approach
are discussed in
[this comment](https://github.com/sourcecred/sourcecred/issues/1004#issuecomment-439641568)

One possible improvement: we could add `addNode` and `addEdge` to the
WeightedGraph, but with semantics that weights must be present. So,
`addEdge` requires an edge and a weight to both be provided. It wouldn't
be hard to implement. This is not needed by any existing client, but
having it could make it much easier to directly create PageRank-able
graphs. (If you don't need the decoupling offered by providing an edge
evaulator separately from specifiying the graph, it is really annoying.
I learned this while trying to create WeightedGraph test cases.)
However, we don't actually need this, and putting this in introduces a
number of subtle edge cases that need attention and testing, so I won't
implement it yet.

Test plan: New, thorough unit tests have been added. Run `yarn test`.