### PR TITLE
Add descriptions for EdgeTypes

### DIFF
--- a/src/analysis/fallbackDeclaration.js
+++ b/src/analysis/fallbackDeclaration.js
@@ -23,6 +23,8 @@ export const fallbackEdgeType: EdgeType = Object.freeze({
   defaultForwardWeight: 1,
   defaultBackwardWeight: 1,
   prefix: EdgeAddress.empty,
+  description:
+    "The fallback EdgeType for edges which don't have any other type",
 });
 
 export const fallbackDeclaration: PluginDeclaration = Object.freeze({

--- a/src/analysis/types.js
+++ b/src/analysis/types.js
@@ -96,4 +96,7 @@ export type EdgeType = {|
   // of this EdgeType. A given edge `e` is a member of the type `t` if
   // `EdgeAddress.hasPrefix(e.address, t.prefix) == true`
   +prefix: EdgeAddressT,
+  // The `description` property should be a human-readable string that makes
+  // it clear to a user what each EdgeType does
+  +description: string,
 |};

--- a/src/explorer/pagerankTable/Aggregation.test.js
+++ b/src/explorer/pagerankTable/Aggregation.test.js
@@ -157,6 +157,7 @@ describe("explorer/pagerankTable/Aggregation", () => {
       defaultForwardWeight: 1,
       defaultBackwardWeight: 1,
       prefix: EdgeAddress.fromParts(["look", "like"]),
+      description: "TODO: Add a description for this EdgeType",
     };
     function aggView(aggregation: FlatAggregation) {
       const el = shallow(<AggregationView aggregation={aggregation} />);

--- a/src/explorer/pagerankTable/aggregate.test.js
+++ b/src/explorer/pagerankTable/aggregate.test.js
@@ -66,6 +66,7 @@ describe("explorer/pagerankTable/aggregate", () => {
         defaultForwardWeight: 1,
         defaultBackwardWeight: 1,
         prefix: EdgeAddress.fromParts(["foo"]),
+        description: "TODO: Add a description for this EdgeType",
       },
       bar: {
         forwardName: "bars",
@@ -73,6 +74,7 @@ describe("explorer/pagerankTable/aggregate", () => {
         defaultForwardWeight: 1,
         defaultBackwardWeight: 1,
         prefix: EdgeAddress.fromParts(["bar"]),
+        description: "TODO: Add a description for this EdgeType",
       },
       empty: {
         forwardName: "empty",
@@ -80,6 +82,7 @@ describe("explorer/pagerankTable/aggregate", () => {
         defaultForwardWeight: 1,
         defaultBackwardWeight: 1,
         prefix: EdgeAddress.empty,
+        description: "TODO: Add a description for this EdgeType",
       },
     };
     const edgeTypesArray = [edgeTypes.foo, edgeTypes.bar];

--- a/src/plugins/demo/declaration.js
+++ b/src/plugins/demo/declaration.js
@@ -28,6 +28,7 @@ export const assemblesEdgeType: EdgeType = Object.freeze({
   backwardName: "is assembled by",
   defaultBackwardWeight: 2 ** -2,
   prefix: EdgeAddress.fromParts(["factorio", "assembles"]),
+  description: "TODO: Add a description for this EdgeType",
 });
 
 export const transportsEdgeType: EdgeType = Object.freeze({
@@ -36,6 +37,7 @@ export const transportsEdgeType: EdgeType = Object.freeze({
   backwardName: "is transported by",
   defaultBackwardWeight: 2 ** -1,
   prefix: EdgeAddress.fromParts(["factorio", "transports"]),
+  description: "TODO: Add a description for this EdgeType",
 });
 
 export const declaration: PluginDeclaration = Object.freeze({

--- a/src/plugins/git/declaration.js
+++ b/src/plugins/git/declaration.js
@@ -19,6 +19,7 @@ const hasParentEdgeType = Object.freeze({
   prefix: E.Prefix.hasParent,
   defaultForwardWeight: 1,
   defaultBackwardWeight: 1,
+  description: "TODO: Add a description for this EdgeType",
 });
 
 const nodeTypes = Object.freeze([commitNodeType]);

--- a/src/plugins/github/declaration.js
+++ b/src/plugins/github/declaration.js
@@ -76,6 +76,7 @@ const authorsEdgeType = Object.freeze({
   defaultForwardWeight: 1 / 2,
   defaultBackwardWeight: 1,
   prefix: E.Prefix.authors,
+  description: "TODO: Add a description for this EdgeType",
 });
 
 const hasParentEdgeType = Object.freeze({
@@ -84,6 +85,7 @@ const hasParentEdgeType = Object.freeze({
   defaultForwardWeight: 1,
   defaultBackwardWeight: 1 / 4,
   prefix: E.Prefix.hasParent,
+  description: "TODO: Add a description for this EdgeType",
 });
 
 const mergedAsEdgeType = Object.freeze({
@@ -92,6 +94,7 @@ const mergedAsEdgeType = Object.freeze({
   defaultForwardWeight: 1 / 2,
   defaultBackwardWeight: 1,
   prefix: E.Prefix.mergedAs,
+  description: "TODO: Add a description for this EdgeType",
 });
 
 const referencesEdgeType = Object.freeze({
@@ -100,6 +103,7 @@ const referencesEdgeType = Object.freeze({
   defaultForwardWeight: 1,
   defaultBackwardWeight: 1 / 16,
   prefix: E.Prefix.references,
+  description: "TODO: Add a description for this EdgeType",
 });
 
 const mentionsAuthorEdgeType = Object.freeze({
@@ -109,6 +113,7 @@ const mentionsAuthorEdgeType = Object.freeze({
   // TODO(#811): Probably change this to 0
   defaultBackwardWeight: 1 / 32,
   prefix: E.Prefix.mentionsAuthor,
+  description: "TODO: Add a description for this EdgeType",
 });
 
 const reactsHeartEdgeType = Object.freeze({
@@ -118,6 +123,7 @@ const reactsHeartEdgeType = Object.freeze({
   // TODO(#811): Probably change this to 0
   defaultBackwardWeight: 1 / 32,
   prefix: E.Prefix.reactsHeart,
+  description: "TODO: Add a description for this EdgeType",
 });
 
 const reactsThumbsUpEdgeType = Object.freeze({
@@ -127,6 +133,7 @@ const reactsThumbsUpEdgeType = Object.freeze({
   // TODO(#811): Probably change this to 0
   defaultBackwardWeight: 1 / 32,
   prefix: E.Prefix.reactsThumbsUp,
+  description: "TODO: Add a description for this EdgeType",
 });
 
 const reactsHoorayEdgeType = Object.freeze({
@@ -136,6 +143,7 @@ const reactsHoorayEdgeType = Object.freeze({
   // TODO(#811): Probably change this to 0
   defaultBackwardWeight: 1 / 32,
   prefix: E.Prefix.reactsHooray,
+  description: "TODO: Add a description for this EdgeType",
 });
 
 const edgeTypes = Object.freeze([


### PR DESCRIPTION
This is the next step in the process to display node and edge descriptions in the UI, as outlined in issue #807. In this PR, the EdgeType defintion in [src/analysis/types.js ](https://github.com/sourcecred/sourcecred/blob/master/src/analysis/types.js) has been updated to include a `+description: string` field, `yarn flow` has been run, and all EdgeTypes throughout the codebase in need of a description have been given one accordingly. _Please note that the majority of EdgeTypes have been given dummy descriptions (`description: "TODO: Add a description for this EdgeType",`) and will need to updated after the technical implementation is complete._

Note: This is a re-attempt at https://github.com/sourcecred/sourcecred/pull/1074 which was merged prematurely.

Test plan:
Verify that all tests pass, and sanity check from @decentralion.