### PR TITLE
MapUtil.pushValue returns the array

### DIFF
--- a/src/util/map.js
+++ b/src/util/map.js
@@ -153,10 +153,11 @@ export function merge<K, V>(maps: $ReadOnlyArray<Map<K, V>>): Map<K, V> {
  * If the key is already in the map, its value will be mutated, not
  * replaced.
  */
-export function pushValue<K, V>(map: Map<K, V[]>, key: K, value: V): void {
+export function pushValue<K, V>(map: Map<K, V[]>, key: K, value: V): V[] {
   let arr = map.get(key);
   if (arr == null) {
     map.set(key, (arr = []));
   }
   arr.push(value);
+  return arr;
 }

--- a/src/util/map.test.js
+++ b/src/util/map.test.js
@@ -325,5 +325,11 @@ describe("util/map", () => {
       MapUtil.pushValue(map, "foo", 1);
       expect(map.get("foo")).toBe(arr);
     });
+    it("returns the resultant array", () => {
+      const arr = [];
+      const map = new Map().set("foo", arr);
+      const result = MapUtil.pushValue(map, "foo", 1);
+      expect(result).toBe(arr);
+    });
   });
 });


### PR DESCRIPTION
Minor change to the API for MapUtil.pushValue. Now it returns the
resultant array. I've found this convenient in at least one case, and
previously we weren't returning anything, so it's a cheap change.

Test plan: Unit test added.