### PR TITLE
Enable loading private git repositories

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## [Unreleased]
+- Enable loading private repositories (#1085)
 - Enable setting type weights to 0 in the UI (#1005)
 - Add support for 🚀 and 👀 reaction types (#1068)
 - Create one page per project, rather than having a selector (#988)

--- a/src/plugins/git/cloneAndLoadRepository.js
+++ b/src/plugins/git/cloneAndLoadRepository.js
@@ -16,7 +16,7 @@ import type {RepoId} from "../../core/repoId";
  *   the parsed Repository from the cloned repo
  */
 export default function cloneAndLoadRepository(repoId: RepoId): Repository {
-  const cloneUrl = `https://github.com/${repoId.owner}/${repoId.name}.git`;
+  const cloneUrl = `git@github.com:${repoId.owner}/${repoId.name}.git`;
   const tmpdir = tmp.dirSync({unsafeCleanup: true});
   const git = localGit(tmpdir.name);
   git(["clone", cloneUrl, ".", "--quiet"]);

--- a/src/plugins/git/gitUtils.js
+++ b/src/plugins/git/gitUtils.js
@@ -4,6 +4,7 @@ import {execFileSync} from "child_process";
 import fs from "fs";
 import mkdirp from "mkdirp";
 import path from "path";
+import process from "process";
 
 export interface Utils {
   exec: GitDriver;
@@ -35,6 +36,10 @@ export function localGit(repositoryPath: string): GitDriver {
       // Ignore global Git settings, for test isolation.
       GIT_CONFIG_NOSYSTEM: "1",
       GIT_ATTR_NOSYSTEM: "1",
+      // Bring over the SSH configuration so that loading private repos is possible
+      // This post has some useful information on SSH_AUTH_SOCK:
+      // http://blog.joncairns.com/2013/12/understanding-ssh-agent-and-ssh-add/
+      SSH_AUTH_SOCK: process.env.SSH_AUTH_SOCK,
       ...(env || {}),
     };
     const options = {env: fullEnv};

--- a/src/plugins/git/gitUtils.js
+++ b/src/plugins/git/gitUtils.js
@@ -4,7 +4,6 @@ import {execFileSync} from "child_process";
 import fs from "fs";
 import mkdirp from "mkdirp";
 import path from "path";
-import process from "process";
 
 export interface Utils {
   exec: GitDriver;


### PR DESCRIPTION
This commit enables loading private repositories, assuming that the user
has ssh-agent configured with keys to allow cloning the private
repository, and has provided a GitHub API token with permissions for the
repository in question.

I have not added automated testing. I don't think a cost-benefit
analysis favors adding such tests at this time:
- This code changes very infrequently, and so is unlikely to break
- If it does break, it will be pretty easy to catch and to fix
- the @sourcecred org is on a free plan, which doesn't allow private
repos, so setting up the test case is a bit of a pain

Test plan: `yarn test --full` passes, so I haven't broken existing Git
clone behavior. Locally, I am able to load private repositories.