### PR TITLE
refactor: describe edge weights consistently

### DIFF
--- a/src/analysis/pagerankNodeDecomposition.test.js
+++ b/src/analysis/pagerankNodeDecomposition.test.js
@@ -132,7 +132,7 @@ describe("analysis/pagerankNodeDecomposition", () => {
         .addEdge(e2)
         .addEdge(e3)
         .addEdge(e4);
-      const edgeWeight = () => ({toWeight: 6.0, froWeight: 3.0});
+      const edgeWeight = () => ({forwards: 6.0, backwards: 3.0});
       const connections = createConnections(g, edgeWeight, 1.0);
       const osmc = createOrderedSparseMarkovChain(connections);
       const params: PagerankParams = {
@@ -158,7 +158,7 @@ describe("analysis/pagerankNodeDecomposition", () => {
 
     it("is valid on the example graph", async () => {
       const g = advancedGraph().graph1();
-      const edgeWeight = () => ({toWeight: 6.0, froWeight: 3.0});
+      const edgeWeight = () => ({forwards: 6.0, backwards: 3.0});
       const connections = createConnections(g, edgeWeight, 1.0);
       const osmc = createOrderedSparseMarkovChain(connections);
       const params: PagerankParams = {

--- a/src/analysis/weightsToEdgeEvaluator.js
+++ b/src/analysis/weightsToEdgeEvaluator.js
@@ -11,10 +11,10 @@ import {NodeTrie, EdgeTrie} from "../core/trie";
  * Given the weight choices and the node and edge types, produces an edge
  * evaluator.
  *
- * The edge evaluator will give a toWeight and froWeight to every edge in the
- * graph according to the provided weights. When multiple weights apply (e.g. a
- * nodeType weight, an edgeType weight, and a manual nodeWeight all affecting
- * the same edge), they are composed multiplicatively.
+ * The edge evaluator will give a forwards and backwards weight to every edge
+ * in the graph according to the provided weights. When multiple weights apply
+ * (e.g. a nodeType weight, an edgeType weight, and a manual nodeWeight all
+ * affecting the same edge), they are composed multiplicatively.
  *
  * When multiple node or edge types may match a given node or edge, only
  * weights for the most specific type are considered (i.e. the type with the
@@ -54,8 +54,8 @@ export function weightsToEdgeEvaluator(
     });
     const {forwards, backwards} = edgeWeight;
     return {
-      toWeight: dstWeight * forwards,
-      froWeight: srcWeight * backwards,
+      forwards: dstWeight * forwards,
+      backwards: srcWeight * backwards,
     };
   };
 }

--- a/src/analysis/weightsToEdgeEvaluator.test.js
+++ b/src/analysis/weightsToEdgeEvaluator.test.js
@@ -47,13 +47,13 @@ describe("analysis/weightsToEdgeEvaluator", () => {
   }
 
   it("applies default weights when none are specified", () => {
-    expect(evaluateEdge(defaultWeights())).toEqual({toWeight: 1, froWeight: 2});
+    expect(evaluateEdge(defaultWeights())).toEqual({forwards: 1, backwards: 2});
   });
 
   it("only matches the most specific node types", () => {
     const weights = defaultWeights();
     weights.nodeTypeWeights.set(NodeAddress.empty, 99);
-    expect(evaluateEdge(weights)).toEqual({toWeight: 99, froWeight: 2});
+    expect(evaluateEdge(weights)).toEqual({forwards: 99, backwards: 2});
   });
 
   it("takes manually specified edge type weights into account", () => {
@@ -64,13 +64,13 @@ describe("analysis/weightsToEdgeEvaluator", () => {
       forwards: 6,
       backwards: 12,
     });
-    expect(evaluateEdge(weights)).toEqual({toWeight: 6, froWeight: 24});
+    expect(evaluateEdge(weights)).toEqual({forwards: 6, backwards: 24});
   });
 
   it("takes manually specified per-node weights into account", () => {
     const weights = defaultWeights();
     weights.nodeManualWeights.set(src, 10);
-    expect(evaluateEdge(weights)).toEqual({toWeight: 1, froWeight: 20});
+    expect(evaluateEdge(weights)).toEqual({forwards: 1, backwards: 20});
   });
 
   it("uses 1 as a default weight for unmatched nodes and edges", () => {
@@ -78,7 +78,7 @@ describe("analysis/weightsToEdgeEvaluator", () => {
       nodeTypes: [],
       edgeTypes: [],
     });
-    expect(evaluator(edge)).toEqual({toWeight: 1, froWeight: 1});
+    expect(evaluator(edge)).toEqual({forwards: 1, backwards: 1});
   });
 
   it("ignores extra weights if they do not apply", () => {

--- a/src/cli/pagerank.test.js
+++ b/src/cli/pagerank.test.js
@@ -131,7 +131,7 @@ describe("cli/pagerank", () => {
       const graphResult = () => ({status: "SUCCESS", graph: graph()});
       const loader = (_unused_repoId) =>
         new Promise((resolve) => resolve(graphResult()));
-      const evaluator = (_unused_edge) => ({toWeight: 1, froWeight: 1});
+      const evaluator = (_unused_edge) => ({forwards: 1, backwards: 1});
       const pagerankGraph = () => new PagerankGraph(graph(), evaluator, 0.001);
       const mockPagerankRunner = (_unused_graph) =>
         new Promise((resolve) => resolve(pagerankGraph()));
@@ -170,7 +170,7 @@ describe("cli/pagerank", () => {
   describe("savePagerankGraph", () => {
     it("saves the PagerankGraphJSON to the right filepath", async () => {
       const graph = new Graph().addNode(node("n"));
-      const evaluator = (_unused_edge) => ({toWeight: 1, froWeight: 2});
+      const evaluator = (_unused_edge) => ({forwards: 1, backwards: 2});
       const prg = new PagerankGraph(graph, evaluator);
       const dirname = tmp.dirSync().name;
       const repoId = makeRepoId("foo", "bar");
@@ -242,8 +242,8 @@ describe("cli/pagerank", () => {
     const prg = new PagerankGraph(
       new Graph().addNode(node("n")),
       (_unused_edge) => ({
-        toWeight: 1,
-        froWeight: 2,
+        forwards: 1,
+        backwards: 2,
       })
     );
     await defaultSaver(repoId, prg);

--- a/src/core/__snapshots__/pagerankGraph.test.js.snap
+++ b/src/core/__snapshots__/pagerankGraph.test.js.snap
@@ -4,13 +4,18 @@ exports[`core/pagerankGraph to/from JSON matches expected snapshot 1`] = `
 Array [
   Object {
     "type": "sourcecred/pagerankGraph",
-    "version": "0.1.0",
+    "version": "0.2.0",
   },
   Object {
-    "froWeights": Array [
+    "backwardsWeights": Array [
       0,
       0,
       0,
+    ],
+    "forwardsWeights": Array [
+      1,
+      1,
+      1,
     ],
     "graphJSON": Array [
       Object {
@@ -119,11 +124,6 @@ Array [
       0.2,
     ],
     "syntheticLoopWeight": 0.001,
-    "toWeights": Array [
-      1,
-      1,
-      1,
-    ],
   },
 ]
 `;

--- a/src/core/attribution/graphToMarkovChain.js
+++ b/src/core/attribution/graphToMarkovChain.js
@@ -44,11 +44,9 @@ export type OrderedSparseMarkovChain = {|
   +chain: SparseMarkovChain,
 |};
 
-// TODO(@decentralion): Rename these fields to `forwards` and `backwards` to
-// deduplicate with the EdgeWeight type defined by analysis/weights
 export type EdgeWeight = {|
-  +toWeight: number, // weight from src to dst
-  +froWeight: number, // weight from dst to src
+  +forwards: number, // weight from src to dst
+  +backwards: number, // weight from dst to src
 |};
 
 export function createConnections(
@@ -83,15 +81,15 @@ export function createConnections(
 
   // Process edges.
   for (const edge of graph.edges({showDangling: false})) {
-    const {toWeight, froWeight} = edgeWeight(edge);
+    const {forwards, backwards} = edgeWeight(edge);
     const {src, dst} = edge;
     processConnection(dst, {
       adjacency: {type: "IN_EDGE", edge},
-      weight: toWeight,
+      weight: forwards,
     });
     processConnection(src, {
       adjacency: {type: "OUT_EDGE", edge},
-      weight: froWeight,
+      weight: backwards,
     });
   }
 

--- a/src/core/attribution/graphToMarkovChain.test.js
+++ b/src/core/attribution/graphToMarkovChain.test.js
@@ -94,7 +94,7 @@ describe("core/attribution/graphToMarkovChain", () => {
         .addEdge(e2)
         .addEdge(e3)
         .addEdge(e4);
-      const edgeWeight = () => ({toWeight: 6.0, froWeight: 3.0});
+      const edgeWeight = () => ({forwards: 6.0, backwards: 3.0});
       const actual = createConnections(g, edgeWeight, 1.0);
       // Total out-weights (for normalization factors):
       //   - for `n1`: 2 out, 0 in, 1 synthetic: 12 + 0 + 1 = 13
@@ -179,7 +179,7 @@ describe("core/attribution/graphToMarkovChain", () => {
         .addEdge(e2)
         .addEdge(e3)
         .addEdge(e4);
-      const edgeWeight = () => ({toWeight: 1, froWeight: 0});
+      const edgeWeight = () => ({forwards: 1, backwards: 0});
       const osmc = createOrderedSparseMarkovChain(
         createConnections(g, edgeWeight, 0.0)
       );
@@ -214,7 +214,7 @@ describe("core/attribution/graphToMarkovChain", () => {
         .addEdge(e1)
         .addEdge(e2)
         .addEdge(e3);
-      const edgeWeight = () => ({toWeight: 1, froWeight: 1});
+      const edgeWeight = () => ({forwards: 1, backwards: 1});
       const osmc = createOrderedSparseMarkovChain(
         createConnections(g, edgeWeight, 0.0)
       );
@@ -245,7 +245,7 @@ describe("core/attribution/graphToMarkovChain", () => {
       function edgeWeight() {
         // These values are technically arbitrary, but make the
         // arithmetic simple.
-        return {toWeight: 4 - epsilon / 2, froWeight: 1 - epsilon / 2};
+        return {forwards: 4 - epsilon / 2, backwards: 1 - epsilon / 2};
       }
       const osmc = createOrderedSparseMarkovChain(
         createConnections(g, edgeWeight, epsilon)
@@ -299,7 +299,7 @@ describe("core/attribution/graphToMarkovChain", () => {
       function graphToOrder(g) {
         const connections = createConnections(
           g,
-          (_) => ({toWeight: 1, froWeight: 1}),
+          (_) => ({forwards: 1, backwards: 1}),
           0.01
         );
         const osmc = createOrderedSparseMarkovChain(connections);

--- a/src/explorer/pagerankTable/sharedTestUtils.js
+++ b/src/explorer/pagerankTable/sharedTestUtils.js
@@ -13,8 +13,8 @@ export async function example() {
   const adapters = await dynamicExplorerAdapterSet();
   const graph = adapters.graph();
   const pnd = await pagerank(graph, (_unused_Edge) => ({
-    toWeight: 1,
-    froWeight: 1,
+    forwards: 1,
+    backwards: 1,
   }));
   const maxEntriesPerList = 123;
   const manualWeights: Map<NodeAddressT, number> = new Map();


### PR DESCRIPTION
This commit resolves an inconsistency where we called edge weights
`toWeight` and `froWeight` in the core/attribution module, but
`forwards` and `backwards` in the analysis module.

I changed field names in the PagerankGraph JSON, so I bumped its compat.

Test plan: `yarn test --full` passes.