### PR TITLE
Refactor pagerankGraph's node filter to throw error at call site

### DIFF
--- a/src/core/pagerankGraph.js
+++ b/src/core/pagerankGraph.js
@@ -186,8 +186,8 @@ export class PagerankGraph {
     return this._syntheticLoopWeight;
   }
 
-  *_nodesIterator(options?: {|+prefix: NodeAddressT|}): Iterator<ScoredNode> {
-    for (const node of this._graph.nodes(options)) {
+  *_nodesIterator(iterator: Iterator<NodeAddressT>): Iterator<ScoredNode> {
+    for (const node of iterator) {
       const score = NullUtil.get(this._scores.get(node));
       yield {node, score};
     }
@@ -202,7 +202,8 @@ export class PagerankGraph {
    */
   nodes(options?: {|+prefix: NodeAddressT|}): Iterator<ScoredNode> {
     this._verifyGraphNotModified();
-    return this._nodesIterator(options);
+    const iterator = this._graph.nodes(options);
+    return this._nodesIterator(iterator);
   }
 
   /**

--- a/src/core/pagerankGraph.test.js
+++ b/src/core/pagerankGraph.test.js
@@ -119,7 +119,7 @@ describe("core/pagerankGraph", () => {
     it("requires a prefix when options are specified", () => {
       const pg = new PagerankGraph(nonEmptyGraph(), defaultEvaluator);
       // $ExpectFlowError
-      expect(() => Array.from(pg.nodes({}))).toThrow("prefix");
+      expect(() => pg.nodes({})).toThrow("prefix");
     });
   });
 


### PR DESCRIPTION
Inspired by a [suggestion] @decentralion made to improve #1105
This will enable `pagerankGraph` to throw an error when it is
called with invalid option parameters. Previously, to elicit
this error we had to access the iterator through `Array.from()`
or similar.

Test plan:
Yarn test passes.
Specifically, I removed the `Array.from()` wrapper around `pagerankGraph`
in the test that checks to see that `pagerankGraph` throws an error when
`nodes()` is passed invalid options.

[suggestion]: https://github.com/sourcecred/sourcecred/pull/1105#pullrequestreview-206496537