### PR TITLE
[draft] Add an org-mode to `sourcecred load`

### DIFF
--- a/src/plugins/github/fetchReposForOrg.js
+++ b/src/plugins/github/fetchReposForOrg.js
@@ -1,0 +1,70 @@
+// @flow
+
+import {type RepoId, makeRepoId} from "../../core/repoId";
+import dedent from "../../util/dedent";
+
+const GITHUB_GRAPHQL_SERVER = "https://api.github.com/graphql";
+async function ghquery(query, token): any {
+  const body = JSON.stringify({query});
+  const fetchOptions = {
+    method: "POST",
+    body,
+    headers: {
+      Authorization: `bearer ${token}`,
+    },
+  };
+  const response = await fetch(GITHUB_GRAPHQL_SERVER, fetchOptions);
+  const json = await response.json();
+  if (json.errors) {
+    throw json.errors;
+  }
+  return json;
+}
+
+export async function fetchReposForOrg(
+  org: string,
+  token: string
+): Promise<$ReadOnlyArray<RepoId>> {
+  const query = dedent`\
+  {
+    search(query: "org:${org}", type: REPOSITORY, first: 50) {
+      nodes {
+        ... on Repository {
+          name
+        }
+      }
+      pageInfo {
+        endCursor
+        hasNextPage
+      }
+    }
+  }
+  `;
+  let json = await ghquery(query, token);
+  console.log(json);
+  let repos = json.data.search.nodes.map((x) => makeRepoId(org, x.name));
+  while (json.data.search.pageInfo.hasNextPage) {
+    const query = dedent`\
+  {
+    search(query: "org:${org}", type: REPOSITORY, first: 50, after: "${
+      json.data.search.pageInfo.endCursor
+    }") {
+      nodes {
+        ... on Repository {
+          name
+        }
+      }
+      pageInfo {
+        endCursor
+        hasNextPage
+      }
+    }
+  }
+  `;
+    json = await ghquery(query, token);
+    const newRepos = json.data.search.nodes.map((x) => makeRepoId(org, x.name));
+    repos = repos.concat(newRepos);
+  }
+  console.log(repos);
+  return repos;
+}


### PR DESCRIPTION
It's common for a project to be split up under many repositories; e.g.
ipfs has 238. We have a feature that allows the user to aggregate cred
for many repositories into one output, but doing so for 238 repos is
incredibly tedious.

This commit adds a `--organization` flag to `sourcecred load` which
loads all non-fork repositories for a given organization, and saves it
to the repoId `organization/combined`.

The list of non-fork repositories is retrieved by using the GitHub
GraphQL search API. Currently, this is implemented without the benefit
of re-using any of our other GraphQL logic; we should probably
de-duplicate it before merging.

Test plan: I've used this for several orgs for demos and it's worked;
hoewver, we should test it before merging.