### PR TITLE
Update reaction types

### DIFF
--- a/src/graphql/mirror.test.js
+++ b/src/graphql/mirror.test.js
@@ -50,6 +50,8 @@ describe("graphql/mirror", () => {
         "HOORAY",
         "CONFUSED",
         "HEART",
+        "ROCKET",
+        "EYES",
       ]),
       Repository: s.object({
         id: s.id(),

--- a/src/plugins/github/__snapshots__/edges.test.js.snap
+++ b/src/plugins/github/__snapshots__/edges.test.js.snap
@@ -237,6 +237,49 @@ Object {
 }
 `;
 
+exports[`plugins/github/edges createEdge works for "reactsRocket" 1`] = `
+Object {
+  "addressParts": Array [
+    "sourcecred",
+    "github",
+    "REACTS",
+    "ROCKET",
+    "5",
+    "sourcecred",
+    "github",
+    "USERLIKE",
+    "USER",
+    "decentralion",
+    "8",
+    "sourcecred",
+    "github",
+    "COMMENT",
+    "PULL",
+    "sourcecred",
+    "example-github",
+    "5",
+    "396430464",
+  ],
+  "dstParts": Array [
+    "sourcecred",
+    "github",
+    "COMMENT",
+    "PULL",
+    "sourcecred",
+    "example-github",
+    "5",
+    "396430464",
+  ],
+  "srcParts": Array [
+    "sourcecred",
+    "github",
+    "USERLIKE",
+    "USER",
+    "decentralion",
+  ],
+}
+`;
+
 exports[`plugins/github/edges createEdge works for "reactsThumbsUp" 1`] = `
 Object {
   "addressParts": Array [

--- a/src/plugins/github/createGraph.js
+++ b/src/plugins/github/createGraph.js
@@ -56,7 +56,8 @@ class GraphCreator {
         if (
           content === Reactions.THUMBS_UP ||
           content === Reactions.HEART ||
-          content === Reactions.HOORAY
+          content === Reactions.HOORAY ||
+          content === Reactions.ROCKET
         ) {
           this.graph.addEdge(
             createEdge.reacts(content, user, reactable.address())

--- a/src/plugins/github/declaration.js
+++ b/src/plugins/github/declaration.js
@@ -131,6 +131,15 @@ const reactsHoorayEdgeType = Object.freeze({
   prefix: E.Prefix.reactsHooray,
 });
 
+const reactsRocketEdgeType = Object.freeze({
+  forwardName: "reacted 🚀 to",
+  backwardName: "got 🚀 from",
+  defaultForwardWeight: 1,
+  // TODO(#811): Probably change this to 0
+  defaultBackwardWeight: 1 / 32,
+  prefix: E.Prefix.reactsRocket,
+});
+
 const edgeTypes = Object.freeze([
   authorsEdgeType,
   hasParentEdgeType,
@@ -140,6 +149,7 @@ const edgeTypes = Object.freeze([
   reactsThumbsUpEdgeType,
   reactsHeartEdgeType,
   reactsHoorayEdgeType,
+  reactsRocketEdgeType,
 ]);
 
 export const declaration: PluginDeclaration = Object.freeze({

--- a/src/plugins/github/edges.js
+++ b/src/plugins/github/edges.js
@@ -39,6 +39,7 @@ export const Prefix = Object.freeze({
   reactsThumbsUp: githubEdgeAddress(REACTS_TYPE, Reactions.THUMBS_UP),
   reactsHeart: githubEdgeAddress(REACTS_TYPE, Reactions.HEART),
   reactsHooray: githubEdgeAddress(REACTS_TYPE, Reactions.HOORAY),
+  reactsRocket: githubEdgeAddress(REACTS_TYPE, Reactions.ROCKET),
 });
 
 export type AuthorsAddress = {|

--- a/src/plugins/github/edges.test.js
+++ b/src/plugins/github/edges.test.js
@@ -82,6 +82,12 @@ describe("plugins/github/edges", () => {
         nodeExamples.user(),
         nodeExamples.issueComment()
       ),
+    reactsRocket: () =>
+      createEdge.reacts(
+        Reactions.ROCKET,
+        nodeExamples.user(),
+        nodeExamples.pullComment()
+      ),
   };
 
   describe("createEdge", () => {

--- a/src/plugins/github/graphView.js
+++ b/src/plugins/github/graphView.js
@@ -320,7 +320,8 @@ export class GraphView {
       if (
         reactionType !== Reactions.THUMBS_UP &&
         reactionType !== Reactions.HEART &&
-        reactionType !== Reactions.HOORAY
+        reactionType !== Reactions.HOORAY &&
+        reactionType !== Reactions.ROCKET
       ) {
         throw new Error(
           `Invariant: Edge ${stringify(

--- a/src/plugins/github/graphqlTypes.js
+++ b/src/plugins/github/graphqlTypes.js
@@ -133,24 +133,30 @@ export type Reaction = {|
 
 export type ReactionContent =
   | "CONFUSED"
+  | "EYES"
   | "HEART"
   | "HOORAY"
   | "LAUGH"
+  | "ROCKET"
   | "THUMBS_DOWN"
   | "THUMBS_UP";
 
 export const ReactionContent$Values: {|
   +CONFUSED: "CONFUSED",
+  +EYES: "EYES",
   +HEART: "HEART",
   +HOORAY: "HOORAY",
   +LAUGH: "LAUGH",
+  +ROCKET: "ROCKET",
   +THUMBS_DOWN: "THUMBS_DOWN",
   +THUMBS_UP: "THUMBS_UP",
 |} = Object.freeze({
   CONFUSED: "CONFUSED",
+  EYES: "EYES",
   HEART: "HEART",
   HOORAY: "HOORAY",
   LAUGH: "LAUGH",
+  ROCKET: "ROCKET",
   THUMBS_DOWN: "THUMBS_DOWN",
   THUMBS_UP: "THUMBS_UP",
 });

--- a/src/plugins/github/schema.js
+++ b/src/plugins/github/schema.js
@@ -25,6 +25,8 @@ export default function schema(): Schema.Schema {
       "HOORAY",
       "CONFUSED",
       "HEART",
+      "ROCKET",
+      "EYES",
     ]),
     Repository: s.object({
       id: s.id(),


### PR DESCRIPTION
Resolves #1054
Added "ROCKET" and "EYES" to the list of reaction types.
Added "ROCKET" as a valid cred signal, kept "EYES" invisible.

My approach was to use `git git grep THUMBS_UP '*.js'`
 and `git grep ThumbsUp '*.js'` to find all the relevant files,
as suggested in #1054

**Test Plan**

1) Inspecting Sourcecred/Mission's UI:
[#13] contains: GOT 🚀 FROM 1 user
@BrianLitwin contains: REACTED 🚀 TO 1 issue
@BrianLitwin contains: REACTED 🚀 TO #13

2) Yarn Test passes

3) `github/edges.test` includes a snapshot test to verify
that we can create an edge using ROCKET

`graphql/mirror.test` now includes "ROCKET" and "EYES" in the  example
GithubSchema, but their inclusion has no effect
on any tests.

**Screenshots**
1.
<img width="378" alt="screenshot 2019-01-22 09 02 12" src="https://user-images.githubusercontent.com/26695477/51540428-6c87b600-1e24-11e9-8334-1d9d993dce01.png">
2.
<img width="525" alt="screenshot 2019-01-22 09 02 41" src="https://user-images.githubusercontent.com/26695477/51540472-84f7d080-1e24-11e9-8847-245c0c09ddd6.png">
<br>
Shoutout to [this comment], which saved me an untold amount of head-scratching,
and also @Decentralion's help debugging in the Issue thread.

[#13]: https://github.com/sourcecred/mission/issues/13
[this comment]: https://github.com/sourcecred/sourcecred/blob/e0762303d466c6a8f86324eb84e3120c29beddb0/src/plugins/github/graphqlTypes.test.js#L13-L15