### PR TITLE
Fix `sourcecred load` for real repos

### DIFF
--- a/src/plugins/git/analysisAdapter.js
+++ b/src/plugins/git/analysisAdapter.js
@@ -59,7 +59,7 @@ export class AnalysisAdapter implements IAnalysisAdapter {
     // hotspot. If so, implement a do-not-modify flag and set it (for safety)
     return this._graph.copy();
   }
-  createdAt(n: NodeAddressT): MsSinceEpoch {
+  createdAt(n: NodeAddressT): MsSinceEpoch | null {
     // Coerce the NodeAddressT into a Git plugin 'RawAddress'.
     // If this coercion is false (i.e. the AnalysisAdapter was passed a non-Git NodeAddress)
     // then this will throw a runtime error.
@@ -69,7 +69,10 @@ export class AnalysisAdapter implements IAnalysisAdapter {
         const hash = addr.hash;
         const commit = this._repository.commits[hash];
         if (commit == null) {
-          throw new Error(`Can't find commit for hash: ${hash}`);
+          // Possibly this commit was merged to a non-master branch.
+          // It's a little hacky to return null. See #1163 for alternative
+          // solutions.
+          return null;
         }
         return commit.createdAt;
       default:

--- a/src/plugins/git/analysisAdapter.test.js
+++ b/src/plugins/git/analysisAdapter.test.js
@@ -52,12 +52,12 @@ describe("plugins/git/analysisAdapter", () => {
         const actualCreatedAt = aa.createdAt(commitAddr);
         expect(actualCreatedAt).toEqual(1519807427000);
       });
-      it("throws an error for an absent commit hash", async () => {
+      it("returns null for an absent commit hash", async () => {
+        // This is a little hacky. See #1163 for discussion.
+        // https://github.com/sourcecred/sourcecred/issues/1163
         const aa = await loadAnalysisAdapter();
         const commitAddr = toRaw({type: "COMMIT", hash: "1234"});
-        expect(() => aa.createdAt(commitAddr)).toThrowError(
-          "Can't find commit"
-        );
+        expect(aa.createdAt(commitAddr)).toEqual(null);
       });
       it("throws an error for an invalid NodeAddress", async () => {
         const aa = await loadAnalysisAdapter();


### PR DESCRIPTION
As discussed in #1163, #1162 caused `sourcecred load` to start failing
for real repos (e.g. sourcecred/research). This commit merges a
somewhat hacky fix.

Test plan: `yarn test` passes, and `sourcecred load sourcecred/research`
works.