### PR TITLE
Visualizer: add shared types and utils

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,6 +7,8 @@
     "better-sqlite3": "wchargin/better-sqlite3#wchargin-private-inmemory-db",
     "chalk": "1.1.3",
     "commonmark": "^0.28.1",
+    "d3-color": "^1.2.3",
+    "d3-interpolate": "^1.3.2",
     "express": "^4.16.3",
     "fs-extra": "3.0.1",
     "history": "^3.0.0",

--- a/src/visualizer/shared.js
+++ b/src/visualizer/shared.js
@@ -1,0 +1,105 @@
+// @flow
+
+import {interpolate} from "d3-interpolate";
+import type {NodeAddressT} from "../core/graph";
+
+/** Represents a position in the GraphVisualizer's display.
+ *
+ * The measurements are in pixels.
+ * Standard SVG coordinates apply; (0,0) is the top left corner.
+ */
+export type Point = {|
+  +x: number,
+  +y: number,
+|};
+
+/**
+ * Represents the size of the GraphVisualizer's display.
+ *
+ * The measurements are in pixels.
+ */
+export type Size = {|
+  +height: number,
+  +width: number,
+|};
+
+/**
+ * The Node is the basic data structure that GraphVisualizer instantiators provide
+ * as data about the nodes in the graph.
+ *
+ * Each Node has the information needed to display it (i.e. score, description, and
+ * scoreRatio). The scoreRatio is provided separately from the score, as the same
+ * score may have different significance in different contexts (is "50" a high score
+ * or a low score?).
+ *
+ * In practice, the score is displayed as text, and the scoreRatio is used to set
+ * attributes like color and radius.
+ *
+ * The Node does not include the position, because the GraphVisualizer assumes
+ * responsibility for positioning nodes, so that the caller does not need to
+ * worry about it.
+ */
+export type Node = {|
+  +address: NodeAddressT,
+  // Short string describing the type of the node.
+  // May be changed to be a type descriptor object in the future.
+  +type: string,
+  // Score of the node.
+  +score: number,
+  // Score of the node as a fraction of the maximum score.
+  // Allows scaling the nodes (in size, color) consistently.
+  // Providing a score ratio outside of the domain [0, 1] is an error.
+  +scoreRatio: number,
+  // Human-readable description of the node. Plain text for now;
+  // markdown may be supported later. Ideally, should not
+  // be more than a sentance long.
+  +description: string,
+|};
+
+/**
+ * PositionedNode wraps a Node with a position in XY space.
+ */
+export type PositionedNode = {|
+  +node: Node,
+  +position: Point,
+|};
+
+export const BACKGROUND_COLOR = "#313131";
+
+export const EDGE_COLOR = "steelblue";
+export const EDGE_OPACITY = 0.6;
+
+export const MIN_COLOR = "#00ABE1";
+export const MAX_COLOR = "#90FF03";
+export const MAX_RADIUS_PIXELS = 20;
+export const MIN_RADIUS_PIXELS = 3;
+export const TRANSITION_DURATION = 3000;
+
+/**
+ * Throws an error if the score ratio is not in the range [0, 1].
+ */
+function validate(scoreRatio: number): number {
+  if (!isFinite(scoreRatio) || scoreRatio > 1 || scoreRatio < 0) {
+    throw new Error(`Invalid score ratio: ${scoreRatio}`);
+  }
+  return scoreRatio;
+}
+/**
+ * Set radius for a node based on the score ratio.
+ *
+ * The radius is proportional to the square root of the score ratio,
+ * so that the area of a resultant circle will be linearly proportional.
+ */
+export function nodeRadius(scoreRatio: number): number {
+  return (
+    Math.sqrt(validate(scoreRatio)) * (MAX_RADIUS_PIXELS - MIN_RADIUS_PIXELS) +
+    MIN_RADIUS_PIXELS
+  );
+}
+
+/**
+ * Sets the color for a node based on the score ratio.
+ */
+export function nodeColor(scoreRatio: number): string {
+  return interpolate(MIN_COLOR, MAX_COLOR)(validate(scoreRatio));
+}

