### PR TITLE
Fill in edge type descriptions

### DIFF
--- a/src/analysis/types.js
+++ b/src/analysis/types.js
@@ -80,23 +80,45 @@ export type EdgeType = {|
   // means. For example, for the GitHub REFERENCES edge type, the forwardName
   // is "references"
   +forwardName: string,
+
   // A brief descriptive name of what the "backward" direction of the edge
   // means. For example, for the GitHub REFERENCES edge type, the backwardName
   // is "referenced by"
   +backwardName: string,
+
   // The default weight for the forward direction of this edge.
   // We use `1` as a default value ("of normal importance").
   // The weights have linear importance, i.e. 2 is twice as important as 1.
   +defaultForwardWeight: number,
+
   // The default weight for the backward direction of this edge.
   // We use `1` as a default value ("of normal importance").
   // The weights have linear importance, i.e. 2 is twice as important as 1.
   +defaultBackwardWeight: number,
+
   // The address that will be used to test whether an edge is a member
   // of this EdgeType. A given edge `e` is a member of the type `t` if
   // `EdgeAddress.hasPrefix(e.address, t.prefix) == true`
   +prefix: EdgeAddressT,
+
   // The `description` property should be a human-readable string that makes
-  // it clear to a user what each EdgeType does
+  // it clear to a user what each EdgeType does.
+  //
+  // By convention, the first line of the description should be a sentence
+  // beginning with the word "Connects", which describes what kinds of nodes
+  // the edge connects and why. Optionally, you may provide examples and additional
+  // context after one blank link. Here is an example (for the "Merged As" edge).
+  //
+  // ```js
+  // const mergedAsDescription = dedent`\
+  //  Connects a GitHub pull request to the Git commit it merged.
+  //
+  //  A pull request can have either one or zero Merged As edges, depending on
+  //  whether or not it was ever merged.
+  //  `
+  // ```
+  //
+  // (Note the use of the `util/dedent.js` makes it easier to write multi-lined
+  // strings with clean formatting.)
   +description: string,
 |};

