### PR TITLE
Fix markov chain semantics for empty graphs

### DIFF
--- a/src/analysis/pagerank.js
+++ b/src/analysis/pagerank.js
@@ -58,13 +58,16 @@ export async function pagerank(
     fullOptions.selfLoopWeight
   );
   const osmc = createOrderedSparseMarkovChain(connections);
-  const distribution = await findStationaryDistribution(osmc.chain, {
+  const distributionResult = await findStationaryDistribution(osmc.chain, {
     verbose: fullOptions.verbose,
     convergenceThreshold: fullOptions.convergenceThreshold,
     maxIterations: fullOptions.maxIterations,
     yieldAfterMs: 30,
   });
-  const pi = distributionToNodeDistribution(osmc.nodeOrder, distribution);
+  const pi = distributionToNodeDistribution(
+    osmc.nodeOrder,
+    distributionResult.distribution
+  );
   const scores = scoreByConstantTotal(
     pi,
     fullOptions.totalScore,

--- a/src/analysis/pagerankNodeDecomposition.test.js
+++ b/src/analysis/pagerankNodeDecomposition.test.js
@@ -7,7 +7,10 @@ import {
   createOrderedSparseMarkovChain,
 } from "../core/attribution/graphToMarkovChain";
 import {findStationaryDistribution} from "../core/attribution/markovChain";
-import {decompose} from "./pagerankNodeDecomposition";
+import {
+  decompose,
+  type PagerankNodeDecomposition,
+} from "./pagerankNodeDecomposition";
 import * as MapUtil from "../util/map";
 
 import {advancedGraph} from "../core/graphTestUtil";
@@ -16,7 +19,7 @@ import {advancedGraph} from "../core/graphTestUtil";
  * Format a decomposition to be shown in a snapshot. This converts
  * addresses and edges to strings to avoid NUL characters.
  */
-function formatDecomposition(d) {
+function formatDecomposition(d: PagerankNodeDecomposition) {
   return MapUtil.mapEntries(d, (key, {score, scoredConnections}) => [
     NodeAddress.toString(key),
     {
@@ -128,16 +131,19 @@ describe("analysis/pagerankNodeDecomposition", () => {
       const edgeWeight = () => ({toWeight: 6.0, froWeight: 3.0});
       const connections = createConnections(g, edgeWeight, 1.0);
       const osmc = createOrderedSparseMarkovChain(connections);
-      const pi = await findStationaryDistribution(osmc.chain, {
+      const distributionResult = await findStationaryDistribution(osmc.chain, {
         verbose: false,
         convergenceThreshold: 1e-6,
         maxIterations: 255,
         yieldAfterMs: 1,
       });
-      const pr = distributionToNodeDistribution(osmc.nodeOrder, pi);
-      const result = decompose(pr, connections);
-      expect(formatDecomposition(result)).toMatchSnapshot();
-      validateDecomposition(result);
+      const pr = distributionToNodeDistribution(
+        osmc.nodeOrder,
+        distributionResult.distribution
+      );
+      const decomposition = decompose(pr, connections);
+      expect(formatDecomposition(decomposition)).toMatchSnapshot();
+      validateDecomposition(decomposition);
     });
 
     it("is valid on the example graph", async () => {
@@ -145,15 +151,18 @@ describe("analysis/pagerankNodeDecomposition", () => {
       const edgeWeight = () => ({toWeight: 6.0, froWeight: 3.0});
       const connections = createConnections(g, edgeWeight, 1.0);
       const osmc = createOrderedSparseMarkovChain(connections);
-      const pi = await findStationaryDistribution(osmc.chain, {
+      const distributionResult = await findStationaryDistribution(osmc.chain, {
         verbose: false,
         convergenceThreshold: 1e-6,
         maxIterations: 255,
         yieldAfterMs: 1,
       });
-      const pr = distributionToNodeDistribution(osmc.nodeOrder, pi);
-      const result = decompose(pr, connections);
-      validateDecomposition(result);
+      const pr = distributionToNodeDistribution(
+        osmc.nodeOrder,
+        distributionResult.distribution
+      );
+      const decomposition = decompose(pr, connections);
+      validateDecomposition(decomposition);
     });
   });
 });

--- a/src/core/attribution/graphToMarkovChain.test.js
+++ b/src/core/attribution/graphToMarkovChain.test.js
@@ -128,9 +128,31 @@ describe("core/attribution/graphToMarkovChain", () => {
         MapUtil.mapValues(map, (_, v) => sortBy(v, (x) => JSON.stringify(x)));
       expect(canonicalize(actual)).toEqual(canonicalize(expected));
     });
+
+    it("works on an empty graph", () => {
+      const connections = createConnections(
+        new Graph(),
+        () => ({toWeight: 1, froWeight: 0}),
+        0.01
+      );
+      expect(connections).toEqual(new Map());
+    });
   });
 
   describe("createOrderedSparseMarkovChain", () => {
+    it("works on an empty graph", () => {
+      const edgeWeight = (_unused_edge) => {
+        throw new Error("Don't even look at me");
+      };
+      const osmc = createOrderedSparseMarkovChain(
+        createConnections(new Graph(), edgeWeight, 1e-3)
+      );
+      const expected = {
+        nodeOrder: [],
+        chain: [],
+      };
+      expect(osmc).toEqual(expected);
+    });
     it("works on a trivial one-node chain with no edge", () => {
       const n = NodeAddress.fromParts(["foo"]);
       const g = new Graph().addNode(n);

--- a/src/core/attribution/markovChain.js
+++ b/src/core/attribution/markovChain.js
@@ -78,8 +78,11 @@ export function sparseMarkovChainFromTransitionMatrix(
 }
 
 export function uniformDistribution(n: number): Distribution {
-  if (isNaN(n) || !isFinite(n) || n !== Math.floor(n) || n <= 0) {
-    throw new Error("expected positive integer, but got: " + n);
+  if (n === 0) {
+    return new Float64Array(0);
+  }
+  if (isNaN(n) || !isFinite(n) || n !== Math.floor(n) || n < 0) {
+    throw new Error("expected nonnegative integer, but got: " + n);
   }
   return new Float64Array(n).fill(1 / n);
 }
@@ -134,6 +137,9 @@ function* findStationaryDistributionGenerator(
   }
   let nIterations = 0;
   let convergenceDelta = NaN;
+  if (chain.length === 0) {
+    return {distribution, nIterations, convergenceDelta};
+  }
   while (true) {
     if (nIterations >= options.maxIterations) {
       if (options.verbose) {

--- a/src/core/attribution/markovChain.js
+++ b/src/core/attribution/markovChain.js
@@ -7,6 +7,17 @@
  */
 export type Distribution = Float64Array;
 
+export type StationaryDistributionResult = {|
+  // The final distribution after attempting to find the stationary distribution
+  // of the markov chain
+  +distribution: Distribution,
+  // How many steps were taken in this convergence attempt
+  +nIterations: number,
+  // The maximum delta between entries in the distribution as of the final
+  // markov chain step. If no steps were taken, convergenceDelta will be NaN
+  +convergenceDelta: number,
+|};
+
 /**
  * A representation of a sparse transition matrix that is convenient for
  * computations on Markov chains.
@@ -102,12 +113,15 @@ function* findStationaryDistributionGenerator(
   chain: SparseMarkovChain,
   options: {|
     +verbose: boolean,
+    // The chain is considered converged once the maximum delta in the
+    // distribution is less than convergenceThreshold
     +convergenceThreshold: number,
+    // We will run maxIterations markov chain steps at most
     +maxIterations: number,
   |}
-): Generator<void, Distribution, void> {
-  let pi = uniformDistribution(chain.length);
-  let scratch = new Float64Array(pi.length);
+): Generator<void, StationaryDistributionResult, void> {
+  let distribution = uniformDistribution(chain.length);
+  let scratch = new Float64Array(distribution.length);
   function computeDelta(pi0, pi1) {
     let maxDelta = -Infinity;
     // Here, we assume that `pi0.nodeOrder` and `pi1.nodeOrder` are the
@@ -118,26 +132,27 @@ function* findStationaryDistributionGenerator(
     });
     return maxDelta;
   }
-  let iteration = 0;
+  let nIterations = 0;
+  let convergenceDelta = NaN;
   while (true) {
-    if (iteration >= options.maxIterations) {
+    if (nIterations >= options.maxIterations) {
       if (options.verbose) {
-        console.log(`[${iteration}] FAILED to converge`);
+        console.log(`[${nIterations}] FAILED to converge`);
       }
-      return pi;
+      return {distribution, nIterations, convergenceDelta};
     }
-    iteration++;
-    sparseMarkovChainActionInto(chain, pi, scratch);
-    const delta = computeDelta(pi, scratch);
-    [scratch, pi] = [pi, scratch];
+    nIterations++;
+    sparseMarkovChainActionInto(chain, distribution, scratch);
+    convergenceDelta = computeDelta(distribution, scratch);
+    [scratch, distribution] = [distribution, scratch];
     if (options.verbose) {
-      console.log(`[${iteration}] delta = ${delta}`);
+      console.log(`[${nIterations}] delta = ${convergenceDelta}`);
     }
-    if (delta < options.convergenceThreshold) {
+    if (convergenceDelta < options.convergenceThreshold) {
       if (options.verbose) {
-        console.log(`[${iteration}] CONVERGED`);
+        console.log(`[${nIterations}] CONVERGED`);
       }
-      return pi;
+      return {distribution, nIterations, convergenceDelta};
     }
     yield;
   }
@@ -154,7 +169,7 @@ export function findStationaryDistribution(
     +maxIterations: number,
     +yieldAfterMs: number,
   |}
-): Promise<Distribution> {
+): Promise<StationaryDistributionResult> {
   let gen = findStationaryDistributionGenerator(chain, {
     verbose: options.verbose,
     convergenceThreshold: options.convergenceThreshold,


### PR DESCRIPTION
While working on #1020, I discovered that attempting to find the
stationary distribution on an empty graph currently throws an error.
This is awkward, since the empty graph is a totally reasonable graph for
our code to work on.

This commit modifies the markov chain semantics so that we can consider
empty chains (which have no probability mass). Attempting to find the
stationary distribution of one immediately returns an empty
distribution, after 0 iteration steps and with a convergence delta of
`NaN`.

Test plan: Unit tests included; `yarn test` should suffice.