### PR TITLE
Attempt to fix CI flakes (#1243)

### DIFF
--- a/.flowconfig-ci
+++ b/.flowconfig-ci
@@ -1,4 +1,4 @@
-# If modifying this file, please modify .flowconfig-ci too!
+# If modifying this file, please modify .flowconfig too!
 [ignore]
 
 [include]
@@ -11,5 +11,6 @@ flow-typed
 [options]
 suppress_comment=\\(.\\|\n\\)*\\$ExpectFlowError
 include_warnings=true
+server.max_workers=1
 
 [strict]

--- a/config/test.js
+++ b/config/test.js
@@ -49,6 +49,22 @@ function makeTasks(
     return ["env", "SOURCECRED_BIN=" + backendOutput, ...invocation];
   }
 
+  function flowCommand(limitMemoryUsage /*: boolean */) {
+    const cmd = [
+      "yarn",
+      "run",
+      "--silent",
+      "flow",
+      "--quiet",
+      "--max-warnings=0",
+    ];
+    // Use only one worker to try to avoid flow flakey failures
+    if (limitMemoryUsage) {
+      cmd.push("--flowconfig-name", ".flowconfig-ci");
+    }
+    return cmd;
+  }
+
   const basicTasks = [
     {
       id: "ensure-flow-typing",
@@ -74,7 +90,7 @@ function makeTasks(
     },
     {
       id: "flow",
-      cmd: ["yarn", "run", "--silent", "flow", "--quiet", "--max-warnings=0"],
+      cmd: flowCommand(limitMemoryUsage),
       deps: [],
     },
     {


### PR DESCRIPTION
This is my latest salvo in trying to fix the persistent CI flakes we've
been having.  (cf #1243) They center on flow failing with `Out of retries,
exiting!`. Here's a representative failure [1].

My approach here is based on a discussion in a [GitHub thread] which
suggests that setting `server.max_workers=1` in the config can fix it.
Unfortunately, since it's in the flowconfig and is not a command line
option, I needed to fork the flowconfig into a CI and non-CI version.

Test plan: Merge it, and see if the flake goes away.

[1]: https://circleci.com/gh/sourcecred/sourcecred/1609?utm_campaign=vcs-integration-link&utm_medium=referral&utm_source=github-build-link
[GitHub thread]: https://github.com/atlassian/react-beautiful-dnd/issues/1007