### PR TITLE
refactor repoIdRegistry

### DIFF
--- a/src/cli/load.js
+++ b/src/cli/load.js
@@ -1,8 +1,6 @@
 // @flow
 // Implementation of `sourcecred load`.
 
-import fs from "fs";
-import stringify from "json-stable-stringify";
 import mkdirp from "mkdirp";
 import path from "path";
 
@@ -201,21 +199,9 @@ const loadPlugin = async ({std, output, repoIds, plugin}) => {
 function addToRepoIdRegistry(repoId) {
   // TODO: Make this function transactional before loading repositories in
   // parallel.
-  const outputFile = path.join(
-    Common.sourcecredDirectory(),
-    RepoIdRegistry.REPO_ID_REGISTRY_FILE
-  );
-  let registry = null;
-  if (fs.existsSync(outputFile)) {
-    const contents = fs.readFileSync(outputFile);
-    const registryJSON = JSON.parse(contents.toString());
-    registry = RepoIdRegistry.fromJSON(registryJSON);
-  } else {
-    registry = RepoIdRegistry.emptyRegistry();
-  }
-  registry = RepoIdRegistry.addRepoId(registry, {repoId});
-
-  fs.writeFileSync(outputFile, stringify(RepoIdRegistry.toJSON(registry)));
+  const oldRegistry = RepoIdRegistry.getRegistry(Common.sourcecredDirectory());
+  const newRegistry = RepoIdRegistry.addEntry(oldRegistry, {repoId});
+  RepoIdRegistry.writeRegistry(newRegistry, Common.sourcecredDirectory());
 }
 
 export const help: Command = async (args, std) => {

--- a/src/core/repoIdRegistry.js
+++ b/src/core/repoIdRegistry.js
@@ -1,11 +1,19 @@
 // @flow
 
-// The repoIdRegistry is written by the CLI load command (src/cli/load.js)
-// and is read by the RepositorySelect component
-// (src/app/credExplorer/RepositorySelect.js)
+/**
+ * The RepoIdRegistry is a small JSON file that SourceCred uses to track which
+ * RepoIds have been loaded.
+ *
+ * The registry consists of Entries. The entry contains the RepoId of the
+ * loaded repository, and may contain additional metadata (e.g. the last-loaded
+ * timestamp).
+ */
 import deepEqual from "lodash.isequal";
 import {toCompat, fromCompat, type Compatible} from "../util/compat";
 import type {RepoId} from "../core/repoId";
+import fs from "fs";
+import path from "path";
+import stringify from "json-stable-stringify";
 
 export const REPO_ID_REGISTRY_FILE = "repositoryRegistry.json";
 export const REPO_ID_REGISTRY_API = "/api/v1/data/repositoryRegistry.json";
@@ -18,15 +26,10 @@ export type RegistryEntry = {|
 export type RepoIdRegistry = $ReadOnlyArray<RegistryEntry>;
 export type RepoIdRegistryJSON = Compatible<RepoIdRegistry>;
 
-export function toJSON(r: RepoIdRegistry): RepoIdRegistryJSON {
-  return toCompat(REPO_ID_REGISTRY_COMPAT, r);
-}
-
-export function fromJSON(j: RepoIdRegistryJSON): RepoIdRegistry {
-  return fromCompat(REPO_ID_REGISTRY_COMPAT, j);
-}
-
-export function addRepoId(
+/**
+ * Adds a new entry to an existing RepoIdRegistry.
+ */
+export function addEntry(
   registry: RepoIdRegistry,
   entry: RegistryEntry
 ): RepoIdRegistry {
@@ -38,6 +41,80 @@ export function addRepoId(
   ];
 }
 
+/**
+ * Get an entry from a RepoIdRegistry, using the RepoId as a key.
+ *
+ * Returns `undefined` if there is no corresponding entry.
+ */
+export function getEntry(
+  registry: RepoIdRegistry,
+  repoId: RepoId
+): RegistryEntry | typeof undefined {
+  for (const entry of registry) {
+    if (deepEqual(entry.repoId, repoId)) {
+      return entry;
+    }
+  }
+  return undefined;
+}
+
+/**
+ * Create a new, empty RepoIdRegistry.
+ */
 export function emptyRegistry(): RepoIdRegistry {
   return [];
+}
+
+/**
+ * Load the RepoIdRegistry from its conventional location within the
+ * provided sourcecredDirectory.
+ *
+ * The conventional location is the REPO_ID_REGISTRY_FILE within
+ * the sourcecred directory.
+ *
+ * If no registry file is present, an empty registry will be returned
+ * (but not written to disk).
+ */
+export function getRegistry(sourcecredDirectory: string): RepoIdRegistry {
+  const registryFile = path.join(sourcecredDirectory, REPO_ID_REGISTRY_FILE);
+  if (fs.existsSync(registryFile)) {
+    const contents = fs.readFileSync(registryFile);
+    const registryJSON: RepoIdRegistryJSON = JSON.parse(contents.toString());
+    return fromJSON(registryJSON);
+  } else {
+    return emptyRegistry();
+  }
+}
+
+/**
+ * Write the RepoIdRegistry to its conventional location within the
+ * provided sourcecredDirectory.
+ *
+ * The conventional location is the REPO_ID_REGISTRY_FILE within
+ * the sourcecred directory.
+ *
+ * If a registry is already present, it will be overwritten.
+ */
+export function writeRegistry(
+  registry: RepoIdRegistry,
+  sourcecredDirectory: string
+) {
+  const registryFile = path.join(sourcecredDirectory, REPO_ID_REGISTRY_FILE);
+  fs.writeFileSync(registryFile, stringify(toJSON(registry)));
+}
+
+/**
+ * Convert a RepoIdRegistry to JSON.
+ * Exported for testing purposes.
+ */
+export function toJSON(r: RepoIdRegistry): RepoIdRegistryJSON {
+  return toCompat(REPO_ID_REGISTRY_COMPAT, r);
+}
+
+/**
+ * Convert a RepoIdRegistryJSON to a RepoIdRegistry.
+ * Exported for testing purposes.
+ */
+export function fromJSON(j: RepoIdRegistryJSON): RepoIdRegistry {
+  return fromCompat(REPO_ID_REGISTRY_COMPAT, j);
 }

--- a/src/core/repoIdRegistry.js
+++ b/src/core/repoIdRegistry.js
@@ -50,12 +50,7 @@ export function getEntry(
   registry: RepoIdRegistry,
   repoId: RepoId
 ): RegistryEntry | typeof undefined {
-  for (const entry of registry) {
-    if (deepEqual(entry.repoId, repoId)) {
-      return entry;
-    }
-  }
-  return undefined;
+  return registry.find((entry) => deepEqual(entry.repoId, repoId));
 }
 
 /**

--- a/src/core/repoIdRegistry.test.js
+++ b/src/core/repoIdRegistry.test.js
@@ -86,6 +86,10 @@ describe("core/repoIdRegistry", () => {
   });
 
   describe("{get,write}Registry", () => {
+    const repoId = () => makeRepoId("foo", "bar");
+    const entry = () => ({repoId: repoId()});
+    const registry = () => addEntry(emptyRegistry(), entry());
+
     it("getRegistry returns empty registry if nothing present", () => {
       const dirname = tmp.dirSync().name;
       expect(getRegistry(dirname)).toEqual(emptyRegistry());
@@ -93,18 +97,15 @@ describe("core/repoIdRegistry", () => {
 
     it("writeRegistry writes a repoIdRegistry to the directory", () => {
       const dirname = tmp.dirSync().name;
-      const repoId = makeRepoId("foo", "bar");
-      const entry = {repoId};
-      const registry = addEntry(emptyRegistry(), entry);
       const registryFile = path.join(dirname, REPO_ID_REGISTRY_FILE);
 
       expect(fs.existsSync(registryFile)).toBe(false);
-      writeRegistry(registry, dirname);
+      writeRegistry(registry(), dirname);
       expect(fs.existsSync(registryFile)).toBe(true);
 
       const contents = fs.readFileSync(registryFile);
       const registryJSON = JSON.parse(contents.toString());
-      expect(toJSON(registry)).toEqual(registryJSON);
+      expect(toJSON(registry())).toEqual(registryJSON);
     });
 
     it("getRegistry returns the registry written by writeRegistry", () => {

--- a/src/core/repoIdRegistry.test.js
+++ b/src/core/repoIdRegistry.test.js
@@ -3,12 +3,19 @@
 import {
   toJSON,
   fromJSON,
-  addRepoId,
+  addEntry,
+  getEntry,
   emptyRegistry,
   type RepoIdRegistry,
+  getRegistry,
+  writeRegistry,
+  REPO_ID_REGISTRY_FILE,
 } from "./repoIdRegistry";
 
 import {makeRepoId} from "../core/repoId";
+import tmp from "tmp";
+import path from "path";
+import fs from "fs";
 
 describe("core/repoIdRegistry", () => {
   describe("fromJSON compose on", () => {
@@ -26,15 +33,16 @@ describe("core/repoIdRegistry", () => {
       ]);
     });
   });
-  describe("addRepoId", () => {
+
+  describe("addEntry", () => {
     it("adds to empty registry", () => {
       expect(
-        addRepoId(emptyRegistry(), {repoId: makeRepoId("foo", "bar")})
+        addEntry(emptyRegistry(), {repoId: makeRepoId("foo", "bar")})
       ).toEqual([{repoId: makeRepoId("foo", "bar")}]);
     });
     it("adds to nonempty registry", () => {
       const registry = [{repoId: makeRepoId("foo", "bar")}];
-      expect(addRepoId(registry, {repoId: makeRepoId("zoo", "zod")})).toEqual([
+      expect(addEntry(registry, {repoId: makeRepoId("zoo", "zod")})).toEqual([
         {repoId: makeRepoId("foo", "bar")},
         {repoId: makeRepoId("zoo", "zod")},
       ]);
@@ -44,7 +52,7 @@ describe("core/repoIdRegistry", () => {
         {repoId: makeRepoId("zoo", "zod")},
         {repoId: makeRepoId("foo", "bar")},
       ];
-      expect(addRepoId(registry, {repoId: makeRepoId("foo", "bar")})).toEqual(
+      expect(addEntry(registry, {repoId: makeRepoId("foo", "bar")})).toEqual(
         registry
       );
     });
@@ -53,13 +61,69 @@ describe("core/repoIdRegistry", () => {
         {repoId: makeRepoId("zoo", "zod")},
         {repoId: makeRepoId("foo", "bar")},
       ];
-      expect(addRepoId(registry, {repoId: makeRepoId("zoo", "zod")})).toEqual([
+      expect(addEntry(registry, {repoId: makeRepoId("zoo", "zod")})).toEqual([
         {repoId: makeRepoId("foo", "bar")},
         {repoId: makeRepoId("zoo", "zod")},
       ]);
     });
   });
+
+  describe("getEntry", () => {
+    it("returns the matching entry by RepoId", () => {
+      const entry = {repoId: makeRepoId("zoo", "zod")};
+      const registry = addEntry(emptyRegistry(), entry);
+      expect(getEntry(registry, entry.repoId)).toBe(entry);
+    });
+    it("returns undefined if there is no matching entry", () => {
+      expect(getEntry(emptyRegistry(), makeRepoId("foo", "bar"))).toBe(
+        undefined
+      );
+    });
+  });
+
   it("empty registry is empty", () => {
     expect(emptyRegistry()).toEqual([]);
+  });
+
+  describe("{get,write}Registry", () => {
+    it("getRegistry returns empty registry if nothing present", () => {
+      const dirname = tmp.dirSync().name;
+      expect(getRegistry(dirname)).toEqual(emptyRegistry());
+    });
+
+    it("writeRegistry writes a repoIdRegistry to the directory", () => {
+      const dirname = tmp.dirSync().name;
+      const repoId = makeRepoId("foo", "bar");
+      const entry = {repoId};
+      const registry = addEntry(emptyRegistry(), entry);
+      const registryFile = path.join(dirname, REPO_ID_REGISTRY_FILE);
+
+      expect(fs.existsSync(registryFile)).toBe(false);
+      writeRegistry(registry, dirname);
+      expect(fs.existsSync(registryFile)).toBe(true);
+
+      const contents = fs.readFileSync(registryFile);
+      const registryJSON = JSON.parse(contents.toString());
+      expect(toJSON(registry)).toEqual(registryJSON);
+    });
+
+    it("getRegistry returns the registry written by writeRegistry", () => {
+      const dirname = tmp.dirSync().name;
+      const repoId = makeRepoId("foo", "bar");
+      const entry = {repoId};
+      const registry = addEntry(emptyRegistry(), entry);
+      writeRegistry(registry, dirname);
+      expect(getRegistry(dirname)).toEqual(registry);
+    });
+
+    it("writeRegistry overwrites any existing registry", () => {
+      const dirname = tmp.dirSync().name;
+      const repoId = makeRepoId("foo", "bar");
+      const entry = {repoId};
+      const registry = addEntry(emptyRegistry(), entry);
+      writeRegistry(registry, dirname);
+      writeRegistry(emptyRegistry(), dirname);
+      expect(getRegistry(dirname)).toEqual(emptyRegistry());
+    });
   });
 });


### PR DESCRIPTION
This commit makes several improvements to `repoIdRegistry`:

- Create `writeRegistry` and `getRegistry` methods to abstract over
  needing to find the right file, populate an empty registry if its not
  available, etc.
- Create `getEntry` for efficiently checking whether a RepoId is in the
  registry
- Rename `addRepoId` to `addEntry` for consistency
- Add docstrings

The `load` command has been refactored to use the new methods.

Test plan: Unit tests added, and they pass. The `load` command is
already thoroughly tested, so regressions are very unlikely.