### PR TITLE
Add empty node prefix test case to graph.test

### DIFF
--- a/src/core/graph.test.js
+++ b/src/core/graph.test.js
@@ -381,6 +381,9 @@ describe("core/graph", () => {
         it("does a prefix filter", () => {
           expectSortedNodes({prefix: n2}, [n2, n3]);
         });
+        it("empty prefix matches all nodes", () => {
+          expectSortedNodes({prefix: NodeAddress.empty}, [n1, n2, n3, n4]);
+        });
         it("yields nothing when prefix matches nothing", () => {
           expectSortedNodes({prefix: NodeAddress.fromParts(["2"])}, []);
         });


### PR DESCRIPTION
Suggested by @decentralion in his review of #1090

Test plan:
yarn test passes. Also verified that the new test case is
failable, if you pass in the wrong array of nodes to `expect()` or
if you mangle the node filter code.