### PR TITLE
PagerankGraph: Add toJSON/fromJSON

### DIFF
--- a/src/core/__snapshots__/pagerankGraph.test.js.snap
+++ b/src/core/__snapshots__/pagerankGraph.test.js.snap
@@ -1,0 +1,76 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`core/pagerankGraph to/from JSON matches expected snapshot 1`] = `
+Array [
+  Object {
+    "type": "sourcecred/pagerankGraph",
+    "version": "0.1.0",
+  },
+  Object {
+    "froWeights": Array [
+      0,
+      0,
+      0,
+    ],
+    "graphJSON": Array [
+      Object {
+        "type": "sourcecred/graph",
+        "version": "0.4.0",
+      },
+      Object {
+        "edges": Array [
+          Object {
+            "address": Array [
+              "hom",
+              "1",
+            ],
+            "dstIndex": 0,
+            "srcIndex": 3,
+          },
+          Object {
+            "address": Array [
+              "hom",
+              "2",
+            ],
+            "dstIndex": 0,
+            "srcIndex": 3,
+          },
+          Object {
+            "address": Array [
+              "loop",
+            ],
+            "dstIndex": 2,
+            "srcIndex": 2,
+          },
+        ],
+        "nodes": Array [
+          Array [
+            "dst",
+          ],
+          Array [
+            "isolated",
+          ],
+          Array [
+            "loop",
+          ],
+          Array [
+            "src",
+          ],
+        ],
+      },
+    ],
+    "scores": Array [
+      0.25,
+      0.25,
+      0.25,
+      0.25,
+    ],
+    "syntheticLoopWeight": 0.001,
+    "toWeights": Array [
+      1,
+      1,
+      1,
+    ],
+  },
+]
+`;

--- a/src/core/pagerankGraph.test.js
+++ b/src/core/pagerankGraph.test.js
@@ -229,4 +229,33 @@ describe("core/pagerankGraph", () => {
       expect(() => pg.equals(pg)).toThrowError("has been modified");
     });
   });
+
+  describe("to/from JSON", () => {
+    it("to->fro is identity", async () => {
+      const pg = examplePagerankGraph();
+      await pg.runPagerank({maxIterations: 1, convergenceThreshold: 0.01});
+      const pgJSON = pg.toJSON();
+      const pg_ = PagerankGraph.fromJSON(pgJSON);
+      expect(pg.equals(pg_)).toBe(true);
+    });
+    it("fro->to is identity", async () => {
+      const pg = examplePagerankGraph();
+      await pg.runPagerank({maxIterations: 1, convergenceThreshold: 0.01});
+      const pgJSON = pg.toJSON();
+      const pg_ = PagerankGraph.fromJSON(pgJSON);
+      const pgJSON_ = pg_.toJSON();
+      expect(pgJSON).toEqual(pgJSON_);
+    });
+    it("is canonical with respect to the graph's history", async () => {
+      const pg1 = new PagerankGraph(advancedGraph().graph1(), defaultEvaluator);
+      const pg2 = new PagerankGraph(advancedGraph().graph2(), defaultEvaluator);
+      const pg1JSON = pg1.toJSON();
+      const pg2JSON = pg2.toJSON();
+      expect(pg1JSON).toEqual(pg2JSON);
+    });
+    it("matches expected snapshot", () => {
+      const pgJSON = examplePagerankGraph().toJSON();
+      expect(pgJSON).toMatchSnapshot();
+    });
+  });
 });


### PR DESCRIPTION
This commit adds serialization logic to `PagerankGraph`. As with many
things in PagerankGraph, it's based on the corresponding logic in `Graph`.
Much like graph, it stores data associated with nodes and edges (in this
case, the scores and edge weights) in an ordered array rather than a
map, so as to avoid repetitiously serializing the node and edge
addresses.

Test plan: Unit tests added, and they should be sufficient. Also take a
look at the included snapshot.