### PR TITLE
rasterize: replace backtick command substitution

### DIFF
--- a/src/assets/logo/rasterize.sh
+++ b/src/assets/logo/rasterize.sh
@@ -14,7 +14,7 @@ main() {
 rasterize() {
     basename=$1
     size=$2
-    inkscape -z "`pwd`/${basename}.svg" -e "`pwd`/rasterized/${basename}_${size}.png" \
+    inkscape -z "${PWD}/${basename}.svg" -e "${PWD}/rasterized/${basename}_${size}.png" \
         -w "${size}" -h "${size}"
 }
 


### PR DESCRIPTION
Summary:
Backticks are discouraged relative to the `$(…)` form for command
substitution, because they are harder to read and do not nest without
exponential escaping:

```shell
$ foo=$(echo $(echo hi $(echo bye)))  # clear
$ foo=`echo \`echo hi \\\`echo bye\\\`\``  # hmm
```

In this context, command substitution should not be used at all; `PWD`
is a special variable that always contains the current working
directory. The new version of the code will be correct even if the
current working directory ends with whitespace that would be stripped
off by the command substitution.

Test Plan:
Prepended an `echo` to the relevant line, and verified that the script
has the same output before and after this change.

wchargin-branch: fix-backticks