--- a/src/visualizer/shared.test.js
+++ b/src/visualizer/shared.test.js
@@ -1,0 +1,49 @@
+// @flow
+
+import {color} from "d3-color";
+import {
+  nodeRadius,
+  nodeColor,
+  MIN_COLOR,
+  MAX_COLOR,
+  MIN_RADIUS_PIXELS,
+  MAX_RADIUS_PIXELS,
+} from "./shared";
+
+describe("visualizer/shared", () => {
+  describe("nodeRadius", () => {
+    it("handles boundary values appropriately", () => {
+      expect(nodeRadius(0)).toEqual(MIN_RADIUS_PIXELS);
+      expect(nodeRadius(1)).toEqual(MAX_RADIUS_PIXELS);
+    });
+    it("throws an error for invalid score ratios", () => {
+      const bads = [Infinity, -Infinity, NaN, -0.1, 1.1];
+      for (const bad of bads) {
+        expect(() => nodeRadius(bad)).toThrowError("Invalid score ratio");
+      }
+    });
+    it("interpolates according to the square root", () => {
+      // Subtract out MIN_RADIUS_PIXELS because we are interpolating
+      // only over the delta MAX_RADIUS_PIXELS - MIN_RADIUS_PIXELS
+      const r4 = nodeRadius(0.4) - MIN_RADIUS_PIXELS;
+      const r1 = nodeRadius(0.1) - MIN_RADIUS_PIXELS;
+      expect(r4 / r1).toBeCloseTo(2);
+    });
+  });
+
+  describe("nodeColor", () => {
+    // I'm going to trust that d3.interpolate does the right thing,
+    // so we're just checking that it's configured/wrapped properly.
+    it("handles boundary values appropriately", () => {
+      const toRGBString = (x) => color(x) + "";
+      expect(nodeColor(0)).toEqual(toRGBString(MIN_COLOR));
+      expect(nodeColor(1)).toEqual(toRGBString(MAX_COLOR));
+    });
+    it("throws an error for invalid score ratios", () => {
+      const bads = [Infinity, -Infinity, NaN, -0.1, 1.1];
+      for (const bad of bads) {
+        expect(() => nodeColor(bad)).toThrowError("Invalid score ratio");
+      }
+    });
+  });
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -2235,6 +2235,18 @@ cyclist@~0.2.2:
   resolved "https://registry.yarnpkg.com/cyclist/-/cyclist-0.2.2.tgz#1b33792e11e914a2fd6d6ed6447464444e5fa640"
   integrity sha1-GzN5LhHpFKL9bW7WRHRkRE5fpkA=
 
+d3-color@1, d3-color@^1.2.3:
+  version "1.2.3"
+  resolved "https://registry.yarnpkg.com/d3-color/-/d3-color-1.2.3.tgz#6c67bb2af6df3cc8d79efcc4d3a3e83e28c8048f"
+  integrity sha512-x37qq3ChOTLd26hnps36lexMRhNXEtVxZ4B25rL0DVdDsGQIJGB18S7y9XDwlDD6MD/ZBzITCf4JjGMM10TZkw==
+
+d3-interpolate@^1.3.2:
+  version "1.3.2"
+  resolved "https://registry.yarnpkg.com/d3-interpolate/-/d3-interpolate-1.3.2.tgz#417d3ebdeb4bc4efcc8fd4361c55e4040211fd68"
+  integrity sha512-NlNKGopqaz9qM1PXh9gBF1KSCVh+jSFErrSlD/4hybwoNX/gt1d8CDbDW+3i+5UOHhjC6s6nMvRxcuoMVNgL2w==
+  dependencies:
+    d3-color "1"
+
 d@1:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/d/-/d-1.0.0.tgz#754bb5bfe55451da69a58b94d45f4c5b0462d58f"


### PR DESCRIPTION
This commit begins work on the graph visualizer (#39) by adding some
shared constants, methods, and types. The two methods (`nodeColor` and
`nodeRadius`) are both tested.

This commit also imports two d3 modules (d3-color and d3-interpolate).

Test plan:
Read the source for `shared.js` and ensure that the types and constants
are sensible, and documented properly.

Run the attached unit tests for `nodeColor` and `nodeRadius`.