### PR TITLE
canonicalize graph orderings

### DIFF
--- a/src/core/attribution/graphToMarkovChain.test.js
+++ b/src/core/attribution/graphToMarkovChain.test.js
@@ -290,4 +290,26 @@ describe("core/attribution/graphToMarkovChain", () => {
       expect(normalize(osmc)).toEqual(normalize(expected));
     });
   });
+
+  describe("graph -> OrderedSparseMarkovChain", () => {
+    it("always uses the graph canoncial ordering", () => {
+      const ag = advancedGraph();
+      const g1 = ag.graph1();
+      const g2 = ag.graph2();
+      function graphToOrder(g) {
+        const connections = createConnections(
+          g,
+          (_) => ({toWeight: 1, froWeight: 1}),
+          0.01
+        );
+        const osmc = createOrderedSparseMarkovChain(connections);
+        return osmc.nodeOrder;
+      }
+      const o1 = graphToOrder(g1);
+      const o2 = graphToOrder(g2);
+      const expected = Array.from(g1.nodes()).map((x) => x.address);
+      expect(o1).toEqual(expected);
+      expect(o2).toEqual(expected);
+    });
+  });
 });

--- a/src/core/graph.test.js
+++ b/src/core/graph.test.js
@@ -18,8 +18,6 @@ import {
   edgeToString,
   edgeToStrings,
   edgeToParts,
-  sortedEdgeAddressesFromJSON,
-  sortedNodeAddressesFromJSON,
 } from "./graph";
 import {advancedGraph, node, partsNode, edge, partsEdge} from "./graphTestUtil";
 
@@ -382,9 +380,27 @@ describe("core/graph", () => {
           const graph = new Graph().addNode(src).addNode(dst);
           expect(graph.hasNode(src.address)).toBe(true);
           expect(graph.hasNode(dst.address)).toBe(true);
-          expect(Array.from(graph.nodes())).toEqual([src, dst]);
+          expect(Array.from(graph.nodes())).toEqual([dst, src]);
           expect(graph.node(src.address)).toEqual(src);
           expect(graph.node(dst.address)).toEqual(dst);
+        });
+      });
+
+      describe("node ordering", () => {
+        const nodes = (g) => Array.from(g.nodes());
+        const sorted = (g) => sortBy(nodes(g), (x) => x.address);
+        it("returns nodes in sorted order, after a sequence of additions and removals", () => {
+          const g1 = advancedGraph().graph1();
+          const g2 = advancedGraph().graph2();
+          expect(sorted(g1)).toEqual(nodes(g1));
+          expect(nodes(g1)).toEqual(nodes(g2));
+        });
+        it("returns nodes in sorted order, after deserialization", () => {
+          const roundTrip = (g) => Graph.fromJSON(g.toJSON());
+          const g1 = roundTrip(advancedGraph().graph1());
+          const g2 = roundTrip(advancedGraph().graph2());
+          expect(sorted(g1)).toEqual(nodes(g1));
+          expect(nodes(g1)).toEqual(nodes(g2));
         });
       });
 
@@ -565,6 +581,24 @@ describe("core/graph", () => {
             g._modificationCount++;
             expect(() => iterator.next()).toThrow("Concurrent modification");
           });
+        });
+      });
+
+      describe("edge ordering", () => {
+        const edges = (g) => Array.from(g.edges({showDangling: true}));
+        const sorted = (g) => sortBy(edges(g), (x) => x.address);
+        it("returns edges in sorted order, after a sequence of additions and removals", () => {
+          const g1 = advancedGraph().graph1();
+          const g2 = advancedGraph().graph2();
+          expect(sorted(g1)).toEqual(edges(g1));
+          expect(edges(g1)).toEqual(edges(g2));
+        });
+        it("returns edges in sorted order, after deserialization", () => {
+          const roundTrip = (g) => Graph.fromJSON(g.toJSON());
+          const g1 = roundTrip(advancedGraph().graph1());
+          const g2 = roundTrip(advancedGraph().graph2());
+          expect(sorted(g1)).toEqual(edges(g1));
+          expect(edges(g1)).toEqual(edges(g2));
         });
       });
 
