### PR TITLE
Update the blacklisted object ids

### DIFF
--- a/src/plugins/github/blacklistedObjectIds.js
+++ b/src/plugins/github/blacklistedObjectIds.js
@@ -9,6 +9,8 @@ export const BLACKLISTED_IDS: $ReadOnlyArray<ObjectId> = Object.freeze([
   "MDEyOk9yZ2FuaXphdGlvbjE3OTUyOTI1",
   "MDEyOk9yZ2FuaXphdGlvbjI5MTkzOTQ=",
   "MDEyOk9yZ2FuaXphdGlvbjEyNDE3MDI0",
+  // In this case, the bot used to be a user (@greenkeeper)
+  "MDM6Qm90MjMwNDAwNzY=",
   // These are the offending reactions.
   "MDg6UmVhY3Rpb24yMTY3ODkyNQ==",
   "MDg6UmVhY3Rpb240NDMwMzQ1",


### PR DESCRIPTION
This adds a blacklisted id for @greenkeeper, a bot which used to be a
user. This is a temporary fix until we solve #998.

Test plan: `yarn test` passes. Before this commit, attempting to load
`probot/probot` fails. After this commit, it succeeds.