### PR TITLE
Quicker failure and description when invalid token supplied

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [Unreleased]
 
+- Fail quicker and with information when using invalid GH token (#1161)
 - Allow the user to save or upload weight settings (#1150)
 - Allow tweaking weights on a per-node basis (#1143)
 - Add the `pagerank` command (#1114)

--- a/src/plugins/github/fetchGithubRepo.js
+++ b/src/plugins/github/fetchGithubRepo.js
@@ -83,6 +83,7 @@ type GithubResponseError =
   | {|+type: "GRAPHQL_ERROR", retry: false, error: mixed|}
   | {|+type: "RATE_LIMIT_EXCEEDED", retry: false, error: mixed|}
   | {|+type: "GITHUB_INTERNAL_EXECUTION_ERROR", retry: true, error: mixed|}
+  | {|+type: "BAD_CREDENTIALS", retry: false, error: mixed|}
   | {|+type: "NO_DATA", retry: true, error: mixed|};
 
 // Fetch against the GitHub API with the provided options, returning a
@@ -126,10 +127,20 @@ function tryGithubFetch(fetch, fetchOptions): Promise<any> {
           }
         }
         if (x.data === undefined) {
-          // See https://github.com/sourcecred/sourcecred/issues/350.
-          return Promise.reject(
-            ({type: "NO_DATA", retry: true, error: x}: GithubResponseError)
-          );
+          // See https://github.com/sourcecred/sourcecred/issues/350
+          if (x.message && x.message.includes("Bad credentials")) {
+            return Promise.reject(
+              ({
+                type: "BAD_CREDENTIALS",
+                retry: false,
+                error: x,
+              }: GithubResponseError)
+            );
+          } else {
+            return Promise.reject(
+              ({type: "NO_DATA", retry: true, error: x}: GithubResponseError)
+            );
+          }
         }
         return Promise.resolve(x.data);
       }),
@@ -204,6 +215,11 @@ export async function postQuery(
           break;
         case "FETCH_ERROR":
           // Network error; no need for additional commentary.
+          break;
+        case "BAD_CREDENTIALS":
+          console.error(
+            "An invalid token was supplied ($SOURCECRED_GITHUB_TOKEN). This is mostly likely caused by supplying a revoked token."
+          );
           break;
         default:
           throw new Error((type: empty));

--- a/src/plugins/github/fetchGithubRepo.js
+++ b/src/plugins/github/fetchGithubRepo.js
@@ -127,7 +127,6 @@ function tryGithubFetch(fetch, fetchOptions): Promise<any> {
           }
         }
         if (x.data === undefined) {
-          // See https://github.com/sourcecred/sourcecred/issues/350
           if (x.message && x.message.includes("Bad credentials")) {
             return Promise.reject(
               ({
@@ -137,6 +136,7 @@ function tryGithubFetch(fetch, fetchOptions): Promise<any> {
               }: GithubResponseError)
             );
           } else {
+            // See https://github.com/sourcecred/sourcecred/issues/350
             return Promise.reject(
               ({type: "NO_DATA", retry: true, error: x}: GithubResponseError)
             );


### PR DESCRIPTION
Fixes #1156

When users export a GitHub API token that has insufficient privileges
or has been revoked, we have been using a catch all error with retry
to handle it. This change adds a new error type for bad credentials
and does not retry.

Test plan:
There are no unit tests that cover this, however, you can test the
change by supplying a revoked token and attempting to load a GitHub
repo.