### PR TITLE
Mirror Refinements 3: added TypenameUpdateResult

### DIFF
--- a/src/graphql/generateFlowTypes.js
+++ b/src/graphql/generateFlowTypes.js
@@ -48,12 +48,18 @@ export default function generateFlowTypes(
     }
   }
   function formatNodeField(field: NodeFieldType): string {
+    if (field.fidelity.type === "UNFAITHFUL") {
+      throw new Error("Unfaithful Fidelity not yet supported");
+    }
     return "null | " + field.elementType;
   }
   function formatConnectionField(field: ConnectionFieldType): string {
     return `$ReadOnlyArray<null | ${field.elementType}>`;
   }
   function formatNestedField(field: NestedFieldType): string {
+    if (field.fidelity.type === "UNFAITHFUL") {
+      throw new Error("Unfaithful Fidelity not yet supported");
+    }
     const eggs = [];
     for (const eggName of Object.keys(field.eggs).sort()) {
       eggs.push({eggName, rhs: formatField(field.eggs[eggName])});

--- a/src/graphql/mirror.js
+++ b/src/graphql/mirror.js
@@ -539,7 +539,8 @@ export class Mirror {
           delete result.neverUpdated;
           return result;
         });
-      return {objects, connections};
+      const typenames: $PropertyType<QueryPlan, "typenames"> = [];
+      return {objects, connections, typenames};
     });
   }
 
@@ -569,6 +570,9 @@ export class Mirror {
       +connectionPageSize: number,
     |}
   ): Queries.Selection[] {
+    if (queryPlan.typenames && queryPlan.typenames.length) {
+      throw new Error("Unfaithful typenames not yet implemented");
+    }
     // Group objects by type, so that we have to specify each type's
     // fieldset fewer times (only once per `nodesOfTypeLimit` nodes
     // instead of for every node).
@@ -1991,6 +1995,9 @@ type QueryPlan = {|
     +objectId: Schema.ObjectId,
     +fieldname: Schema.Fieldname,
     +endCursor: EndCursor | void, // `undefined` if never fetched
+  |}>,
+  +typenames: $ReadOnlyArray<{|
+    +id: Schema.ObjectId,
   |}>,
 |};
 

--- a/src/graphql/mirror.js
+++ b/src/graphql/mirror.js
@@ -1133,6 +1133,11 @@ export class Mirror {
             case "PRIMITIVE":
               return b.field(fieldname);
             case "NODE":
+              if (field.fidelity.type === "UNFAITHFUL") {
+                throw new Error(
+                  "Handling unfaithful fields is not yet implemented"
+                );
+              }
               return b.field(
                 fieldname,
                 {},
@@ -1151,6 +1156,11 @@ export class Mirror {
                     case "PRIMITIVE":
                       return b.field(childFieldname);
                     case "NODE":
+                      if (field.fidelity.type === "UNFAITHFUL") {
+                        throw new Error(
+                          "Handling unfaithful fields is not yet implemented"
+                        );
+                      }
                       return b.field(
                         childFieldname,
                         {},
@@ -1908,6 +1918,11 @@ export function _buildSchemaInfo(schema: Schema.Schema): SchemaInfo {
               entry.primitiveFieldNames.push(fieldname);
               break;
             case "NODE":
+              if (field.fidelity.type === "UNFAITHFUL") {
+                throw new Error(
+                  "Handling unfaithful fields is not yet implemented"
+                );
+              }
               entry.linkFieldNames.push(fieldname);
               break;
             case "CONNECTION":
@@ -1926,6 +1941,11 @@ export function _buildSchemaInfo(schema: Schema.Schema): SchemaInfo {
                     nestedFieldData.primitives[eggFieldname] = eggField;
                     break;
                   case "NODE":
+                    if (eggField.fidelity.type === "UNFAITHFUL") {
+                      throw new Error(
+                        "Handling unfaithful fields is not yet implemented"
+                      );
+                    }
                     nestedFieldData.nodes[eggFieldname] = eggField;
                     break;
                   // istanbul ignore next

--- a/src/graphql/mirror.test.js
+++ b/src/graphql/mirror.test.js
@@ -682,6 +682,7 @@ describe("graphql/mirror", () => {
             // issue:ab/cd#3.comments was loaded after the cutoff
             // issue:ab/cd#4.comments was loaded exactly at the cutoff
           ],
+          typenames: [],
         };
         expect(actual).toEqual(expected);
       });
@@ -707,6 +708,7 @@ describe("graphql/mirror", () => {
               endCursor: null,
             },
           ],
+          typenames: [],
         };
         expect(() => {
           mirror._queryFromPlan(plan, {
@@ -777,6 +779,7 @@ describe("graphql/mirror", () => {
               endCursor: "cursor#996",
             },
           ],
+          typenames: [],
         };
         const actual = mirror._queryFromPlan(plan, {
           nodesLimit: 4,
@@ -849,6 +852,23 @@ describe("graphql/mirror", () => {
             ])
           ),
         ]);
+      });
+      it("rejects non-null typenames", () => {
+        const db = new Database(":memory:");
+        const mirror = new Mirror(db, buildGithubSchema());
+        const plan = {
+          objects: [],
+          connections: [],
+          typenames: [{id: "fail"}],
+        };
+        expect(() => {
+          mirror._queryFromPlan(plan, {
+            nodesLimit: 10,
+            nodesOfTypeLimit: 5,
+            connectionLimit: 5,
+            connectionPageSize: 23,
+          });
+        }).toThrow("Unfaithful typenames not yet implemented");
       });
     });
 
@@ -1210,6 +1230,7 @@ describe("graphql/mirror", () => {
         expect(spyFindOutdated.mock.results[2].value).toEqual({
           objects: [],
           connections: [],
+          typenames: [],
         });
 
         // We should have constructed two query plans, with the same

--- a/src/graphql/schema.test.js
+++ b/src/graphql/schema.test.js
@@ -152,6 +152,24 @@ describe("graphql/schema", () => {
         'field "O"/"foo" has invalid type "Color" of kind "ENUM"'
       );
     });
+    it("disallows objects with node fields of unfaithful type", () => {
+      const s = Schema;
+
+      expect(() => {
+        s.node("Color", s.unfaithful(["Color", "Color"]));
+      }).toThrowError("duplicate unfaithful typename Color");
+      const types2 = {
+        Color: s.object({id: s.id()}),
+        Q: s.object({
+          id: s.id(),
+          bar: s.node("Color", s.unfaithful(["Color"])),
+        }),
+        O: s.object({id: s.id(), foo: s.node("Color", s.unfaithful(["Tree"]))}),
+      };
+      expect(() => Schema.schema(types2)).toThrowError(
+        'field "O"/"foo" has invalid actualTypename Tree in its unfaithful fidelity'
+      );
+    });
     it("disallows objects with connection fields of unknown type", () => {
       const s = Schema;
       const types = {


### PR DESCRIPTION
This commit addresses (#998) and (#996) and corresponds to
3.) in @wchargin's suggested implementation plan.

Creates a new update result type: `TypenameUpdateResult`

    - `id` : The GrapQL id of the `UNFAITHFUL` node
    - `__typename` : The Canonical typename

This also creates a new `_FIELD_PREFIX` for
TypeNameUpdateResults

Test Plan: This commit adds a check in `_updateData`
for any kind of query that is a Typename update
and returns a `Not Yet Implemented Error`

The test `it processes a reasonable input correctly` in
`_updateData` has been reformatted due to
facebook/Flow #2892

This PR depends on #1096 