### PR TITLE
try reverting tmp upgrade

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "retry": "^0.12.0",
     "rimraf": "^2.6.3",
     "svg-react-loader": "^0.4.6",
-    "tmp": "^0.1.0",
+    "tmp": "^0.0.33",
     "whatwg-fetch": "2.0.3"
   },
   "devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -8877,13 +8877,6 @@ tmp@^0.0.33:
   dependencies:
     os-tmpdir "~1.0.2"
 
-tmp@^0.1.0:
-  version "0.1.0"
-  resolved "https://registry.yarnpkg.com/tmp/-/tmp-0.1.0.tgz#ee434a4e22543082e294ba6201dcc6eafefa2877"
-  integrity sha512-J7Z2K08jbGcdA1kkQpJSqLF6T0tdQqpR2pnSUXsIchbPdTI9v3e85cLW0d6WDhwuAleOV71j2xWs8qMPfK7nKw==
-  dependencies:
-    rimraf "^2.6.3"
-
 tmpl@1.0.x:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/tmpl/-/tmpl-1.0.4.tgz#23640dd7b42d00433911140820e5cf440e521dd1"


### PR DESCRIPTION
After merging #1201, we started seeing build failures ([1], [2]) on
CircleCI. I can't reproduce them locally, but they seem related to the
`tmp` module, so let's try reverting the upgrade.

Test plan: `yarn test` passes locally. Let's see how it does on CI.

[1]: https://circleci.com/gh/sourcecred/sourcecred/1091
[2]: https://circleci.com/gh/sourcecred/sourcecred/1092