### PR TITLE
Fix a build break due to merge conflicts

### DIFF
--- a/src/plugins/github/declaration.js
+++ b/src/plugins/github/declaration.js
@@ -153,6 +153,7 @@ const reactsRocketEdgeType = Object.freeze({
   // TODO(#811): Probably change this to 0
   defaultBackwardWeight: 1 / 32,
   prefix: E.Prefix.reactsRocket,
+  description: "TODO: Add a description for this EdgeType",
 });
 
 const edgeTypes = Object.freeze([


### PR DESCRIPTION
PR #1075 added a new EdgeType, and #1080 added a new field to EdgeTypes.
Both PRs merged and this broke the build.

This very trivial commit fixes the build breakage in a noncontroversial
way (copies the placeholder edge description used for every other edge
over).

Test plan: `yarn test` passes.