### PR TITLE
mirror: allow updating blacklisted ids

### DIFF
--- a/src/graphql/mirror.js
+++ b/src/graphql/mirror.js
@@ -223,11 +223,11 @@ export class Mirror {
         } else if (
           !deepEqual(existingConfig.blacklistedIds, mirrorConfig.blacklistedIds)
         ) {
-          console.error(dedent`\
-            Warning: Database already loaded with different blacklistedIds.\
+          console.warn(dedent`\
+            Warning: Database already loaded with different blacklistedIds.
             Unexpected behavior may result. Consider resetting your cache.`);
           // We don't need to do the rest of the initialization, because it was
-          // setup, albiet with different options.
+          // set up, albeit with different options.
           // (The blacklisted Ids are not used in the rest of this initialization.)
           return;
         } else {


### PR DESCRIPTION
Now the GitHub mirror will warn when the blacklisted ids are
inconsistent, rather than throwing an error.

This bit of tolerance is quite convenient, because you might know that
the change in blacklisted ids was for a totally different repo, and have
a reason to want to keep your cache around. Of course, you'll eventually
want to reset the cache so that you stop seeing the warning message. :)

Test plan: Tests updated; `yarn test` passes.