### PR TITLE
redirect routing for prototype

### DIFF
--- a/src/homepage/PrototypesPage.js
+++ b/src/homepage/PrototypesPage.js
@@ -26,7 +26,7 @@ export default function makePrototypesPage(
           <ul>
             {registry.map((x) => (
               <li key={stringify(x)}>
-                <Link to={`/prototypes/${x.repoId.owner}/${x.repoId.name}/`}>
+                <Link to={`/prototype/${x.repoId.owner}/${x.repoId.name}/`}>
                   {`${x.repoId.owner}/${x.repoId.name}`}
                 </Link>
               </li>

--- a/src/homepage/routeData.js
+++ b/src/homepage/routeData.js
@@ -48,7 +48,7 @@ function makeRouteData(registry /*: RepoIdRegistry */) /*: RouteData */ {
       navTitle: "Prototype",
     },
     ...registry.map((entry) => ({
-      path: `/prototypes/${entry.repoId.owner}/${entry.repoId.name}/`,
+      path: `/prototype/${entry.repoId.owner}/${entry.repoId.name}/`,
       contents: {
         type: "PAGE",
         component: () => require("./ProjectPage").default(entry.repoId),


### PR DESCRIPTION
This PR is a fix for Issue #1019 

Using just the prototype route seems to be working perfectly fine and I think this might be ready for master.

However when I omit the trailing-slash from the route the page will not display. I don't know if making the trailing-slash at the end of the route would break anything but I think it would be kinda useful/helpful.  