### PR TITLE
meta: add .mailmap entry for Dandelion

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1,0 +1,1 @@
+Dandelion Mané <decentralion@dandelion.io> <dl@dandelion.io>


### PR DESCRIPTION
Summary:
@decentralion has used two emails to commit to Git: one exclusively
prior to 2018-05-21 and one exclusively after that date. This commit
adds a mailmap file to list their canonical email address. For more
information, see `man git-check-mailmap`:
<https://www.git-scm.com/docs/git-check-mailmap>

Test Plan:
See `git log --format=%ad --author=dl@` for dates of commits under the
old email, and `git log --format=%ad --author=dandelion@` for dates of
commits under the new email, to confirm the date ranges listed above.

Before this change:

    $ git shortlog -nse | head -3
       443	William Chargin <wchargin@gmail.com>
       291	Dandelion Mané <decentralion@dandelion.io>
       129	Dandelion Mané <dl@dandelion.io>

After this change:

    $ git shortlog -nse | head -3
       444	William Chargin <wchargin@gmail.com>
       420	Dandelion Mané <decentralion@dandelion.io>
        12	Brian Litwin <brian.n.litwin@gmail.com>

wchargin-branch: dandelion-mailmap