### PR TITLE
update_snapshots.sh updates generated flow types

### DIFF
--- a/scripts/update_snapshots.sh
+++ b/scripts/update_snapshots.sh
@@ -7,6 +7,8 @@ toplevel="$(git -C "$(dirname "$0")" rev-parse --show-toplevel)"
 cd "${toplevel}"
 
 yarn backend
+echo "Updating GitHub graphql flow types"
+node ./bin/generateGithubGraphqlFlowTypes.js > src/plugins/github/graphqlTypes.js
 echo "Updating for sharness/test_load_example_github.t"
 (cd sharness; UPDATE_SNAPSHOT=1 ./test_load_example_github.t -l)
 echo "Updating git/loadRepositoryTest.sh"


### PR DESCRIPTION
The generated GitHub GraphQL flow types are a kind of snapshot, and it
can be hard to remember/discover how to update them when making changes
to schema. Therefore, I've included them in the snapshot update script.

Test plan: I used it to update the types, and it worked as intended.