### PR TITLE
Make PagerankGraph convergence options optional

### DIFF
--- a/src/core/pagerankGraph.test.js
+++ b/src/core/pagerankGraph.test.js
@@ -9,7 +9,12 @@ import {
   type Edge,
   type EdgesOptions,
 } from "./graph";
-import {PagerankGraph, Direction} from "./pagerankGraph";
+import {
+  PagerankGraph,
+  Direction,
+  DEFAULT_MAX_ITERATIONS,
+  DEFAULT_CONVERGENCE_THRESHOLD,
+} from "./pagerankGraph";
 import {advancedGraph} from "./graphTestUtil";
 import * as NullUtil from "../util/null";
 
@@ -485,6 +490,20 @@ describe("core/pagerankGraph", () => {
       }
       expect(total).toBeCloseTo(1);
     }
+
+    it("runs PageRank with default options if not specified", () => {
+      const pg1 = examplePagerankGraph();
+      const pg2 = examplePagerankGraph();
+      const pg3 = examplePagerankGraph();
+      pg1.runPagerank();
+      pg2.runPagerank({});
+      pg3.runPagerank({
+        maxIterations: DEFAULT_MAX_ITERATIONS,
+        convergenceThreshold: DEFAULT_CONVERGENCE_THRESHOLD,
+      });
+      expect(pg1.equals(pg2)).toBe(true);
+      expect(pg1.equals(pg3)).toBe(true);
+    });
 
     it("promise rejects if the graph was modified", async () => {
       const pg = examplePagerankGraph();


### PR DESCRIPTION
Right now PagerankGraph requires that the user choose specific values
for maxIterations and convergenceThreshold when running PageRank.

I also rename `PagerankConvergenceOptions` to `PagerankOptions`.

The motivation is that I want to add future arguments to the same
options dict (e.g. alpha and the seed vector), so the rename is
appropriate, and allowing the options to be unset (and thus inherit
default values) will make the whole API much cleaner as I add more
options.

Test plan: Unit test added. `yarn test` passes.