### PR TITLE
Rename "AppAdapter" -> "ExplorerAdapter"

### DIFF
--- a/src/explorer/App.js
+++ b/src/explorer/App.js
@@ -19,7 +19,7 @@ import {
   type StateTransitionMachineInterface,
   initialState,
 } from "./state";
-import {StaticAdapterSet} from "./adapters/adapterSet";
+import {StaticExplorerAdapterSet} from "./adapters/explorerAdapterSet";
 
 const credOverviewUrl =
   "https://discuss.sourcecred.io/t/a-gentle-introduction-to-cred/20";
@@ -28,7 +28,7 @@ const feedbackUrl =
 
 export class AppPage extends React.Component<{|
   +assets: Assets,
-  +adapters: StaticAdapterSet,
+  +adapters: StaticExplorerAdapterSet,
   +repoId: RepoId,
 |}> {
   static _LOCAL_STORE = new CheckedLocalStore(
@@ -54,7 +54,7 @@ export class AppPage extends React.Component<{|
 type Props = {|
   +assets: Assets,
   +localStore: LocalStore,
-  +adapters: StaticAdapterSet,
+  +adapters: StaticExplorerAdapterSet,
   +repoId: RepoId,
 |};
 type State = {|

--- a/src/explorer/App.test.js
+++ b/src/explorer/App.test.js
@@ -7,8 +7,11 @@ import {Graph} from "../core/graph";
 import {makeRepoId} from "../core/repoId";
 import {Assets} from "../webutil/assets";
 import testLocalStore from "../webutil/testLocalStore";
-import {DynamicAdapterSet, StaticAdapterSet} from "./adapters/adapterSet";
-import {FactorioStaticAdapter} from "../plugins/demo/appAdapter";
+import {
+  DynamicExplorerAdapterSet,
+  StaticExplorerAdapterSet,
+} from "./adapters/explorerAdapterSet";
+import {FactorioStaticAdapter} from "../plugins/demo/explorerAdapter";
 import {defaultWeightsForAdapter} from "./weights/weights";
 
 import {PagerankTable} from "./pagerankTable/Table";
@@ -37,7 +40,7 @@ describe("explorer/App", () => {
     const el = shallow(
       <App
         assets={new Assets("/foo/")}
-        adapters={new StaticAdapterSet([])}
+        adapters={new StaticExplorerAdapterSet([])}
         localStore={localStore}
         repoId={makeRepoId("foo", "bar")}
       />
@@ -56,7 +59,10 @@ describe("explorer/App", () => {
     };
   }
 
-  const emptyAdapters = new DynamicAdapterSet(new StaticAdapterSet([]), []);
+  const emptyAdapters = new DynamicExplorerAdapterSet(
+    new StaticExplorerAdapterSet([]),
+    []
+  );
   const exampleStates = {
     readyToLoadGraph: (loadingState) => {
       return () => ({

--- a/src/explorer/adapters/explorerAdapter.js
+++ b/src/explorer/adapters/explorerAdapter.js
@@ -6,13 +6,13 @@ import type {Assets} from "../../webutil/assets";
 import type {RepoId} from "../../core/repoId";
 import type {PluginDeclaration} from "../../analysis/pluginDeclaration";
 
-export interface StaticAppAdapter {
+export interface StaticExplorerAdapter {
   declaration(): PluginDeclaration;
-  load(assets: Assets, repoId: RepoId): Promise<DynamicAppAdapter>;
+  load(assets: Assets, repoId: RepoId): Promise<DynamicExplorerAdapter>;
 }
 
-export interface DynamicAppAdapter {
+export interface DynamicExplorerAdapter {
   graph(): Graph;
   nodeDescription(NodeAddressT): ReactNode;
-  static (): StaticAppAdapter;
+  static (): StaticExplorerAdapter;
 }

--- a/src/explorer/adapters/explorerAdapterSet.js
+++ b/src/explorer/adapters/explorerAdapterSet.js
@@ -5,19 +5,22 @@ import {NodeTrie, EdgeTrie} from "../../core/trie";
 import type {Assets} from "../../webutil/assets";
 import type {RepoId} from "../../core/repoId";
 
-import type {StaticAppAdapter, DynamicAppAdapter} from "./appAdapter";
+import type {
+  StaticExplorerAdapter,
+  DynamicExplorerAdapter,
+} from "./explorerAdapter";
 import type {EdgeType, NodeType} from "../../analysis/types";
 
 import {FallbackStaticAdapter} from "./fallbackAdapter";
 
-export class StaticAdapterSet {
-  _adapters: $ReadOnlyArray<StaticAppAdapter>;
-  _adapterNodeTrie: NodeTrie<StaticAppAdapter>;
-  _adapterEdgeTrie: EdgeTrie<StaticAppAdapter>;
+export class StaticExplorerAdapterSet {
+  _adapters: $ReadOnlyArray<StaticExplorerAdapter>;
+  _adapterNodeTrie: NodeTrie<StaticExplorerAdapter>;
+  _adapterEdgeTrie: EdgeTrie<StaticExplorerAdapter>;
   _typeNodeTrie: NodeTrie<NodeType>;
   _typeEdgeTrie: EdgeTrie<EdgeType>;
 
-  constructor(adapters: $ReadOnlyArray<StaticAppAdapter>): void {
+  constructor(adapters: $ReadOnlyArray<StaticExplorerAdapter>): void {
     this._adapters = [new FallbackStaticAdapter(), ...adapters];
     this._adapterNodeTrie = new NodeTrie();
     this._adapterEdgeTrie = new EdgeTrie();
@@ -37,7 +40,7 @@ export class StaticAdapterSet {
     this.edgeTypes().forEach((t) => this._typeEdgeTrie.add(t.prefix, t));
   }
 
-  adapters(): $ReadOnlyArray<StaticAppAdapter> {
+  adapters(): $ReadOnlyArray<StaticExplorerAdapter> {
     return this._adapters;
   }
 
@@ -49,11 +52,11 @@ export class StaticAdapterSet {
     return [].concat(...this._adapters.map((x) => x.declaration().edgeTypes));
   }
 
-  adapterMatchingNode(x: NodeAddressT): StaticAppAdapter {
+  adapterMatchingNode(x: NodeAddressT): StaticExplorerAdapter {
     return this._adapterNodeTrie.getLast(x);
   }
 
-  adapterMatchingEdge(x: EdgeAddressT): StaticAppAdapter {
+  adapterMatchingEdge(x: EdgeAddressT): StaticExplorerAdapter {
     return this._adapterEdgeTrie.getLast(x);
   }
 
@@ -65,24 +68,24 @@ export class StaticAdapterSet {
     return this._typeEdgeTrie.getLast(x);
   }
 
-  load(assets: Assets, repoId: RepoId): Promise<DynamicAdapterSet> {
+  load(assets: Assets, repoId: RepoId): Promise<DynamicExplorerAdapterSet> {
     return Promise.all(this._adapters.map((a) => a.load(assets, repoId))).then(
-      (adapters) => new DynamicAdapterSet(this, adapters)
+      (adapters) => new DynamicExplorerAdapterSet(this, adapters)
     );
   }
 }
 
-export class DynamicAdapterSet {
-  _adapters: $ReadOnlyArray<DynamicAppAdapter>;
-  _staticAdapterSet: StaticAdapterSet;
-  _adapterNodeTrie: NodeTrie<DynamicAppAdapter>;
-  _adapterEdgeTrie: EdgeTrie<DynamicAppAdapter>;
+export class DynamicExplorerAdapterSet {
+  _adapters: $ReadOnlyArray<DynamicExplorerAdapter>;
+  _staticExplorerAdapterSet: StaticExplorerAdapterSet;
+  _adapterNodeTrie: NodeTrie<DynamicExplorerAdapter>;
+  _adapterEdgeTrie: EdgeTrie<DynamicExplorerAdapter>;
 
   constructor(
-    staticAdapterSet: StaticAdapterSet,
-    adapters: $ReadOnlyArray<DynamicAppAdapter>
+    staticExplorerAdapterSet: StaticExplorerAdapterSet,
+    adapters: $ReadOnlyArray<DynamicExplorerAdapter>
   ): void {
-    this._staticAdapterSet = staticAdapterSet;
+    this._staticExplorerAdapterSet = staticExplorerAdapterSet;
     this._adapters = adapters;
     this._adapterNodeTrie = new NodeTrie();
     this._adapterEdgeTrie = new EdgeTrie();
@@ -92,15 +95,15 @@ export class DynamicAdapterSet {
     });
   }
 
-  adapterMatchingNode(x: NodeAddressT): DynamicAppAdapter {
+  adapterMatchingNode(x: NodeAddressT): DynamicExplorerAdapter {
     return this._adapterNodeTrie.getLast(x);
   }
 
-  adapterMatchingEdge(x: EdgeAddressT): DynamicAppAdapter {
+  adapterMatchingEdge(x: EdgeAddressT): DynamicExplorerAdapter {
     return this._adapterEdgeTrie.getLast(x);
   }
 
-  adapters(): $ReadOnlyArray<DynamicAppAdapter> {
+  adapters(): $ReadOnlyArray<DynamicExplorerAdapter> {
     return this._adapters;
   }
 
@@ -109,6 +112,6 @@ export class DynamicAdapterSet {
   }
 
   static() {
-    return this._staticAdapterSet;
+    return this._staticExplorerAdapterSet;
   }
 }

--- a/src/explorer/adapters/explorerAdapterSet.test.js
+++ b/src/explorer/adapters/explorerAdapterSet.test.js
@@ -1,8 +1,8 @@
 // @flow
 
 import {NodeAddress, EdgeAddress, Graph} from "../../core/graph";
-import {FactorioStaticAdapter} from "../../plugins/demo/appAdapter";
-import {StaticAdapterSet} from "./adapterSet";
+import {FactorioStaticAdapter} from "../../plugins/demo/explorerAdapter";
+import {StaticExplorerAdapterSet} from "./explorerAdapterSet";
 import {FallbackStaticAdapter} from "./fallbackAdapter";
 import {
   FALLBACK_NAME,
@@ -12,17 +12,17 @@ import {
 import {Assets} from "../../webutil/assets";
 import {makeRepoId} from "../../core/repoId";
 
-describe("explorer/adapters/adapterSet", () => {
-  describe("StaticAdapterSet", () => {
+describe("explorer/adapters/explorerAdapterSet", () => {
+  describe("StaticExplorerAdapterSet", () => {
     function example() {
       const x = new FactorioStaticAdapter();
       const fallback = new FallbackStaticAdapter();
-      const sas = new StaticAdapterSet([x]);
+      const sas = new StaticExplorerAdapterSet([x]);
       return {x, fallback, sas};
     }
     it("errors if two plugins have the same name", () => {
       const x = new FactorioStaticAdapter();
-      const shouldError = () => new StaticAdapterSet([x, x]);
+      const shouldError = () => new StaticExplorerAdapterSet([x, x]);
       expect(shouldError).toThrowError("Multiple plugins with name");
     });
     it("always includes the fallback plugin", () => {
@@ -101,7 +101,7 @@ describe("explorer/adapters/adapterSet", () => {
       );
       expect(type).toBe(fallbackEdgeType);
     });
-    it("loads a dynamicAdapterSet", async () => {
+    it("loads a dynamicExplorerAdapterSet", async () => {
       const {x, sas} = example();
       x.loadingMock = jest.fn().mockResolvedValue();
       expect(x.loadingMock).toHaveBeenCalledTimes(0);
@@ -116,17 +116,17 @@ describe("explorer/adapters/adapterSet", () => {
     });
   });
 
-  describe("DynamicAdapterSet", () => {
+  describe("DynamicExplorerAdapterSet", () => {
     async function example() {
       const x = new FactorioStaticAdapter();
-      const sas = new StaticAdapterSet([x]);
+      const sas = new StaticExplorerAdapterSet([x]);
       const das = await sas.load(
         new Assets("/my/gateway/"),
         makeRepoId("foo", "bar")
       );
       return {x, sas, das};
     }
-    it("allows retrieval of the original StaticAdapterSet", async () => {
+    it("allows retrieval of the original StaticExplorerAdapterSet", async () => {
       const {sas, das} = await example();
       expect(das.static()).toBe(sas);
     });

--- a/src/explorer/adapters/fallbackAdapter.js
+++ b/src/explorer/adapters/fallbackAdapter.js
@@ -1,12 +1,15 @@
 // @flow
 
 import {fallbackDeclaration} from "../../analysis/fallbackDeclaration";
-import type {StaticAppAdapter, DynamicAppAdapter} from "./appAdapter";
+import type {
+  StaticExplorerAdapter,
+  DynamicExplorerAdapter,
+} from "./explorerAdapter";
 import {Assets} from "../../webutil/assets";
 import {type RepoId} from "../../core/repoId";
 import {Graph, NodeAddress, type NodeAddressT} from "../../core/graph";
 
-export class FallbackStaticAdapter implements StaticAppAdapter {
+export class FallbackStaticAdapter implements StaticExplorerAdapter {
   declaration() {
     return fallbackDeclaration;
   }
@@ -16,7 +19,7 @@ export class FallbackStaticAdapter implements StaticAppAdapter {
   }
 }
 
-export class FallbackDynamicAdapter implements DynamicAppAdapter {
+export class FallbackDynamicAdapter implements DynamicExplorerAdapter {
   graph() {
     return new Graph();
   }

--- a/src/explorer/pagerankTable/Connection.js
+++ b/src/explorer/pagerankTable/Connection.js
@@ -6,7 +6,7 @@ import * as NullUtil from "../../util/null";
 import type {NodeAddressT} from "../../core/graph";
 import type {Connection} from "../../core/attribution/graphToMarkovChain";
 import type {ScoredConnection} from "../../analysis/pagerankNodeDecomposition";
-import {DynamicAdapterSet} from "../adapters/adapterSet";
+import {DynamicExplorerAdapterSet} from "../adapters/explorerAdapterSet";
 import {TableRow} from "./TableRow";
 import {NodeRow} from "./Node";
 
@@ -87,7 +87,7 @@ export class ConnectionRow extends React.PureComponent<ConnectionRowProps> {
 
 export class ConnectionView extends React.PureComponent<{|
   +connection: Connection,
-  +adapters: DynamicAdapterSet,
+  +adapters: DynamicExplorerAdapterSet,
 |}> {
   render() {
     const {connection, adapters} = this.props;

--- a/src/explorer/pagerankTable/Table.js
+++ b/src/explorer/pagerankTable/Table.js
@@ -6,8 +6,8 @@ import * as NullUtil from "../../util/null";
 
 import {type NodeAddressT, NodeAddress} from "../../core/graph";
 import type {PagerankNodeDecomposition} from "../../analysis/pagerankNodeDecomposition";
-import {DynamicAdapterSet} from "../adapters/adapterSet";
-import type {DynamicAppAdapter} from "../adapters/appAdapter";
+import {DynamicExplorerAdapterSet} from "../adapters/explorerAdapterSet";
+import type {DynamicExplorerAdapter} from "../adapters/explorerAdapter";
 import {FALLBACK_NAME} from "../../analysis/fallbackDeclaration";
 import type {WeightedTypes} from "../../analysis/weights";
 import {WeightConfig} from "../weights/WeightConfig";
@@ -16,7 +16,7 @@ import {NodeRowList} from "./Node";
 
 type PagerankTableProps = {|
   +pnd: PagerankNodeDecomposition,
-  +adapters: DynamicAdapterSet,
+  +adapters: DynamicExplorerAdapterSet,
   +weightedTypes: WeightedTypes,
   +onWeightedTypesChange: (WeightedTypes) => void,
   +maxEntriesPerList: number,
@@ -92,7 +92,7 @@ export class PagerankTable extends React.PureComponent<
       throw new Error("Impossible.");
     }
 
-    function optionGroup(adapter: DynamicAppAdapter) {
+    function optionGroup(adapter: DynamicExplorerAdapter) {
       const header = (
         <option
           key={adapter.static().declaration().nodePrefix}
@@ -124,7 +124,7 @@ export class PagerankTable extends React.PureComponent<
           <option value={NodeAddress.empty}>Show all</option>
           {sortBy(
             adapters.adapters(),
-            (a: DynamicAppAdapter) => a.static().declaration().name
+            (a: DynamicExplorerAdapter) => a.static().declaration().name
           )
             .filter((a) => a.static().declaration().name !== FALLBACK_NAME)
             .map(optionGroup)}

--- a/src/explorer/pagerankTable/Table.test.js
+++ b/src/explorer/pagerankTable/Table.test.js
@@ -10,7 +10,7 @@ import {example, COLUMNS} from "./sharedTestUtils";
 import {NodeRowList} from "./Node";
 import {WeightConfig} from "../weights/WeightConfig";
 import {defaultWeightsForAdapter} from "../weights/weights";
-import {FactorioStaticAdapter} from "../../plugins/demo/appAdapter";
+import {FactorioStaticAdapter} from "../../plugins/demo/explorerAdapter";
 
 require("../../webutil/testUtil").configureEnzyme();
 describe("explorer/pagerankTable/Table", () => {

--- a/src/explorer/pagerankTable/shared.js
+++ b/src/explorer/pagerankTable/shared.js
@@ -7,13 +7,13 @@ import {
   NodeAddress,
 } from "../../core/graph";
 
-import {DynamicAdapterSet} from "../adapters/adapterSet";
+import {DynamicExplorerAdapterSet} from "../adapters/explorerAdapterSet";
 
 import type {PagerankNodeDecomposition} from "../../analysis/pagerankNodeDecomposition";
 
 export function nodeDescription(
   address: NodeAddressT,
-  adapters: DynamicAdapterSet
+  adapters: DynamicExplorerAdapterSet
 ): ReactNode {
   const adapter = adapters.adapterMatchingNode(address);
   try {
@@ -28,7 +28,7 @@ export function nodeDescription(
 export function edgeVerb(
   address: EdgeAddressT,
   direction: "FORWARD" | "BACKWARD",
-  adapters: DynamicAdapterSet
+  adapters: DynamicExplorerAdapterSet
 ): string {
   const edgeType = adapters.static().typeMatchingEdge(address);
   return direction === "FORWARD" ? edgeType.forwardName : edgeType.backwardName;
@@ -36,7 +36,7 @@ export function edgeVerb(
 
 export type SharedProps = {|
   +pnd: PagerankNodeDecomposition,
-  +adapters: DynamicAdapterSet,
+  +adapters: DynamicExplorerAdapterSet,
   +maxEntriesPerList: number,
 |};
 

--- a/src/explorer/pagerankTable/sharedTestUtils.js
+++ b/src/explorer/pagerankTable/sharedTestUtils.js
@@ -2,12 +2,12 @@
 
 import {pagerank} from "../../analysis/pagerank";
 import {defaultWeightsForAdapterSet} from "../weights/weights";
-import {dynamicAdapterSet} from "../../plugins/demo/appAdapter";
+import {dynamicExplorerAdapterSet} from "../../plugins/demo/explorerAdapter";
 
 export const COLUMNS = () => ["Description", "", "Cred"];
 
 export async function example() {
-  const adapters = await dynamicAdapterSet();
+  const adapters = await dynamicExplorerAdapterSet();
   const weightedTypes = defaultWeightsForAdapterSet(adapters.static());
   const graph = adapters.graph();
   const pnd = await pagerank(graph, (_unused_Edge) => ({

--- a/src/explorer/state.js
+++ b/src/explorer/state.js
@@ -12,7 +12,10 @@ import {
   pagerank,
 } from "../analysis/pagerank";
 
-import {StaticAdapterSet, DynamicAdapterSet} from "./adapters/adapterSet";
+import {
+  StaticExplorerAdapterSet,
+  DynamicExplorerAdapterSet,
+} from "./adapters/explorerAdapterSet";
 import type {WeightedTypes} from "../analysis/weights";
 import {weightsToEdgeEvaluator} from "../analysis/weightsToEdgeEvaluator";
 
@@ -67,11 +70,11 @@ export function createStateTransitionMachine(
 
 // Exported for testing purposes.
 export interface StateTransitionMachineInterface {
-  +loadGraph: (Assets, StaticAdapterSet) => Promise<boolean>;
+  +loadGraph: (Assets, StaticExplorerAdapterSet) => Promise<boolean>;
   +runPagerank: (WeightedTypes, NodeAddressT) => Promise<void>;
   +loadGraphAndRunPagerank: (
     Assets,
-    StaticAdapterSet,
+    StaticExplorerAdapterSet,
     WeightedTypes,
     NodeAddressT
   ) => Promise<void>;
@@ -85,7 +88,7 @@ export class StateTransitionMachine implements StateTransitionMachineInterface {
   setState: (AppState) => void;
   loadGraphWithAdapters: (
     assets: Assets,
-    adapters: StaticAdapterSet,
+    adapters: StaticExplorerAdapterSet,
     repoId: RepoId
   ) => Promise<GraphWithAdapters>;
   pagerank: (
@@ -99,7 +102,7 @@ export class StateTransitionMachine implements StateTransitionMachineInterface {
     setState: (AppState) => void,
     loadGraphWithAdapters: (
       assets: Assets,
-      adapters: StaticAdapterSet,
+      adapters: StaticExplorerAdapterSet,
       repoId: RepoId
     ) => Promise<GraphWithAdapters>,
     pagerank: (
@@ -117,7 +120,7 @@ export class StateTransitionMachine implements StateTransitionMachineInterface {
   /** Loads the graph, reports whether it was successful */
   async loadGraph(
     assets: Assets,
-    adapters: StaticAdapterSet
+    adapters: StaticExplorerAdapterSet
   ): Promise<boolean> {
     const state = this.getState();
     if (state.type !== "READY_TO_LOAD_GRAPH") {
@@ -202,7 +205,7 @@ export class StateTransitionMachine implements StateTransitionMachineInterface {
 
   async loadGraphAndRunPagerank(
     assets: Assets,
-    adapters: StaticAdapterSet,
+    adapters: StaticExplorerAdapterSet,
     weightedTypes: WeightedTypes,
     totalScoreNodePrefix: NodeAddressT
   ) {
@@ -227,11 +230,11 @@ export class StateTransitionMachine implements StateTransitionMachineInterface {
 
 export type GraphWithAdapters = {|
   +graph: Graph,
-  +adapters: DynamicAdapterSet,
+  +adapters: DynamicExplorerAdapterSet,
 |};
 export async function loadGraphWithAdapters(
   assets: Assets,
-  adapters: StaticAdapterSet,
+  adapters: StaticExplorerAdapterSet,
   repoId: RepoId
 ): Promise<GraphWithAdapters> {
   const dynamicAdapters = await adapters.load(assets, repoId);

--- a/src/explorer/state.test.js
+++ b/src/explorer/state.test.js
@@ -12,12 +12,15 @@ import {makeRepoId, type RepoId} from "../core/repoId";
 import {type EdgeEvaluator} from "../analysis/pagerank";
 import type {WeightedTypes} from "../analysis/weights";
 import {defaultWeightsForAdapterSet} from "./weights/weights";
-import {StaticAdapterSet, DynamicAdapterSet} from "./adapters/adapterSet";
+import {
+  StaticExplorerAdapterSet,
+  DynamicExplorerAdapterSet,
+} from "./adapters/explorerAdapterSet";
 import type {
   PagerankNodeDecomposition,
   PagerankOptions,
 } from "../analysis/pagerank";
-import {staticAdapterSet} from "../plugins/demo/appAdapter";
+import {staticExplorerAdapterSet} from "../plugins/demo/explorerAdapter";
 
 describe("explorer/state", () => {
   function example(startingState: AppState) {
@@ -28,7 +31,7 @@ describe("explorer/state", () => {
     };
     const loadGraphMock: (
       assets: Assets,
-      adapters: StaticAdapterSet,
+      adapters: StaticExplorerAdapterSet,
       repoId: RepoId
     ) => Promise<GraphWithAdapters> = jest.fn();
     const pagerankMock: (
@@ -69,12 +72,15 @@ describe("explorer/state", () => {
     };
   }
   function weightedTypes(): WeightedTypes {
-    return defaultWeightsForAdapterSet(staticAdapterSet());
+    return defaultWeightsForAdapterSet(staticExplorerAdapterSet());
   }
   function graphWithAdapters(): GraphWithAdapters {
     return {
       graph: new Graph(),
-      adapters: new DynamicAdapterSet(new StaticAdapterSet([]), []),
+      adapters: new DynamicExplorerAdapterSet(
+        new StaticExplorerAdapterSet([]),
+        []
+      ),
     };
   }
   function pagerankNodeDecomposition() {
@@ -90,7 +96,10 @@ describe("explorer/state", () => {
       for (const b of badStates) {
         const {stm} = example(b);
         await expect(
-          stm.loadGraph(new Assets("/my/gateway/"), new StaticAdapterSet([]))
+          stm.loadGraph(
+            new Assets("/my/gateway/"),
+            new StaticExplorerAdapterSet([])
+          )
         ).rejects.toThrow("incorrect state");
       }
     });
@@ -98,7 +107,7 @@ describe("explorer/state", () => {
       const {stm, loadGraphMock} = example(readyToLoadGraph());
       expect(loadGraphMock).toHaveBeenCalledTimes(0);
       const assets = new Assets("/my/gateway/");
-      const adapters = new StaticAdapterSet([]);
+      const adapters = new StaticExplorerAdapterSet([]);
       stm.loadGraph(assets, adapters);
       expect(loadGraphMock).toHaveBeenCalledTimes(1);
       expect(loadGraphMock).toHaveBeenCalledWith(
@@ -110,7 +119,10 @@ describe("explorer/state", () => {
     it("immediately sets loading status", () => {
       const {getState, stm} = example(readyToLoadGraph());
       expect(loading(getState())).toBe("NOT_LOADING");
-      stm.loadGraph(new Assets("/my/gateway/"), new StaticAdapterSet([]));
+      stm.loadGraph(
+        new Assets("/my/gateway/"),
+        new StaticExplorerAdapterSet([])
+      );
       expect(loading(getState())).toBe("LOADING");
       expect(getState().type).toBe("READY_TO_LOAD_GRAPH");
     });
@@ -120,7 +132,7 @@ describe("explorer/state", () => {
       loadGraphMock.mockResolvedValue(gwa);
       const succeeded = await stm.loadGraph(
         new Assets("/my/gateway/"),
-        new StaticAdapterSet([])
+        new StaticExplorerAdapterSet([])
       );
       expect(succeeded).toBe(true);
       const state = getState();
@@ -139,7 +151,7 @@ describe("explorer/state", () => {
       loadGraphMock.mockRejectedValue(error);
       const succeeded = await stm.loadGraph(
         new Assets("/my/gateway/"),
-        new StaticAdapterSet([])
+        new StaticExplorerAdapterSet([])
       );
       expect(succeeded).toBe(false);
       const state = getState();
@@ -208,7 +220,7 @@ describe("explorer/state", () => {
       (stm: any).runPagerank = jest.fn();
       stm.loadGraph.mockResolvedValue(true);
       const assets = new Assets("/gateway/");
-      const adapters = new StaticAdapterSet([]);
+      const adapters = new StaticExplorerAdapterSet([]);
       const prefix = NodeAddress.fromParts(["bar"]);
       const wt = weightedTypes();
       await stm.loadGraphAndRunPagerank(assets, adapters, wt, prefix);
@@ -223,7 +235,7 @@ describe("explorer/state", () => {
       (stm: any).runPagerank = jest.fn();
       stm.loadGraph.mockResolvedValue(false);
       const assets = new Assets("/gateway/");
-      const adapters = new StaticAdapterSet([]);
+      const adapters = new StaticExplorerAdapterSet([]);
       const prefix = NodeAddress.fromParts(["bar"]);
       await stm.loadGraphAndRunPagerank(
         assets,
@@ -242,7 +254,7 @@ describe("explorer/state", () => {
       const wt = weightedTypes();
       await stm.loadGraphAndRunPagerank(
         new Assets("/gateway/"),
-        new StaticAdapterSet([]),
+        new StaticExplorerAdapterSet([]),
         wt,
         prefix
       );
@@ -258,7 +270,7 @@ describe("explorer/state", () => {
       const wt = weightedTypes();
       await stm.loadGraphAndRunPagerank(
         new Assets("/gateway/"),
-        new StaticAdapterSet([]),
+        new StaticExplorerAdapterSet([]),
         wt,
         prefix
       );

--- a/src/explorer/weights/PluginWeightConfig.js
+++ b/src/explorer/weights/PluginWeightConfig.js
@@ -5,7 +5,7 @@ import deepEqual from "lodash.isequal";
 import * as MapUtil from "../../util/map";
 import {NodeTypeConfig} from "./NodeTypeConfig";
 import {EdgeTypeConfig} from "./EdgeTypeConfig";
-import {StaticAppAdapter} from "../adapters/appAdapter";
+import {StaticExplorerAdapter} from "../adapters/explorerAdapter";
 import {styledVariable} from "./EdgeTypeConfig";
 import type {
   WeightedTypes,
@@ -14,7 +14,7 @@ import type {
 } from "../../analysis/weights";
 
 export type Props = {|
-  +adapter: StaticAppAdapter,
+  +adapter: StaticExplorerAdapter,
   +onChange: (WeightedTypes) => void,
   +weightedTypes: WeightedTypes,
 |};

--- a/src/explorer/weights/PluginWeightConfig.test.js
+++ b/src/explorer/weights/PluginWeightConfig.test.js
@@ -7,7 +7,7 @@ import {
   inserterNodeType,
   assemblesEdgeType,
 } from "../../plugins/demo/declaration";
-import {FactorioStaticAdapter} from "../../plugins/demo/appAdapter";
+import {FactorioStaticAdapter} from "../../plugins/demo/explorerAdapter";
 import {
   fallbackNodeType,
   fallbackEdgeType,

--- a/src/explorer/weights/WeightConfig.js
+++ b/src/explorer/weights/WeightConfig.js
@@ -4,13 +4,13 @@ import React, {type Node as ReactNode} from "react";
 import * as NullUtil from "../../util/null";
 import * as MapUtil from "../../util/map";
 
-import type {StaticAdapterSet} from "../adapters/adapterSet";
+import type {StaticExplorerAdapterSet} from "../adapters/explorerAdapterSet";
 import type {WeightedTypes} from "../../analysis/weights";
 import {PluginWeightConfig} from "./PluginWeightConfig";
 import {FALLBACK_NAME} from "../../analysis/fallbackDeclaration";
 
 type Props = {|
-  +adapters: StaticAdapterSet,
+  +adapters: StaticExplorerAdapterSet,
   +weightedTypes: WeightedTypes,
   +onChange: (WeightedTypes) => void,
 |};

--- a/src/explorer/weights/WeightConfig.test.js
+++ b/src/explorer/weights/WeightConfig.test.js
@@ -5,8 +5,8 @@ import {shallow} from "enzyme";
 import {PluginWeightConfig} from "./PluginWeightConfig";
 import {
   FactorioStaticAdapter,
-  staticAdapterSet,
-} from "../../plugins/demo/appAdapter";
+  staticExplorerAdapterSet,
+} from "../../plugins/demo/explorerAdapter";
 import {inserterNodeType} from "../../plugins/demo/declaration";
 import {FALLBACK_NAME} from "../../analysis/fallbackDeclaration";
 import {defaultWeightsForAdapterSet, defaultWeightsForAdapter} from "./weights";
@@ -18,7 +18,7 @@ describe("explorer/weights/WeightConfig", () => {
   describe("WeightConfig", () => {
     function example() {
       const onChange = jest.fn();
-      const adapters = staticAdapterSet();
+      const adapters = staticExplorerAdapterSet();
       const types = defaultWeightsForAdapterSet(adapters);
       types.nodes.set(inserterNodeType.prefix, {
         weight: 707,
@@ -76,7 +76,7 @@ describe("explorer/weights/WeightConfig", () => {
         type: inserterNodeType,
       });
       const expectedFullWeights = defaultWeightsForAdapterSet(
-        staticAdapterSet()
+        staticExplorerAdapterSet()
       );
       expectedFullWeights.nodes.set(inserterNodeType.prefix, {
         weight: 955,

--- a/src/explorer/weights/weights.js
+++ b/src/explorer/weights/weights.js
@@ -5,17 +5,17 @@ import {
   combineWeights,
   defaultWeightsForDeclaration,
 } from "../../analysis/weights";
-import type {StaticAppAdapter} from "../adapters/appAdapter";
-import type {StaticAdapterSet} from "../adapters/adapterSet";
+import type {StaticExplorerAdapter} from "../adapters/explorerAdapter";
+import type {StaticExplorerAdapterSet} from "../adapters/explorerAdapterSet";
 
 export function defaultWeightsForAdapter(
-  adapter: StaticAppAdapter
+  adapter: StaticExplorerAdapter
 ): WeightedTypes {
   return defaultWeightsForDeclaration(adapter.declaration());
 }
 
 export function defaultWeightsForAdapterSet(
-  adapters: StaticAdapterSet
+  adapters: StaticExplorerAdapterSet
 ): WeightedTypes {
   return combineWeights(adapters.adapters().map(defaultWeightsForAdapter));
 }

--- a/src/explorer/weights/weights.test.js
+++ b/src/explorer/weights/weights.test.js
@@ -8,8 +8,8 @@ import {
 import {declaration} from "../../plugins/demo/declaration";
 import {
   FactorioStaticAdapter,
-  staticAdapterSet,
-} from "../../plugins/demo/appAdapter";
+  staticExplorerAdapterSet,
+} from "../../plugins/demo/explorerAdapter";
 
 describe("explorer/weights/weights", () => {
   describe("defaultWeightsForAdapter", () => {
@@ -22,9 +22,9 @@ describe("explorer/weights/weights", () => {
 
   describe("defaultWeightsForAdapterSet", () => {
     it("works on a demo adapter set", () => {
-      expect(defaultWeightsForAdapterSet(staticAdapterSet())).toEqual(
+      expect(defaultWeightsForAdapterSet(staticExplorerAdapterSet())).toEqual(
         combineWeights(
-          staticAdapterSet()
+          staticExplorerAdapterSet()
             .adapters()
             .map(defaultWeightsForAdapter)
         )

--- a/src/homepage/homepageExplorer.js
+++ b/src/homepage/homepageExplorer.js
@@ -3,15 +3,15 @@
 import React from "react";
 
 import type {Assets} from "../webutil/assets";
-import {StaticAdapterSet} from "../explorer/adapters/adapterSet";
-import {StaticAppAdapter as GithubAdapter} from "../plugins/github/appAdapter";
-import {StaticAppAdapter as GitAdapter} from "../plugins/git/appAdapter";
+import {StaticExplorerAdapterSet} from "../explorer/adapters/explorerAdapterSet";
+import {StaticExplorerAdapter as GithubAdapter} from "../plugins/github/explorerAdapter";
+import {StaticExplorerAdapter as GitAdapter} from "../plugins/git/explorerAdapter";
 import {GithubGitGateway} from "../plugins/github/githubGitGateway";
 import {AppPage} from "../explorer/App";
 import type {RepoId} from "../core/repoId";
 
-function homepageStaticAdapters(): StaticAdapterSet {
-  return new StaticAdapterSet([
+function homepageStaticAdapters(): StaticExplorerAdapterSet {
+  return new StaticExplorerAdapterSet([
     new GithubAdapter(),
     new GitAdapter(new GithubGitGateway()),
   ]);

--- a/src/plugins/demo/explorerAdapter.js
+++ b/src/plugins/demo/explorerAdapter.js
@@ -3,16 +3,16 @@
 import type {PluginDeclaration} from "../../analysis/pluginDeclaration";
 import {declaration} from "./declaration";
 import type {
-  StaticAppAdapter,
-  DynamicAppAdapter,
-} from "../../explorer/adapters/appAdapter";
-import {StaticAdapterSet} from "../../explorer/adapters/adapterSet";
+  StaticExplorerAdapter,
+  DynamicExplorerAdapter,
+} from "../../explorer/adapters/explorerAdapter";
+import {StaticExplorerAdapterSet} from "../../explorer/adapters/explorerAdapterSet";
 import {Assets} from "../../webutil/assets";
 import {type RepoId, makeRepoId} from "../../core/repoId";
 import {NodeAddress, type NodeAddressT} from "../../core/graph";
 import {graph} from "./graph";
 
-export class FactorioStaticAdapter implements StaticAppAdapter {
+export class FactorioStaticAdapter implements StaticExplorerAdapter {
   loadingMock: (assets: Assets, repoId: RepoId) => Promise<mixed>;
   declaration(): PluginDeclaration {
     return declaration;
@@ -26,7 +26,7 @@ export class FactorioStaticAdapter implements StaticAppAdapter {
   }
 }
 
-export class FactorioDynamicAdapter implements DynamicAppAdapter {
+export class FactorioDynamicAdapter implements DynamicExplorerAdapter {
   graph() {
     return graph();
   }
@@ -38,12 +38,12 @@ export class FactorioDynamicAdapter implements DynamicAppAdapter {
   }
 }
 
-export function staticAdapterSet() {
-  return new StaticAdapterSet([new FactorioStaticAdapter()]);
+export function staticExplorerAdapterSet() {
+  return new StaticExplorerAdapterSet([new FactorioStaticAdapter()]);
 }
 
-export async function dynamicAdapterSet() {
-  return await staticAdapterSet().load(
+export async function dynamicExplorerAdapterSet() {
+  return await staticExplorerAdapterSet().load(
     new Assets("/gateway/"),
     makeRepoId("foo", "bar")
   );

--- a/src/plugins/git/explorerAdapter.js
+++ b/src/plugins/git/explorerAdapter.js
@@ -1,8 +1,8 @@
 // @flow
 import type {
-  StaticAppAdapter as IStaticAppAdapter,
-  DynamicAppAdapter as IDynamicAppAdapter,
-} from "../../explorer/adapters/appAdapter";
+  StaticExplorerAdapter as IStaticExplorerAdapter,
+  DynamicExplorerAdapter as IDynamicExplorerAdapter,
+} from "../../explorer/adapters/explorerAdapter";
 import {Graph} from "../../core/graph";
 import * as N from "./nodes";
 import {description} from "./render";
@@ -13,7 +13,7 @@ import type {GitGateway} from "./gitGateway";
 import type {PluginDeclaration} from "../../analysis/pluginDeclaration";
 import {declaration} from "./declaration";
 
-export class StaticAppAdapter implements IStaticAppAdapter {
+export class StaticExplorerAdapter implements IStaticExplorerAdapter {
   _gitGateway: GitGateway;
 
   constructor(gg: GitGateway): void {
@@ -22,7 +22,7 @@ export class StaticAppAdapter implements IStaticAppAdapter {
   declaration(): PluginDeclaration {
     return declaration;
   }
-  async load(assets: Assets, repoId: RepoId): Promise<IDynamicAppAdapter> {
+  async load(assets: Assets, repoId: RepoId): Promise<IDynamicExplorerAdapter> {
     const baseUrl = `/api/v1/data/data/${repoId.owner}/${repoId.name}/git/`;
     async function loadGraph() {
       const url = assets.resolve(baseUrl + "graph.json");
@@ -45,11 +45,11 @@ export class StaticAppAdapter implements IStaticAppAdapter {
       loadGraph(),
       loadRepository(),
     ]);
-    return new DynamicAppAdapter(this._gitGateway, graph, repository);
+    return new DynamicExplorerAdapter(this._gitGateway, graph, repository);
   }
 }
 
-class DynamicAppAdapter implements IDynamicAppAdapter {
+class DynamicExplorerAdapter implements IDynamicExplorerAdapter {
   +_graph: Graph;
   +_repository: Repository;
   +_gitGateway: GitGateway;
@@ -72,6 +72,6 @@ class DynamicAppAdapter implements IDynamicAppAdapter {
     return description(address, this._repository, this._gitGateway);
   }
   static() {
-    return new StaticAppAdapter(this._gitGateway);
+    return new StaticExplorerAdapter(this._gitGateway);
   }
 }

--- a/src/plugins/github/explorerAdapter.js
+++ b/src/plugins/github/explorerAdapter.js
@@ -2,9 +2,9 @@
 import pako from "pako";
 
 import type {
-  StaticAppAdapter as IStaticAppAdapter,
-  DynamicAppAdapter as IDynamicAppAdapter,
-} from "../../explorer/adapters/appAdapter";
+  StaticExplorerAdapter as IStaticExplorerAdapter,
+  DynamicExplorerAdapter as IDynamicExplorerAdapter,
+} from "../../explorer/adapters/explorerAdapter";
 import {type Graph, NodeAddress} from "../../core/graph";
 import {createGraph} from "./createGraph";
 import * as N from "./nodes";
@@ -15,11 +15,11 @@ import type {RepoId} from "../../core/repoId";
 import type {PluginDeclaration} from "../../analysis/pluginDeclaration";
 import {declaration} from "./declaration";
 
-export class StaticAppAdapter implements IStaticAppAdapter {
+export class StaticExplorerAdapter implements IStaticExplorerAdapter {
   declaration(): PluginDeclaration {
     return declaration;
   }
-  async load(assets: Assets, repoId: RepoId): Promise<IDynamicAppAdapter> {
+  async load(assets: Assets, repoId: RepoId): Promise<IDynamicExplorerAdapter> {
     const url = assets.resolve(
       `/api/v1/data/data/${repoId.owner}/${repoId.name}/github/view.json.gz`
     );
@@ -32,11 +32,11 @@ export class StaticAppAdapter implements IStaticAppAdapter {
     const json = JSON.parse(pako.ungzip(blob, {to: "string"}));
     const view = RelationalView.fromJSON(json);
     const graph = createGraph(view);
-    return new DynamicAppAdapter(view, graph);
+    return new DynamicExplorerAdapter(view, graph);
   }
 }
 
-class DynamicAppAdapter implements IDynamicAppAdapter {
+class DynamicExplorerAdapter implements IDynamicExplorerAdapter {
   +_view: RelationalView;
   +_graph: Graph;
   constructor(view: RelationalView, graph: Graph): void {
@@ -57,6 +57,6 @@ class DynamicAppAdapter implements IDynamicAppAdapter {
     return this._graph;
   }
   static() {
-    return new StaticAppAdapter();
+    return new StaticExplorerAdapter();
   }
 }


### PR DESCRIPTION
There are two kinds of plugin adapters: adapters for doing cred
analysis, called "analysis adapters", and adapters for the cred
explorer, which are confusingly called "app adapters".

This commit decreases the confusion by renaming app adapters to explorer
adapters across the codebase. In a future commit, I will add
documentation to the adapter interfaces so that it is clearer to a
newcomer to the codebase why these interfaces exist.

Thanks to @BrianLitwin, who asked a question during [office hours]
that surfaced this issue.

[office hours]: https://github.com/sourcecred/mission/issues/12

Test plan: `yarn test` passes, suggests that this rename went off
without a hitch. Code review as a sanity check.

Also: grepping for `AppAdapter` returns 0 results:
```
$ git grep AppAdapter | wc -l
0
```

Note: After producing this commit, I can confirm that the word "adapter"
starts to look like utter gibberish after you type it often enough.