### PR TITLE
Remove console error from default timeline loader

### DIFF
--- a/src/explorer/TimelineApp.js
+++ b/src/explorer/TimelineApp.js
@@ -90,7 +90,6 @@ export async function defaultLoader(
   projectId: ProjectId
 ): Promise<LoadResult> {
   async function fetchCred(): Promise<TimelineCred> {
-    console.error(">>>DEFAULTLOADER");
     const encodedId = encodeProjectId(projectId);
     const url = assets.resolve(`api/v1/data/projects/${encodedId}/cred.json`);
     const response = await fetch(url);


### PR DESCRIPTION
Summary:
This is firing on a production page load of the “prototype” link from
the homepage, and does not seem to actually be an error condition.

Test Plan:
Run `yarn start`, navigate to `/timeline/sourcecred/example-github/`,
and observe that the console error has disappeared.

wchargin-branch: defaultloader-console-error