### PR TITLE
Fixes broken link README

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ Please also take a look at our [contributing guide].
 
 If you’re looking for a place to start, we’ve tagged some [good first issues].
 
-[forum]: https://discuss.sourcecred.io
+[forum]: https://discourse.sourcecred.io/ 
 [Discord]: https://discord.gg/tsBTgc9
 [contributing guide]: https://github.com/sourcecred/sourcecred/blob/master/CONTRIBUTING.md
 [good first issues]: https://github.com/sourcecred/sourcecred/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # [SourceCred](https://sourcecred.io)
 
 [![Build Status](https://circleci.com/gh/sourcecred/sourcecred.svg?style=svg)](https://circleci.com/gh/sourcecred/sourcecred)
-[![Discourse topics](https://img.shields.io/discourse/https/discuss.sourcecred.io/topics.svg)](https://discourse.sourcecred.io)
+[![Discourse topics](https://img.shields.io/discourse/https/discourse.sourcecred.io/topics.svg)](https://discourse.sourcecred.io)
 [![Discord](https://img.shields.io/discord/453243919774253079.svg)](https://discord.gg/tsBTgc9)
 
 SourceCred creates reputation networks for open-source projects.

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ For an example of SourceCred in action, you can see SourceCred’s own [prototyp
 
 [our website]: https://sourcecred.io/
 [prototype]: https://sourcecred.io/prototype/
-[A Gentle Introduction to Cred]: https://discuss.sourcecred.io/t/a-gentle-introduction-to-cred/20
+[A Gentle Introduction to Cred]: https://discourse.sourcecred.io/t/a-gentle-introduction-to-cred/20
 
 ## Current Status
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # [SourceCred](https://sourcecred.io)
 
 [![Build Status](https://circleci.com/gh/sourcecred/sourcecred.svg?style=svg)](https://circleci.com/gh/sourcecred/sourcecred)
-[![Discourse topics](https://img.shields.io/discourse/https/discuss.sourcecred.io/topics.svg)](discuss.sourcecred.io)
+[![Discourse topics](https://img.shields.io/discourse/https/discuss.sourcecred.io/topics.svg)](https://discourse.sourcecred.io)
 [![Discord](https://img.shields.io/discord/453243919774253079.svg)](https://discord.gg/tsBTgc9)
 
 SourceCred creates reputation networks for open-source projects.

--- a/src/explorer/App.js
+++ b/src/explorer/App.js
@@ -23,7 +23,7 @@ import {StaticExplorerAdapterSet} from "./adapters/explorerAdapterSet";
 import {userNodeType} from "../plugins/github/declaration";
 
 const credOverviewUrl =
-  "https://discuss.sourcecred.io/t/a-gentle-introduction-to-cred/20";
+  "https://discourse.sourcecred.io/t/a-gentle-introduction-to-cred/20";
 const feedbackUrl =
   "https://docs.google.com/forms/d/e/1FAIpQLSdwxqFJNQIVS3EqISJ0EUcr1aixARDVA51DMURWSYgORFPHcQ/viewform";
 


### PR DESCRIPTION
This commit fixes three broken links (two in the README, one in the prototype app) that were still pointing to `https://discuss.sourcecred.io/`. 

Test plan:
Verify that there are no other bad links to the old Discourse location, by running git grep "discuss.sourcecred.io".