### PR TITLE
Graph: reify Object nodes

### DIFF
--- a/src/core/attribution/graphToMarkovChain.js
+++ b/src/core/attribution/graphToMarkovChain.js
@@ -59,8 +59,8 @@ export function createConnections(
   const result = new Map();
   const totalOutWeight: Map<NodeAddressT, number> = new Map();
   for (const node of graph.nodes()) {
-    result.set(node, []);
-    totalOutWeight.set(node, 0);
+    result.set(node.address, []);
+    totalOutWeight.set(node.address, 0);
   }
 
   function processConnection(target: NodeAddressT, connection: Connection) {
@@ -75,7 +75,7 @@ export function createConnections(
 
   // Add self-loops.
   for (const node of graph.nodes()) {
-    processConnection(node, {
+    processConnection(node.address, {
       adjacency: {type: "SYNTHETIC_LOOP"},
       weight: syntheticLoopWeight,
     });

--- a/src/core/attribution/graphToMarkovChain.test.js
+++ b/src/core/attribution/graphToMarkovChain.test.js
@@ -22,7 +22,7 @@ describe("core/attribution/graphToMarkovChain", () => {
     // This chain isn't a proper stochastic chain, but that's okay:
     // the actual values aren't relevant.
     const old = {
-      nodeOrder: [n1, n2, n3],
+      nodeOrder: [n1.address, n2.address, n3.address],
       chain: [
         {
           neighbor: new Uint32Array([0, 1]),
@@ -32,10 +32,10 @@ describe("core/attribution/graphToMarkovChain", () => {
         {neighbor: new Uint32Array([]), weight: new Float64Array([])},
       ],
     };
-    const newOrder = [n2, n3, n1];
+    const newOrder = [n2.address, n3.address, n1.address];
     const actual = permute(old, newOrder);
     const expected = {
-      nodeOrder: [n2, n3, n1],
+      nodeOrder: [n2.address, n3.address, n1.address],
       chain: [
         {neighbor: new Uint32Array([1]), weight: new Float64Array([0.9])},
         {neighbor: new Uint32Array([]), weight: new Float64Array([])},
@@ -52,7 +52,7 @@ describe("core/attribution/graphToMarkovChain", () => {
     // This chain isn't a proper stochastic chain, but that's okay:
     // the actual values aren't relevant.
     const old = {
-      nodeOrder: [n2, n3, n1],
+      nodeOrder: [n2.address, n3.address, n1.address],
       chain: [
         {neighbor: new Uint32Array([1]), weight: new Float64Array([0.9])},
         {neighbor: new Uint32Array([]), weight: new Float64Array([])},
@@ -64,7 +64,7 @@ describe("core/attribution/graphToMarkovChain", () => {
     };
     const actual = normalizeNeighbors(old);
     const expected = {
-      nodeOrder: [n2, n3, n1],
+      nodeOrder: [n2.address, n3.address, n1.address],
       chain: [
         {neighbor: new Uint32Array([1]), weight: new Float64Array([0.9])},
         {neighbor: new Uint32Array([]), weight: new Float64Array([])},
@@ -101,17 +101,17 @@ describe("core/attribution/graphToMarkovChain", () => {
       //   - for `n2`: 1 out, 1 in, 1 synthetic: 6 + 3 + 1 = 10
       //   - for `n3`: 1 out, 3 in, 1 synthetic: 6 + 9 + 1 = 16
       const expected = new Map()
-        .set(n1, [
+        .set(n1.address, [
           {adjacency: {type: "SYNTHETIC_LOOP"}, weight: 1 / 13},
           {adjacency: {type: "OUT_EDGE", edge: e1}, weight: 3 / 10},
           {adjacency: {type: "OUT_EDGE", edge: e3}, weight: 3 / 16},
         ])
-        .set(n2, [
+        .set(n2.address, [
           {adjacency: {type: "SYNTHETIC_LOOP"}, weight: 1 / 10},
           {adjacency: {type: "IN_EDGE", edge: e1}, weight: 6 / 13},
           {adjacency: {type: "OUT_EDGE", edge: e2}, weight: 3 / 16},
         ])
-        .set(n3, [
+        .set(n3.address, [
           {adjacency: {type: "SYNTHETIC_LOOP"}, weight: 1 / 16},
           {adjacency: {type: "IN_EDGE", edge: e2}, weight: 6 / 10},
           {adjacency: {type: "IN_EDGE", edge: e3}, weight: 6 / 13},
@@ -134,7 +134,7 @@ describe("core/attribution/graphToMarkovChain", () => {
         createConnections(g, edgeWeight, 1e-3)
       );
       const expected = {
-        nodeOrder: [n1],
+        nodeOrder: [n1.address],
         chain: [
           {neighbor: new Uint32Array([0]), weight: new Float64Array([1.0])},
         ],
@@ -161,7 +161,7 @@ describe("core/attribution/graphToMarkovChain", () => {
         createConnections(g, edgeWeight, 0.0)
       );
       const expected = {
-        nodeOrder: [n1, n2, n3],
+        nodeOrder: [n1.address, n2.address, n3.address],
         chain: [
           {
             neighbor: new Uint32Array([0, 1, 2]),
@@ -196,7 +196,7 @@ describe("core/attribution/graphToMarkovChain", () => {
         createConnections(g, edgeWeight, 0.0)
       );
       const expected = {
-        nodeOrder: [n1, n2, n3],
+        nodeOrder: [n1.address, n2.address, n3.address],
         chain: [
           {
             neighbor: new Uint32Array([0, 1, 2]),
@@ -244,10 +244,10 @@ describe("core/attribution/graphToMarkovChain", () => {
       //   - dst: `epsilon / 2` from dst, `(8 - epsilon) / 8` from src
       const expected = {
         nodeOrder: [
-          ag.nodes.src,
-          ag.nodes.dst,
-          ag.nodes.loop,
-          ag.nodes.isolated,
+          ag.nodes.src.address,
+          ag.nodes.dst.address,
+          ag.nodes.loop.address,
+          ag.nodes.isolated.address,
         ],
         chain: [
           {

--- a/src/core/graph.js
+++ b/src/core/graph.js
@@ -50,32 +50,38 @@ import * as NullUtil from "../util/null";
  * const commitPrefix = NodeAddress.fromParts(["sourcecred", "git", "commit"]);
  * const commitNodes = graph.nodes({prefix: commitPrefix});
  *
- * In the case of a node, the address is all the graph knows about. If you have
- * any other metadata you want to store about the node—like its commit message
- * or its favorite color—you can store that in another database. The Graph is
- * just a graph, not a key value store.
+ * The graph represents nodes as the `Node` data type, which includes an
+ * address (NodeAddressT) as well as a few other fields that are needed for
+ * calculating and displaying cred. The Graph is intended to be a lightweight
+ * data structure, so only data directly needed for cred analysis is included.
+ * If there's other data you want to store (e.g. the full text of posts that
+ * are tracked in the graph), you can use the node address as a key for a
+ * separate database.
  *
- * Edges need a little more data, since the graph needs to know what nodes the
- * edge connects. Each edge is an object with `src` and `dst` fields. These
- * fields represent the "source" of the edge and the "destination" of the edge
- * respectively, and both fields contain `NodeAddressT`s. The edge also has
- * its own address, which is an `EdgeAddressT`.
- * Here's a toy example:
+ * Edges are represented by `Edge` objects. They have `src` and `dst` fields.
+ * These fields represent the "source" of the edge and the "destination" of the
+ * edge respectively, and both fields contain `NodeAddressT`s. The edge also
+ * has its own address, which is an `EdgeAddressT`.
  *
- * const pr = NodeAddress.fromParts(["pull_request", "1"]);
- * const me = NodeAddress.fromParts(["user", "decentralion"]);
- * const authored = EdgeAddress.fromParts(["authored", "pull_request", "1"]);
- * const edge = {src: me, dst: pr, address: authored};
+ * Here's a toy example of creating a graph:
  *
- * Creating a graph is as simple as invoking the constructor and adding nodes and edges:
+ * ```js
+ * const prAddress = NodeAddress.fromParts(["pull_request", "1"]);
+ * const pr: Node = {address: prAddress}
+ * const myAddress = NodeAddress.fromParts(["user", "decentralion"]);
+ * const me: Node = {addess: myAddress}
+ * const authoredAddress = EdgeAddress.fromParts(["authored", "pull_request", "1"]);
+ * const edge = {src: me, dst: pr, address: authoredAddress};
  *
  * const g = new Graph();
  * g.addNode(pr);
  * g.addNode(me);
  * g.addEdge(edge);
+ * ```
  *
  * Graph has a number of accessor methods:
- * - `hasNode` to check if a node is in the Graph
+ * - `hasNode` to check if a node address is in the Graph
+ * - `node` to retrieve a node by its address
  * - `nodes` to iterate over the nodes in the graph
  * - `hasEdge` to check if an edge address is in the Graph
  * - `edge` to retrieve an edge by its address
@@ -100,6 +106,13 @@ export const EdgeAddress: AddressModule<EdgeAddressT> = (makeAddressModule({
 }): AddressModule<string>);
 
 /**
+ * Represents a node in the graph.
+ */
+export type Node = {|
+  +address: NodeAddressT,
+|};
+
+/**
  * An edge between two nodes.
  */
 export type Edge = {|
@@ -110,7 +123,7 @@ export type Edge = {|
 
 const COMPAT_INFO = {type: "sourcecred/graph", version: "0.4.0"};
 
-export type Neighbor = {|+node: NodeAddressT, +edge: Edge|};
+export type Neighbor = {|+node: Node, +edge: Edge|};
 
 export opaque type DirectionT = Symbol;
 export const Direction: {|
@@ -151,7 +164,7 @@ export opaque type GraphJSON = Compatible<{|
 export type ModificationCount = number;
 
 export class Graph {
-  _nodes: Set<NodeAddressT>;
+  _nodes: Map<NodeAddressT, Node>;
   _edges: Map<EdgeAddressT, Edge>;
   // Map every node address present in the graph to its inEdges (edges for
   // which it is a dst) and outEdges (edges for which it is a src)
@@ -169,7 +182,7 @@ export class Graph {
       when: -1,
       failure: "Invariants never checked",
     };
-    this._nodes = new Set();
+    this._nodes = new Map();
     this._edges = new Map();
     this._incidentEdges = new Map();
     this._maybeCheckInvariants();
@@ -232,11 +245,21 @@ export class Graph {
    *
    * Returns `this` for chaining.
    */
-  addNode(a: NodeAddressT): this {
-    NodeAddress.assertValid(a);
-    if (!this._nodes.has(a)) {
-      this._nodes.add(a);
-      this._incidentEdges.set(a, {inEdges: [], outEdges: []});
+  addNode(node: Node): this {
+    const {address} = node;
+    NodeAddress.assertValid(address);
+    const existingNode = this._nodes.get(address);
+    if (existingNode == null) {
+      this._nodes.set(address, node);
+      this._incidentEdges.set(address, {inEdges: [], outEdges: []});
+    } else {
+      if (!deepEqual(node, existingNode)) {
+        const strNode = nodeToString(node);
+        const strExisting = nodeToString(existingNode);
+        throw new Error(
+          `conflict between new node ${strNode} and existing ${strExisting}`
+        );
+      }
     }
     this._markModification();
     this._maybeCheckInvariants();
@@ -289,6 +312,17 @@ export class Graph {
   }
 
   /**
+   * Returns the Node matching a given NodeAddressT, if such a node exists,
+   * or undefined otherwise.
+   */
+  node(address: NodeAddressT): ?Node {
+    NodeAddress.assertValid(address);
+    const result = this._nodes.get(address);
+    this._maybeCheckInvariants();
+    return result;
+  }
+
+  /**
    * Returns an iterator over all of the nodes in the graph.
    *
    * Optionally, the caller can provide a node prefix. If
@@ -301,7 +335,7 @@ export class Graph {
    *
    * [1]: https://github.com/sourcecred/sourcecred/blob/7c7fa2d83d4fd5ba38efb2b2f4e0244235ac1312/src/core/address.js#L74
    */
-  nodes(options?: {|+prefix: NodeAddressT|}): Iterator<NodeAddressT> {
+  nodes(options?: {|+prefix: NodeAddressT|}): Iterator<Node> {
     const prefix = options != null ? options.prefix : NodeAddress.empty;
     if (prefix == null) {
       throw new Error(`Invalid prefix: ${String(prefix)}`);
@@ -314,9 +348,9 @@ export class Graph {
   *_nodesIterator(
     initialModificationCount: ModificationCount,
     prefix: NodeAddressT
-  ): Iterator<NodeAddressT> {
-    for (const node of this._nodes) {
-      if (NodeAddress.hasPrefix(node, prefix)) {
+  ): Iterator<Node> {
+    for (const node of this._nodes.values()) {
+      if (NodeAddress.hasPrefix(node.address, prefix)) {
         this._checkForComodification(initialModificationCount);
         this._maybeCheckInvariants();
         yield node;
@@ -572,8 +606,14 @@ export class Graph {
             continue; // don't yield loop edges twice.
           }
         }
-        const neighborNode = adjacency.direction === "IN" ? edge.src : edge.dst;
-        if (nodeFilter(neighborNode) && edgeFilter(edge.address)) {
+        const neighborNodeAddress =
+          adjacency.direction === "IN" ? edge.src : edge.dst;
+        const neighborNode = this.node(neighborNodeAddress);
+        if (
+          nodeFilter(neighborNodeAddress) &&
+          edgeFilter(edge.address) &&
+          neighborNode != null
+        ) {
           this._checkForComodification(initialModificationCount);
           this._maybeCheckInvariants();
           yield {edge, node: neighborNode};
@@ -623,10 +663,12 @@ export class Graph {
    * the number of edges.
    */
   toJSON(): GraphJSON {
-    const sortedNodes = Array.from(this.nodes()).sort();
+    const sortedNodeAddresses = Array.from(this.nodes())
+      .map((x) => x.address)
+      .sort();
     const nodeToSortedIndex = new Map();
-    sortedNodes.forEach((node, i) => {
-      nodeToSortedIndex.set(node, i);
+    sortedNodeAddresses.forEach((address, i) => {
+      nodeToSortedIndex.set(address, i);
     });
     const sortedEdges = sortBy(Array.from(this.edges()), (x) => x.address);
     const indexedEdges = sortedEdges.map(({src, dst, address}) => {
@@ -635,7 +677,7 @@ export class Graph {
       return {srcIndex, dstIndex, address: EdgeAddress.toParts(address)};
     });
     const rawJSON = {
-      nodes: sortedNodes.map((x) => NodeAddress.toParts(x)),
+      nodes: sortedNodeAddresses.map((x) => NodeAddress.toParts(x)),
       edges: indexedEdges,
     };
     const result = toCompat(COMPAT_INFO, rawJSON);
@@ -646,15 +688,23 @@ export class Graph {
   /**
    * Deserializes a GraphJSON into a new Graph.
    */
-  static fromJSON(json: GraphJSON): Graph {
-    const {nodes: nodesJSON, edges} = fromCompat(COMPAT_INFO, json);
+  static fromJSON(compatJson: GraphJSON): Graph {
+    const json = fromCompat(COMPAT_INFO, compatJson);
+    const nodesJSON: AddressJSON[] = json.nodes;
+    const edgesJSON: IndexedEdgeJSON[] = json.edges;
     const result = new Graph();
-    const nodes = nodesJSON.map((x) => NodeAddress.fromParts(x));
+    const nodes: Node[] = nodesJSON.map((x) => ({
+      address: NodeAddress.fromParts(x),
+    }));
     nodes.forEach((n) => result.addNode(n));
-    edges.forEach(({address, srcIndex, dstIndex}) => {
+    edgesJSON.forEach(({address, srcIndex, dstIndex}) => {
       const src = nodes[srcIndex];
       const dst = nodes[dstIndex];
-      result.addEdge({address: EdgeAddress.fromParts(address), src, dst});
+      result.addEdge({
+        address: EdgeAddress.fromParts(address),
+        src: src.address,
+        dst: dst.address,
+      });
     });
     return result;
   }
@@ -714,7 +764,8 @@ export class Graph {
   }
 
   _checkInvariants() {
-    // Definition. A node `n` is in the graph if `_nodes.has(n)`.
+    // Definition. A node `n` is in the graph if `n` is deep-equal to
+    // `_nodes.get(n.address)`.
     //
     // Definition. An edge `e` is in the graph if `e` is deep-equal to
     // `_edges.get(e.address)`.
@@ -723,14 +774,20 @@ export class Graph {
     // values modulo deep equality (or, from context, an element of such a
     // class).
 
-    // Invariant 1. For a node `n`, if `n` is in the graph, then
-    // `_incidentEdges.has(n)`. The value of `_incidentEdges.get(n)`
-    // is an object with two fields: `inEdges` and `outEdges`, both of which are
-    // arrays of `Edge`s
-    for (const node of this._nodes) {
-      if (!this._incidentEdges.has(node)) {
+    // Invariant 1. For a node address `a`, if `_nodes.has(a)` and
+    // `_nodes.get(a) === n`, then:
+    // 1. `n.address` equals `a`;
+    // 2. `_incidentEdges.has(n)`;
+    for (const [address, node] of this._nodes) {
+      if (node.address !== address) {
         throw new Error(
-          `missing incident-edges for ${NodeAddress.toString(node)}`
+          `bad node address: ${nodeToString(node)} does not match ${address}`
+        );
+      }
+
+      if (!this._incidentEdges.has(address)) {
+        throw new Error(
+          `missing incident-edges for ${NodeAddress.toString(address)}`
         );
       }
     }
@@ -740,8 +797,8 @@ export class Graph {
     //  1. `e.address` equals `a`;
     //  2. `e.src` is in the graph;
     //  3. `e.dst` is in the graph;
-    //  4. `_inEdges.get(e.dst)` contains `e`; and
-    //  5. `_outEdges.get(e.src)` contains `e`.
+    //  4. `_incidentEdges.get(e.dst).inEdges` contains `e`; and
+    //  5. `_incidentEdges.get(e.src).outEdges` contains `e`.
     //
     // We check 2.1, 2.2, and 2.3 here, and check 2.4 and 2.5 later for
     // improved performance.
@@ -868,6 +925,16 @@ export class Graph {
       this.checkInvariants();
     }
   }
+}
+
+/**
+ * Convert a node into a human readable string.
+ *
+ * The precise behavior is an implementation detail and subject to change.
+ */
+export function nodeToString(node: Node): string {
+  const address = NodeAddress.toString(node.address);
+  return `{address: ${address}}`;
 }
 
 /**

--- a/src/core/graphTestUtil.js
+++ b/src/core/graphTestUtil.js
@@ -1,22 +1,24 @@
 // @flow
 
-import {
-  EdgeAddress,
-  Graph,
-  NodeAddress,
-  type NodeAddressT,
-  type Edge,
-} from "./graph";
+import {EdgeAddress, Graph, NodeAddress, type Node, type Edge} from "./graph";
 
 /**
- * Create a new NodeAddressT from an array of string address parts.
+ * Create a new Node from an array of string address parts.
  *
- * Note: This is included as a preliminary clean-up method so that it will be easy to
- * switch Graph nodes from being represented by a NodeAddressT to a rich Node object.
- * In a followon commit, this method will create a Node instead of a NodeAddressT.
+ * Fields on the node will be set with dummy values.
+ * Test code should endeavor to use this whenever the code
+ * is not testing how specific fields are handled; that way, adding
+ * new fields will not require updating unrelated test code across
+ * the codebase.
+ *
+ * The returned node is frozen; as such, it is safe to re-use this exact
+ * object across test cases. If any non-primitive field is added to Node,
+ * please ensure this function freezes that field explicitly.
  */
-export function partsNode(parts: string[]): NodeAddressT {
-  return NodeAddress.fromParts(parts);
+export function partsNode(parts: string[]): Node {
+  return Object.freeze({
+    address: NodeAddress.fromParts(parts),
+  });
 }
 
 /**
@@ -24,7 +26,7 @@ export function partsNode(parts: string[]): NodeAddressT {
  *
  * The same considerations as partsNode apply.
  */
-export function node(name: string): NodeAddressT {
+export function node(name: string): Node {
   return partsNode([name]);
 }
 
@@ -35,15 +37,11 @@ export function node(name: string): NodeAddressT {
  *
  * The returned edge is frozen, so it is safe to use across test cases.
  */
-export function partsEdge(
-  parts: string[],
-  src: NodeAddressT,
-  dst: NodeAddressT
-): Edge {
+export function partsEdge(parts: string[], src: Node, dst: Node): Edge {
   return Object.freeze({
     address: EdgeAddress.fromParts(parts),
-    src,
-    dst,
+    src: src.address,
+    dst: dst.address,
   });
 }
 
@@ -52,7 +50,7 @@ export function partsEdge(
  *
  * The same considerations as partsEdge apply.
  */
-export function edge(name: string, src: NodeAddressT, dst: NodeAddressT): Edge {
+export function edge(name: string, src: Node, dst: Node): Edge {
   return partsEdge([name], src, dst);
 }
 
@@ -117,11 +115,11 @@ export function advancedGraph() {
       // N: [phantomNode, src, isolated, dst], E: [hom1, phantomEdge2, hom2]
       .removeEdge(hom1.address)
       // N: [phantomNode, src, isolated, dst], E: [phantomEdge2, hom2]
-      .removeNode(phantomNode)
+      .removeNode(phantomNode.address)
       // N: [src, isolated, dst], E: [phantomEdge2, hom2]
       .removeEdge(phantomEdge2.address)
       // N: [src, isolated, dst], E: [hom2]
-      .removeNode(isolated)
+      .removeNode(isolated.address)
       // N: [src, dst], E: [hom2]
       .addNode(isolated)
       // N: [src, dst, isolated], E: [hom2]

--- a/src/explorer/pagerankTable/Aggregation.test.js
+++ b/src/explorer/pagerankTable/Aggregation.test.js
@@ -24,7 +24,7 @@ describe("explorer/pagerankTable/Aggregation", () => {
   describe("AggregationRowList", () => {
     it("instantiates AggregationRows for each aggregation", async () => {
       const {adapters, pnd, sharedProps} = await example();
-      const node = factorioNodes.inserter1;
+      const node = factorioNodes.inserter1.address;
       const depth = 20;
       const connections = NullUtil.get(pnd.get(node)).scoredConnections;
       const aggregations = aggregateFlat(
@@ -57,7 +57,7 @@ describe("explorer/pagerankTable/Aggregation", () => {
   describe("AggregationRow", () => {
     async function setup() {
       const {pnd, adapters, sharedProps} = await example();
-      const target = factorioNodes.inserter1;
+      const target = factorioNodes.inserter1.address;
       const {scoredConnections} = NullUtil.get(pnd.get(target));
       const aggregations = aggregateFlat(
         scoredConnections,

--- a/src/explorer/pagerankTable/Connection.test.js
+++ b/src/explorer/pagerankTable/Connection.test.js
@@ -19,7 +19,7 @@ describe("explorer/pagerankTable/Connection", () => {
       let {sharedProps} = await example();
       sharedProps = {...sharedProps, maxEntriesPerList};
       const depth = 2;
-      const node = factorioNodes.inserter1;
+      const node = factorioNodes.inserter1.address;
       const connections = NullUtil.get(sharedProps.pnd.get(node))
         .scoredConnections;
       const component = (
@@ -67,7 +67,7 @@ describe("explorer/pagerankTable/Connection", () => {
   describe("ConnectionRow", () => {
     async function setup() {
       const {pnd, sharedProps} = await example();
-      const target = factorioNodes.inserter1;
+      const target = factorioNodes.inserter1.address;
       const {scoredConnections} = NullUtil.get(pnd.get(target));
       const scoredConnection = scoredConnections[0];
       const depth = 2;
@@ -147,7 +147,9 @@ describe("explorer/pagerankTable/Connection", () => {
   describe("ConnectionView", () => {
     async function setup() {
       const {pnd, adapters} = await example();
-      const {scoredConnections} = NullUtil.get(pnd.get(factorioNodes.machine1));
+      const {scoredConnections} = NullUtil.get(
+        pnd.get(factorioNodes.machine1.address)
+      );
       const connections = scoredConnections.map((sc) => sc.connection);
       function connectionByType(t) {
         return NullUtil.get(

--- a/src/explorer/pagerankTable/Node.test.js
+++ b/src/explorer/pagerankTable/Node.test.js
@@ -81,7 +81,7 @@ describe("explorer/pagerankTable/Node", () => {
       if (props.sharedProps !== null) {
         sharedProps = {...sharedProps, ...props.sharedProps};
       }
-      const node = factorioNodes.inserter1;
+      const node = factorioNodes.inserter1.address;
       const component = shallow(
         <NodeRow
           node={NullUtil.orElse(props.node, node)}
@@ -113,7 +113,7 @@ describe("explorer/pagerankTable/Node", () => {
       });
       describe("with a weight slider", () => {
         async function setupSlider(initialWeight: number = 0) {
-          const node = factorioNodes.inserter1;
+          const node = factorioNodes.inserter1.address;
           const manualWeights = new Map([[node, initialWeight]]);
           const partialSharedProps: any = {manualWeights};
           const {row, sharedProps} = await setup({

--- a/src/plugins/git/createGraph.js
+++ b/src/plugins/git/createGraph.js
@@ -20,7 +20,7 @@ class GraphCreator {
   }
 
   addNode(a: GN.StructuredAddress) {
-    this.graph.addNode(GN.toRaw(a));
+    this.graph.addNode({address: GN.toRaw(a)});
   }
 
   addRepository(repository: GT.Repository) {
@@ -31,10 +31,10 @@ class GraphCreator {
 
   addCommit(commit: GT.Commit) {
     const node: GN.CommitAddress = {type: GN.COMMIT_TYPE, hash: commit.hash};
-    this.graph.addNode(GN.toRaw(node));
+    this.graph.addNode({address: GN.toRaw(node)});
     for (const parentHash of commit.parentHashes) {
       const parent: GN.CommitAddress = {type: GN.COMMIT_TYPE, hash: parentHash};
-      this.graph.addNode(GN.toRaw(parent));
+      this.graph.addNode({address: GN.toRaw(parent)});
       this.graph.addEdge(GE.createEdge.hasParent(node, parent));
     }
   }

--- a/src/plugins/git/createGraph.test.js
+++ b/src/plugins/git/createGraph.test.js
@@ -17,8 +17,8 @@ describe("plugins/git/createGraph", () => {
 
     it("only has commit nodes and has_parent edges", () => {
       const graph = createGraph(makeData());
-      for (const n of graph.nodes()) {
-        if (!NodeAddress.hasPrefix(n, NodePrefix.commit)) {
+      for (const {address} of graph.nodes()) {
+        if (!NodeAddress.hasPrefix(address, NodePrefix.commit)) {
           throw new Error("Found non-commit node");
         }
       }

--- a/src/plugins/github/createGraph.js
+++ b/src/plugins/github/createGraph.js
@@ -46,7 +46,7 @@ class GraphCreator {
         hash: commit.hash(),
       };
       const gitCommit = GitNode.toRaw(gitCommitAddress);
-      this.graph.addNode(gitCommit);
+      this.graph.addNode({address: gitCommit});
       this.graph.addEdge(
         createEdge.correspondsToCommit(commit.address(), gitCommitAddress)
       );
@@ -78,7 +78,7 @@ class GraphCreator {
   }
 
   addNode(addr: N.StructuredAddress) {
-    this.graph.addNode(N.toRaw(addr));
+    this.graph.addNode({address: N.toRaw(addr)});
   }
 
   addAuthors(entity: R.AuthoredEntity) {


### PR DESCRIPTION
This commit modifies the base `Graph` class so that nodes are now
represented by `Node` objects rather than `NodeAddressT`. The intention
is to start adding additional fields (e.g. description and timestamp) to
nodes, although that is not included in this commit.

See #1136 for rationale.

Test plan: The graph is very well tested, and this commit adds
additional tests and invariant checking. Some additional test code
needed update. `yarn test --full` passes, and the SourceCred UI works as
expected.