### PR TITLE
Make `yarn test` more quiet

### DIFF
--- a/config/test.js
+++ b/config/test.js
@@ -8,7 +8,10 @@ main();
 
 function main() {
   const options = parseArgs();
-  execDependencyGraph(makeTasks(options.mode)).then(({success}) => {
+  const printVerboseResults = options.mode === "FULL";
+  const runOptions = {printVerboseResults};
+  const tasks = makeTasks(options.mode);
+  execDependencyGraph(tasks, runOptions).then(({success}) => {
     process.exitCode = success ? 0 : 1;
   });
 }

--- a/src/tools/execDependencyGraph.js
+++ b/src/tools/execDependencyGraph.js
@@ -37,6 +37,9 @@ type RunOptions = {|
   +taskLaunchLabel?: string,
   +overallPassLabel?: string,
   +overallFailLabel?: string,
+  // Determines whether we print the contents of stdout and stderr for
+  // all tasks (printVerboseResults === true) or just for failing tasks.
+  +printVerboseResults?: boolean,
 |};
 */
 
@@ -46,6 +49,7 @@ const defaultOptions = {
   taskLaunchLabel: " GO ",
   overallPassLabel: "SUCCESS",
   overallFailLabel: "FAILURE",
+  printVerboseResults: false,
 };
 
 module.exports = async function execDependencyGraph(
@@ -179,10 +183,12 @@ module.exports = async function execDependencyGraph(
     });
   }
 
-  printSection("Full results");
-  for (const task of tasks) {
-    const result = completedTasks.get(task.id);
-    displayResult(task.id, result, "FULL");
+  if (fullOptions.printVerboseResults) {
+    printSection("Full results");
+    for (const task of tasks) {
+      const result = completedTasks.get(task.id);
+      displayResult(task.id, result, "FULL");
+    }
   }
 
   printSection("Overview");


### PR DESCRIPTION
This commit adds a new runOption for execDependencyGraph, namely
`printVerboseResults`. If this flag is true, then execDependencyGraph
will print a "Full Results" section along with the standard error and
standard out of every task, regardless of whether it failed or
succeeded. (Note, this is the existing behavior for all invocations
prior to this commit).

If the flag is not true, then execDependencyGraph will not print a full
results section, and stdout/stderr will be logged only for tasks that
fail.

This commit also modifies `yarn test` to use the new flag so that it
prints verbose tests only when the `--full` option is provided. This is
consistent with our sharness behavior: we print the full sharness logs
only when `--full` was provided.

This fixes #1035, and ensures that running `yarn test` has a high signal
to noise ratio (i.e. it only shows an enumeration of top level tasks).
This improves the developer ergonomics of SourceCred by not having a
super commonly used and core script spam the user with mostly irrelevant
information.

Test plan:

Run `yarn test` when all tests are passing, and observe that the output
has much less noise:

```
yarn run v1.12.3
$ node ./config/test.js
tmpdir for backend output: /tmp/sourcecred-test-6337SZ9smvWsWvqE

Starting tasks
  GO   ensure-flow-typing
  GO   check-stopships
  GO   check-pretty
  GO   lint
  GO   flow
  GO   unit
  GO   backend
 PASS  check-stopships
 PASS  ensure-flow-typing
 PASS  flow
 PASS  backend
  GO   sharness
 PASS  sharness
 PASS  check-pretty
 PASS  lint
 PASS  unit

Overview
Final result:  SUCCESS
Done in 11.66s.
```

Run `yarn test` when there is a real failure (e.g. a unit test failure)
and observe that full details on the failure, including the output from
stdout/stderr, is still provided.

Run `yarn test --full` and observe that full, verbose logs are provided.