### PR TITLE
Move EdgeOptions error checking into helper function

### DIFF
--- a/src/core/graph.js
+++ b/src/core/graph.js
@@ -457,25 +457,10 @@ export class Graph {
    * undefined.
    */
   edges(options?: EdgesOptions): Iterator<Edge> {
-    if (options == null) {
-      options = {
-        addressPrefix: EdgeAddress.empty,
-        srcPrefix: NodeAddress.empty,
-        dstPrefix: NodeAddress.empty,
-      };
-    }
-    if (options.addressPrefix == null) {
-      throw new Error(
-        `Invalid address prefix: ${String(options.addressPrefix)}`
-      );
-    }
-    if (options.srcPrefix == null) {
-      throw new Error(`Invalid src prefix: ${String(options.srcPrefix)}`);
-    }
-    if (options.dstPrefix == null) {
-      throw new Error(`Invalid dst prefix: ${String(options.dstPrefix)}`);
-    }
-    const result = this._edgesIterator(this._modificationCount, options);
+    const result = this._edgesIterator(
+      this._modificationCount,
+      validateEdgeOptions(options)
+    );
     this._maybeCheckInvariants();
     return result;
   }
@@ -935,4 +920,24 @@ export function sortedNodeAddressesFromJSON(
 ): $ReadOnlyArray<NodeAddressT> {
   const {nodes} = fromCompat(COMPAT_INFO, json);
   return nodes.map((x) => NodeAddress.fromParts(x));
+}
+
+function validateEdgeOptions(options?: EdgesOptions) {
+  if (options == null) {
+    return {
+      addressPrefix: EdgeAddress.empty,
+      srcPrefix: NodeAddress.empty,
+      dstPrefix: NodeAddress.empty,
+    };
+  }
+  if (options.addressPrefix == null) {
+    throw new Error(`Invalid address prefix: ${String(options.addressPrefix)}`);
+  }
+  if (options.srcPrefix == null) {
+    throw new Error(`Invalid src prefix: ${String(options.srcPrefix)}`);
+  }
+  if (options.dstPrefix == null) {
+    throw new Error(`Invalid dst prefix: ${String(options.dstPrefix)}`);
+  }
+  return options;
 }


### PR DESCRIPTION
This is motivated by the desire to check for errors at the call site
of `edges()` in both `graph` and `pagerankGraph`, ie at the iterator
wrapper method, as discussed w/ @decentralion on Discord. PagerankGraph
will need to do the same error checking at it's `edges()` method, and
this helper function will enable us to re-use the error checking logic
in both classes.

Test plan:
yarn test passes.
I'm not sure if it makes sense to test this function separately, since
it's creation was motivated by the desire to test the consistency of
`graph` and `pagerankGraph`.