### PR TITLE
Removed incorrect information from README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,8 @@ First, make sure that you have the following dependencies:
 
 [Node]: https://nodejs.org/en/
 [Yarn]: https://yarnpkg.com/lang/en/
+[GitHub API token]: https://github.com/settings/tokens
+
 [macos-gnu]: https://github.com/sourcecred/sourcecred/issues/698#issuecomment-417202213
 
 Then, run the following commands to clone and build SourceCred:

--- a/README.md
+++ b/README.md
@@ -32,15 +32,12 @@ First, make sure that you have the following dependencies:
   - Install [Node] (tested on v12.x.x and v10.x.x).
   - Install [Yarn] (tested on v1.7.0).
   - Create a [GitHub API token]. No special permissions are required.
-  - Ensure that you have an SSH key (`id_rsa`) for `git` to use. On unix-like systems, this is usually stored in `~/.ssh/`. If you do not, you can generate one by following these [instructions](https://help.github.com/en/articles/generating-a-new-ssh-key-and-adding-it-to-the-ssh-agent).
   - For macOS users: Ensure that your environment provides GNU
     coreutils. [See this comment for details about what, how, and
     why.][macos-gnu]
 
 [Node]: https://nodejs.org/en/
 [Yarn]: https://yarnpkg.com/lang/en/
-[GitHub API token]: https://github.com/settings/tokens
-
 [macos-gnu]: https://github.com/sourcecred/sourcecred/issues/698#issuecomment-417202213
 
 Then, run the following commands to clone and build SourceCred:


### PR DESCRIPTION
#1167 added some info to the README about how the user needs to have ssh keys setup. This was true at the time, but changed as a result of #1210. This commit fixes that up by removing the now-outdated information.