### PR TITLE
discourse fetch: add rate limiting

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
     "aphrodite": "^2.1.0",
     "base64url": "^3.0.1",
     "better-sqlite3": "^5.4.0",
+    "bottleneck": "^2.19.5",
     "chalk": "2.4.2",
     "commonmark": "^0.29.0",
     "d3-array": "^2.2.0",

--- a/src/plugins/discourse/fetch.test.js
+++ b/src/plugins/discourse/fetch.test.js
@@ -27,7 +27,7 @@ describe("plugins/discourse/fetch", () => {
         throw new Error(`couldn't load snapshot for ${file}`);
       }
     }
-    const snapshotFetcher = () => new Fetcher(options, snapshotFetch);
+    const snapshotFetcher = () => new Fetcher(options, snapshotFetch, 0);
 
     it("loads LatestTopicId from snapshot", async () => {
       const topicId = await snapshotFetcher().latestTopicId();
@@ -55,7 +55,7 @@ describe("plugins/discourse/fetch", () => {
       return Promise.resolve(resp);
     };
     const fetcherWithStatus = (status: number) =>
-      new Fetcher(options, fakeFetch(status));
+      new Fetcher(options, fakeFetch(status), 0);
     function expectError(name, f, status) {
       it(`${name} errors on ${String(status)}`, () => {
         const fetcher = fetcherWithStatus(status);
@@ -96,7 +96,7 @@ describe("plugins/discourse/fetch", () => {
         fetchOptions = _options;
         return Promise.resolve(new Response("", {status: 404}));
       };
-      await new Fetcher(options, fakeFetch).post(1337);
+      await new Fetcher(options, fakeFetch, 0).post(1337);
       if (fetchOptions == null) {
         throw new Error("fetchOptions == null");
       }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1799,6 +1799,11 @@ boolbase@~1.0.0:
   resolved "https://registry.yarnpkg.com/boolbase/-/boolbase-1.0.0.tgz#68dff5fbe60c51eb37725ea9e3ed310dcc1e776e"
   integrity sha1-aN/1++YMUes3cl6p4+0xDcwed24=
 
+bottleneck@^2.19.5:
+  version "2.19.5"
+  resolved "https://registry.yarnpkg.com/bottleneck/-/bottleneck-2.19.5.tgz#5df0b90f59fd47656ebe63c78a98419205cadd91"
+  integrity sha512-VHiNCbI1lKdl44tGrhNfU3lup0Tj/ZBMJB5/2ZbNXRCPuRCO7ed2mgcK4r17y+KB2EfuYuRaVlwNbAeaWGSpbw==
+
 brace-expansion@^1.0.0, brace-expansion@^1.1.7:
   version "1.1.11"
   resolved "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-1.1.11.tgz#3c7fcbf529d87226f3d2f52b966ff5271eb441dd"


### PR DESCRIPTION
This implements rate limiting to the Discourse fetch logic, so that we
can actually load nontrivial servers without getting a 529 failure.

We could have used retry; I thought it was more polite to actually limit
the rate at which we make requests. However, to avoid seeing 529s in
practice, I left a bit of a buffer: we make only 55 requests per minute,
although 60 would be allowed.

If we want to improve Discourse loading time, we could boost up to the
full 60 request/min, but add in retries. (Or we could switch to retries
entirely.)

Test plan: This logic is untested, however my full discourse-plugin
branch uses it to do full Discourse loads without issue.