### PR TITLE
Decrease GitHub TTL from 7 days to 12 hours

### DIFF
--- a/src/plugins/github/fetchGithubRepo.js
+++ b/src/plugins/github/fetchGithubRepo.js
@@ -59,7 +59,7 @@ export default async function fetchGithubRepo(
 
   // These are arbitrary tuning parameters.
   // TODO(#638): Design a configuration system for plugins.
-  const ttlSeconds = 60 * 60 * 24 * 7;
+  const ttlSeconds = 60 * 60 * 12;
   const nodesLimit = 100;
   const connectionLimit = 100;
 


### PR DESCRIPTION
As described in #987, we use a single TTL across GitHub types. Right
now, the TTL is set to 7 days. This means that it's possible to run
`sourcecred load`, but still be missing the last 7 days worth of issues.
Now that we're doing timeline cred (cf #1212), this is not acceptable.

As a workaround until we fix #987, I'm decreasing the TTL to 12 hours.
That's still long enough to make a good experience for someone who is
tweaking config and calling `sourcecred load` a lot, but ensures that
freshly-loaded results still have recent activity.

Test plan: `yarn test`