### PR TITLE
Add GitHub entity descriptions

### DIFF
--- a/src/plugins/github/__snapshots__/relationalView.test.js.snap
+++ b/src/plugins/github/__snapshots__/relationalView.test.js.snap
@@ -10,6 +10,8 @@ Array [
 
 exports[`plugins/github/relationalView Comment has body 1`] = `"seems a bit capricious"`;
 
+exports[`plugins/github/relationalView Comment has description 1`] = `"[comment](https://github.com/sourcecred/example-github/pull/5#discussion_r171460198) on [review](https://github.com/sourcecred/example-github/pull/5#pullrequestreview-100313899) on [#5](https://github.com/sourcecred/example-github/pull/5): This pull request will be more contentious. I can feel it..."`;
+
 exports[`plugins/github/relationalView Comment has parent 1`] = `
 Object {
   "url": "https://github.com/sourcecred/example-github/pull/5#pullrequestreview-100313899",
@@ -141,6 +143,8 @@ Array [
 ]
 `;
 
+exports[`plugins/github/relationalView Commit has description 1`] = `"[0a22334](https://github.com/sourcecred/example-github/commit/0a223346b4e6dec0127b1e6aa892c4ee0424b66a): Merge pull request #3 from sourcecred/add-readme"`;
+
 exports[`plugins/github/relationalView Commit has message 1`] = `
 "Merge pull request #3 from sourcecred/add-readme
 
@@ -175,6 +179,8 @@ Array [
 `;
 
 exports[`plugins/github/relationalView Issue has body 1`] = `"This issue references another issue, namely #1"`;
+
+exports[`plugins/github/relationalView Issue has description 1`] = `"[#2](https://github.com/sourcecred/example-github/issues/2): A referencing issue."`;
 
 exports[`plugins/github/relationalView Issue has number 1`] = `"2"`;
 
@@ -219,6 +225,8 @@ exports[`plugins/github/relationalView Pull has body 1`] = `
 `;
 
 exports[`plugins/github/relationalView Pull has deletions 1`] = `0`;
+
+exports[`plugins/github/relationalView Pull has description 1`] = `"[#5](https://github.com/sourcecred/example-github/pull/5): This pull request will be more contentious. I can feel it..."`;
 
 exports[`plugins/github/relationalView Pull has mergedAs 1`] = `
 Object {
@@ -345,6 +353,8 @@ Array [
 ]
 `;
 
+exports[`plugins/github/relationalView Repo has description 1`] = `"[sourcecred/example-github](https://github.com/sourcecred/example-github)"`;
+
 exports[`plugins/github/relationalView Repo has name 1`] = `"example-github"`;
 
 exports[`plugins/github/relationalView Repo has owner 1`] = `"sourcecred"`;
@@ -398,6 +408,8 @@ Array [
 
 exports[`plugins/github/relationalView Review has body 1`] = `"hmmm.jpg"`;
 
+exports[`plugins/github/relationalView Review has description 1`] = `"[review](https://github.com/sourcecred/example-github/pull/5#pullrequestreview-100313899) on [#5](https://github.com/sourcecred/example-github/pull/5): This pull request will be more contentious. I can feel it..."`;
+
 exports[`plugins/github/relationalView Review has parent 1`] = `
 Object {
   "url": "https://github.com/sourcecred/example-github/pull/5",
@@ -409,6 +421,8 @@ exports[`plugins/github/relationalView Review has state 1`] = `"CHANGES_REQUESTE
 exports[`plugins/github/relationalView Review has timestampMs 1`] = `1519878210000`;
 
 exports[`plugins/github/relationalView Review has url 1`] = `"https://github.com/sourcecred/example-github/pull/5#pullrequestreview-100313899"`;
+
+exports[`plugins/github/relationalView Userlike has description 1`] = `"[@wchargin](https://github.com/wchargin)"`;
 
 exports[`plugins/github/relationalView Userlike has login 1`] = `"wchargin"`;
 

--- a/src/plugins/github/relationalView.js
+++ b/src/plugins/github/relationalView.js
@@ -724,6 +724,9 @@ export class _Entity<+T: Entry> {
   timestampMs(): number | null {
     throw new Error("Not implemented.");
   }
+  description(): string {
+    throw new Error("Not implemented.");
+  }
 }
 
 type RepoEntry = {|
@@ -762,6 +765,9 @@ export class Repo extends _Entity<RepoEntry> {
   timestampMs(): number {
     return this._entry.timestampMs;
   }
+  description(): string {
+    return `[${this.owner()}/${this.name()}](${this.url()})`;
+  }
 }
 
 type IssueEntry = {|
@@ -795,6 +801,9 @@ export class Issue extends _Entity<IssueEntry> {
   }
   timestampMs(): number {
     return this._entry.timestampMs;
+  }
+  description(): string {
+    return `[#${this.number()}](${this.url()}): ${this.title()}`;
   }
   *comments(): Iterator<Comment> {
     for (const address of this._entry.comments) {
@@ -861,6 +870,9 @@ export class Pull extends _Entity<PullEntry> {
   timestampMs(): number {
     return this._entry.timestampMs;
   }
+  description(): string {
+    return `[#${this.number()}](${this.url()}): ${this.title()}`;
+  }
   *reviews(): Iterator<Review> {
     for (const address of this._entry.reviews) {
       const review = this._view.review(address);
@@ -924,6 +936,9 @@ export class Review extends _Entity<ReviewEntry> {
   timestampMs(): number {
     return this._entry.timestampMs;
   }
+  description(): string {
+    return `[review](${this.url()}) on ${this.parent().description()}`;
+  }
   references(): Iterator<ReferentEntity> {
     return this._view._references(this);
   }
@@ -968,6 +983,9 @@ export class Comment extends _Entity<CommentEntry> {
   }
   timestampMs(): number {
     return this._entry.timestampMs;
+  }
+  description(): string {
+    return `[comment](${this.url()}) on ${this.parent().description()}`;
   }
   authors(): Iterator<Userlike> {
     return getAuthors(this._view, this._entry);
@@ -1014,6 +1032,11 @@ export class Commit extends _Entity<CommitEntry> {
   timestampMs(): number {
     return this._entry.timestampMs;
   }
+  description(): string {
+    const shortHash = this.hash().slice(0, 7);
+    const headline = this.message().split("\n")[0];
+    return `[${shortHash}](${this.url()}): ${headline}`;
+  }
 }
 
 type UserlikeEntry = {|
@@ -1033,6 +1056,9 @@ export class Userlike extends _Entity<UserlikeEntry> {
   }
   timestampMs(): null {
     return null;
+  }
+  description(): string {
+    return `[@${this.login()}](${this.url()})`;
   }
 }
 

--- a/src/plugins/github/relationalView.test.js
+++ b/src/plugins/github/relationalView.test.js
@@ -84,6 +84,7 @@ describe("plugins/github/relationalView", () => {
     has("name", () => entity.name());
     has("url", () => entity.url());
     has("timestampMs", () => entity.timestampMs());
+    has("description", () => entity.description());
     hasEntities("issues", () => entity.issues());
     hasEntities("pulls", () => entity.pulls());
   });
@@ -97,6 +98,7 @@ describe("plugins/github/relationalView", () => {
     has("url", () => entity.url());
     has("parent", () => entity.parent());
     has("timestampMs", () => entity.timestampMs());
+    has("description", () => entity.description());
     hasEntities("comments", () => entity.comments());
     hasEntities("authors", () => entity.authors());
     has("reactions", () => entity.reactions());
@@ -118,6 +120,7 @@ describe("plugins/github/relationalView", () => {
     hasEntities("authors", () => entity.authors());
     has("reactions", () => entity.reactions());
     has("timestampMs", () => entity.timestampMs());
+    has("description", () => entity.description());
   });
 
   const review = Array.from(pull.reviews())[0];
@@ -130,6 +133,7 @@ describe("plugins/github/relationalView", () => {
     hasEntities("comments", () => entity.comments());
     hasEntities("authors", () => entity.authors());
     has("timestampMs", () => entity.timestampMs());
+    has("description", () => entity.description());
   });
 
   const comment = Array.from(review.comments())[0];
@@ -141,6 +145,7 @@ describe("plugins/github/relationalView", () => {
     hasEntities("authors", () => entity.authors());
     has("reactions", () => entity.reactions());
     has("timestampMs", () => entity.timestampMs());
+    has("description", () => entity.description());
   });
 
   const commit = Array.from(view.commits())[0];
@@ -150,6 +155,7 @@ describe("plugins/github/relationalView", () => {
     has("message", () => entity.message());
     hasEntities("authors", () => entity.authors());
     has("timestampMs", () => entity.timestampMs());
+    has("description", () => entity.description());
   });
 
   const userlike = Array.from(review.authors())[0];
@@ -158,6 +164,7 @@ describe("plugins/github/relationalView", () => {
     has("login", () => entity.login());
     has("url", () => entity.url());
     has("timestampMs", () => entity.timestampMs());
+    has("description", () => entity.description());
   });
 
   describe("entity", () => {


### PR DESCRIPTION
Every GitHub entity now has a `description` method which returns a short
markdown description. These will be added to the graph as part of #1136.

Test plan: Inspected snapshots, `yarn test --full`.