### PR TITLE
gitignore: ignore .DS_Store files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,7 @@
 .env.development.local
 .env.test.local
 .env.production.local
+.DS_Store
 
 npm-debug.log*
 yarn-debug.log*


### PR DESCRIPTION
They are created by MacOS indexing.

Test plan: They no longer pollute my tree.