### PR TITLE
Test node 12 and node 10

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,9 +6,13 @@
 version: 2.1
 
 executors:
-  sourcecred_node:
+  node10:
     docker:
-      - image: circleci/node:8.12.0
+      - image: circleci/node:10
+    working_directory: ~/repo
+  node12:
+    docker:
+      - image: circleci/node:12
     working_directory: ~/repo
 
 commands:
@@ -28,13 +32,19 @@ commands:
 
 jobs:
   test:
-    executor: sourcecred_node
+    executor: node12
     steps:
       - checkout
       - set_up_node_modules
       - run: yarn test
   test_full:
-    executor: sourcecred_node
+    executor: node12
+    steps:
+      - checkout
+      - set_up_node_modules
+      - run: yarn test --full
+  test_full_10:
+    executor: node10
     steps:
       - checkout
       - set_up_node_modules
@@ -50,6 +60,11 @@ workflows:
             branches:
               only:
                 - master
+      - test_full_10:
+          filters:
+            branches:
+              only:
+                - master
   nightly:
     triggers:
       - schedule:
@@ -60,3 +75,4 @@ workflows:
                 - master
     jobs:
       - test_full
+      - test_full_10

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ We’re working on adding more information to the prototype, such as tracking mo
 If you’d like to try it out, you can run a local copy of SourceCred as follows.
 First, make sure that you have the following dependencies:
 
-  - Install [Node] (tested on v8.x.x).
+  - Install [Node] (tested on v12.x.x and v10.x.x).
   - Install [Yarn] (tested on v1.7.0).
   - Create a [GitHub API token]. No special permissions are required.
   - For macOS users: Ensure that your environment provides GNU


### PR DESCRIPTION
This commit changes CI to test against node 12 and 10 instead of node 8.

I test against node 12 by default (it will be LTS soon, and it has a
number of nice improvements compared to 10). We test node10 on the
nightly and post-merge, that way we will still discover quickly if we
have a problem with node 10, but it won't slow down CI for merges.

I'm just dropping explicit support for node 8 entirely, since node 8 is
end-of-life soon (Dec 19).

Test plan: I've locally verified that `yarn test --full` passes for both
node 10 and node 12.