### PR TITLE
Make SourceCred a public package

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "sourcecred",
   "version": "0.4.0",
-  "private": true,
+  "private": false,
   "dependencies": {
     "aphrodite": "^2.1.0",
     "base64url": "^3.0.1",
@@ -98,7 +98,7 @@
     "flow": "flow",
     "lint": "eslint src config --max-warnings 0"
   },
-  "license": "MIT + Apache-2",
+  "license": "(MIT OR Apache-2.0)",
   "jest": {
     "collectCoverageFrom": [
       "src/**/*.{js,jsx,mjs}"


### PR DESCRIPTION
I'm mostly motivated by wanting to get greenkeeper lockfile
auto-updating working (see #1269) although this is also a first step
towards making SourceCred usable from NPM (#1232).

For now, see this as us making sure we claim the sourcecred package name
on npm (see: https://www.npmjs.com/package/sourcecred).

I also fixed the license spec so that it's valid SPDX.