### PR TITLE
Remove non-standard bare-`catch` blocks

### DIFF
--- a/src/core/_getProjectIds.js
+++ b/src/core/_getProjectIds.js
@@ -26,7 +26,7 @@ module.exports = async function getProjectIds(
   let entries = [];
   try {
     entries = await fs.readdir(projectsPath);
-  } catch {
+  } catch (e) {
     return [];
   }
   const getProjectId = async (entry) => {
@@ -34,7 +34,7 @@ module.exports = async function getProjectIds(
       const jsonPath = path.join(projectsPath, entry, "project.json");
       await fs.stat(jsonPath);
       return base64url.decode(entry);
-    } catch {
+    } catch (e) {
       return null;
     }
   };


### PR DESCRIPTION
Summary:
In ES6, the [`try` statement grammar][1] requires a catch parameter; the
parameter is only optional in the latest draft of ECMAScript, which is
of course not yet ratified as any actual standard.

Even though we don’t officially pledge to support Node 8, this is
currently the only breakage, and it’s easy enough to fix.

[1]: https://www.ecma-international.org/ecma-262/6.0/#sec-try-statement

Test Plan:
Running `yarn start` on Node v8.11.4 no longer raises a syntax error.

wchargin-branch: catch-parameter