### PR TITLE
Mirror Refinements 1: added Fidelity types to schema module

### DIFF
--- a/src/graphql/generateFlowTypes.js
+++ b/src/graphql/generateFlowTypes.js
@@ -48,12 +48,18 @@ export default function generateFlowTypes(
     }
   }
   function formatNodeField(field: NodeFieldType): string {
+    if (field.fidelity.type === "UNFAITHFUL") {
+      throw new Error("Unfaithful Fidelity not yet supported");
+    }
     return "null | " + field.elementType;
   }
   function formatConnectionField(field: ConnectionFieldType): string {
     return `$ReadOnlyArray<null | ${field.elementType}>`;
   }
   function formatNestedField(field: NestedFieldType): string {
+    if (field.fidelity.type === "UNFAITHFUL") {
+      throw new Error("Unfaithful Fidelity not yet supported");
+    }
     const eggs = [];
     for (const eggName of Object.keys(field.eggs).sort()) {
       eggs.push({eggName, rhs: formatField(field.eggs[eggName])});

--- a/src/graphql/generateFlowTypes.test.js
+++ b/src/graphql/generateFlowTypes.test.js
@@ -142,5 +142,44 @@ describe("graphql/generateFlowTypes", () => {
       });
       expect(run(s1)).toEqual(run(s2));
     });
+
+    it("throws on unfaithful node", () => {
+      const s = Schema;
+      const schema = s.schema({
+        Actor: s.union(["Human", "TalentedChimpanzee"]),
+        Human: s.object({
+          id: s.id(),
+          oldPainter: s.node("Actor", s.unfaithful(["Actor"])),
+        }),
+        TalentedChimpanzee: s.object({
+          id: s.id(),
+        }),
+      });
+      expect(() => run(schema)).toThrow(
+        "Unfaithful Fidelity not yet supported"
+      );
+    });
+
+    it("throws on unfaithful nested node", () => {
+      const s = Schema;
+      const schema = s.schema({
+        PaintJob: s.object({
+          id: s.id(),
+          details: s.nested({
+            oldPainter: s.node("Actor", s.unfaithful(["oldPainter"])),
+          }),
+        }),
+        Actor: s.union(["Human", "TalentedChimpanzee"]),
+        Human: s.object({
+          id: s.id(),
+        }),
+        TalentedChimpanzee: s.object({
+          id: s.id(),
+        }),
+      });
+      expect(() => run(schema)).toThrow(
+        "Unfaithful Fidelity not yet supported"
+      );
+    });
   });
 });

