### PR TITLE
Node and edge description tooltips

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,10 +7,9 @@
 - Enable setting type weights to 0 in the UI (#1005)
 - Add support for 🚀 and 👀 reaction types (#1068)
 - Create one page per project, rather than having a selector (#988)
-  <!-- Please add new entries to the _top_ of this section. -->
+ <!-- Please add new entries to the _top_ of this section. -->
 
 ## [0.2.0]
-
 - Cache GitHub data, allowing for incremental and resumable loading (#622)
 - Hyperlink Git commits to GitHub (#887)
 - Relicense from MIT to MIT + Apache-2 (#812)
@@ -23,7 +22,6 @@
 - Add `MentionsAuthor` edges to the graph (#808)
 
 ## [0.1.0]
-
 - Organize weight config by plugin (#773)
 - Configure edge forward/backward weights separately (#749)
 - Combine "load graph" and "run pagerank" into one button (#759)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
 - Enable setting type weights to 0 in the UI (#1005)
 - Add support for 🚀 and 👀 reaction types (#1068)
 - Create one page per project, rather than having a selector (#988)
- <!-- Please add new entries to the _top_ of this section. -->
+<!-- Please add new entries to the _top_ of this section. -->
 
 ## [0.2.0]
 - Cache GitHub data, allowing for incremental and resumable loading (#622)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,13 +1,16 @@
 # Changelog
 
 ## [Unreleased]
+
+- Add description tooltips for node and edge types in the weight configuration UI (#1081)
 - Enable loading private repositories (#1085)
 - Enable setting type weights to 0 in the UI (#1005)
 - Add support for 🚀 and 👀 reaction types (#1068)
 - Create one page per project, rather than having a selector (#988)
-<!-- Please add new entries to the _top_ of this section. -->
+  <!-- Please add new entries to the _top_ of this section. -->
 
 ## [0.2.0]
+
 - Cache GitHub data, allowing for incremental and resumable loading (#622)
 - Hyperlink Git commits to GitHub (#887)
 - Relicense from MIT to MIT + Apache-2 (#812)
@@ -20,6 +23,7 @@
 - Add `MentionsAuthor` edges to the graph (#808)
 
 ## [0.1.0]
+
 - Organize weight config by plugin (#773)
 - Configure edge forward/backward weights separately (#749)
 - Combine "load graph" and "run pagerank" into one button (#759)

--- a/src/explorer/weights/EdgeTypeConfig.js
+++ b/src/explorer/weights/EdgeTypeConfig.js
@@ -15,6 +15,7 @@ export class EdgeTypeConfig extends React.Component<{
         <EdgeWeightSlider
           name={this.props.weightedType.type.backwardName}
           weight={this.props.weightedType.forwardWeight}
+          description={this.props.weightedType.type.description}
           onChange={(forwardWeight) => {
             this.props.onChange({
               ...this.props.weightedType,
@@ -25,6 +26,7 @@ export class EdgeTypeConfig extends React.Component<{
         <EdgeWeightSlider
           name={this.props.weightedType.type.forwardName}
           weight={this.props.weightedType.backwardWeight}
+          description={this.props.weightedType.type.description}
           onChange={(backwardWeight) => {
             this.props.onChange({
               ...this.props.weightedType,
@@ -57,6 +59,7 @@ export class EdgeWeightSlider extends React.Component<WeightSliderProps> {
       <WeightSlider
         name={modifiedName}
         weight={this.props.weight}
+        description={this.props.description}
         onChange={this.props.onChange}
       />
     );

--- a/src/explorer/weights/EdgeTypeConfig.test.js
+++ b/src/explorer/weights/EdgeTypeConfig.test.js
@@ -54,7 +54,12 @@ describe("explorer/weights/EdgeTypeConfig", () => {
     function example() {
       const onChange = jest.fn();
       const element = shallow(
-        <EdgeWeightSlider weight={3} name="foo" onChange={onChange} />
+        <EdgeWeightSlider
+          weight={3}
+          name="foo"
+          description="Description for test slider"
+          onChange={onChange}
+        />
       );
       const weightSlider = element.find(WeightSlider);
       return {element, onChange, weightSlider};

--- a/src/explorer/weights/EdgeTypeConfig.test.js
+++ b/src/explorer/weights/EdgeTypeConfig.test.js
@@ -35,6 +35,12 @@ describe("explorer/weights/EdgeTypeConfig", () => {
       expect(backwardSlider.props().name).toBe(assemblesEdgeType.forwardName);
       expect(backwardSlider.props().weight).toBe(wet.backwardWeight);
     });
+    it("has a description", () => {
+      const {backwardSlider} = example();
+      expect(backwardSlider.props().description).toBe(
+        assemblesEdgeType.description
+      );
+    });
     it("forward weight slider onChange works", () => {
       const {wet, forwardSlider, onChange} = example();
       forwardSlider.props().onChange(9);

--- a/src/explorer/weights/NodeTypeConfig.js
+++ b/src/explorer/weights/NodeTypeConfig.js
@@ -13,6 +13,7 @@ export class NodeTypeConfig extends React.Component<{
       <WeightSlider
         name={this.props.weightedType.type.name}
         weight={this.props.weightedType.weight}
+        description={this.props.weightedType.type.description}
         onChange={(weight) => {
           this.props.onChange({
             ...this.props.weightedType,

--- a/src/explorer/weights/NodeTypeConfig.test.js
+++ b/src/explorer/weights/NodeTypeConfig.test.js
@@ -28,6 +28,10 @@ describe("explorer/weights/NodeTypeConfig", () => {
       expect(slider.props().name).toBe(wnt.type.name);
       expect(slider.props().weight).toBe(wnt.weight);
     });
+    it("has a description", () => {
+      const {wnt, slider} = example();
+      expect(slider.props().description).toBe(wnt.type.description);
+    });
     it("weight slider onChange works", () => {
       const {wnt, slider, onChange} = example();
       slider.props().onChange(9);

--- a/src/explorer/weights/WeightSlider.js
+++ b/src/explorer/weights/WeightSlider.js
@@ -28,6 +28,7 @@ export type Props = {|
   +name: React$Node,
   // Callback invoked with the new weight after the user adjusts the slider.
   +onChange: (Weight) => void,
+  +description: string
 |};
 
 /**
@@ -54,7 +55,7 @@ export type Props = {|
 export class WeightSlider extends React.Component<Props> {
   render() {
     return (
-      <label style={{display: "flex"}}>
+      <label style={{display: "flex"}} title={this.props.description}>
         <span style={{flexGrow: 1}}>{this.props.name}</span>
         <input
           type="range"

--- a/src/explorer/weights/WeightSlider.js
+++ b/src/explorer/weights/WeightSlider.js
@@ -28,7 +28,7 @@ export type Props = {|
   +name: React$Node,
   // Callback invoked with the new weight after the user adjusts the slider.
   +onChange: (Weight) => void,
-  +description: string
+  +description: string,
 |};
 
 /**

--- a/src/explorer/weights/WeightSlider.test.js
+++ b/src/explorer/weights/WeightSlider.test.js
@@ -69,6 +69,15 @@ describe("explorer/weights/WeightSlider", () => {
         expect(onChange).toHaveBeenCalledWith(sliderToWeight(sliderVal));
       }
     });
+    it("has a description tooltip", () => {
+      const {element} = example(0);
+      expect(
+        element
+          .find("label")
+          .at(0)
+          .prop("title")
+      ).toBe("A test description");
+    });
     it("the weight and slider position may be inconsistent", () => {
       // If the weight does not correspond to an integer slider value, then
       // changing the slider to its current position can change the weight.

--- a/src/explorer/weights/WeightSlider.test.js
+++ b/src/explorer/weights/WeightSlider.test.js
@@ -20,7 +20,7 @@ describe("explorer/weights/WeightSlider", () => {
     function example(weight: Weight) {
       const onChange = jest.fn();
       const element = shallow(
-        <WeightSlider weight={weight} name="foo" onChange={onChange} />
+        <WeightSlider weight={weight} name="foo" onChange={onChange} description="A test description" />
       );
       return {element, onChange};
     }

--- a/src/explorer/weights/WeightSlider.test.js
+++ b/src/explorer/weights/WeightSlider.test.js
@@ -20,7 +20,12 @@ describe("explorer/weights/WeightSlider", () => {
     function example(weight: Weight) {
       const onChange = jest.fn();
       const element = shallow(
-        <WeightSlider weight={weight} name="foo" onChange={onChange} description="A test description" />
+        <WeightSlider
+          weight={weight}
+          name="foo"
+          onChange={onChange}
+          description="A test description"
+        />
       );
       return {element, onChange};
     }


### PR DESCRIPTION
Adds tooltip showing edge and node type descriptions to weigh configuration sliders in SourceCred UI. Addresses issue #807. (The diff will make more sense once the revert in #1079 is approved and merged.)

Test plan:

Start SourceCred, open the weight config, and mouse over a node type name. Confirm that you see a tooltip describing that node type. Do the same for an edge type and verify that there's a tooltip.


 