### PR TITLE
give build_static_site.sh access to cache

### DIFF
--- a/scripts/build_static_site.sh
+++ b/scripts/build_static_site.sh
@@ -108,6 +108,9 @@ parse_args() {
 
 build() {
     sourcecred_data="$(mktemp -d --suffix ".sourcecred-data")"
+    # Give sourcecred access to the full cache. This will greatly speed
+    # up site builds on repos that have already been loaded.
+    ln -s "${SOURCECRED_DIRECTORY}/cache" "${sourcecred_data}/cache"
     export SOURCECRED_DIRECTORY="${sourcecred_data}"
 
     if [ "${BACKEND}" -ne 0 ]; then


### PR DESCRIPTION
This modifies `scripts/build_static_site.sh` so that it uses the cache
available in `$SOURCECRED_DIRECTORY/cache`. This makes the script less
hermetic, but also enormously faster for regular usage.

We use a symbolic link for efficiency, and so that the user's main cache
is updated by the data loaded by build_static_site.

Test plan: I've manually verified that running build_static_site.sh is
now fast, when building repos which are already locally present in
cache. Existing tests pass. The user's cache is not removed.