### PR TITLE
remove dep on `mkdirp`

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,6 @@
     "lodash.clonedeep": "^4.5.0",
     "lodash.isequal": "^4.5.0",
     "lodash.sortby": "^4.7.0",
-    "mkdirp": "^0.5.1",
     "object-assign": "4.1.1",
     "pako": "^1.0.6",
     "promise": "8.0.3",

--- a/src/cli/load.js
+++ b/src/cli/load.js
@@ -1,7 +1,6 @@
 // @flow
 // Implementation of `sourcecred load`.
 
-import mkdirp from "mkdirp";
 import path from "path";
 import chalk from "chalk";
 
@@ -303,7 +302,7 @@ export const loadIndividualPlugin = async (
       repoIdToString(output),
       plugin
     );
-    mkdirp.sync(directory);
+    fs.mkdirpSync(directory);
     return directory;
   }
   const outputDirectory = scopedDirectory("data");

--- a/src/plugins/git/example/exampleRepo.js
+++ b/src/plugins/git/example/exampleRepo.js
@@ -1,7 +1,7 @@
 // @flow
 
-import mkdirp from "mkdirp";
 import tmp from "tmp";
+import fs from "fs-extra";
 
 import {makeUtils} from "../gitUtils";
 import type {Hash} from "../types";
@@ -31,7 +31,7 @@ export const SUBMODULE_COMMIT_2: Hash =
  */
 export function createExampleRepo(intoDirectory: string): RepositoryInfo {
   const repositoryPath = intoDirectory;
-  mkdirp(repositoryPath);
+  fs.mkdirpSync(repositoryPath);
   const git = makeUtils(repositoryPath);
   const commits = [];
   function commit(message) {
@@ -112,7 +112,7 @@ export function createExampleSubmoduleRepo(
   intoDirectory: string
 ): RepositoryInfo {
   const repositoryPath = intoDirectory;
-  mkdirp(repositoryPath);
+  fs.mkdirpSync(repositoryPath);
   const git = makeUtils(repositoryPath);
   const commits = [];
   function commit(message) {

--- a/src/plugins/git/gitUtils.js
+++ b/src/plugins/git/gitUtils.js
@@ -1,8 +1,7 @@
 // @flow
 
 import {execFileSync} from "child_process";
-import fs from "fs";
-import mkdirp from "mkdirp";
+import fs from "fs-extra";
 import path from "path";
 
 export interface Utils {
@@ -62,7 +61,7 @@ export function makeUtils(repositoryPath: string): Utils {
     writeAndStage(filename: string, contents: string) {
       const filepath = path.join(repositoryPath, filename);
       const dirpath = path.join(repositoryPath, path.dirname(filename));
-      mkdirp.sync(dirpath);
+      fs.mkdirpSync(dirpath);
       fs.writeFileSync(filepath, contents);
       git(["add", filename]);
     },


### PR DESCRIPTION
There's no need for us to depend on `mkdirp`, because the `fs-extra`
module already has `fs.mkdirp` and `fs.mkdirpSync`. This commit removes
the dep from our `package.json`, and removes all explicit imports of it.

Test plan: `yarn test --full` passes. `git grep "import mkdirp"` has no
hits.