### PR TITLE
tools: make `update_snapshots.sh` reentrant

### DIFF
--- a/scripts/update_snapshots.sh
+++ b/scripts/update_snapshots.sh
@@ -6,16 +6,33 @@ set -eu
 toplevel="$(git -C "$(dirname "$0")" rev-parse --show-toplevel)"
 cd "${toplevel}"
 
-yarn backend
-echo "Updating GitHub graphql flow types"
-node ./bin/generateGithubGraphqlFlowTypes.js > src/plugins/github/graphqlTypes.js
-echo "Updating for sharness/test_load_example_github.t"
+tmpdir="$(mktemp -d)"
+cleanup() {
+    rm -r "${tmpdir}"
+}
+trap cleanup EXIT
+
+SOURCECRED_BIN="${tmpdir}/bin"
+yarn run --silent backend --output-path "${SOURCECRED_BIN}"
+export SOURCECRED_BIN  # for Sharness and shell tests
+export NODE_PATH="${toplevel}/node_modules${NODE_PATH:+:${NODE_PATH}}"
+
+echo "Updating GitHub GraphQL Flow types"
+cp .prettierrc.json "${SOURCECRED_BIN}/"
+node "${SOURCECRED_BIN}/generateGithubGraphqlFlowTypes.js" \
+    >src/plugins/github/graphqlTypes.js
+
+echo "Updating sharness/test_load_example_github.t"
 (cd sharness; UPDATE_SNAPSHOT=1 ./test_load_example_github.t -l)
+
 echo "Updating git/loadRepositoryTest.sh"
-./src/plugins/git/loadRepositoryTest.sh -u
+./src/plugins/git/loadRepositoryTest.sh -u --no-build
+
 echo "Updating github/fetchGithubOrgTest.sh"
 ./src/plugins/github/fetchGithubOrgTest.sh -u --no-build
+
 echo "Updating github/fetchGithubRepoTest.sh"
 ./src/plugins/github/fetchGithubRepoTest.sh -u --no-build
+
 echo "Updating Jest snapshots"
 yarn unit -u


### PR DESCRIPTION
Summary:
General cleanup to `update_snapshots.sh`, primarily such that it is free
of race conditions and does not clobber your build output directory. The
mechanism is the same as used in `yarn test`, via `SOURCECRED_BIN`.

Test Plan:
Remove your build directories (`rm -r ./bin ./build`), then run this
script (`./scripts/update_snapshots.sh`) and check that each subprocess
is properly invoked and all tests pass. Check that the temporary build
directory is cleaned up.

wchargin-branch: update-snapshots-cleanup