### PR TITLE
Update better-sqlite3 to v5

### DIFF
--- a/flow-typed/npm/better-sqlite3_vx.x.x.js
+++ b/flow-typed/npm/better-sqlite3_vx.x.x.js
@@ -63,7 +63,7 @@ declare type bettersqlite3$BoundParameter =
 declare class bettersqlite3$Statement {
   +database: bettersqlite3$Database;
   +source: string;
-  +returnsData: boolean;
+  +reader: boolean;
 
   run(...params: bettersqlite3$BoundParameter[]): bettersqlite3$RunResult;
   get(...params: bettersqlite3$BoundParameter[]): any;
@@ -89,7 +89,7 @@ declare interface bettersqlite3$RunResult {
   // TODO: This is actually `Integer.IntLike` from npm/integer, but we
   // don't have those typedefs. For now, `number` is a good
   // approximation.
-  lastInsertROWID: number;
+  lastInsertRowid: number;
 }
 
 declare class bettersqlite3$SqliteError extends Error {

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "dependencies": {
     "aphrodite": "^2.1.0",
-    "better-sqlite3": "wchargin/better-sqlite3#wchargin-private-inmemory-db",
+    "better-sqlite3": "^5.4.0",
     "chalk": "1.1.3",
     "commonmark": "^0.28.1",
     "express": "^4.16.3",

--- a/src/graphql/mirror.js
+++ b/src/graphql/mirror.js
@@ -354,7 +354,7 @@ export class Mirror {
   _createUpdate(updateTimestamp: Date): UpdateId {
     return this._db
       .prepare("INSERT INTO updates (time_epoch_millis) VALUES (?)")
-      .run(+updateTimestamp).lastInsertROWID;
+      .run(+updateTimestamp).lastInsertRowid;
   }
 
   /**
@@ -2160,7 +2160,7 @@ function _primitivesTableName(typename: Schema.Typename) {
 export function _makeSingleUpdateFunction<Args: BindingDictionary>(
   stmt: Statement
 ): (Args) => void {
-  if (stmt.returnsData) {
+  if (stmt.reader) {
     throw new Error(
       "Cannot create update function for statement that returns data: " +
         stmt.source

--- a/src/graphql/mirror.test.js
+++ b/src/graphql/mirror.test.js
@@ -280,7 +280,8 @@ describe("graphql/mirror", () => {
         // update-related test code.
         date.setUTCMilliseconds(12345);
 
-        mirror._createUpdate(date);
+        const rowId = mirror._createUpdate(date);
+        expect(rowId).toEqual(1);
         expect(+date).toBe(12345); // please don't mutate the date...
         expect(
           db

--- a/yarn.lock
+++ b/yarn.lock
@@ -1244,12 +1244,13 @@ bcrypt-pbkdf@^1.0.0:
   dependencies:
     tweetnacl "^0.14.3"
 
-better-sqlite3@wchargin/better-sqlite3#wchargin-private-inmemory-db:
-  version "4.1.4"
-  resolved "https://codeload.github.com/wchargin/better-sqlite3/tar.gz/41f429eb11d020326065ab4e3da4433425e4be5c"
+better-sqlite3@^5.4.0:
+  version "5.4.0"
+  resolved "https://registry.yarnpkg.com/better-sqlite3/-/better-sqlite3-5.4.0.tgz#88c4894f6c0484dc0a89a9ba12268976cd26b1da"
+  integrity sha512-Uj1ZYOcq1GtFyFgJgqMVDoDLTy1B1pM9+bULnlX8szRX4cPjE/7JbKxCzQGhYlZlLkHQvtXXhCZ3skqsQ2byMA==
   dependencies:
-    bindings "^1.3.0"
-    integer "^1.0.5"
+    integer "^2.1.0"
+    tar "^4.4.6"
 
 big.js@^3.1.3:
   version "3.2.0"
@@ -1260,11 +1261,6 @@ binary-extensions@^1.0.0:
   version "1.11.0"
   resolved "https://registry.yarnpkg.com/binary-extensions/-/binary-extensions-1.11.0.tgz#46aa1751fb6a2f93ee5e689bb1087d4b14c6c205"
   integrity sha1-RqoXUftqL5PuXmibsQh9SxTGwgU=
-
-bindings@^1.3.0:
-  version "1.3.0"
-  resolved "https://registry.yarnpkg.com/bindings/-/bindings-1.3.0.tgz#b346f6ecf6a95f5a815c5839fc7cdb22502f1ed7"
-  integrity sha512-DpLh5EzMR2kzvX1KIlVC0VkC3iZtHKTgdtZ0a3pglBZdaQFjt5S9g9xd1lE+YvXyfd6mtCeRnrUfOLYiTMlNSw==
 
 block-stream@*:
   version "0.0.9"
@@ -1716,6 +1712,11 @@ chownr@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/chownr/-/chownr-1.0.1.tgz#e2a75042a9551908bebd25b8523d5f9769d79181"
   integrity sha1-4qdQQqlVGQi+vSW4Uj1fl2nXkYE=
+
+chownr@^1.1.1:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/chownr/-/chownr-1.1.2.tgz#a18f1e0b269c8a6a5d3c86eb298beb14c3dd7bf6"
+  integrity sha512-GkfeAQh+QNy3wquu9oIZr6SS5x7wGdSgNQvD10X3r+AZr1Oys22HW8kAmDMvNg2+Dm0TeGaEuO8gFwdBXxwO8A==
 
 ci-info@^1.0.0:
   version "1.1.2"
@@ -4285,12 +4286,10 @@ inquirer@3.3.0, inquirer@^3.0.6:
     strip-ansi "^4.0.0"
     through "^2.3.6"
 
-integer@^1.0.5:
-  version "1.0.5"
-  resolved "https://registry.yarnpkg.com/integer/-/integer-1.0.5.tgz#cadbf6078290389e8e4e29226e6b0044433deec1"
-  integrity sha512-3jqqAHL1gwgl3y0YzFLU0E1fECboNMz9RON8ycqRr3P/cAZN6kcMWWn35UybkYNuB1VjhpSf5WnAqmN0WpKP1Q==
-  dependencies:
-    bindings "^1.3.0"
+integer@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/integer/-/integer-2.1.0.tgz#29134ea2f7ba3362ed4dbe6bcca992b1f18ff276"
+  integrity sha512-vBtiSgrEiNocWvvZX1RVfeOKa2mCHLZQ2p9nkQkQZ/BvEiY+6CcUz0eyjvIiewjJoeNidzg2I+tpPJvpyspL1w==
 
 internal-ip@1.2.0:
   version "1.2.0"
@@ -5825,10 +5824,25 @@ minipass@^2.2.1, minipass@^2.3.3:
     safe-buffer "^5.1.2"
     yallist "^3.0.0"
 
+minipass@^2.3.5:
+  version "2.3.5"
+  resolved "https://registry.yarnpkg.com/minipass/-/minipass-2.3.5.tgz#cacebe492022497f656b0f0f51e2682a9ed2d848"
+  integrity sha512-Gi1W4k059gyRbyVUZQ4mEqLm0YIUiGYfvxhF6SIlk3ui1WVxMTGfGdQ2SInh3PDrRTVvPKgULkpJtT4RH10+VA==
+  dependencies:
+    safe-buffer "^5.1.2"
+    yallist "^3.0.0"
+
 minizlib@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/minizlib/-/minizlib-1.1.0.tgz#11e13658ce46bc3a70a267aac58359d1e0c29ceb"
   integrity sha512-4T6Ur/GctZ27nHfpt9THOdRZNgyJ9FZchYO1ceg5S8Q3DNLCKYy44nCZzgCJgcvx2UM8czmqak5BCxJMrq37lA==
+  dependencies:
+    minipass "^2.2.1"
+
+minizlib@^1.2.1:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/minizlib/-/minizlib-1.2.1.tgz#dd27ea6136243c7c880684e8672bb3a45fd9b614"
+  integrity sha512-7+4oTUOWKg7AuL3vloEWekXY2/D20cevzsrNT2kGWm+39J9hGTCBv8VI5Pm5lXZ/o3/mdR4f8rflAPhnQb8mPA==
   dependencies:
     minipass "^2.2.1"
 
@@ -8504,6 +8518,19 @@ tar@^4:
     safe-buffer "^5.1.2"
     yallist "^3.0.2"
 
+tar@^4.4.6:
+  version "4.4.10"
+  resolved "https://registry.yarnpkg.com/tar/-/tar-4.4.10.tgz#946b2810b9a5e0b26140cf78bea6b0b0d689eba1"
+  integrity sha512-g2SVs5QIxvo6OLp0GudTqEf05maawKUxXru104iaayWA09551tFCTI8f1Asb4lPfkBr91k07iL4c11XO3/b0tA==
+  dependencies:
+    chownr "^1.1.1"
+    fs-minipass "^1.2.5"
+    minipass "^2.3.5"
+    minizlib "^1.2.1"
+    mkdirp "^0.5.0"
+    safe-buffer "^5.1.2"
+    yallist "^3.0.3"
+
 test-exclude@^4.1.1:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/test-exclude/-/test-exclude-4.1.1.tgz#4d84964b0966b0087ecc334a2ce002d3d9341e26"
@@ -9327,6 +9354,11 @@ yallist@^3.0.0, yallist@^3.0.2:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/yallist/-/yallist-3.0.2.tgz#8452b4bb7e83c7c188d8041c1a837c773d6d8bb9"
   integrity sha1-hFK0u36Dx8GI2AQcGoN8dz1ti7k=
+
+yallist@^3.0.3:
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/yallist/-/yallist-3.0.3.tgz#b4b049e314be545e3ce802236d6cd22cd91c3de9"
+  integrity sha512-S+Zk8DEWE6oKpV+vI3qWkaK+jSbIK86pCwe2IF/xwIpQ8jEuxpw9NyaGjmp9+BoJv5FV2piqCDcoCtStppiq2A==
 
 yargs-parser@^4.2.0:
   version "4.2.1"


### PR DESCRIPTION
When we took a dep on better-sqlite3 in #836, we used a fork, because
better-sqlite3 did not yet support private in-memory databases via the
`:memory:` filepath. As of better-sqlite3 v5, this has been added to
mainline, so we no longer need the fork.

The v4->v5 transition involves some breaking changes. The only ones that
affected us were two field renames, from `lastUpdateROWID` to
`lastUpdateRowid`, and `returnsData` to `reader`.

Test plan:
After updating the field accesses, `yarn test --full` passes. For added
safety, I also blew away cache, loaded a nontrivial repository, and
verified that the full cred workflow still works.

cc @wchargin