### PR TITLE
Elide assertValid & assertValidParts in production

### DIFF
--- a/src/core/address.js
+++ b/src/core/address.js
@@ -126,9 +126,11 @@ export function makeAddressModule(options: Options): AddressModule<string> {
   );
 
   function assertValid(address: Address, what?: string): void {
-    // TODO(perf): If this function becomes a bottleneck, consider
-    // omitting it entirely in production. If this is undesirable, a
-    // number of micro-optimizations can be made.
+    // istanbul ignore if
+    if (process.env.NODE_ENV !== "test") {
+      // Catching invalid addresses in test code should be sufficient
+      return;
+    }
     const prefix = what == null ? "" : `${what}: `;
     if (address == null) {
       throw new Error(prefix + `expected ${name}, got: ${String(address)}`);
@@ -160,9 +162,11 @@ export function makeAddressModule(options: Options): AddressModule<string> {
     parts: $ReadOnlyArray<string>,
     what?: string
   ): void {
-    // TODO(perf): If this function becomes a bottleneck, consider
-    // omitting it entirely in production. If this is undesirable, a
-    // number of micro-optimizations can be made.
+    // istanbul ignore if
+    if (process.env.NODE_ENV !== "test") {
+      // Catching invalid parts in test code should be sufficient
+      return;
+    }
     const prefix = what == null ? "" : `${what}: `;
     if (parts == null) {
       throw new Error(


### PR DESCRIPTION
This commit substantially improves SourceCred's performance in
production.

Measurement methodology: I create a new tab in Chrome, navigate to my local
prototypes, and select go-ipfs. I then turn on profiling, and click the
analyze button, and then turn off profiling when analysis is done. I
then go to the "bottom-up" tab in the JS analysis box on the bottom and
sort by "Total Time".

__Before this commit:__

|        fn        | total time | time as % |
|:---------------- | ----------:| ---------:|
| assertValid      |      815ms |      8.6% |
| assertValidParts |      261ms |      2.7% |

__After this commit:__

|        fn        | total time | time as % |
|:---------------- | ----------:| ---------:|
| assertValid      |       21ms |      0.2% |
| assertValidParts |       23ms |      0.3% |

Test plan: `yarn test`, also performance measurement as described above.

Fixes #1011.