### PR TITLE
Include full projects on sourcecred.io

### DIFF
--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -76,10 +76,10 @@ build_and_deploy() {
     "${sourcecred_repo}/scripts/build_static_site.sh" \
         --target "${static_site}" \
         ${DEPLOY_CNAME_URL:+--cname "${DEPLOY_CNAME_URL}"} \
-        --repo ipfs/js-ipfs \
-        --repo ipfs/go-ipfs \
-        --repo sourcecred/sourcecred \
-        --repo sourcecred/research \
+        --project @sourcecred \
+        --project @filecoin-project \
+        --project @ipld \
+        --project @libp2p \
         ;
 
     sourcecred_site="$(mktemp -d --suffix ".sourcecred-site")"


### PR DESCRIPTION
This updates the deploys script so that we now load full projects for
@libp2p, @ipld, @sourcecred, and @filecoin-project.

I'd like to support @ipfs, but we need to tackle #1256 first.

Test plan: Ran deploy, verified that it produced good output, and then actually deployed.