### PR TITLE
gitignore: remove OS-specific configurations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,7 +17,6 @@
 .env.development.local
 .env.test.local
 .env.production.local
-.DS_Store
 
 npm-debug.log*
 yarn-debug.log*


### PR DESCRIPTION
Summary:
To elaborate a bit: The repository-level `.gitignore` file is for
artifacts that are generated _by the code/build of that project_. This
includes `node_modules/`, `bin/`, `build/`, etc. These should be
necessary for all users of the project.

The user-level `.gitignore_global` file is for files that _your system_
generates. These are swap files (`.swp` `.swo` `.swa` for Vim), file
system metadata (`.DS_Store` for macOS, `Thumbs.db` for Windows), trash
directories, etc.

(See `man gitignore` for details about the two files. Take a look at
[the `.gitignore` for Git itself][git-gitignore] as an example.)

[git-gitignore]: https://github.com/git/git/blob/master/.gitignore

It doesn’t make sense to put the latter category of patterns into the
project’s `.gitignore`. You can’t accommodate every programming
environment under the sun. The file would be hundreds of lines.

By removing these patterns from the `.gitignore`, we help teach users
about how to configure `.gitignore_global` to set up their own
environment properly, once and for all.

This reverts commit 816c954f3d0bc1a54bb47450c6a1086ddafa806d.

Test Plan:
The `.gitignore` now only contains patterns specific to SourceCred.

wchargin-branch: gitignore-project-only