### PR TITLE
PagerankGraph reuses existing distribution

### DIFF
--- a/src/core/pagerankGraph.test.js
+++ b/src/core/pagerankGraph.test.js
@@ -609,6 +609,22 @@ describe("core/pagerankGraph", () => {
       expect(results.convergenceDelta).toBeLessThan(convergenceThreshold);
       checkProbabilityDistribution(pg);
     });
+    it("re-uses existing scores as a starting point", async () => {
+      const pg = examplePagerankGraph();
+      const convergenceThreshold = 0.001;
+      const results1 = await pg.runPagerank({
+        maxIterations: 170,
+        convergenceThreshold,
+      });
+      expect(results1.convergenceDelta).toBeLessThan(convergenceThreshold);
+      // It should still converge without any iterations, because it uses the
+      // final distribution as a starting point
+      const results2 = await pg.runPagerank({
+        maxIterations: 0,
+        convergenceThreshold,
+      });
+      expect(results2.convergenceDelta).toEqual(results1.convergenceDelta);
+    });
   });
 
   describe("equals", () => {


### PR DESCRIPTION
This commit modifies `PagerankGraph.runPagerank` so that rather than
always starting from a uniform distribution, it starts with the
PagerankGraph's existing score distribution. The PagerankGraph
initializes with a uniform score over nodes, so it has the exact same
behavior on the first time that runPagerank is called. On subsequent
calls, PageRank will likely converge a lot faster, because it's starting
from converged scores. (It should still be a lot faster in cases where
e.g. the user has tweaked the weights.)

In certain degerate cases, this could change the resultant scores.
Specifically, if there are isolated nodes in the graph and alpha=0, then
the isolated nodes' final scores depends on the initial score. In
general, I think this won't be an issue as we expect alpha > 0 in normal
usage.

Test plan: I added a unit test to verify this property, by checking that
running PageRank with maxIterations==0 on an already-converged graph
results in a still-converged graph. Also, existing tests pass.

I think we can now close #1020.