@@ -1492,22 +1526,5 @@ describe("core/graph", () => {
       };
       expect(edgeToParts(edge)).toEqual(expected);
     });
-  });
-
-  it("sortedEdgeAddressesFromJSON", () => {
-    const json = advancedGraph()
-      .graph1()
-      .toJSON();
-    const sortedEdgeAddresses = sortedEdgeAddressesFromJSON(json);
-    const expected = sortedEdgeAddresses.slice().sort();
-    expect(sortedEdgeAddresses).toEqual(expected);
-  });
-  it("sortedNodeAddressesFromJSON", () => {
-    const json = advancedGraph()
-      .graph1()
-      .toJSON();
-    const sortedNodeAddresses = sortedNodeAddressesFromJSON(json);
-    const expected = sortedNodeAddresses.slice().sort();
-    expect(sortedNodeAddresses).toEqual(expected);
   });
 });

--- a/src/core/pagerankGraph.js
+++ b/src/core/pagerankGraph.js
@@ -10,8 +10,6 @@ import {
   type NodeAddressT,
   type EdgeAddressT,
   type GraphJSON,
-  sortedEdgeAddressesFromJSON,
-  sortedNodeAddressesFromJSON,
   NodeAddress,
   type NeighborsOptions,
 } from "./graph";
@@ -567,19 +565,9 @@ export class PagerankGraph {
     this._verifyGraphNotModified();
 
     const graphJSON = this.graph().toJSON();
-    const nodes = sortedNodeAddressesFromJSON(graphJSON).filter((x) =>
-      this.graph().hasNode(x)
-    );
-    const scores: number[] = nodes.map((x) =>
-      NullUtil.get(this._scores.get(x))
-    );
+    const scores = Array.from(this.nodes()).map((x) => x.score);
 
-    const edgeAddresses = sortedEdgeAddressesFromJSON(graphJSON).filter(
-      (a) => this.graph().isDanglingEdge(a) === false
-    );
-    const edgeWeights: EdgeWeight[] = edgeAddresses.map((x) =>
-      NullUtil.get(this._edgeWeights.get(x))
-    );
+    const edgeWeights = Array.from(this.edges()).map((x) => x.weight);
     const toWeights: number[] = edgeWeights.map((x) => x.toWeight);
     const froWeights: number[] = edgeWeights.map((x) => x.froWeight);
 
@@ -604,16 +592,14 @@ export class PagerankGraph {
     } = fromCompat(COMPAT_INFO, json);
     const graph = Graph.fromJSON(graphJSON);
 
-    const nodeAddresses = sortedNodeAddressesFromJSON(graphJSON).filter((x) =>
-      graph.hasNode(x)
-    );
+    const nodeAddresses = Array.from(graph.nodes()).map((x) => x.address);
     const scoreMap: Map<NodeAddressT, number> = new Map();
     for (let i = 0; i < nodeAddresses.length; i++) {
       scoreMap.set(nodeAddresses[i], scores[i]);
     }
 
-    const edgeAddresses = sortedEdgeAddressesFromJSON(graphJSON).filter(
-      (x) => graph.isDanglingEdge(x) === false
+    const edgeAddresses = Array.from(graph.edges({showDangling: false})).map(
+      (x) => x.address
     );
     const edgeWeights: Map<EdgeAddressT, EdgeWeight> = new Map();
     for (let i = 0; i < edgeAddresses.length; i++) {


### PR DESCRIPTION
This pull request ensures that graph always iterates over nodes and edges in a canonical ordering, and ensures that the graphToMarkovChain module respects that ordering.

These are fairly atomic changes that make my work on #862 a little easier.

Test plan: Each commit has tests. I've also self-reviewed both commits.