--- a/src/graphql/mirror.js
+++ b/src/graphql/mirror.js
@@ -1133,6 +1133,13 @@ export class Mirror {
             case "PRIMITIVE":
               return b.field(fieldname);
             case "NODE":
+              // istanbul ignore if
+              if (field.fidelity.type === "UNFAITHFUL") {
+                throw new Error(
+                  "Invariant violation: unfaithful fidelity " +
+                    JSON.stringify(field)
+                );
+              }
               return b.field(
                 fieldname,
                 {},
@@ -1151,6 +1158,13 @@ export class Mirror {
                     case "PRIMITIVE":
                       return b.field(childFieldname);
                     case "NODE":
+                      // istanbul ignore if
+                      if (field.fidelity.type === "UNFAITHFUL") {
+                        throw new Error(
+                          "Invariant violation: unfaithful fidelity " +
+                            JSON.stringify(field)
+                        );
+                      }
                       return b.field(
                         childFieldname,
                         {},
@@ -1908,6 +1922,11 @@ export function _buildSchemaInfo(schema: Schema.Schema): SchemaInfo {
               entry.primitiveFieldNames.push(fieldname);
               break;
             case "NODE":
+              if (field.fidelity.type === "UNFAITHFUL") {
+                throw new Error(
+                  "Handling unfaithful fields is not yet implemented"
+                );
+              }
               entry.linkFieldNames.push(fieldname);
               break;
             case "CONNECTION":
@@ -1926,6 +1945,11 @@ export function _buildSchemaInfo(schema: Schema.Schema): SchemaInfo {
                     nestedFieldData.primitives[eggFieldname] = eggField;
                     break;
                   case "NODE":
+                    if (eggField.fidelity.type === "UNFAITHFUL") {
+                      throw new Error(
+                        "Handling unfaithful fields is not yet implemented"
+                      );
+                    }
                     nestedFieldData.nodes[eggFieldname] = eggField;
                     break;
                   // istanbul ignore next

--- a/src/graphql/schema.js
+++ b/src/graphql/schema.js
@@ -69,7 +69,11 @@ export type PrimitiveTypeAnnotation = {|
   +nonNull: boolean,
   +elementType: Typename,
 |};
-export type NodeFieldType = {|+type: "NODE", +elementType: Typename|};
+export type NodeFieldType = {|
+  +type: "NODE",
+  +elementType: Typename,
+  +fidelity: Fidelity,
+|};
 export type ConnectionFieldType = {|
   +type: "CONNECTION",
   +elementType: Typename,
@@ -77,7 +81,11 @@ export type ConnectionFieldType = {|
 export type NestedFieldType = {|
   +type: "NESTED",
   +eggs: {+[Fieldname]: PrimitiveFieldType | NodeFieldType},
+  +fidelity: Fidelity,
 |};
+export type Fidelity =
+  | {|+type: "FAITHFUL"|}
+  | {|+type: "UNFAITHFUL", actualTypenames: {|+[Typename]: true|}|};
 
 // Every object must have exactly one `id` field, and it must have this
 // name.
@@ -115,6 +123,29 @@ export function schema(types: {[Typename]: NodeType}): Schema {
               );
             }
           }
+          function validateFidelity(path, fidelity: Fidelity) {
+            const self = `field ${path
+              .map((x) => JSON.stringify(x))
+              .join("/")}`;
+            switch (fidelity.type) {
+              case "FAITHFUL":
+                return;
+              case "UNFAITHFUL":
+                for (const possibleTypename in fidelity.actualTypenames) {
+                  const fidelityType = types[possibleTypename];
+                  if (fidelityType == null) {
+                    throw new Error(
+                      `${self} has invalid actualTypename ` +
+                        `"${possibleTypename}" in its unfaithful fidelity`
+                    );
+                  }
+                }
+                return;
+              // istanbul ignore next: unreachable per Flow
+              default:
+                throw new Error((fidelity.type: empty));
+            }
+          }
           switch (field.type) {
             case "ID":
               // Nothing to check.
@@ -129,6 +160,7 @@ export function schema(types: {[Typename]: NodeType}): Schema {
               }
               break;
             case "NODE":
+              validateFidelity([typename, fieldname], field.fidelity);
               assertKind([typename, fieldname], field.elementType, [
                 "OBJECT",
                 "UNION",
@@ -154,6 +186,7 @@ export function schema(types: {[Typename]: NodeType}): Schema {
                     }
                     break;
                   case "NODE":
+                    validateFidelity([typename, fieldname], field.fidelity);
                     assertKind(
                       [typename, fieldname, eggName],
                       egg.elementType,
@@ -256,8 +289,11 @@ export function primitive(
   return {type: "PRIMITIVE", annotation: annotation || null};
 }
 
-export function node(elementType: Typename): NodeFieldType {
-  return {type: "NODE", elementType};
+export function node(
+  elementType: Typename,
+  fidelity?: Fidelity = faithful()
+): NodeFieldType {
+  return {type: "NODE", elementType, fidelity};
 }
 
 export function connection(elementType: Typename): ConnectionFieldType {
@@ -272,8 +308,26 @@ export function nullable(elementType: Typename): PrimitiveTypeAnnotation {
   return {nonNull: false, elementType};
 }
 
-export function nested(eggs: {
-  +[Fieldname]: PrimitiveFieldType | NodeFieldType,
-}): NestedFieldType {
-  return {type: "NESTED", eggs: {...eggs}};
+export function nested(
+  eggs: {
+    +[Fieldname]: PrimitiveFieldType | NodeFieldType,
+  },
+  fidelity?: Fidelity = faithful()
+): NestedFieldType {
+  return {type: "NESTED", eggs: {...eggs}, fidelity};
+}
+
+export function faithful(): Fidelity {
+  return {type: "FAITHFUL"};
+}
+
+export function unfaithful(typenames: $ReadOnlyArray<Typename>): Fidelity {
+  const actualTypenames: {|[Typename]: true|} = ({}: any);
+  for (const t of typenames) {
+    if (actualTypenames[t] === true) {
+      throw new Error(`duplicate unfaithful typename "${t}"`);
+    }
+    actualTypenames[t] = true;
+  }
+  return {type: "UNFAITHFUL", actualTypenames};
 }


### PR DESCRIPTION
This commit addresses (#998) and (#996) and corresponds to
1.) in @wchargin's suggested implementation plan.

The following adds a `Fidelity` type to Mirror.

`Fidelity` is either:
    - `FAITHFUL`
    - `UNFAITHFUL`

An `UNFAITHFUL` type has an `actualTypenames` property that lists
all the types of objects that can be returned when the field is
queried.

`fidelity` thus is added to Objects that are prone to inconsistent
typenames. These are `NodeFieldType` and `NestedFieldType`.

If any schema contains a Node or Nested Node  with a field that
contains an `UNFAITHFUL` `fidelity` type, a `Not Yet Implemented`
Error is thrown.

Test Plan:

A test has been added to the constructor to check that an error
is thrown given a schema that contains unfaithful fields.

Added a function for creating an unfaithful github schema,
`buildGithubSchemaUnfaithful`.

Added tests to `schema.test.js` to check validity of Unfaithful
Fidelity and duplicate `actualTypenames`