### PR TITLE
Add descriptions for NodeTypes

### DIFF
--- a/src/analysis/fallbackDeclaration.js
+++ b/src/analysis/fallbackDeclaration.js
@@ -14,7 +14,7 @@ export const fallbackNodeType: NodeType = Object.freeze({
   prefix: NodeAddress.empty,
   defaultWeight: 1,
   description:
-    "NodeType for nodes that don't have any other type (aka a fallback)",
+    "The fallback NodeType for nodes which don't have any other type",
 });
 
 export const fallbackEdgeType: EdgeType = Object.freeze({

--- a/src/analysis/fallbackDeclaration.js
+++ b/src/analysis/fallbackDeclaration.js
@@ -14,7 +14,7 @@ export const fallbackNodeType: NodeType = Object.freeze({
   prefix: NodeAddress.empty,
   defaultWeight: 1,
   description:
-    "The fallback NodeType for nodes which don't have any other type",
+    "NodeType for nodes that don't have any other type (aka a fallback)",
 });
 
 export const fallbackEdgeType: EdgeType = Object.freeze({

--- a/src/analysis/fallbackDeclaration.js
+++ b/src/analysis/fallbackDeclaration.js
@@ -13,6 +13,8 @@ export const fallbackNodeType: NodeType = Object.freeze({
   pluralName: "nodes",
   prefix: NodeAddress.empty,
   defaultWeight: 1,
+  description:
+    "The fallback NodeType for nodes which don't have any other type",
 });
 
 export const fallbackEdgeType: EdgeType = Object.freeze({

--- a/src/analysis/types.js
+++ b/src/analysis/types.js
@@ -15,4 +15,7 @@ export type NodeType = {|
   +pluralName: string,
   +prefix: NodeAddressT,
   +defaultWeight: number,
+  // The '+description' property should be a several word description that makes
+  // it clear to a user what each NodeType does
+  +description: string,
 |};

--- a/src/analysis/types.js
+++ b/src/analysis/types.js
@@ -15,7 +15,7 @@ export type NodeType = {|
   +pluralName: string,
   +prefix: NodeAddressT,
   +defaultWeight: number,
-  // The '+description' property should be a several word description that makes
+  // The `description` property should be a human-readable string that makes
   // it clear to a user what each NodeType does
   +description: string,
 |};

--- a/src/explorer/pagerankTable/Aggregation.test.js
+++ b/src/explorer/pagerankTable/Aggregation.test.js
@@ -149,6 +149,7 @@ describe("explorer/pagerankTable/Aggregation", () => {
       pluralName: "whatDoth",
       defaultWeight: 1,
       prefix: NodeAddress.empty,
+      description: "Lucy In The Sky With Diamonds",
     };
     const edgeType: EdgeType = {
       forwardName: "marsellus",

--- a/src/explorer/pagerankTable/Aggregation.test.js
+++ b/src/explorer/pagerankTable/Aggregation.test.js
@@ -149,7 +149,7 @@ describe("explorer/pagerankTable/Aggregation", () => {
       pluralName: "whatDoth",
       defaultWeight: 1,
       prefix: NodeAddress.empty,
-      description: "NodeType for the AggregationView",
+      description: "An example NodeType for testing purposes",
     };
     const edgeType: EdgeType = {
       forwardName: "marsellus",

--- a/src/explorer/pagerankTable/Aggregation.test.js
+++ b/src/explorer/pagerankTable/Aggregation.test.js
@@ -149,7 +149,7 @@ describe("explorer/pagerankTable/Aggregation", () => {
       pluralName: "whatDoth",
       defaultWeight: 1,
       prefix: NodeAddress.empty,
-      description: "Lucy In The Sky With Diamonds",
+      description: "NodeType for the AggregationView",
     };
     const edgeType: EdgeType = {
       forwardName: "marsellus",

--- a/src/explorer/pagerankTable/aggregate.test.js
+++ b/src/explorer/pagerankTable/aggregate.test.js
@@ -1,6 +1,6 @@
 // @flow
 
-import {EdgeAddress, NodeAddress} from "../../core/graph";
+import {EdgeAddress, NodeAddress, type NodeAddressT} from "../../core/graph";
 import * as NullUtil from "../../util/null";
 import {
   aggregateByNodeType,
@@ -9,42 +9,47 @@ import {
   aggregateFlat,
   aggregationKey,
 } from "./aggregate";
+import type {NodeType} from "../../analysis/types";
 
 describe("explorer/pagerankTable/aggregate", () => {
   // TODO: If making major modifications to these tests, consider switching
   // from the hand-maintained connections and types, and instead use the demo
   // adadpters from app/adapters/demoAdapters
   function example() {
-    const nodes = {
+    const nodes: {[string]: NodeAddressT} = {
       root: NodeAddress.fromParts(["root"]),
       zap: NodeAddress.fromParts(["zap"]),
       kif: NodeAddress.fromParts(["kif"]),
     };
 
-    const nodeTypes = {
+    const nodeTypes: {[string]: NodeType} = {
       root: {
         name: "root",
         pluralName: "roots",
         prefix: nodes.root,
         defaultWeight: 0,
+        description: "This NodeType corresponds to one node with address root",
       },
       zap: {
         name: "zap",
         pluralName: "zaps",
         prefix: nodes.zap,
         defaultWeight: 0,
+        description: "This NodeType corresponds to one node with address zap",
       },
       kif: {
         name: "kif",
         pluralName: "kifs",
         prefix: nodes.kif,
         defaultWeight: 0,
+        description: "This NodeType corresponds to one node with address kif",
       },
       empty: {
         name: "empty",
         pluralName: "empties",
         prefix: NodeAddress.empty,
         defaultWeight: 0,
+        description: "This NodeType matches every node",
       },
     };
 

--- a/src/explorer/pagerankTable/aggregate.test.js
+++ b/src/explorer/pagerankTable/aggregate.test.js
@@ -16,40 +16,40 @@ describe("explorer/pagerankTable/aggregate", () => {
   // from the hand-maintained connections and types, and instead use the demo
   // adadpters from app/adapters/demoAdapters
   function example() {
-    const nodes: {[string]: NodeAddressT} = {
+    const nodes: {+[string]: NodeAddressT} = {
       root: NodeAddress.fromParts(["root"]),
       zap: NodeAddress.fromParts(["zap"]),
       kif: NodeAddress.fromParts(["kif"]),
     };
 
-    const nodeTypes: {[string]: NodeType} = {
+    const nodeTypes: {+[string]: NodeType} = {
       root: {
         name: "root",
         pluralName: "roots",
         prefix: nodes.root,
         defaultWeight: 0,
-        description: "This NodeType corresponds to one node with address root",
+        description: "NodeType for the address named 'root'",
       },
       zap: {
         name: "zap",
         pluralName: "zaps",
         prefix: nodes.zap,
         defaultWeight: 0,
-        description: "This NodeType corresponds to one node with address zap",
+        description: "NodeType for the address named 'zap'",
       },
       kif: {
         name: "kif",
         pluralName: "kifs",
         prefix: nodes.kif,
         defaultWeight: 0,
-        description: "This NodeType corresponds to one node with address kif",
+        description: "NodeType for the address named 'kif'",
       },
       empty: {
         name: "empty",
         pluralName: "empties",
         prefix: NodeAddress.empty,
         defaultWeight: 0,
-        description: "This NodeType matches every node",
+        description: "NodeType for an empty address. This matches every node",
       },
     };
 

--- a/src/explorer/pagerankTable/aggregate.test.js
+++ b/src/explorer/pagerankTable/aggregate.test.js
@@ -28,28 +28,32 @@ describe("explorer/pagerankTable/aggregate", () => {
         pluralName: "roots",
         prefix: nodes.root,
         defaultWeight: 0,
-        description: "NodeType for the address named 'root'",
+        description:
+          "This NodeType corresponds to the node with the address named `root`",
       },
       zap: {
         name: "zap",
         pluralName: "zaps",
         prefix: nodes.zap,
         defaultWeight: 0,
-        description: "NodeType for the address named 'zap'",
+        description:
+          "This NodeType corresponds to the node with the address named `zap`",
       },
       kif: {
         name: "kif",
         pluralName: "kifs",
         prefix: nodes.kif,
         defaultWeight: 0,
-        description: "NodeType for the address named 'kif'",
+        description:
+          "This NodeType corresponds to the node with the address named `kif`",
       },
       empty: {
         name: "empty",
         pluralName: "empties",
         prefix: NodeAddress.empty,
         defaultWeight: 0,
-        description: "NodeType for an empty address. This matches every node",
+        description:
+          "This NodeType is for an empty address, which matches every node",
       },
     };
 

--- a/src/plugins/demo/declaration.js
+++ b/src/plugins/demo/declaration.js
@@ -11,6 +11,7 @@ export const inserterNodeType: NodeType = Object.freeze({
   pluralName: "inserters",
   prefix: NodeAddress.fromParts(["factorio", "inserter"]),
   defaultWeight: 1,
+  description: "Nodes for Factorio inserter objects in demo plugin",
 });
 
 export const machineNodeType: NodeType = Object.freeze({
@@ -18,6 +19,7 @@ export const machineNodeType: NodeType = Object.freeze({
   pluralName: "machines",
   prefix: NodeAddress.fromParts(["factorio", "machine"]),
   defaultWeight: 2,
+  description: "Nodes for Factorio inserter objects in demo plugin",
 });
 
 export const assemblesEdgeType: EdgeType = Object.freeze({

--- a/src/plugins/demo/declaration.js
+++ b/src/plugins/demo/declaration.js
@@ -11,7 +11,7 @@ export const inserterNodeType: NodeType = Object.freeze({
   pluralName: "inserters",
   prefix: NodeAddress.fromParts(["factorio", "inserter"]),
   defaultWeight: 1,
-  description: "Nodes for Factorio inserter objects in demo plugin",
+  description: "NodeType for Factorio inserter objects in demo plugin",
 });
 
 export const machineNodeType: NodeType = Object.freeze({
@@ -19,7 +19,7 @@ export const machineNodeType: NodeType = Object.freeze({
   pluralName: "machines",
   prefix: NodeAddress.fromParts(["factorio", "machine"]),
   defaultWeight: 2,
-  description: "Nodes for Factorio inserter objects in demo plugin",
+  description: "NodeType for Factorio machine objects in demo plugin",
 });
 
 export const assemblesEdgeType: EdgeType = Object.freeze({

--- a/src/plugins/demo/declaration.js
+++ b/src/plugins/demo/declaration.js
@@ -11,7 +11,7 @@ export const inserterNodeType: NodeType = Object.freeze({
   pluralName: "inserters",
   prefix: NodeAddress.fromParts(["factorio", "inserter"]),
   defaultWeight: 1,
-  description: "NodeType for Factorio inserter objects in demo plugin",
+  description: "Nodes for Factorio inserter objects in demo plugin",
 });
 
 export const machineNodeType: NodeType = Object.freeze({
@@ -19,7 +19,7 @@ export const machineNodeType: NodeType = Object.freeze({
   pluralName: "machines",
   prefix: NodeAddress.fromParts(["factorio", "machine"]),
   defaultWeight: 2,
-  description: "NodeType for Factorio machine objects in demo plugin",
+  description: "Nodes for Factorio machine objects in demo plugin",
 });
 
 export const assemblesEdgeType: EdgeType = Object.freeze({

--- a/src/plugins/git/declaration.js
+++ b/src/plugins/git/declaration.js
@@ -10,7 +10,7 @@ const commitNodeType: NodeType = Object.freeze({
   pluralName: "Commits",
   prefix: N.Prefix.commit,
   defaultWeight: 2,
-  description: "NodeType for representing a git commit",
+  description: "NodeType representing a git commit",
 });
 
 const hasParentEdgeType = Object.freeze({

--- a/src/plugins/git/declaration.js
+++ b/src/plugins/git/declaration.js
@@ -10,7 +10,7 @@ const commitNodeType: NodeType = Object.freeze({
   pluralName: "Commits",
   prefix: N.Prefix.commit,
   defaultWeight: 2,
-  description: "This a NodeType representing a git commit",
+  description: "NodeType for representing a git commit",
 });
 
 const hasParentEdgeType = Object.freeze({

--- a/src/plugins/git/declaration.js
+++ b/src/plugins/git/declaration.js
@@ -1,14 +1,16 @@
 // @flow
 
 import type {PluginDeclaration} from "../../analysis/pluginDeclaration";
+import type {NodeType} from "../../analysis/types";
 import * as N from "./nodes";
 import * as E from "./edges";
 
-const commitNodeType = Object.freeze({
+const commitNodeType: NodeType = Object.freeze({
   name: "Commit",
   pluralName: "Commits",
   prefix: N.Prefix.commit,
   defaultWeight: 2,
+  description: "This a NodeType representing a git commit",
 });
 
 const hasParentEdgeType = Object.freeze({

--- a/src/plugins/github/declaration.js
+++ b/src/plugins/github/declaration.js
@@ -9,6 +9,7 @@ const repoNodeType = Object.freeze({
   pluralName: "Repositories",
   prefix: N.Prefix.repo,
   defaultWeight: 4,
+  description: "NodeType for a GitHub repository",
 });
 
 const issueNodeType = Object.freeze({
@@ -16,6 +17,7 @@ const issueNodeType = Object.freeze({
   pluralName: "Issues",
   prefix: N.Prefix.issue,
   defaultWeight: 2,
+  description: "NodeType for a GitHub issue",
 });
 
 const pullNodeType = Object.freeze({
@@ -23,6 +25,7 @@ const pullNodeType = Object.freeze({
   pluralName: "Pull requests",
   prefix: N.Prefix.pull,
   defaultWeight: 4,
+  description: "NodeType for a GitHub pull request",
 });
 
 const reviewNodeType = Object.freeze({
@@ -30,6 +33,7 @@ const reviewNodeType = Object.freeze({
   pluralName: "Pull request reviews",
   prefix: N.Prefix.review,
   defaultWeight: 1,
+  description: "NodeType for a GitHub code review",
 });
 
 const commentNodeType = Object.freeze({
@@ -37,6 +41,7 @@ const commentNodeType = Object.freeze({
   pluralName: "Comments",
   prefix: N.Prefix.comment,
   defaultWeight: 1,
+  description: "NodeType for a GitHub comment",
 });
 
 const userNodeType = Object.freeze({
@@ -44,6 +49,7 @@ const userNodeType = Object.freeze({
   pluralName: "Users",
   prefix: N.Prefix.user,
   defaultWeight: 1,
+  description: "NodeType for a GitHub user",
 });
 
 const botNodeType = Object.freeze({
@@ -51,6 +57,7 @@ const botNodeType = Object.freeze({
   pluralName: "Bots",
   prefix: N.Prefix.bot,
   defaultWeight: 0.25,
+  description: "NodeType for a GitHub bot account",
 });
 
 const nodeTypes = Object.freeze([


### PR DESCRIPTION
As highlighted by @decentralion in issue #807, adding some info to the UI about the purpose of each Node and Edge type will help users understand what each one does as the number of Nodes/Edges increases. This PR modifies the`NodeType` defintion in src/analysis/types.js to include a `+description: string` field, then updates all NodeTypes throughout the codebase in need of descriptions, as indicated by `yarn flow`.

Test plan:

Verify that all tests pass and the descriptions makes sense.