### PR TITLE
Fix a conflict between #1140 and #1141

### DIFF
--- a/src/core/pagerankGraph.test.js
+++ b/src/core/pagerankGraph.test.js
@@ -75,8 +75,8 @@ describe("core/pagerankGraph", () => {
       expect(e1.equals(e2)).toBe(false);
       await e1.runPagerank();
       await e2.runPagerank();
-      for (const {node, score} of e1.nodes()) {
-        const otherScore = NullUtil.get(e2.node(node)).score;
+      for (const {address, score} of e1.nodes()) {
+        const otherScore = NullUtil.get(e2.node(address)).score;
         expect(otherScore).toBeCloseTo(score);
       }
     });


### PR DESCRIPTION
In #1140 I rename a field in PagerankGraph.ScoredNode, and in #1141 I
added a new test which referenced the field.

I merged them in quick succession, introducing a conflict. This PR fixes
it.

Test plan:
`yarn test` passes.