### PR TITLE
homepage: remove misleading CSS import

### DIFF
--- a/src/homepage/index.js
+++ b/src/homepage/index.js
@@ -8,8 +8,6 @@ import createRelativeHistory from "../webutil/createRelativeHistory";
 import App from "./App";
 import createRouteDataFromEnvironment from "./createRouteDataFromEnvironment";
 
-import "./index.css";
-
 const target = document.getElementById("root");
 if (target == null) {
   throw new Error("Unable to find root element!");


### PR DESCRIPTION
Summary:
We use Aphrodite, not CSS imports, for styling. We do have a small
`index.css` file that is included during server-side rendering, and is
only referenced from `src/homepage/server.js`. But our `index.js` file
also has a superfluous `import "./style.css"`, which might suggest that
we support CSS imports more generally. This patch removes that import.

Thanks to @brianlitwin on Discord for pointing out that this might be
confusing.

Test Plan:
Verified that, under both `yarn start` and `yarn build`, the appearance
is the same, and the document still includes a `<style>` element with
the contents of `index.css` (which is included by `server.js`).

wchargin-branch: remove-css-import