### PR TITLE
Run tests on the ci-test branch

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -60,11 +60,13 @@ workflows:
             branches:
               only:
                 - master
+                - ci-test
       - test_full_10:
           filters:
             branches:
               only:
                 - master
+                - ci-test
   nightly:
     triggers:
       - schedule:


### PR DESCRIPTION
This modifies config.yml so that it will run full tests on a branch
called "ci-test". This will make it easier for us to test attemtps to
fix full build issues, without needing to iterate against master
directly.