### PR TITLE
Make tests use SOURCECRED_GITHUB_TOKEN

### DIFF
--- a/src/plugins/github/example/README.md
+++ b/src/plugins/github/example/README.md
@@ -9,12 +9,12 @@ the GitHub api query changes. To regenerate the demo data, run the following
 command:
 
 ```shell
-$ GITHUB_TOKEN="your_token_here" src/plugins/github/fetchGithubRepoTest.sh -u
+$ SOURCECRED_GITHUB_TOKEN="your_token_here" src/plugins/github/fetchGithubRepoTest.sh -u
 ```
 
 You can also just verify that the data is up-to-date by running:
 ```shell
-$ GITHUB_TOKEN="your_token_here" src/plugins/github/fetchGithubRepoTest.sh
+$ SOURCECRED_GITHUB_TOKEN="your_token_here" src/plugins/github/fetchGithubRepoTest.sh
 ```
 
 There is a known issue where GitHub's end cursor output depends on your current

--- a/src/plugins/github/fetchGithubOrgTest.sh
+++ b/src/plugins/github/fetchGithubOrgTest.sh
@@ -7,7 +7,7 @@ data_file=src/plugins/github/example/organizations.snapshot
 usage() {
   printf 'usage: %s [-u|--updateSnapshot] [--[no-]build] [--help]\n' "$0"
   printf 'Required environment variables:\n'
-  printf '  GITHUB_TOKEN: A 40-character hex string API token.\n'
+  printf '  SOURCECRED_GITHUB_TOKEN: A 40-character hex string API token.\n'
   printf 'Flags:\n'
   printf '  -u|--updateSnapshot\n'
   printf '      Update the stored file instead of checking its contents\n'
@@ -24,8 +24,8 @@ usage() {
 }
 
 fetch() {
-  if [ -z "${GITHUB_TOKEN:-}" ]; then
-    printf >&2 'Please set the GITHUB_TOKEN environment variable\n'
+  if [ -z "${SOURCECRED_GITHUB_TOKEN:-}" ]; then
+    printf >&2 'Please set the SOURCECRED_GITHUB_TOKEN environment variable\n'
     printf >&2 'to a 40-character hex string API token from GitHub.\n'
     return 1
   fi
@@ -33,15 +33,15 @@ fetch() {
   PAGE_SIZE=1
   echo "# results for org: sourcecred-test-organization"
   node "${SOURCECRED_BIN:-./bin}/fetchAndPrintGithubOrg.js" \
-    sourcecred-test-organization "${GITHUB_TOKEN}" "${PAGE_SIZE}"
+    sourcecred-test-organization "${SOURCECRED_GITHUB_TOKEN}" "${PAGE_SIZE}"
   echo
   echo "# results for org: sourcecred-empty-organization"
   node "${SOURCECRED_BIN:-./bin}/fetchAndPrintGithubOrg.js" \
-    sourcecred-empty-organization "${GITHUB_TOKEN}" "${PAGE_SIZE}"
+    sourcecred-empty-organization "${SOURCECRED_GITHUB_TOKEN}" "${PAGE_SIZE}"
   echo
   echo "# results for org: sourcecred-nonexistent-organization"
   node "${SOURCECRED_BIN:-./bin}/fetchAndPrintGithubOrg.js" \
-    sourcecred-nonexistent-organization "${GITHUB_TOKEN}" "${PAGE_SIZE}"
+    sourcecred-nonexistent-organization "${SOURCECRED_GITHUB_TOKEN}" "${PAGE_SIZE}"
 }
 
 check() {

--- a/src/plugins/github/fetchGithubRepoTest.sh
+++ b/src/plugins/github/fetchGithubRepoTest.sh
@@ -7,7 +7,7 @@ data_file=src//plugins/github/example/example-github.json
 usage() {
   printf 'usage: %s [-u|--updateSnapshot] [--[no-]build] [--help]\n' "$0"
   printf 'Required environment variables:\n'
-  printf '  GITHUB_TOKEN: A 40-character hex string API token.\n'
+  printf '  SOURCECRED_GITHUB_TOKEN: A 40-character hex string API token.\n'
   printf 'Flags:\n'
   printf '  -u|--updateSnapshot\n'
   printf '      Update the stored file instead of checking its contents\n'
@@ -24,13 +24,13 @@ usage() {
 }
 
 fetch() {
-  if [ -z "${GITHUB_TOKEN:-}" ]; then
-    printf >&2 'Please set the GITHUB_TOKEN environment variable\n'
+  if [ -z "${SOURCECRED_GITHUB_TOKEN:-}" ]; then
+    printf >&2 'Please set the SOURCECRED_GITHUB_TOKEN environment variable\n'
     printf >&2 'to a 40-character hex string API token from GitHub.\n'
     return 1
   fi
   node "${SOURCECRED_BIN:-./bin}/fetchAndPrintGithubRepo.js" \
-    sourcecred example-github "${GITHUB_TOKEN}"
+    sourcecred example-github "${SOURCECRED_GITHUB_TOKEN}"
 }
 
 check() {


### PR DESCRIPTION
Across SourceCred usage, we depend on the `SOURCECRED_GITHUB_TOKEN`
environment variable being set. Confusingly, some tests expect
`GITHUB_TOKEN` instead of `SOURCECRED_GITHUB_TOKEN`.

This commit resolves that inconsistency, by having all tests that read
from the environment use `SOURCECRED_GITHUB_TOKEN`. This was already
available as a secret in our CI configuration, so no change is needed
there. (After this merges, we may remove the GITHUB_TOKEN variable from
the environment.)

Test plan: `yarn test --full` passes without the environment variable
set. Also, the following grep produces only innocuous hits.

```
git grep -P "(?<\!SOURCECRED_)GITHUB_TOKEN"
```