--- a/src/explorer/pagerankTable/Aggregation.test.js
+++ b/src/explorer/pagerankTable/Aggregation.test.js
@@ -157,7 +157,7 @@ describe("explorer/pagerankTable/Aggregation", () => {
       defaultForwardWeight: 1,
       defaultBackwardWeight: 1,
       prefix: EdgeAddress.fromParts(["look", "like"]),
-      description: "TODO: Add a description for this EdgeType",
+      description: "An example EdgeType for testing purposes",
     };
     function aggView(aggregation: FlatAggregation) {
       const el = shallow(<AggregationView aggregation={aggregation} />);

--- a/src/explorer/pagerankTable/Aggregation.test.js
+++ b/src/explorer/pagerankTable/Aggregation.test.js
@@ -157,7 +157,7 @@ describe("explorer/pagerankTable/Aggregation", () => {
       defaultForwardWeight: 1,
       defaultBackwardWeight: 1,
       prefix: EdgeAddress.fromParts(["look", "like"]),
-      description: "An example EdgeType for testing purposes",
+      description: "Connects example nodes for testing purposes.",
     };
     function aggView(aggregation: FlatAggregation) {
       const el = shallow(<AggregationView aggregation={aggregation} />);

--- a/src/explorer/pagerankTable/aggregate.test.js
+++ b/src/explorer/pagerankTable/aggregate.test.js
@@ -66,7 +66,7 @@ describe("explorer/pagerankTable/aggregate", () => {
         defaultForwardWeight: 1,
         defaultBackwardWeight: 1,
         prefix: EdgeAddress.fromParts(["foo"]),
-        description: "TODO: Add a description for this EdgeType",
+        description: "The 'foo' example edge type",
       },
       bar: {
         forwardName: "bars",
@@ -74,7 +74,7 @@ describe("explorer/pagerankTable/aggregate", () => {
         defaultForwardWeight: 1,
         defaultBackwardWeight: 1,
         prefix: EdgeAddress.fromParts(["bar"]),
-        description: "TODO: Add a description for this EdgeType",
+        description: "The 'bar' example edge type",
       },
       empty: {
         forwardName: "empty",
@@ -82,7 +82,7 @@ describe("explorer/pagerankTable/aggregate", () => {
         defaultForwardWeight: 1,
         defaultBackwardWeight: 1,
         prefix: EdgeAddress.empty,
-        description: "TODO: Add a description for this EdgeType",
+        description: "The empty edge type (matches all edges)",
       },
     };
     const edgeTypesArray = [edgeTypes.foo, edgeTypes.bar];

--- a/src/explorer/pagerankTable/aggregate.test.js
+++ b/src/explorer/pagerankTable/aggregate.test.js
@@ -66,7 +66,7 @@ describe("explorer/pagerankTable/aggregate", () => {
         defaultForwardWeight: 1,
         defaultBackwardWeight: 1,
         prefix: EdgeAddress.fromParts(["foo"]),
-        description: "The 'foo' example edge type",
+        description: "Connects example foo edges.",
       },
       bar: {
         forwardName: "bars",
@@ -74,7 +74,7 @@ describe("explorer/pagerankTable/aggregate", () => {
         defaultForwardWeight: 1,
         defaultBackwardWeight: 1,
         prefix: EdgeAddress.fromParts(["bar"]),
-        description: "The 'bar' example edge type",
+        description: "Connects example bar edges.",
       },
       empty: {
         forwardName: "empty",
@@ -82,7 +82,7 @@ describe("explorer/pagerankTable/aggregate", () => {
         defaultForwardWeight: 1,
         defaultBackwardWeight: 1,
         prefix: EdgeAddress.empty,
-        description: "The empty edge type (matches all edges)",
+        description: "Connects arbitrary edges.",
       },
     };
     const edgeTypesArray = [edgeTypes.foo, edgeTypes.bar];

--- a/src/plugins/demo/declaration.js
+++ b/src/plugins/demo/declaration.js
@@ -28,7 +28,7 @@ export const assemblesEdgeType: EdgeType = Object.freeze({
   backwardName: "is assembled by",
   defaultBackwardWeight: 2 ** -2,
   prefix: EdgeAddress.fromParts(["factorio", "assembles"]),
-  description: "TODO: Add a description for this EdgeType",
+  description: "Demo assembly edge type",
 });
 
 export const transportsEdgeType: EdgeType = Object.freeze({
@@ -37,7 +37,7 @@ export const transportsEdgeType: EdgeType = Object.freeze({
   backwardName: "is transported by",
   defaultBackwardWeight: 2 ** -1,
   prefix: EdgeAddress.fromParts(["factorio", "transports"]),
-  description: "TODO: Add a description for this EdgeType",
+  description: "Demo transportation edge type",
 });
 
 export const declaration: PluginDeclaration = Object.freeze({

--- a/src/plugins/demo/declaration.js
+++ b/src/plugins/demo/declaration.js
@@ -28,7 +28,7 @@ export const assemblesEdgeType: EdgeType = Object.freeze({
   backwardName: "is assembled by",
   defaultBackwardWeight: 2 ** -2,
   prefix: EdgeAddress.fromParts(["factorio", "assembles"]),
-  description: "Demo assembly edge type",
+  description: "Connects assembly machines to products they assemble.",
 });
 
 export const transportsEdgeType: EdgeType = Object.freeze({
@@ -37,7 +37,7 @@ export const transportsEdgeType: EdgeType = Object.freeze({
   backwardName: "is transported by",
   defaultBackwardWeight: 2 ** -1,
   prefix: EdgeAddress.fromParts(["factorio", "transports"]),
-  description: "Demo transportation edge type",
+  description: "Connects transporter belts to objects they transport.",
 });
 
 export const declaration: PluginDeclaration = Object.freeze({

--- a/src/plugins/git/declaration.js
+++ b/src/plugins/git/declaration.js
@@ -19,7 +19,8 @@ const hasParentEdgeType = Object.freeze({
   prefix: E.Prefix.hasParent,
   defaultForwardWeight: 1,
   defaultBackwardWeight: 1,
-  description: "TODO: Add a description for this EdgeType",
+  description:
+    "A Git hasParent edge connects a Git commit to its parent commit(s).",
 });
 
 const nodeTypes = Object.freeze([commitNodeType]);

--- a/src/plugins/git/declaration.js
+++ b/src/plugins/git/declaration.js
@@ -19,8 +19,7 @@ const hasParentEdgeType = Object.freeze({
   prefix: E.Prefix.hasParent,
   defaultForwardWeight: 1,
   defaultBackwardWeight: 1,
-  description:
-    "A Git hasParent edge connects a Git commit to its parent commit(s).",
+  description: "Connects a Git commit to its parent commit(s).",
 });
 
 const nodeTypes = Object.freeze([commitNodeType]);

--- a/src/plugins/github/declaration.js
+++ b/src/plugins/github/declaration.js
@@ -78,8 +78,9 @@ const authorsEdgeType = Object.freeze({
   defaultBackwardWeight: 1,
   prefix: E.Prefix.authors,
   description: dedent`\
-    An authors edge connects a GitHub userlike account to a post\
-    that they authored. Examples of posts include issues, pull requests, and comments.
+    Connects a GitHub account to a post that they authored.
+
+    Examples of posts include issues, pull requests, and comments.
   `,
 });
 
@@ -90,7 +91,8 @@ const hasParentEdgeType = Object.freeze({
   defaultBackwardWeight: 1 / 4,
   prefix: E.Prefix.hasParent,
   description: dedent`\
-    A hasParent edge connects a GitHub entity to its child entities.
+    Connects a GitHub entity to its child posts.
+
     For example, a Repository has Issues and Pull Requests as children, and a
     Pull Request has comments and reviews as children.
   `,
@@ -103,8 +105,7 @@ const mergedAsEdgeType = Object.freeze({
   defaultBackwardWeight: 1,
   prefix: E.Prefix.mergedAs,
   description: dedent`\
-    A mergedAs edge connects a GitHub pull request to the commit that it merges,
-    assuming that the pull request has merged.
+    Connects a GitHub pull request to the Git commit that it merges.
   `,
 });
 
@@ -115,10 +116,11 @@ const referencesEdgeType = Object.freeze({
   defaultBackwardWeight: 0,
   prefix: E.Prefix.references,
   description: dedent`\
-    A references edge connects a GitHub post to a GitHub entity that it
-    references. For example, if you write a GitHub issue comment that says
-    "thanks @username for pull #1337", it will create references edges to both
-    the user @username, and to pull #1337 in the same repository.
+    Connects a GitHub post to an entity that it references.
+
+    For example, if you write a GitHub issue comment that says "thanks
+    @username for pull #1337", it will create references edges to both the user
+    @username, and to pull #1337 in the same repository.
   `,
 });
 
@@ -129,9 +131,10 @@ const mentionsAuthorEdgeType = Object.freeze({
   defaultBackwardWeight: 0,
   prefix: E.Prefix.mentionsAuthor,
   description: dedent`\
-    When a post in a particular thread mentions a particular user, that post
-    will have a \`MentionsAuthorEdge\` connecting it to any posts written by the
-    mentioned user. The intuition is that if a post is mentioning an author by name,
+    Connects a post which mentions a user to posts in the same thread that
+    were authored by the mentioned user.
+
+    The intuition is that if a post is mentioning an author by name,
     their contributions in that thread are probably particularly valuable.
 
     This is an experimental feature and may be removed in a future version of SourceCred.
@@ -145,7 +148,7 @@ const reactsHeartEdgeType = Object.freeze({
   defaultBackwardWeight: 0,
   prefix: E.Prefix.reactsHeart,
   description: dedent`\
-    A reactsHeart edge connects users to posts that they gave a ❤️ reaction to.
+    Connects users to posts to which they gave a ❤️ reaction.
   `,
 });
 
@@ -156,7 +159,7 @@ const reactsThumbsUpEdgeType = Object.freeze({
   defaultBackwardWeight: 0,
   prefix: E.Prefix.reactsThumbsUp,
   description: dedent`\
-    A reactsThumbsUp edge connects users to posts that they gave a 👍 reaction to.
+    Connects users to posts to which they gave a 👍 reaction.
   `,
 });
 
@@ -167,7 +170,7 @@ const reactsHoorayEdgeType = Object.freeze({
   defaultBackwardWeight: 0,
   prefix: E.Prefix.reactsHooray,
   description: dedent`\
-    A reactsHooray edge connects users to posts that they gave a 🎉 reaction to.
+    Connects users to posts to which they gave a 🎉 reaction.
   `,
 });
 
@@ -178,7 +181,7 @@ const reactsRocketEdgeType = Object.freeze({
   defaultBackwardWeight: 0,
   prefix: E.Prefix.reactsRocket,
   description: dedent`\
-    A reactsRocket edge connects users to posts that they gave a 🚀 reaction to.
+    Connects users to posts to which they gave a 🚀 reaction.
   `,
 });
 

--- a/src/plugins/github/declaration.js
+++ b/src/plugins/github/declaration.js
@@ -91,7 +91,7 @@ const hasParentEdgeType = Object.freeze({
   defaultBackwardWeight: 1 / 4,
   prefix: E.Prefix.hasParent,
   description: dedent`\
-    Connects a GitHub entity to its child posts.
+    Connects a GitHub entity to its child entities.
 
     For example, a Repository has Issues and Pull Requests as children, and a
     Pull Request has comments and reviews as children.
@@ -131,7 +131,7 @@ const mentionsAuthorEdgeType = Object.freeze({
   defaultBackwardWeight: 0,
   prefix: E.Prefix.mentionsAuthor,
   description: dedent`\
-    Connects a post which mentions a user to posts in the same thread that
+    Connects a post that mentions a user to posts in the same thread that
     were authored by the mentioned user.
 
     The intuition is that if a post is mentioning an author by name,

--- a/src/plugins/github/declaration.js
+++ b/src/plugins/github/declaration.js
@@ -3,6 +3,7 @@
 import type {PluginDeclaration} from "../../analysis/pluginDeclaration";
 import * as N from "./nodes";
 import * as E from "./edges";
+import dedent from "../../util/dedent";
 
 const repoNodeType = Object.freeze({
   name: "Repository",
@@ -76,7 +77,10 @@ const authorsEdgeType = Object.freeze({
   defaultForwardWeight: 1 / 2,
   defaultBackwardWeight: 1,
   prefix: E.Prefix.authors,
-  description: "TODO: Add a description for this EdgeType",
+  description: dedent`\
+    An authors edge connects a GitHub userlike account to a post\
+    that they authored. Examples of posts include issues, pull requests, and comments.
+  `,
 });
 
 const hasParentEdgeType = Object.freeze({
@@ -85,7 +89,11 @@ const hasParentEdgeType = Object.freeze({
   defaultForwardWeight: 1,
   defaultBackwardWeight: 1 / 4,
   prefix: E.Prefix.hasParent,
-  description: "TODO: Add a description for this EdgeType",
+  description: dedent`\
+    A hasParent edge connects a GitHub entity to its child entities.
+    For example, a Repository has Issues and Pull Requests as children, and a
+    Pull Request has comments and reviews as children.
+  `,
 });
 
 const mergedAsEdgeType = Object.freeze({
@@ -94,7 +102,10 @@ const mergedAsEdgeType = Object.freeze({
   defaultForwardWeight: 1 / 2,
   defaultBackwardWeight: 1,
   prefix: E.Prefix.mergedAs,
-  description: "TODO: Add a description for this EdgeType",
+  description: dedent`\
+    A mergedAs edge connects a GitHub pull request to the commit that it merges,
+    assuming that the pull request has merged.
+  `,
 });
 
 const referencesEdgeType = Object.freeze({
@@ -103,7 +114,12 @@ const referencesEdgeType = Object.freeze({
   defaultForwardWeight: 1,
   defaultBackwardWeight: 0,
   prefix: E.Prefix.references,
-  description: "TODO: Add a description for this EdgeType",
+  description: dedent`\
+    A references edge connects a GitHub post to a GitHub entity that it
+    references. For example, if you write a GitHub issue comment that says
+    "thanks @username for pull #1337", it will create references edges to both
+    the user @username, and to pull #1337 in the same repository.
+  `,
 });
 
 const mentionsAuthorEdgeType = Object.freeze({
@@ -112,7 +128,14 @@ const mentionsAuthorEdgeType = Object.freeze({
   defaultForwardWeight: 1,
   defaultBackwardWeight: 0,
   prefix: E.Prefix.mentionsAuthor,
-  description: "TODO: Add a description for this EdgeType",
+  description: dedent`\
+    When a post in a particular thread mentions a particular user, that post
+    will have a \`MentionsAuthorEdge\` connecting it to any posts written by the
+    mentioned user. The intuition is that if a post is mentioning an author by name,
+    their contributions in that thread are probably particularly valuable.
+
+    This is an experimental feature and may be removed in a future version of SourceCred.
+  `,
 });
 
 const reactsHeartEdgeType = Object.freeze({
@@ -121,7 +144,9 @@ const reactsHeartEdgeType = Object.freeze({
   defaultForwardWeight: 2,
   defaultBackwardWeight: 0,
   prefix: E.Prefix.reactsHeart,
-  description: "TODO: Add a description for this EdgeType",
+  description: dedent`\
+    A reactsHeart edge connects users to posts that they gave a ❤️ reaction to.
+  `,
 });
 
 const reactsThumbsUpEdgeType = Object.freeze({
@@ -130,7 +155,9 @@ const reactsThumbsUpEdgeType = Object.freeze({
   defaultForwardWeight: 1,
   defaultBackwardWeight: 0,
   prefix: E.Prefix.reactsThumbsUp,
-  description: "TODO: Add a description for this EdgeType",
+  description: dedent`\
+    A reactsThumbsUp edge connects users to posts that they gave a 👍 reaction to.
+  `,
 });
 
 const reactsHoorayEdgeType = Object.freeze({
@@ -139,7 +166,9 @@ const reactsHoorayEdgeType = Object.freeze({
   defaultForwardWeight: 4,
   defaultBackwardWeight: 0,
   prefix: E.Prefix.reactsHooray,
-  description: "TODO: Add a description for this EdgeType",
+  description: dedent`\
+    A reactsHooray edge connects users to posts that they gave a 🎉 reaction to.
+  `,
 });
 
 const reactsRocketEdgeType = Object.freeze({
@@ -148,7 +177,9 @@ const reactsRocketEdgeType = Object.freeze({
   defaultForwardWeight: 1,
   defaultBackwardWeight: 0,
   prefix: E.Prefix.reactsRocket,
-  description: "TODO: Add a description for this EdgeType",
+  description: dedent`\
+    A reactsRocket edge connects users to posts that they gave a 🚀 reaction to.
+  `,
 });
 
 const edgeTypes = Object.freeze([


### PR DESCRIPTION
Pull #1080 added in a description field for edge types, but put in a
placeholder message for each actual description. This pull adds in
descriptions for each edge type.

Test plan: `yarn test` passes, and additionally
`git grep 'TODO: Add a description for this edge type'` returns no hits.