### PR TITLE
add timestamp to registry entries

### DIFF
--- a/src/cli/load.js
+++ b/src/cli/load.js
@@ -213,7 +213,8 @@ function addToRepoIdRegistry(repoId) {
   } else {
     registry = RepoIdRegistry.emptyRegistry();
   }
-  registry = RepoIdRegistry.addRepoId(registry, {repoId});
+  let timestamp = new Date();
+  registry = RepoIdRegistry.addRepoId(registry, {repoId, timestamp});
 
   fs.writeFileSync(outputFile, stringify(RepoIdRegistry.toJSON(registry)));
 }

--- a/src/cli/load.test.js
+++ b/src/cli/load.test.js
@@ -18,6 +18,8 @@ jest.mock("../plugins/git/loadGitData", () => ({
   loadGitData: jest.fn(),
 }));
 
+export const fakeTimestamp = new Date();
+
 type JestMockFn = $Call<typeof jest.fn>;
 const execDependencyGraph: JestMockFn = (require("../tools/execDependencyGraph"): any);
 const loadGithubData: JestMockFn = (require("../plugins/github/loadGithubData")
@@ -430,7 +432,7 @@ describe("cli/load", () => {
           .toString();
         const registry = RepoIdRegistry.fromJSON(JSON.parse(blob));
         const expected: RepoIdRegistry.RepoIdRegistry = [
-          {repoId: stringToRepoId("foo/combined")},
+          {repoId: stringToRepoId("foo/combined"), timestamp: fakeTimestamp},
         ];
         expect(registry).toEqual(expected);
       });
@@ -441,8 +443,14 @@ describe("cli/load", () => {
           path.join(sourcecredDirectory, RepoIdRegistry.REPO_ID_REGISTRY_FILE),
           JSON.stringify(
             RepoIdRegistry.toJSON([
-              {repoId: stringToRepoId("previous/one")},
-              {repoId: stringToRepoId("previous/two")},
+              {
+                repoId: stringToRepoId("previous/one"),
+                timestamp: fakeTimestamp,
+              },
+              {
+                repoId: stringToRepoId("previous/two"),
+                timestamp: fakeTimestamp,
+              },
             ])
           )
         );
@@ -455,9 +463,9 @@ describe("cli/load", () => {
           .toString();
         const registry = RepoIdRegistry.fromJSON(JSON.parse(blob));
         const expected: RepoIdRegistry.RepoIdRegistry = [
-          {repoId: stringToRepoId("previous/one")},
-          {repoId: stringToRepoId("previous/two")},
-          {repoId: stringToRepoId("foo/combined")},
+          {repoId: stringToRepoId("previous/one"), timestamp: fakeTimestamp},
+          {repoId: stringToRepoId("previous/two"), timestamp: fakeTimestamp},
+          {repoId: stringToRepoId("foo/combined"), timestamp: fakeTimestamp},
         ];
         expect(registry).toEqual(expected);
       });

--- a/src/core/repoIdRegistry.js
+++ b/src/core/repoIdRegistry.js
@@ -14,6 +14,7 @@ const REPO_ID_REGISTRY_COMPAT = {type: "REPO_ID_REGISTRY", version: "0.2.0"};
 
 export type RegistryEntry = {|
   +repoId: RepoId,
+  +timestamp: Date,
 |};
 export type RepoIdRegistry = $ReadOnlyArray<RegistryEntry>;
 export type RepoIdRegistryJSON = Compatible<RepoIdRegistry>;

--- a/src/core/repoIdRegistry.test.js
+++ b/src/core/repoIdRegistry.test.js
@@ -9,6 +9,7 @@ import {
 } from "./repoIdRegistry";
 
 import {makeRepoId} from "../core/repoId";
+import {fakeTimestamp} from "../cli/load.test";
 
 describe("core/repoIdRegistry", () => {
   describe("fromJSON compose on", () => {
@@ -21,41 +22,59 @@ describe("core/repoIdRegistry", () => {
     });
     it("nonempty registry", () => {
       checkExample([
-        {repoId: makeRepoId("foo", "bar")},
-        {repoId: makeRepoId("zoo", "zod")},
+        {repoId: makeRepoId("foo", "bar"), timestamp: fakeTimestamp},
+        {repoId: makeRepoId("zoo", "zod"), timestamp: fakeTimestamp},
       ]);
     });
   });
   describe("addRepoId", () => {
     it("adds to empty registry", () => {
       expect(
-        addRepoId(emptyRegistry(), {repoId: makeRepoId("foo", "bar")})
-      ).toEqual([{repoId: makeRepoId("foo", "bar")}]);
+        addRepoId(emptyRegistry(), {
+          repoId: makeRepoId("foo", "bar"),
+          timestamp: fakeTimestamp,
+        })
+      ).toEqual([{repoId: makeRepoId("foo", "bar"), timestamp: fakeTimestamp}]);
     });
     it("adds to nonempty registry", () => {
-      const registry = [{repoId: makeRepoId("foo", "bar")}];
-      expect(addRepoId(registry, {repoId: makeRepoId("zoo", "zod")})).toEqual([
-        {repoId: makeRepoId("foo", "bar")},
-        {repoId: makeRepoId("zoo", "zod")},
+      const registry = [
+        {repoId: makeRepoId("foo", "bar"), timestamp: fakeTimestamp},
+      ];
+      expect(
+        addRepoId(registry, {
+          repoId: makeRepoId("zoo", "zod"),
+          timestamp: fakeTimestamp,
+        })
+      ).toEqual([
+        {repoId: makeRepoId("foo", "bar"), timestamp: fakeTimestamp},
+        {repoId: makeRepoId("zoo", "zod"), timestamp: fakeTimestamp},
       ]);
     });
     it("adding repoId that is already the last has no effect", () => {
       const registry = [
-        {repoId: makeRepoId("zoo", "zod")},
-        {repoId: makeRepoId("foo", "bar")},
+        {repoId: makeRepoId("zoo", "zod"), timestamp: fakeTimestamp},
+        {repoId: makeRepoId("foo", "bar"), timestamp: fakeTimestamp},
       ];
-      expect(addRepoId(registry, {repoId: makeRepoId("foo", "bar")})).toEqual(
-        registry
-      );
+      expect(
+        addRepoId(registry, {
+          repoId: makeRepoId("foo", "bar"),
+          timestamp: fakeTimestamp,
+        })
+      ).toEqual(registry);
     });
     it("adding already-existing repoId shifts it to the end", () => {
       const registry = [
-        {repoId: makeRepoId("zoo", "zod")},
-        {repoId: makeRepoId("foo", "bar")},
+        {repoId: makeRepoId("zoo", "zod"), timestamp: fakeTimestamp},
+        {repoId: makeRepoId("foo", "bar"), timestamp: fakeTimestamp},
       ];
-      expect(addRepoId(registry, {repoId: makeRepoId("zoo", "zod")})).toEqual([
-        {repoId: makeRepoId("foo", "bar")},
-        {repoId: makeRepoId("zoo", "zod")},
+      expect(
+        addRepoId(registry, {
+          repoId: makeRepoId("zoo", "zod"),
+          timestamp: fakeTimestamp,
+        })
+      ).toEqual([
+        {repoId: makeRepoId("foo", "bar"), timestamp: fakeTimestamp},
+        {repoId: makeRepoId("zoo", "zod"), timestamp: fakeTimestamp},
       ]);
     });
   });

--- a/src/homepage/PrototypesPage.js
+++ b/src/homepage/PrototypesPage.js
@@ -29,6 +29,7 @@ export default function makePrototypesPage(
                 <Link to={`/prototypes/${x.repoId.owner}/${x.repoId.name}/`}>
                   {`${x.repoId.owner}/${x.repoId.name}`}
                 </Link>
+                <span>{` last updated on ${x.timestamp.toString()}`}</span>
               </li>
             ))}
           </ul>

--- a/src/homepage/routeData.test.js
+++ b/src/homepage/routeData.test.js
@@ -2,12 +2,19 @@
 
 import {stringToRepoId} from "../core/repoId";
 import {makeRouteData} from "./routeData";
+import {fakeTimestamp} from "../cli/load.test";
 
 describe("homepage/routeData", () => {
   function routeData() {
     return makeRouteData([
-      {repoId: stringToRepoId("sourcecred/example-github")},
-      {repoId: stringToRepoId("sourcecred/sourcecred")},
+      {
+        repoId: stringToRepoId("sourcecred/example-github"),
+        timestamp: fakeTimestamp,
+      },
+      {
+        repoId: stringToRepoId("sourcecred/sourcecred"),
+        timestamp: fakeTimestamp,
+      },
     ]);
   }
 


### PR DESCRIPTION
This attaches a timestamp to every entry as it is loaded into the registry.

I have not begun any new testing on this in any way yet. I have modified the relevant tests that deal with loading the entries into the registry. Which seems to accept the new form of the entry data-structure, however it fails to recieve the the expected timestamp. I'm very new to testing but I think I have a way to fix up my crude timestamp 'monkey-patching' in the tests using a feature in jest called Snapshot Property Matchers. I believe this would be a much better solution than the weird timestamp export that i have placed inside of load.test.js

Any comments, advice, or further discussion would be greatly appreciated.