### PR TITLE
Replace invocations of `npm` with `yarn`

### DIFF
--- a/config/test.js
+++ b/config/test.js
@@ -54,40 +54,31 @@ function makeTasks(mode /*: "BASIC" | "FULL" */) {
     },
     {
       id: "check-pretty",
-      cmd: ["npm", "run", "--silent", "check-pretty"],
+      cmd: ["yarn", "run", "--silent", "check-pretty"],
       deps: [],
     },
     {
       id: "lint",
-      cmd: ["npm", "run", "--silent", "lint"],
+      cmd: ["yarn", "run", "--silent", "lint"],
       deps: [],
     },
     {
       id: "flow",
-      cmd: [
-        "npm",
-        "run",
-        "--silent",
-        "flow",
-        "--",
-        "--quiet",
-        "--max-warnings=0",
-      ],
+      cmd: ["yarn", "run", "--silent", "flow", "--quiet", "--max-warnings=0"],
       deps: [],
     },
     {
       id: "unit",
-      cmd: ["npm", "run", "--silent", "unit", "--", "--ci", "--maxWorkers=4"],
+      cmd: ["yarn", "run", "--silent", "unit", "--ci", "--maxWorkers=4"],
       deps: [],
     },
     {
       id: "backend",
       cmd: [
-        "npm",
+        "yarn",
         "run",
         "--silent",
         "backend",
-        "--",
         "--output-path",
         backendOutput,
       ],
@@ -96,7 +87,7 @@ function makeTasks(mode /*: "BASIC" | "FULL" */) {
     {
       id: {BASIC: "sharness", FULL: "sharness-full"}[mode],
       cmd: withSourcecredBinEnv([
-        "npm",
+        "yarn",
         "run",
         "--silent",
         {BASIC: "sharness", FULL: "sharness-full"}[mode],

--- a/package.json
+++ b/package.json
@@ -71,7 +71,7 @@
     "unit": "BABEL_ENV=test NODE_ENV=test jest --env=jsdom",
     "sharness": "make -sC ./sharness prove PROVE_OPTS=-f TEST_OPTS='--chain-lint'",
     "sharness-full": "make -sC ./sharness prove PROVE_OPTS=-vf TEST_OPTS='-v --chain-lint --long'",
-    "coverage": "npm run unit -- --coverage",
+    "coverage": "yarn run unit --coverage",
     "flow": "flow",
     "lint": "eslint src config --max-warnings 0"
   },


### PR DESCRIPTION
Currently, our underlying test script uses npm rather than yarn to
execute the tests. This is awkward, because we use yarn everywhere else
in lieu of npm. It turns out that some setups have node available
without npm, and in such environments our tests fail with a cryptic
ENOENT error.

This changes the tests to use yarn instead.

Test plan: `yarn test --full` passes.

Thanks to @wpank for help uncovering this issue.