### PR TITLE
deps: pin an exact version of Prettier

### DIFF
--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
     "flow-bin": "^0.104.0",
     "jest": "^24.8.0",
     "jest-fetch-mock": "^2.1.2",
-    "prettier": "^1.18.2",
+    "prettier": "1.18.2",
     "raf": "3.4.1",
     "react-dev-utils": "^5.0.0",
     "static-site-generator-webpack-plugin": "^3.4.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6635,7 +6635,7 @@ prelude-ls@~1.1.2:
   resolved "https://registry.yarnpkg.com/prelude-ls/-/prelude-ls-1.1.2.tgz#21932a549f5e52ffd9a827f570e04be62a97da54"
   integrity sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ=
 
-prettier@^1.18.2:
+prettier@1.18.2:
   version "1.18.2"
   resolved "https://registry.yarnpkg.com/prettier/-/prettier-1.18.2.tgz#6823e7c5900017b4bd3acf46fe9ac4b4d7bda9ea"
   integrity sha512-OeHeMc0JhFE9idD4ZdtNibzY0+TPHSpSSb9h8FqtP+YnoZZ1sl8Vc9b1sasjfymH3SonAF4QcA2+mzHPhMvIiw==


### PR DESCRIPTION
Summary:
[Prettier docs] recommend pinning an exact version because their semver
policy does not extend to stylistic changes, and so patch releases may
change the formatting output.

Given some recent discussion about formatting skew of unknown cause,
this seems like a reasonable safety measure.

Generated with `yarn add --dev --exact prettier`.

[Prettier docs]: https://prettier.io/docs/en/install.html

wchargin-branch: prettier-exact