### PR TITLE
TimelineExplorer: Enable changing selected type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Unreleased]
 
 <!-- Please add new entries to the _top_ of this section. -->
+- Enable viewing cred over time for GitHub repos (#1268)
 - Remove unused CLI commands (`pagerank` and `analyze`) (#1254)
 - Track cred on the project level, not the repo level (#1233)
 - Fix a bug with GitHub reference detection with multiple repos (#1233)

--- a/src/explorer/TimelineApp.js
+++ b/src/explorer/TimelineApp.js
@@ -4,7 +4,11 @@ import React from "react";
 import type {Assets} from "../webutil/assets";
 import {TimelineExplorer} from "./TimelineExplorer";
 import {TimelineCred} from "../analysis/timeline/timelineCred";
-import {declaration as githubDeclaration} from "../plugins/github/declaration";
+import {
+  declaration as githubDeclaration,
+  userNodeType,
+  repoNodeType,
+} from "../plugins/github/declaration";
 import {DEFAULT_CRED_CONFIG} from "../plugins/defaultCredConfig";
 import {encodeProjectId, type ProjectId} from "../core/project";
 
@@ -70,6 +74,8 @@ export class TimelineApp extends React.Component<Props, State> {
             initialTimelineCred={timelineCred}
             projectId={this.props.projectId}
             declarations={[githubDeclaration]}
+            defaultNodeType={userNodeType}
+            filterableNodeTypes={[userNodeType, repoNodeType]}
           />
         );
       }


### PR DESCRIPTION
The code is mostly ported from the legacy app. However, we no longer
assume that we are showing every type for every plugin. Instead, the
types are manually selected. For now, we permit the GitHub user type,
and the GitHub repo type, as these are the two types that are included
in filtered timeline cred.

Test plan: Manual inspection is necessary, since this frontend is mostly
untested. I've done that inspection. Also, `yarn test` passes.