### PR TITLE
add a loadDiscourse method

### DIFF
--- a/src/plugins/discourse/loadDiscourse.js
+++ b/src/plugins/discourse/loadDiscourse.js
@@ -1,0 +1,30 @@
+// @flow
+
+import Database from "better-sqlite3";
+import base64url from "base64url";
+import {Fetcher, type DiscourseFetchOptions} from "./fetch";
+import {Mirror} from "./mirror";
+import {createGraph} from "./createGraph";
+import {TaskReporter} from "../../util/taskReporter";
+import {Graph} from "../../core/graph";
+import path from "path";
+
+export type {DiscourseFetchOptions} from "./fetch";
+
+export type Options = {|
+  +fetchOptions: DiscourseFetchOptions,
+  +cacheDirectory: string,
+|};
+
+export async function loadDiscourse(
+  options: Options,
+  reporter: TaskReporter
+): Promise<Graph> {
+  const filename = base64url.encode(options.fetchOptions.serverUrl) + ".db";
+  const db = new Database(path.join(options.cacheDirectory, filename));
+  const fetcher = new Fetcher(options.fetchOptions);
+  const mirror = new Mirror(db, fetcher, options.fetchOptions.serverUrl);
+  await mirror.update(reporter);
+  const graph = createGraph(options.fetchOptions.serverUrl, mirror);
+  return graph;
+}


### PR DESCRIPTION
This is the analogue to `github/loadGraph`, but for Discourse. It
basically pipes together the mechanisms for loading Discourse data and
creating a Discourse graph from them, resulting in a single endpoint for
consumption in the API.

In contrast to github, the method is called `loadDiscourse` and not
`loadGraph`, which seemed more appropriate to me. I haven't changed
the corresponding GitHub method's name. (I'm currently knowingly letting
conceputal debt accumulate around the plugin interface; I expect to do a
full refactor within the next few months.)

Test plan: This is the kind of "pipe together tested APIs involving IO"
code which I have decided not to write explicit tests for. However, it
is still protected by flow, and I have a branch (`discourse-plugin`)
which uses this code to do a full Discourse load.