### PR TITLE
Move default pagerank settings to pagerankGraph

### DIFF
--- a/src/analysis/pagerank.js
+++ b/src/analysis/pagerank.js
@@ -2,6 +2,11 @@
 
 import {type Edge, Graph, NodeAddress, type NodeAddressT} from "../core/graph";
 import {
+  DEFAULT_MAX_ITERATIONS,
+  DEFAULT_CONVERGENCE_THRESHOLD,
+  DEFAULT_SYNTHETIC_LOOP_WEIGHT,
+} from "../core/pagerankGraph";
+import {
   distributionToNodeDistribution,
   createConnections,
   createOrderedSparseMarkovChain,
@@ -35,9 +40,9 @@ export type EdgeEvaluator = (Edge) => EdgeWeight;
 function defaultOptions(): PagerankOptions {
   return {
     verbose: false,
-    selfLoopWeight: 1e-3,
-    convergenceThreshold: 1e-7,
-    maxIterations: 255,
+    selfLoopWeight: DEFAULT_SYNTHETIC_LOOP_WEIGHT,
+    convergenceThreshold: DEFAULT_CONVERGENCE_THRESHOLD,
+    maxIterations: DEFAULT_MAX_ITERATIONS,
     totalScore: 1000,
     totalScoreNodePrefix: NodeAddress.empty,
   };

--- a/src/core/pagerankGraph.js
+++ b/src/core/pagerankGraph.js
@@ -70,6 +70,8 @@ export type PagerankConvergenceReport = {|
 |};
 
 export const DEFAULT_SYNTHETIC_LOOP_WEIGHT = 1e-3;
+export const DEFAULT_MAX_ITERATIONS = 255;
+export const DEFAULT_CONVERGENCE_THRESHOLD = 1e-7;
 
 const COMPAT_INFO = {type: "sourcecred/pagerankGraph", version: "0.1.0"};
 


### PR DESCRIPTION
This commit moves the default Pagerank options out of
`analysis/pagerank` and to `core/pagerankGraph`. This reflects the
gradual migration of core pagerank logic into `pagerankGraph`.

Test plan: `yarn test` should suffice. It's a trivial change.