### PR TITLE
Make `TaskReporter` an easily-tested interface

### DIFF
--- a/src/util/taskReporter.js
+++ b/src/util/taskReporter.js
@@ -8,6 +8,11 @@ type MsSinceEpoch = number;
 type ConsoleLog = (string) => void;
 type GetTime = () => MsSinceEpoch;
 
+export interface TaskReporter {
+  start(taskId: TaskId): TaskReporter;
+  finish(taskId: TaskId): TaskReporter;
+}
+
 /**
  * This class is a lightweight utility for reporting task progress to the
  * command line.
@@ -19,7 +24,7 @@ type GetTime = () => MsSinceEpoch;
  * - The same task id may be re-used after the first task with that id is
  * finished.
  */
-export class TaskReporter {
+export class LoggingTaskReporter implements TaskReporter {
   // Maps the task to the time
   activeTasks: Map<TaskId, MsSinceEpoch>;
   _consoleLog: ConsoleLog;
@@ -53,6 +58,50 @@ export class TaskReporter {
     this._consoleLog(finishMessage(taskId, elapsedTime));
     this.activeTasks.delete(taskId);
     return this;
+  }
+}
+
+export type TaskEntry = {taskId: TaskId, type: "START" | "FINISH"};
+/**
+ * TestTaskReporter is a mock TaskReporter for testing purposes.
+ *
+ * Rather than emitting any messages or taking timing information, it allows retrieving
+ * the sequence of task updates that were sent to the reporter.
+ *
+ * This makes it easy for test code to verify that the TaskReporter was sent the right
+ * sequence of tasks.
+ *
+ * Callers can also check what tasks are still active (e.g. to verify that there are no
+ * active tasks unfinished at the end of a method.)
+ */
+export class TestTaskReporter implements TaskReporter {
+  _activeTasks: Set<TaskId>;
+  _entries: TaskEntry[];
+  constructor() {
+    this._activeTasks = new Set();
+    this._entries = [];
+  }
+  start(taskId: TaskId) {
+    if (this._activeTasks.has(taskId)) {
+      throw new Error(`task ${taskId} already active`);
+    }
+    this._activeTasks.add(taskId);
+    this._entries.push({taskId, type: "START"});
+    return this;
+  }
+  finish(taskId: TaskId) {
+    if (!this._activeTasks.has(taskId)) {
+      throw new Error(`task ${taskId} not active`);
+    }
+    this._activeTasks.delete(taskId);
+    this._entries.push({taskId, type: "FINISH"});
+    return this;
+  }
+  entries(): TaskEntry[] {
+    return this._entries.slice();
+  }
+  activeTasks(): TaskId[] {
+    return Array.from(this._activeTasks);
   }
 }
 


### PR DESCRIPTION
This commit refactors the `util/taskReporter` module so that
`TaskReporter` is an interface; the class previously called
`TaskReporter` is renamed to `LoggingTaskReporter`. We also export a
`TestTaskReporter` which implements the interface, and is very easy to
test.

The motivation: This will make it much easier to write tested code that
uses a `TaskReporter`, as now the test code can provide a
`TestTaskReporter` and check that all tasks get finished, that task
ids are as expected, etc.

Test plan: The `TestTaskReporter` is tested. Run `yarn test`.