### PR TITLE
(metadata-2) Refactor Graph to support object Nodes

### DIFF
--- a/src/analysis/loadGraph.test.js
+++ b/src/analysis/loadGraph.test.js
@@ -16,6 +16,7 @@ import type {
 import * as RepoIdRegistry from "../core/repoIdRegistry";
 import {makeRepoId, type RepoId} from "../core/repoId";
 import {loadGraph} from "./loadGraph";
+import {node} from "../core/graphTestUtil";
 
 const declaration = (name) => ({
   name,
@@ -115,8 +116,10 @@ describe("analysis/loadGraph", () => {
       expect(result).toEqual({status: "REPO_NOT_LOADED"});
     });
     it("returns status:SUCCESS with merged graph on success", async () => {
-      const g1 = new Graph().addNode(NodeAddress.fromParts(["g1"]));
-      const g2 = new Graph().addNode(NodeAddress.fromParts(["g2"]));
+      const n1 = node("n1");
+      const n2 = node("n2");
+      const g1 = new Graph().addNode(n1);
+      const g2 = new Graph().addNode(n2);
       const m1 = new MockStaticAdapter("foo", g1);
       const m2 = new MockStaticAdapter("bar", g2);
       const mergedGraph = Graph.merge([g1, g2]);

--- a/src/analysis/pagerankNodeDecomposition.test.js
+++ b/src/analysis/pagerankNodeDecomposition.test.js
@@ -17,7 +17,7 @@ import {
 } from "./pagerankNodeDecomposition";
 import * as MapUtil from "../util/map";
 
-import {advancedGraph} from "../core/graphTestUtil";
+import {advancedGraph, node} from "../core/graphTestUtil";
 
 /**
  * Format a decomposition to be shown in a snapshot. This converts
@@ -117,13 +117,29 @@ function validateDecomposition(decomposition) {
 describe("analysis/pagerankNodeDecomposition", () => {
   describe("decompose", () => {
     it("has the expected output on a simple asymmetric chain", async () => {
-      const n1 = NodeAddress.fromParts(["n1"]);
-      const n2 = NodeAddress.fromParts(["n2"]);
-      const n3 = NodeAddress.fromParts(["sink"]);
-      const e1 = {src: n1, dst: n2, address: EdgeAddress.fromParts(["e1"])};
-      const e2 = {src: n2, dst: n3, address: EdgeAddress.fromParts(["e2"])};
-      const e3 = {src: n1, dst: n3, address: EdgeAddress.fromParts(["e3"])};
-      const e4 = {src: n3, dst: n3, address: EdgeAddress.fromParts(["e4"])};
+      const n1 = node("n1");
+      const n2 = node("n2");
+      const n3 = node("sink");
+      const e1 = {
+        src: n1.address,
+        dst: n2.address,
+        address: EdgeAddress.fromParts(["e1"]),
+      };
+      const e2 = {
+        src: n2.address,
+        dst: n3.address,
+        address: EdgeAddress.fromParts(["e2"]),
+      };
+      const e3 = {
+        src: n1.address,
+        dst: n3.address,
+        address: EdgeAddress.fromParts(["e3"]),
+      };
+      const e4 = {
+        src: n3.address,
+        dst: n3.address,
+        address: EdgeAddress.fromParts(["e4"]),
+      };
       const g = new Graph()
         .addNode(n1)
         .addNode(n2)

--- a/src/cli/exportGraph.test.js
+++ b/src/cli/exportGraph.test.js
@@ -2,7 +2,8 @@
 
 import {run} from "./testUtil";
 import {help, makeExportGraph} from "./exportGraph";
-import {Graph, NodeAddress} from "../core/graph";
+import {Graph} from "../core/graph";
+import {node} from "../core/graphTestUtil";
 import stringify from "json-stable-stringify";
 
 import {makeRepoId} from "../core/repoId";
@@ -61,7 +62,8 @@ describe("cli/exportGraph", () => {
     });
 
     it("on load success, prints the stringified graph to stdout", async () => {
-      const graph = new Graph().addNode(NodeAddress.empty);
+      const n = node("n");
+      const graph = new Graph().addNode(n);
       const loadGraphResult = {status: "SUCCESS", graph};
       const exportGraph = makeExportGraph(
         (_unused_repoId) => new Promise((resolve) => resolve(loadGraphResult))

--- a/src/cli/load.js
+++ b/src/cli/load.js
@@ -314,7 +314,8 @@ export async function saveTimestamps(
   const adapters = await Promise.all(
     adapterLoaders.map((a) => a.load(Common.sourcecredDirectory(), repoId))
   );
-  const timestampMap = createTimestampMap(graph.nodes(), adapters);
+  const nodeAddresses = Array.from(graph.nodes()).map((n) => n.address);
+  const timestampMap = createTimestampMap(nodeAddresses, adapters);
   writeTimestampMap(timestampMap, Common.sourcecredDirectory(), repoId);
 }
 

--- a/src/cli/pagerank.test.js
+++ b/src/cli/pagerank.test.js
@@ -14,7 +14,7 @@ import {
   defaultSaver,
 } from "./pagerank";
 import {Graph, NodeAddress, EdgeAddress} from "../core/graph";
-import {advancedGraph} from "../core/graphTestUtil";
+import {node, advancedGraph} from "../core/graphTestUtil";
 import {
   PagerankGraph,
   DEFAULT_SYNTHETIC_LOOP_WEIGHT,
@@ -29,6 +29,7 @@ import {weightsToEdgeEvaluator} from "../analysis/weightsToEdgeEvaluator";
 import {makeRepoId, repoIdToString} from "../core/repoId";
 
 describe("cli/pagerank", () => {
+  const n = node("n");
   describe("'help' command", () => {
     it("prints usage when given no arguments", async () => {
       expect(await run(help, [])).toEqual({
@@ -127,7 +128,7 @@ describe("cli/pagerank", () => {
     });
 
     describe("on successful load", () => {
-      const graph = () => new Graph().addNode(NodeAddress.empty);
+      const graph = () => new Graph().addNode(n);
       const graphResult = () => ({status: "SUCCESS", graph: graph()});
       const loader = (_unused_repoId) =>
         new Promise((resolve) => resolve(graphResult()));
@@ -169,7 +170,7 @@ describe("cli/pagerank", () => {
 
   describe("savePagerankGraph", () => {
     it("saves the PagerankGraphJSON to the right filepath", async () => {
-      const graph = new Graph().addNode(NodeAddress.empty);
+      const graph = new Graph().addNode(n);
       const evaluator = (_unused_edge) => ({toWeight: 1, froWeight: 2});
       const prg = new PagerankGraph(graph, evaluator);
       const dirname = tmp.dirSync().name;
@@ -229,10 +230,10 @@ describe("cli/pagerank", () => {
       expect(actualPagerankGraph.equals(expectedPagerankGraph)).toBe(true);
     });
     it("default pageRank is robust to nodes that are not owned by any plugin", async () => {
-      const graph = new Graph().addNode(NodeAddress.empty).addEdge({
+      const graph = new Graph().addNode(n).addEdge({
         address: EdgeAddress.empty,
-        src: NodeAddress.empty,
-        dst: NodeAddress.empty,
+        src: n.address,
+        dst: n.address,
       });
       await defaultPagerank(graph);
     });
@@ -241,10 +242,10 @@ describe("cli/pagerank", () => {
     const dirname = tmp.dirSync().name;
     process.env.SOURCECRED_DIRECTORY = dirname;
     const repoId = makeRepoId("foo", "bar");
-    const prg = new PagerankGraph(
-      new Graph().addNode(NodeAddress.empty),
-      (_unused_edge) => ({toWeight: 1, froWeight: 2})
-    );
+    const prg = new PagerankGraph(new Graph().addNode(n), (_unused_edge) => ({
+      toWeight: 1,
+      froWeight: 2,
+    }));
     await defaultSaver(repoId, prg);
     const expectedPath = path.join(
       dirname,

--- a/src/core/__snapshots__/graph.test.js.snap
+++ b/src/core/__snapshots__/graph.test.js.snap
@@ -17,11 +17,10 @@ Array [
       },
       Object {
         "address": Array [
-          "edge",
-          "2",
+          "wat",
         ],
-        "dstIndex": 1,
-        "srcIndex": 0,
+        "dstIndex": 0,
+        "srcIndex": 1,
       },
     ],
     "nodes": Array [

--- a/src/core/attribution/graphToMarkovChain.js
+++ b/src/core/attribution/graphToMarkovChain.js
@@ -112,8 +112,8 @@ export function createConnections(
   const result = new Map();
   const totalOutWeight: Map<NodeAddressT, number> = new Map();
   for (const node of graph.nodes()) {
-    result.set(node, []);
-    totalOutWeight.set(node, 0);
+    result.set(node.address, []);
+    totalOutWeight.set(node.address, 0);
   }
 
   function processConnection(target: NodeAddressT, connection: Connection) {
@@ -128,7 +128,7 @@ export function createConnections(
 
   // Add self-loops.
   for (const node of graph.nodes()) {
-    processConnection(node, {
+    processConnection(node.address, {
       adjacency: {type: "SYNTHETIC_LOOP"},
       weight: syntheticLoopWeight,
     });

--- a/src/core/attribution/graphToMarkovChain.test.js
+++ b/src/core/attribution/graphToMarkovChain.test.js
@@ -14,17 +14,17 @@ import {
 } from "./graphToMarkovChain";
 import * as MapUtil from "../../util/map";
 
-import {advancedGraph} from "../graphTestUtil";
+import {node, advancedGraph} from "../graphTestUtil";
 
 describe("core/attribution/graphToMarkovChain", () => {
+  const n1 = node("n1");
+  const n2 = node("n2");
+  const n3 = node("n3");
   describe("permute", () => {
-    const n1 = NodeAddress.fromParts(["n1"]);
-    const n2 = NodeAddress.fromParts(["n2"]);
-    const n3 = NodeAddress.fromParts(["n3"]);
     // This chain isn't a proper stochastic chain, but that's okay:
     // the actual values aren't relevant.
     const old = {
-      nodeOrder: [n1, n2, n3],
+      nodeOrder: [n1.address, n2.address, n3.address],
       chain: [
         {
           neighbor: new Uint32Array([0, 1]),
@@ -34,10 +34,10 @@ describe("core/attribution/graphToMarkovChain", () => {
         {neighbor: new Uint32Array([]), weight: new Float64Array([])},
       ],
     };
-    const newOrder = [n2, n3, n1];
+    const newOrder = [n2.address, n3.address, n1.address];
     const actual = permute(old, newOrder);
     const expected = {
-      nodeOrder: [n2, n3, n1],
+      nodeOrder: [n2.address, n3.address, n1.address],
       chain: [
         {neighbor: new Uint32Array([1]), weight: new Float64Array([0.9])},
         {neighbor: new Uint32Array([]), weight: new Float64Array([])},
@@ -51,13 +51,10 @@ describe("core/attribution/graphToMarkovChain", () => {
   });
 
   describe("normalizeNeighbors", () => {
-    const n1 = NodeAddress.fromParts(["n1"]);
-    const n2 = NodeAddress.fromParts(["n2"]);
-    const n3 = NodeAddress.fromParts(["n3"]);
     // This chain isn't a proper stochastic chain, but that's okay:
     // the actual values aren't relevant.
     const old = {
-      nodeOrder: [n2, n3, n1],
+      nodeOrder: [n2.address, n3.address, n1.address],
       chain: [
         {neighbor: new Uint32Array([1]), weight: new Float64Array([0.9])},
         {neighbor: new Uint32Array([]), weight: new Float64Array([])},
@@ -69,7 +66,7 @@ describe("core/attribution/graphToMarkovChain", () => {
     };
     const actual = normalizeNeighbors(old);
     const expected = {
-      nodeOrder: [n2, n3, n1],
+      nodeOrder: [n2.address, n3.address, n1.address],
       chain: [
         {neighbor: new Uint32Array([1]), weight: new Float64Array([0.9])},
         {neighbor: new Uint32Array([]), weight: new Float64Array([])},
@@ -86,13 +83,27 @@ describe("core/attribution/graphToMarkovChain", () => {
     // The tests for `createOrderedSparseMarkovChain` also must invoke
     // `createConnections`, so we add only light testing separately.
     it("works on a simple asymmetric chain", () => {
-      const n1 = NodeAddress.fromParts(["n1"]);
-      const n2 = NodeAddress.fromParts(["n2"]);
-      const n3 = NodeAddress.fromParts(["sink"]);
-      const e1 = {src: n1, dst: n2, address: EdgeAddress.fromParts(["e1"])};
-      const e2 = {src: n2, dst: n3, address: EdgeAddress.fromParts(["e2"])};
-      const e3 = {src: n1, dst: n3, address: EdgeAddress.fromParts(["e3"])};
-      const e4 = {src: n3, dst: n3, address: EdgeAddress.fromParts(["e4"])};
+      const e1 = {
+        src: n1.address,
+        dst: n2.address,
+        address: EdgeAddress.fromParts(["e1"]),
+      };
+      const e2 = {
+        src: n2.address,
+        dst: n3.address,
+        address: EdgeAddress.fromParts(["e2"]),
+      };
+      const e3 = {
+        src: n1.address,
+        dst: n3.address,
+        address: EdgeAddress.fromParts(["e3"]),
+      };
+      const e4 = {
+        src: n3.address,
+        dst: n3.address,
+        address: EdgeAddress.fromParts(["e4"]),
+      };
+
       const g = new Graph()
         .addNode(n1)
         .addNode(n2)
@@ -108,17 +119,17 @@ describe("core/attribution/graphToMarkovChain", () => {
       //   - for `n2`: 1 out, 1 in, 1 synthetic: 6 + 3 + 1 = 10
       //   - for `n3`: 1 out, 3 in, 1 synthetic: 6 + 9 + 1 = 16
       const expected = new Map()
-        .set(n1, [
+        .set(n1.address, [
           {adjacency: {type: "SYNTHETIC_LOOP"}, weight: 1 / 13},
           {adjacency: {type: "OUT_EDGE", edge: e1}, weight: 3 / 10},
           {adjacency: {type: "OUT_EDGE", edge: e3}, weight: 3 / 16},
         ])
-        .set(n2, [
+        .set(n2.address, [
           {adjacency: {type: "SYNTHETIC_LOOP"}, weight: 1 / 10},
           {adjacency: {type: "IN_EDGE", edge: e1}, weight: 6 / 13},
           {adjacency: {type: "OUT_EDGE", edge: e2}, weight: 3 / 16},
         ])
-        .set(n3, [
+        .set(n3.address, [
           {adjacency: {type: "SYNTHETIC_LOOP"}, weight: 1 / 16},
           {adjacency: {type: "IN_EDGE", edge: e2}, weight: 6 / 10},
           {adjacency: {type: "IN_EDGE", edge: e3}, weight: 6 / 13},
@@ -133,8 +144,7 @@ describe("core/attribution/graphToMarkovChain", () => {
 
   describe("createOrderedSparseMarkovChain", () => {
     it("works on a trivial one-node chain with no edge", () => {
-      const n = NodeAddress.fromParts(["foo"]);
-      const g = new Graph().addNode(n);
+      const g = new Graph().addNode(n1);
       const edgeWeight = (_unused_edge) => {
         throw new Error("Don't even look at me");
       };
@@ -142,7 +152,7 @@ describe("core/attribution/graphToMarkovChain", () => {
         createConnections(g, edgeWeight, 1e-3)
       );
       const expected = {
-        nodeOrder: [n],
+        nodeOrder: [n1.address],
         chain: [
           {neighbor: new Uint32Array([0]), weight: new Float64Array([1.0])},
         ],
@@ -151,13 +161,27 @@ describe("core/attribution/graphToMarkovChain", () => {
     });
 
     it("works on a simple asymmetric chain", () => {
-      const n1 = NodeAddress.fromParts(["n1"]);
-      const n2 = NodeAddress.fromParts(["n2"]);
-      const n3 = NodeAddress.fromParts(["sink"]);
-      const e1 = {src: n1, dst: n2, address: EdgeAddress.fromParts(["e1"])};
-      const e2 = {src: n2, dst: n3, address: EdgeAddress.fromParts(["e2"])};
-      const e3 = {src: n1, dst: n3, address: EdgeAddress.fromParts(["e3"])};
-      const e4 = {src: n3, dst: n3, address: EdgeAddress.fromParts(["e4"])};
+      const e1 = {
+        src: n1.address,
+        dst: n2.address,
+        address: EdgeAddress.fromParts(["e1"]),
+      };
+      const e2 = {
+        src: n2.address,
+        dst: n3.address,
+        address: EdgeAddress.fromParts(["e2"]),
+      };
+      const e3 = {
+        src: n1.address,
+        dst: n3.address,
+        address: EdgeAddress.fromParts(["e3"]),
+      };
+      const e4 = {
+        src: n3.address,
+        dst: n3.address,
+        address: EdgeAddress.fromParts(["e4"]),
+      };
+
       const g = new Graph()
         .addNode(n1)
         .addNode(n2)
@@ -171,7 +195,7 @@ describe("core/attribution/graphToMarkovChain", () => {
         createConnections(g, edgeWeight, 0.0)
       );
       const expected = {
-        nodeOrder: [n1, n2, n3],
+        nodeOrder: [n1.address, n2.address, n3.address],
         chain: [
           {
             neighbor: new Uint32Array([0, 1, 2]),
@@ -191,12 +215,21 @@ describe("core/attribution/graphToMarkovChain", () => {
     });
 
     it("works on a symmetric K_3", () => {
-      const n1 = NodeAddress.fromParts(["n1"]);
-      const n2 = NodeAddress.fromParts(["n2"]);
-      const n3 = NodeAddress.fromParts(["n3"]);
-      const e1 = {src: n1, dst: n2, address: EdgeAddress.fromParts(["e1"])};
-      const e2 = {src: n2, dst: n3, address: EdgeAddress.fromParts(["e2"])};
-      const e3 = {src: n3, dst: n1, address: EdgeAddress.fromParts(["e3"])};
+      const e1 = {
+        src: n1.address,
+        dst: n2.address,
+        address: EdgeAddress.fromParts(["e1"]),
+      };
+      const e2 = {
+        src: n2.address,
+        dst: n3.address,
+        address: EdgeAddress.fromParts(["e2"]),
+      };
+      const e3 = {
+        src: n3.address,
+        dst: n1.address,
+        address: EdgeAddress.fromParts(["e3"]),
+      };
       const g = new Graph()
         .addNode(n1)
         .addNode(n2)
@@ -209,7 +242,7 @@ describe("core/attribution/graphToMarkovChain", () => {
         createConnections(g, edgeWeight, 0.0)
       );
       const expected = {
-        nodeOrder: [n1, n2, n3],
+        nodeOrder: [n1.address, n2.address, n3.address],
         chain: [
           {
             neighbor: new Uint32Array([0, 1, 2]),
@@ -257,10 +290,10 @@ describe("core/attribution/graphToMarkovChain", () => {
       //   - dst: `epsilon / 2` from dst, `(8 - epsilon) / 8` from src
       const expected = {
         nodeOrder: [
-          ag.nodes.src(),
-          ag.nodes.dst(),
-          ag.nodes.loop(),
-          ag.nodes.isolated(),
+          ag.nodes.src.address,
+          ag.nodes.dst.address,
+          ag.nodes.loop.address,
+          ag.nodes.isolated.address,
         ],
         chain: [
           {
@@ -282,11 +315,9 @@ describe("core/attribution/graphToMarkovChain", () => {
   describe("distributionToNodeDistribution", () => {
     it("works", () => {
       const pi = new Float64Array([0.25, 0.75]);
-      const n1 = NodeAddress.fromParts(["foo"]);
-      const n2 = NodeAddress.fromParts(["bar"]);
-      expect(distributionToNodeDistribution([n1, n2], pi)).toEqual(
-        new Map().set(n1, 0.25).set(n2, 0.75)
-      );
+      expect(
+        distributionToNodeDistribution([n1.address, n2.address], pi)
+      ).toEqual(new Map().set(n1.address, 0.25).set(n2.address, 0.75));
     });
   });
 

--- a/src/core/graphTestUtil.js
+++ b/src/core/graphTestUtil.js
@@ -2,6 +2,31 @@
 
 import {EdgeAddress, Graph, NodeAddress} from "./graph";
 
+/**
+ * Create a new Node from an array of string address parts.
+ *
+ * Fields on the node will be set with dummy values.
+ * Test code should endeavor to use this whenever the code
+ * is not testing how specific fields are handled; that way, adding
+ * new fields will not require updating unrelated test code across
+ * the codebase.
+ *
+ * The returned node is frozen; as such, it is safe to re-use this exact
+ * object across test cases. If any non-primitive field is added to Node,
+ * please ensure this function freezes that field explicitly.
+ */
+export const partsNode = (parts: string[]) =>
+  Object.freeze({
+    address: NodeAddress.fromParts(parts),
+  });
+
+/**
+ * Create a new Node from a single address part.
+ *
+ * The same considerations as partsNode apply.
+ */
+export const node = (name: string) => partsNode([name]);
+
 export function advancedGraph() {
   // The advanced graph has the following features:
   // - Multiple edges of same hom, from `src` to `dst`
@@ -13,88 +38,89 @@ export function advancedGraph() {
   // logically equivalent but very different history
   // To avoid contamination, every piece is exposed as a function
   // which generates a clean copy of that piece.
-  const src = () => NodeAddress.fromParts(["src"]);
-  const dst = () => NodeAddress.fromParts(["dst"]);
-  const hom1 = () => ({
-    src: src(),
-    dst: dst(),
+  const src = node("src");
+  const dst = node("dst");
+  const hom1 = Object.freeze({
+    src: src.address,
+    dst: dst.address,
     address: EdgeAddress.fromParts(["hom", "1"]),
   });
-  const hom2 = () => ({
-    src: src(),
-    dst: dst(),
+  const hom2 = Object.freeze({
+    src: src.address,
+    dst: dst.address,
     address: EdgeAddress.fromParts(["hom", "2"]),
   });
-  const loop = () => NodeAddress.fromParts(["loop"]);
-  const loop_loop = () => ({
-    src: loop(),
-    dst: loop(),
+  const loop = node("loop");
+  const loop_loop = Object.freeze({
+    src: loop.address,
+    dst: loop.address,
     address: EdgeAddress.fromParts(["loop"]),
   });
-  const isolated = () => NodeAddress.fromParts(["isolated"]);
+  const isolated = node("isolated");
   const graph1 = () =>
     new Graph()
-      .addNode(src())
-      .addNode(dst())
-      .addNode(loop())
-      .addNode(isolated())
-      .addEdge(hom1())
-      .addEdge(hom2())
-      .addEdge(loop_loop());
+      .addNode(src)
+      .addNode(dst)
+      .addNode(loop)
+      .addNode(isolated)
+      .addEdge(hom1)
+      .addEdge(hom2)
+      .addEdge(loop_loop);
 
   // graph2 is logically equivalent to graph1, but is constructed with very
   // different history.
   // Use this to check that logically equivalent graphs are treated
   // equivalently, regardless of their history.
-  const phantomNode = () => NodeAddress.fromParts(["phantom"]);
-  const phantomEdge1 = () => ({
-    src: src(),
-    dst: phantomNode(),
+  const phantomNode = node("phantom");
+  const phantomEdge1 = Object.freeze({
+    src: src.address,
+    dst: phantomNode.address,
     address: EdgeAddress.fromParts(["phantom"]),
   });
-  const phantomEdge2 = () => ({
-    src: src(),
-    dst: isolated(),
+  const phantomEdge2 = Object.freeze({
+    src: src.address,
+    dst: isolated.address,
     address: EdgeAddress.fromParts(["not", "so", "isolated"]),
   });
+
   // To verify that the graphs are equivalent, every mutation is preceded
   // by a comment stating what the set of nodes and edges are prior to that mutation
   const graph2 = () =>
     new Graph()
       // N: [], E: []
-      .addNode(phantomNode())
+      .addNode(phantomNode)
       // N: [phantomNode], E: []
-      .addNode(src())
+      .addNode(src)
       // N: [phantomNode, src], E: []
-      .addEdge(phantomEdge1())
+      .addEdge(phantomEdge1)
       // N: [phantomNode, src], E: [phantomEdge1]
-      .addNode(isolated())
+      .addNode(isolated)
       // N: [phantomNode, src, isolated], E: [phantomEdge1]
-      .removeEdge(phantomEdge1().address)
+      .removeEdge(phantomEdge1.address)
       // N: [phantomNode, src, isolated], E: []
-      .addNode(dst())
+      .addNode(dst)
       // N: [phantomNode, src, isolated, dst], E: []
-      .addEdge(hom1())
+      .addEdge(hom1)
       // N: [phantomNode, src, isolated, dst], E: [hom1]
-      .addEdge(phantomEdge2())
+      .addEdge(phantomEdge2)
       // N: [phantomNode, src, isolated, dst], E: [hom1, phantomEdge2]
-      .addEdge(hom2())
+      .addEdge(hom2)
       // N: [phantomNode, src, isolated, dst], E: [hom1, phantomEdge2, hom2]
-      .removeEdge(hom1().address)
+      .removeEdge(hom1.address)
       // N: [phantomNode, src, isolated, dst], E: [phantomEdge2, hom2]
-      .removeNode(phantomNode())
+      .removeNode(phantomNode.address)
       // N: [src, isolated, dst], E: [phantomEdge2, hom2]
-      .removeEdge(phantomEdge2().address)
+      .removeEdge(phantomEdge2.address)
       // N: [src, isolated, dst], E: [hom2]
-      .removeNode(isolated())
+      .removeNode(isolated.address)
       // N: [src, dst], E: [hom2]
-      .addNode(isolated())
+      .addNode(isolated)
       // N: [src, dst, isolated], E: [hom2]
-      .addNode(loop())
+      .addNode(loop)
       // N: [src, dst, isolated, loop], E: [hom2]
-      .addEdge(loop_loop())
+      .addEdge(loop_loop)
       // N: [src, dst, isolated, loop], E: [hom2, loop_loop]
-      .addEdge(hom1());
+      .addEdge(hom1);
   // N: [src, dst, isolated, loop], E: [hom2, loop_loop, hom1]
   const nodes = {src, dst, loop, isolated, phantomNode};
   const edges = {hom1, hom2, loop_loop, phantomEdge1, phantomEdge2};

--- a/src/core/pagerankGraph.js
+++ b/src/core/pagerankGraph.js
@@ -5,6 +5,7 @@ import deepEqual from "lodash.isequal";
 import {toCompat, fromCompat, type Compatible} from "../util/compat";
 import {
   Graph,
+  type Node,
   type Edge,
   type EdgesOptions,
   type NodeAddressT,
@@ -35,7 +36,7 @@ export type {EdgeWeight} from "./attribution/graphToMarkovChain";
 export type EdgeEvaluator = (Edge) => EdgeWeight;
 
 export type ScoredNode = {|
-  +address: NodeAddressT,
+  +node: Node,
   +score: number,
 |};
 
@@ -213,7 +214,7 @@ export class PagerankGraph {
     this._scores = new Map();
     const graphNodes = Array.from(this._graph.nodes());
     for (const node of graphNodes) {
-      this._scores.set(node, 1 / graphNodes.length);
+      this._scores.set(node.address, 1 / graphNodes.length);
     }
     this.setEdgeEvaluator(edgeEvaluator);
   }
@@ -225,13 +226,13 @@ export class PagerankGraph {
   setEdgeEvaluator(edgeEvaluator: EdgeEvaluator): this {
     this._totalOutWeight = new Map();
     this._edgeWeights = new Map();
-    for (const node of this._graph.nodes()) {
-      this._totalOutWeight.set(node, this._syntheticLoopWeight);
+    for (const {address} of this._graph.nodes()) {
+      this._totalOutWeight.set(address, this._syntheticLoopWeight);
     }
-    const addOutWeight = (node: NodeAddressT, weight: number) => {
-      const previousWeight = NullUtil.get(this._totalOutWeight.get(node));
+    const addOutWeight = (address: NodeAddressT, weight: number) => {
+      const previousWeight = NullUtil.get(this._totalOutWeight.get(address));
       const newWeight = previousWeight + weight;
-      this._totalOutWeight.set(node, newWeight);
+      this._totalOutWeight.set(address, newWeight);
     };
     for (const edge of this._graph.edges()) {
       const weights = edgeEvaluator(edge);
@@ -265,10 +266,10 @@ export class PagerankGraph {
     return this._syntheticLoopWeight;
   }
 
-  *_nodesIterator(iterator: Iterator<NodeAddressT>): Iterator<ScoredNode> {
+  *_nodesIterator(iterator: Iterator<Node>): Iterator<ScoredNode> {
     for (const node of iterator) {
-      const score = NullUtil.get(this._scores.get(node));
-      yield {address: node, score};
+      const score = NullUtil.get(this._scores.get(node.address));
+      yield {node, score};
     }
   }
 
@@ -290,13 +291,14 @@ export class PagerankGraph {
    *
    * TODO(#1020): Allow optional filtering, as in Graph.node.
    */
-  node(x: NodeAddressT): ?ScoredNode {
+  node(addr: NodeAddressT): ?ScoredNode {
     this._verifyGraphNotModified();
-    const score = this._scores.get(x);
-    if (score == null) {
+    const node = this._graph.node(addr);
+    if (node == null) {
       return null;
     } else {
-      return {address: x, score};
+      const score = NullUtil.get(this._scores.get(addr));
+      return {node, score};
     }
   }
 
@@ -394,7 +396,7 @@ export class PagerankGraph {
   ): Iterator<ScoredNeighbor> {
     const graphNeighbors = this.graph().neighbors(target, options);
     for (const {node, edge} of graphNeighbors) {
-      const scoredNode = NullUtil.get(this.node(node));
+      const scoredNode = NullUtil.get(this.node(node.address));
       const weightedEdge = NullUtil.get(this.edge(edge.address));
       // We compute how much of target's score is attributable to the neighbor.
       // First, we find out how much edge weight there was from node to target,
@@ -408,7 +410,7 @@ export class PagerankGraph {
       }
       // We normalize this edge weight by the total outWeight for `node`.
       const normalizedEdgeWeight =
-        relevantEdgeWeight / this.totalOutWeight(node);
+        relevantEdgeWeight / this.totalOutWeight(node.address);
 
       // Then we directly compute the score contribution
       const scoreContribution = scoredNode.score * normalizedEdgeWeight;

--- a/src/explorer/pagerankTable/Aggregation.test.js
+++ b/src/explorer/pagerankTable/Aggregation.test.js
@@ -24,7 +24,7 @@ describe("explorer/pagerankTable/Aggregation", () => {
   describe("AggregationRowList", () => {
     it("instantiates AggregationRows for each aggregation", async () => {
       const {adapters, pnd, sharedProps} = await example();
-      const node = factorioNodes.inserter1;
+      const node = factorioNodes.inserter1.address;
       const depth = 20;
       const connections = NullUtil.get(pnd.get(node)).scoredConnections;
       const aggregations = aggregateFlat(
@@ -57,7 +57,7 @@ describe("explorer/pagerankTable/Aggregation", () => {
   describe("AggregationRow", () => {
     async function setup() {
       const {pnd, adapters, sharedProps} = await example();
-      const target = factorioNodes.inserter1;
+      const target = factorioNodes.inserter1.address;
       const {scoredConnections} = NullUtil.get(pnd.get(target));
       const aggregations = aggregateFlat(
         scoredConnections,

--- a/src/explorer/pagerankTable/Connection.test.js
+++ b/src/explorer/pagerankTable/Connection.test.js
@@ -19,7 +19,7 @@ describe("explorer/pagerankTable/Connection", () => {
       let {sharedProps} = await example();
       sharedProps = {...sharedProps, maxEntriesPerList};
       const depth = 2;
-      const node = factorioNodes.inserter1;
+      const node = factorioNodes.inserter1.address;
       const connections = NullUtil.get(sharedProps.pnd.get(node))
         .scoredConnections;
       const component = (
@@ -67,7 +67,7 @@ describe("explorer/pagerankTable/Connection", () => {
   describe("ConnectionRow", () => {
     async function setup() {
       const {pnd, sharedProps} = await example();
-      const target = factorioNodes.inserter1;
+      const target = factorioNodes.inserter1.address;
       const {scoredConnections} = NullUtil.get(pnd.get(target));
       const scoredConnection = scoredConnections[0];
       const depth = 2;
@@ -147,7 +147,9 @@ describe("explorer/pagerankTable/Connection", () => {
   describe("ConnectionView", () => {
     async function setup() {
       const {pnd, adapters} = await example();
-      const {scoredConnections} = NullUtil.get(pnd.get(factorioNodes.machine1));
+      const {scoredConnections} = NullUtil.get(
+        pnd.get(factorioNodes.machine1.address)
+      );
       const connections = scoredConnections.map((sc) => sc.connection);
       function connectionByType(t) {
         return NullUtil.get(

--- a/src/explorer/pagerankTable/Node.test.js
+++ b/src/explorer/pagerankTable/Node.test.js
@@ -81,7 +81,7 @@ describe("explorer/pagerankTable/Node", () => {
       if (props.sharedProps !== null) {
         sharedProps = {...sharedProps, ...props.sharedProps};
       }
-      const node = factorioNodes.inserter1;
+      const node = factorioNodes.inserter1.address;
       const component = shallow(
         <NodeRow
           node={NullUtil.orElse(props.node, node)}
@@ -114,7 +114,7 @@ describe("explorer/pagerankTable/Node", () => {
       describe("with a weight slider", () => {
         async function setupSlider(initialWeight: number = 0) {
           const node = factorioNodes.inserter1;
-          const manualWeights = new Map([[node, initialWeight]]);
+          const manualWeights = new Map([[node.address, initialWeight]]);
           const partialSharedProps: any = {manualWeights};
           const {row, sharedProps} = await setup({
             sharedProps: partialSharedProps,
@@ -145,12 +145,12 @@ describe("explorer/pagerankTable/Node", () => {
           expect(onManualWeightsChange).toHaveBeenCalledTimes(0);
           input.simulate("change", {target: {valueAsNumber: MIN_SLIDER}});
           expect(onManualWeightsChange).toHaveBeenLastCalledWith(
-            node,
+            node.address,
             sliderToWeight(MIN_SLIDER)
           );
           input.simulate("change", {target: {valueAsNumber: MAX_SLIDER}});
           expect(onManualWeightsChange).toHaveBeenLastCalledWith(
-            node,
+            node.address,
             sliderToWeight(MAX_SLIDER)
           );
           expect(onManualWeightsChange).toHaveBeenCalledTimes(2);

--- a/src/plugins/demo/graph.js
+++ b/src/plugins/demo/graph.js
@@ -1,28 +1,29 @@
 // @flow
 
-import {Graph, NodeAddress, EdgeAddress} from "../../core/graph";
+import {Graph, EdgeAddress} from "../../core/graph";
+import {partsNode} from "../../core/graphTestUtil";
 
 export const nodes = Object.freeze({
-  inserter1: NodeAddress.fromParts(["factorio", "inserter", "1"]),
-  machine1: NodeAddress.fromParts(["factorio", "machine", "1"]),
-  inserter2: NodeAddress.fromParts(["factorio", "inserter", "2"]),
-  machine2: NodeAddress.fromParts(["factorio", "machine", "2"]),
+  inserter1: partsNode(["factorio", "inserter", "1"]),
+  machine1: partsNode(["factorio", "machine", "1"]),
+  inserter2: partsNode(["factorio", "inserter", "2"]),
+  machine2: partsNode(["factorio", "machine", "2"]),
 });
 
 export const edges = Object.freeze({
   transports1: Object.freeze({
-    src: nodes.inserter1,
-    dst: nodes.machine1,
+    src: nodes.inserter1.address,
+    dst: nodes.machine1.address,
     address: EdgeAddress.fromParts(["factorio", "transports", "1"]),
   }),
   assembles1: Object.freeze({
-    src: nodes.machine1,
-    dst: nodes.inserter2,
+    src: nodes.machine1.address,
+    dst: nodes.inserter2.address,
     address: EdgeAddress.fromParts(["factorio", "assembles", "1"]),
   }),
   transports2: Object.freeze({
-    src: nodes.inserter2,
-    dst: nodes.machine2,
+    src: nodes.inserter2.address,
+    dst: nodes.machine2.address,
     address: EdgeAddress.fromParts(["factorio", "assembles", "2"]),
   }),
 });

--- a/src/plugins/git/createGraph.js
+++ b/src/plugins/git/createGraph.js
@@ -19,10 +19,6 @@ class GraphCreator {
     this.graph = new Graph();
   }
 
-  addNode(a: GN.StructuredAddress) {
-    this.graph.addNode(GN.toRaw(a));
-  }
-
   addRepository(repository: GT.Repository) {
     for (const commitHash of Object.keys(repository.commits)) {
       this.addCommit(repository.commits[commitHash]);
@@ -31,10 +27,10 @@ class GraphCreator {
 
   addCommit(commit: GT.Commit) {
     const node: GN.CommitAddress = {type: GN.COMMIT_TYPE, hash: commit.hash};
-    this.graph.addNode(GN.toRaw(node));
+    this.graph.addNode({address: GN.toRaw(node)});
     for (const parentHash of commit.parentHashes) {
       const parent: GN.CommitAddress = {type: GN.COMMIT_TYPE, hash: parentHash};
-      this.graph.addNode(GN.toRaw(parent));
+      this.graph.addNode({address: GN.toRaw(parent)});
       this.graph.addEdge(GE.createEdge.hasParent(node, parent));
     }
   }

--- a/src/plugins/git/createGraph.test.js
+++ b/src/plugins/git/createGraph.test.js
@@ -17,8 +17,8 @@ describe("plugins/git/createGraph", () => {
 
     it("only has commit nodes and has_parent edges", () => {
       const graph = createGraph(makeData());
-      for (const n of graph.nodes()) {
-        if (!NodeAddress.hasPrefix(n, NodePrefix.commit)) {
+      for (const {address} of graph.nodes()) {
+        if (!NodeAddress.hasPrefix(address, NodePrefix.commit)) {
           throw new Error("Found non-commit node");
         }
       }

--- a/src/plugins/github/createGraph.js
+++ b/src/plugins/github/createGraph.js
@@ -1,8 +1,8 @@
 // @flow
 
 import {Graph} from "../../core/graph";
-import * as GitNode from "../git/nodes";
 import * as N from "./nodes";
+import * as GitNode from "../git/nodes";
 import * as R from "./relationalView";
 import {createEdge} from "./edges";
 import {findMentionsAuthorReferences} from "./heuristics/mentionsAuthorReference";
@@ -47,7 +47,7 @@ class GraphCreator {
         hash: commit.hash(),
       };
       const gitCommit = GitNode.toRaw(gitCommitAddress);
-      this.graph.addNode(gitCommit);
+      this.graph.addNode({address: gitCommit});
       this.graph.addEdge(
         createEdge.correspondsToCommit(commit.address(), gitCommitAddress)
       );
@@ -83,7 +83,7 @@ class GraphCreator {
   }
 
   addNode(addr: N.StructuredAddress) {
-    this.graph.addNode(N.toRaw(addr));
+    this.graph.addNode({address: N.toRaw(addr)});
   }
 
   addAuthors(entity: R.AuthoredEntity) {

--- a/src/plugins/odyssey/example.js
+++ b/src/plugins/odyssey/example.js
@@ -1,6 +1,6 @@
 // @flow
 
-import {OdysseyInstance, type Node} from "./instance";
+import {OdysseyInstance, type OdysseyNode} from "./instance";
 
 /**
  * An example Odyssey instance, based on work at the Odyssey Hackathon.
@@ -53,8 +53,8 @@ export function hackathonExample(): OdysseyInstance {
 
   function addContribution(
     description: string,
-    authors: Node[],
-    impacted: Node[]
+    authors: OdysseyNode[],
+    impacted: OdysseyNode[]
   ) {
     const contrib = instance.addNode("CONTRIBUTION", description);
     for (const author of authors) {

--- a/src/plugins/odyssey/instance.js
+++ b/src/plugins/odyssey/instance.js
@@ -29,7 +29,7 @@ import {toCompat, fromCompat, type Compatible} from "../../util/compat";
 
 import * as NullUtil from "../../util/null";
 
-export type Node = {|
+export type OdysseyNode = {|
   +nodeTypeIdentifier: OdysseyNodeTypeIdentifier,
   +address: NodeAddressT,
   +description: string,
@@ -82,7 +82,7 @@ export class OdysseyInstance {
   addNode(
     typeIdentifier: OdysseyNodeTypeIdentifier,
     description: string
-  ): Node {
+  ): OdysseyNode {
     if (!isOdysseyNodeTypeIdentifier(typeIdentifier)) {
       throw new Error(
         `Tried to add node with invalid type identifier: ${typeIdentifier}`
@@ -93,7 +93,8 @@ export class OdysseyInstance {
       typeIdentifier,
       String(this._count)
     );
-    this._graph.addNode(address);
+    const node = {address};
+    this._graph.addNode(node);
     this._count++;
     this._descriptions.set(address, description);
     return NullUtil.get(this.node(address));
@@ -102,7 +103,7 @@ export class OdysseyInstance {
   /**
    * Retrieve the Node corresponding to a given node address, if it exists.
    */
-  node(address: NodeAddressT): ?Node {
+  node(address: NodeAddressT): ?OdysseyNode {
     if (!this._graph.hasNode(address)) {
       return null;
     }
@@ -124,7 +125,7 @@ export class OdysseyInstance {
    *
    * Optionally filter to only nodes of a chosen type.
    */
-  nodes(typeIdentifier?: OdysseyNodeTypeIdentifier): Iterator<Node> {
+  nodes(typeIdentifier?: OdysseyNodeTypeIdentifier): Iterator<OdysseyNode> {
     const prefix =
       typeIdentifier == null
         ? NODE_PREFIX
@@ -132,9 +133,9 @@ export class OdysseyInstance {
     return this._nodesIterator(prefix);
   }
 
-  *_nodesIterator(prefix: NodeAddressT): Iterator<Node> {
-    for (const a of this._graph.nodes({prefix})) {
-      yield NullUtil.get(this.node(a));
+  *_nodesIterator(prefix: NodeAddressT): Iterator<OdysseyNode> {
+    for (const {address} of this._graph.nodes({prefix})) {
+      yield NullUtil.get(this.node(address));
     }
   }
 
@@ -144,8 +145,8 @@ export class OdysseyInstance {
   // TODO(@decentralion): Add support for edge types (also configured on a per-instance basis).
   addEdge(
     type: OdysseyEdgeTypeIdentifier,
-    src: Node,
-    dst: Node
+    src: OdysseyNode,
+    dst: OdysseyNode
   ): OdysseyInstance {
     if (!isOdysseyEdgeTypeIdentifier(type)) {
       throw new Error(`Invalid Odyssey edge type identifier: ${type}`);


### PR DESCRIPTION
Presently, the base Graph tracks nodes as `NodeAddressT`s, without the
possibility of storing any metadata with the node.

This commit changes that: now the Graph has a `Node` type, which is an
object. At present, that type only contains an address; it will be
extended in future commits.

See #1136 for some discussion of this approach, and in particular [this
comment] for justification.

[this comment]: https://github.com/sourcecred/sourcecred/issues/1136#issuecomment-498078988

Because this changes the basic APIs in Graph, it churns the entire
codebase. To minimize future churn, I've defined helper functions,
`partsNode` and `node`, in `graphTestUtil`. These helper functions
create simple dummy nodes in situations where we don't much care about
the nodes' fields. This way, as we add new fields we won't need to
update all of the test code again.

I removed the short example from the Graph module docstring. My
reasoning was, we aren't actually typechecking that code, so it could go
out of date as we add fields to Graph. I'd rather keep the docstring
more high-level for now and ensure its sync'd.

Test plan: `yarn test --full` passes. Check the documentation on the
Graph module, and take a look at snapshot changes.