### PR TITLE
Fix #1226

### DIFF
--- a/scripts/build_static_site.sh
+++ b/scripts/build_static_site.sh
@@ -108,9 +108,16 @@ parse_args() {
 
 build() {
     sourcecred_data="$(mktemp -d --suffix ".sourcecred-data")"
-    # Give sourcecred access to the full cache. This will greatly speed
-    # up site builds on repos that have already been loaded.
-    ln -s "${SOURCECRED_DIRECTORY}/cache" "${sourcecred_data}/cache"
+
+    if [ -n "${SOURCECRED_DIRECTORY:-}" ]; then
+        # If $SOURCECRED_DIRECTORY is available, then give sourcecred access to
+        # the cache. This will greatly speed up site builds on repos that have
+        # already been loaded.
+        # Note this speedup will only apply if the SOURCECRED_DIRECTORY has been
+        # explicitly set.
+        ln -s "${SOURCECRED_DIRECTORY}/cache" "${sourcecred_data}/cache"
+    fi
+
     export SOURCECRED_DIRECTORY="${sourcecred_data}"
 
     if [ "${BACKEND}" -ne 0 ]; then


### PR DESCRIPTION
This resolves an issue where build_static_site.sh fails if the
$SOURCECRED_DIRECTORY is not set.

I tried to add a test for this, but was unsuccessful; see discussion in
[a575638].

Test plan: I manually verified that running build_static_site.sh with an
unset SOURCECRED_DIRECTORY fails before this commit, and passes
afterwards.

[a575638]: https://github.com/sourcecred/sourcecred/commit/a575638fa47265cb624663894c4e28ba2bddc2e4