### PR TITLE
Add helpful message when missing gnu-coreutils

### DIFF
--- a/config/test.js
+++ b/config/test.js
@@ -81,6 +81,11 @@ function makeTasks(mode /*: "BASIC" | "FULL" */) {
       deps: [],
     },
     {
+      id: "check-gnu-coreutils",
+      cmd: ["./scripts/check-gnu-coreutils.sh"],
+      deps: [],
+    },
+    {
       id: "backend",
       cmd: [
         "npm",
@@ -101,7 +106,7 @@ function makeTasks(mode /*: "BASIC" | "FULL" */) {
         "--silent",
         {BASIC: "sharness", FULL: "sharness-full"}[mode],
       ]),
-      deps: ["backend"],
+      deps: ["backend", "check-gnu-coreutils"],
     },
   ];
   const extraTasks = [

--- a/scripts/check-gnu-coreutils.sh
+++ b/scripts/check-gnu-coreutils.sh
@@ -1,0 +1,10 @@
+#!/bin/sh
+set -eu
+
+if ! 2>/dev/null >/dev/null readlink -f . ; then
+  >&2 echo "Error: Your environment does not provide GNU coreutils"
+  >&2 echo "You're likely developing on macOS."
+  >&2 echo "Please see the following link for a fix:"
+  >&2 echo "https://github.com/sourcecred/sourcecred/issues/698#issuecomment-417202213"
+  exit 1
+fi


### PR DESCRIPTION
As described in #1033: Currently, developers in environments without gnu
coreutils (notably: macOS) get an extremely confusing error message when
they run `yarn test`. This commit ensures that such users instead get a
helpful message with a link to the fix.

Follows @wchargin's proposed approach for fixing #1033, so that Mac
developers get clear guidance on how to get their development
environment working properly.

Expected behavior is that `yarn test` passes when GNU coreutils are
present, and fails with the following message when they are not:

Fixes #1033

```
 FAIL  check-gnu-coreutils
Exit code: 1
Contents of stderr:
    Error: Your environment does not provide GNU coreutils
    You're likely developing on macOS.
    Please see the following link for a fix:
    https://github.com/sourcecred/sourcecred/issues/698#issuecomment-417202213
```

Test plan:

Verify that on a machine with gnu coreutils present, the command passes
and does not print irrelevant output.

Verify that on a machine without gnu coreutils available, the command
fails, and prints exactly the error message expected, without any extra
output related to the test's implementation.

Paired-with: @anthrocypher