### PR TITLE
mirror: allow fetching all usernames

### DIFF
--- a/src/plugins/discourse/createGraph.js
+++ b/src/plugins/discourse/createGraph.js
@@ -130,17 +130,19 @@ export function createGraph(serverUrl: string, data: DiscourseData): Graph {
   const g = new Graph();
   const topicIdToTitle: Map<TopicId, string> = new Map();
 
+  for (const username of data.users()) {
+    g.addNode(userNode(serverUrl, username));
+  }
+
   for (const topic of data.topics()) {
     topicIdToTitle.set(topic.id, topic.title);
     g.addNode(topicNode(serverUrl, topic));
-    g.addNode(userNode(serverUrl, topic.authorUsername));
     g.addEdge(authorsTopicEdge(serverUrl, topic));
   }
 
   for (const post of data.posts()) {
     const topicTitle = topicIdToTitle.get(post.topicId) || "[unknown topic]";
     g.addNode(postNode(serverUrl, post, topicTitle));
-    g.addNode(userNode(serverUrl, post.authorUsername));
     g.addEdge(authorsPostEdge(serverUrl, post));
     g.addEdge(topicContainsPostEdge(serverUrl, post));
     let replyToPostIndex = post.replyToPostIndex;

--- a/src/plugins/discourse/createGraph.test.js
+++ b/src/plugins/discourse/createGraph.test.js
@@ -40,6 +40,16 @@ describe("plugins/discourse/createGraph", () => {
     posts(): $ReadOnlyArray<Post> {
       return this._posts;
     }
+    users(): $ReadOnlyArray<string> {
+      const users = new Set();
+      for (const {authorUsername} of this.posts()) {
+        users.add(authorUsername);
+      }
+      for (const {authorUsername} of this.topics()) {
+        users.add(authorUsername);
+      }
+      return Array.from(users);
+    }
     findPostInTopic(topicId: TopicId, indexWithinTopic: number): ?PostId {
       const post = this._posts.filter(
         (p) => p.topicId === topicId && p.indexWithinTopic === indexWithinTopic

--- a/src/plugins/discourse/mirror.test.js
+++ b/src/plugins/discourse/mirror.test.js
@@ -194,6 +194,21 @@ describe("plugins/discourse/mirror", () => {
     expect(mirror.posts()).toEqual(posts);
   });
 
+  it("provides usernames for all active users", async () => {
+    const {mirror, fetcher} = example();
+    fetcher.addPost(2, null, "alpha");
+    fetcher.addPost(3, null, "beta");
+    fetcher.addPost(3, 1, "alpha");
+    await mirror.update();
+    // credbot appears because it is the nominal author of all topics
+    expect(
+      mirror
+        .users()
+        .slice()
+        .sort()
+    ).toEqual(["alpha", "beta", "credbot"]);
+  });
+
   describe("update semantics", () => {
     it("only fetches new topics on `update`", async () => {
       const {mirror, fetcher} = example();


### PR DESCRIPTION
This is a minor change to the Discourse mirror so that it supports a
query to get all users from the server. It will be convenient for a
followon change which makes `update` search for every user's likes.

I also modified createGraph so that it uses the new method, which
results in code that is cleaner and slightly more efficient.

Test plan: Unit tests updated.