### PR TITLE
Add creationTimeline

### DIFF
--- a/src/analysis/temporal/creationTimeline.js
+++ b/src/analysis/temporal/creationTimeline.js
@@ -1,0 +1,85 @@
+// @flow
+
+import sortBy from "lodash.sortby";
+import {type MsSinceEpoch} from "../analysisAdapter";
+import {type NodeAddressT} from "../../core/graph";
+
+/**
+ * An interval expressing a range of time.
+ *
+ * The interval includes the startTime but not the endTime, i.e. it is half-open
+ * as [startTime, endTime).
+ */
+export type Interval = {+startTime: MsSinceEpoch, +endTime: MsSinceEpoch};
+
+/**
+ * Interval-segemented timeline of the creation history of nodes in the graph.
+ * Includes the "timeless" nodes (those without any timestamp) in a separate field.
+ *
+ * This is a classic finnicky algorithm, there are a lot of edge cases to
+ * consider, like how the algorithm should handle intervals that don't have any
+ * created nodes. (We skip them, which is consistent with viewing the created
+ * nodes in each interval as the seed--without any created nodes, we wouldn't
+ * be able to provide a valid seed.) This algorithm is pretty thoroughly tested
+ * with attention to the edge cases, so take a look at the tests as
+ * documentation on how it's supposed to behave.
+ */
+export type CreationTimeline = {
+  creationIntervals: $ReadOnlyArray<{|
+    +interval: Interval,
+    +nodes: $ReadOnlyArray<NodeAddressT>,
+  |}>,
+  timelessNodes: $ReadOnlyArray<NodeAddressT>,
+};
+export function computeCreationTimeline(
+  timestamps: Map<NodeAddressT, MsSinceEpoch | null>,
+  intervalLengthMs: number
+): CreationTimeline {
+  if (intervalLengthMs <= 1) {
+    throw new Error("interval length must be >= 1");
+  }
+  const timestampNodes = [];
+  const timelessNodes = [];
+  for (const [address, timestamp] of timestamps.entries()) {
+    if (timestamp == null) {
+      timelessNodes.push(address);
+    } else {
+      timestampNodes.push([address, timestamp]);
+    }
+  }
+
+  if (timestampNodes.length === 0) {
+    return {creationIntervals: [], timelessNodes};
+  }
+  const timestampSortedNodes = sortBy(timestampNodes, (x) => x[1]);
+  let currentInterval = {
+    interval: {
+      startTime: timestampSortedNodes[0][1],
+      endTime: timestampSortedNodes[0][1] + intervalLengthMs,
+    },
+    nodes: [],
+  };
+  const creationIntervals = [];
+  for (const [n: NodeAddressT, c: MsSinceEpoch] of timestampSortedNodes) {
+    while (c >= currentInterval.interval.endTime) {
+      // Potential perf optimization: If there are long stretches without any node
+      // creation, it's a bit silly to create and then discard these intervals.
+      // We could just 'jump ahead' to the next populated interval.
+      if (currentInterval.nodes.length > 0) {
+        creationIntervals.push(currentInterval);
+      }
+      currentInterval = {
+        interval: {
+          startTime: currentInterval.interval.endTime,
+          endTime: currentInterval.interval.endTime + intervalLengthMs,
+        },
+        nodes: [],
+      };
+    }
+    currentInterval.nodes.push(n);
+  }
+  if (currentInterval.nodes.length > 0) {
+    creationIntervals.push(currentInterval);
+  }
+  return {creationIntervals, timelessNodes};
+}

--- a/src/analysis/temporal/creationTimeline.test.js
+++ b/src/analysis/temporal/creationTimeline.test.js
@@ -1,0 +1,69 @@
+// @flow
+
+import {computeCreationTimeline} from "./creationTimeline";
+import {NodeAddress} from "../../core/graph";
+
+describe("src/analysis/temporal/creationTimeline", () => {
+  const foo = NodeAddress.fromParts(["foo"]);
+  const bar = NodeAddress.fromParts(["bar"]);
+
+  it("gives empty timeline with empty input", () => {
+    const {creationIntervals, timelessNodes} = computeCreationTimeline(
+      new Map(),
+      10
+    );
+    expect(creationIntervals).toHaveLength(0);
+    expect(timelessNodes).toHaveLength(0);
+  });
+  it("gives empty intervals if all nodes are timeless", () => {
+    const map = new Map([[foo, null], [bar, null]]);
+    const {creationIntervals, timelessNodes} = computeCreationTimeline(map, 10);
+    expect(creationIntervals).toHaveLength(0);
+    expect(timelessNodes).toEqual([foo, bar]);
+  });
+  it("throws an error if the intervalLength is 0", () => {
+    const bads = [-10, 0, 0.5];
+    for (const bad of bads) {
+      expect(() => computeCreationTimeline(new Map(), bad)).toThrowError(
+        "interval length"
+      );
+    }
+  });
+  it("creates intervals starting at first non-null timestamp", () => {
+    const map = new Map([[foo, 7], [bar, null]]);
+    const {creationIntervals, timelessNodes} = computeCreationTimeline(map, 10);
+    expect(creationIntervals).toHaveLength(1);
+    const {interval, nodes} = creationIntervals[0];
+    expect(interval).toEqual({startTime: 7, endTime: 17});
+    expect(nodes).toEqual([foo]);
+    expect(timelessNodes).toEqual([bar]);
+  });
+  it("buckets multiple nodes into the same interval", () => {
+    const map = new Map([[foo, 7], [bar, 9]]);
+    const {creationIntervals, timelessNodes} = computeCreationTimeline(map, 10);
+    expect(creationIntervals).toHaveLength(1);
+    const {interval, nodes} = creationIntervals[0];
+    expect(interval).toEqual({startTime: 7, endTime: 17});
+    expect(nodes).toEqual([foo, bar]);
+    expect(timelessNodes).toEqual([]);
+  });
+  it("puts nodes exactly on a boundary into the next interval", () => {
+    const map = new Map([[foo, 7], [bar, 17]]);
+    const {creationIntervals, timelessNodes} = computeCreationTimeline(map, 10);
+    expect(creationIntervals).toHaveLength(2);
+    expect(creationIntervals[0].interval).toEqual({startTime: 7, endTime: 17});
+    expect(creationIntervals[0].nodes).toEqual([foo]);
+    expect(creationIntervals[1].interval).toEqual({startTime: 17, endTime: 27});
+    expect(creationIntervals[1].nodes).toEqual([bar]);
+    expect(timelessNodes).toEqual([]);
+  });
+  it("skips over empty intervals", () => {
+    const map = new Map([[foo, 7], [bar, 17]]);
+    const {creationIntervals, timelessNodes} = computeCreationTimeline(map, 2);
+    expect(creationIntervals[0].interval).toEqual({startTime: 7, endTime: 9});
+    expect(creationIntervals[0].nodes).toEqual([foo]);
+    expect(creationIntervals[1].interval).toEqual({startTime: 17, endTime: 19});
+    expect(creationIntervals[1].nodes).toEqual([bar]);
+    expect(timelessNodes).toEqual([]);
+  });
+});


### PR DESCRIPTION
This has the methods for organizing the creation history of a graph into
fixed-time-width intervals where each interval is associated with the
nodes created in that time slice.

Test plan: Unit tests included, `yarn test` passes.