### PR TITLE
Add optional node prefix filter to pagerankGraph

### DIFF
--- a/src/core/pagerankGraph.js
+++ b/src/core/pagerankGraph.js
@@ -186,8 +186,8 @@ export class PagerankGraph {
     return this._syntheticLoopWeight;
   }
 
-  *_nodesIterator(): Iterator<ScoredNode> {
-    for (const node of this._graph.nodes()) {
+  *_nodesIterator(options?: {|+prefix: NodeAddressT|}): Iterator<ScoredNode> {
+    for (const node of this._graph.nodes(options)) {
       const score = NullUtil.get(this._scores.get(node));
       yield {node, score};
     }
@@ -196,11 +196,13 @@ export class PagerankGraph {
   /**
    * Provides node and score for every node in the underlying graph.
    *
-   * TODO(#1020): Allow optional filtering, as in Graph.nodes.
+   * Optionally, provide a node prefix to return an iterator containing
+   * only node/score objects whose nodes match the provided node prefix.
+   * See Graph.nodes and Address.hasPrefix for details.
    */
-  nodes(): Iterator<ScoredNode> {
+  nodes(options?: {|+prefix: NodeAddressT|}): Iterator<ScoredNode> {
     this._verifyGraphNotModified();
-    return this._nodesIterator();
+    return this._nodesIterator(options);
   }
 
   /**


### PR DESCRIPTION
Continuing work on #1020.
Adding an optional parameter to `nodes()` which enables optional
node prefix filtering.

Test plan:

@decentralion suggested on Discord that the tests should verify:
1) the parameter was passed to `_graph` correctly
2) the augmentation logic was applied correctly

The tests I added are identical to the tests in `graph.test`, except
that they verify that the result of `pagerankGraph` matches that of
`graph`. On one hand, this creates a dependence on `graph`,
as these tests don't verify that the filter works correctly, only that
graph has applied the filter and returned the iterator.
However, my prevailing thought is that it isn't `pagerankGraph's` responsibility
to test the behavior of `graph`, and so testing the exact filter results
of `pagerankGraph` like we do in `graph.test` isn't the best strategy, and
testing that `pagerankGraph`'s results equal `graph`'s results is a better strategy.

The tests also check that a `score` is provided alongside each `node` in the iterator,
to minimally satisfy @decentralion's second spec.

yarn test passes.