### PR TITLE
api: add support for loading Discourse servers

### DIFF
--- a/src/cli/load.js
+++ b/src/cli/load.js
@@ -110,6 +110,7 @@ const loadCommand: Command = async (args, std) => {
     params,
     sourcecredDirectory: Common.sourcecredDirectory(),
     githubToken,
+    discourseKey: null,
   }));
   // Deliberately load in serial because GitHub requests that their API not
   // be called concurrently

--- a/src/cli/load.test.js
+++ b/src/cli/load.test.js
@@ -7,6 +7,7 @@ import {LoggingTaskReporter} from "../util/taskReporter";
 import {NodeAddress} from "../core/graph";
 import {run} from "./testUtil";
 import loadCommand, {help} from "./load";
+import type {LoadOptions} from "../api/load";
 import {defaultWeights, toJSON as weightsToJSON} from "../analysis/weights";
 import * as Common from "./common";
 
@@ -67,11 +68,16 @@ describe("cli/load", () => {
 
     it("calls load with a single repo", async () => {
       const invocation = run(loadCommand, ["foo/bar"]);
-      const expectedOptions = {
-        project: {id: "foo/bar", repoIds: [makeRepoId("foo", "bar")]},
+      const expectedOptions: LoadOptions = {
+        project: {
+          id: "foo/bar",
+          repoIds: [makeRepoId("foo", "bar")],
+          discourseServer: null,
+        },
         params: {alpha: 0.05, intervalDecay: 0.5, weights: defaultWeights()},
         sourcecredDirectory: Common.sourcecredDirectory(),
         githubToken: fakeGithubToken,
+        discourseKey: null,
       };
       expect(await invocation).toEqual({
         exitCode: 0,
@@ -86,11 +92,16 @@ describe("cli/load", () => {
 
     it("calls load with multiple repos", async () => {
       const invocation = run(loadCommand, ["foo/bar", "zoink/zod"]);
-      const expectedOptions = (projectId: string) => ({
-        project: {id: projectId, repoIds: [stringToRepoId(projectId)]},
+      const expectedOptions: (string) => LoadOptions = (projectId: string) => ({
+        project: {
+          id: projectId,
+          repoIds: [stringToRepoId(projectId)],
+          discourseServer: null,
+        },
         params: {alpha: 0.05, intervalDecay: 0.5, weights: defaultWeights()},
         sourcecredDirectory: Common.sourcecredDirectory(),
         githubToken: fakeGithubToken,
+        discourseKey: null,
       });
       expect(await invocation).toEqual({
         exitCode: 0,
@@ -118,11 +129,16 @@ describe("cli/load", () => {
         "--weights",
         weightsFile,
       ]);
-      const expectedOptions = {
-        project: {id: "foo/bar", repoIds: [makeRepoId("foo", "bar")]},
+      const expectedOptions: LoadOptions = {
+        project: {
+          id: "foo/bar",
+          repoIds: [makeRepoId("foo", "bar")],
+          discourseServer: null,
+        },
         params: {alpha: 0.05, intervalDecay: 0.5, weights},
         sourcecredDirectory: Common.sourcecredDirectory(),
         githubToken: fakeGithubToken,
+        discourseKey: null,
       };
       expect(await invocation).toEqual({
         exitCode: 0,

--- a/src/core/project.js
+++ b/src/core/project.js
@@ -12,8 +12,9 @@ export type ProjectId = string;
  * Right now it has an `id` (which should be unique across a user's projects)
  * and an array of GitHub RepoIds.
  *
- * In the future, we will add support for more plugins (and remove the
- * hardcoded GitHub support).
+ * In the future, instead of hardcoding support for plugins like GitHub and Discourse,
+ * we will have a generic system for storing plugin-specific config, keyed by plugin
+ * identifier.
  *
  * We may add more fields (e.g. a description) to this object in the futre.
  *
@@ -24,6 +25,10 @@ export type ProjectId = string;
 export type Project = {|
   +id: ProjectId,
   +repoIds: $ReadOnlyArray<RepoId>,
+  +discourseServer: {|
+    +serverUrl: string,
+    +apiUsername: string,
+  |} | null,
 |};
 
 const COMPAT_INFO = {type: "sourcecred/project", version: "0.1.0"};

--- a/src/core/project.test.js
+++ b/src/core/project.test.js
@@ -17,10 +17,12 @@ describe("core/project", () => {
   const p1: Project = deepFreeze({
     id: "foo/bar",
     repoIds: [foobar],
+    discourseServer: null,
   });
   const p2: Project = deepFreeze({
     id: "@foo",
     repoIds: [foobar, foozod],
+    discourseServer: {serverUrl: "https://example.com", apiUsername: "credbot"},
   });
   describe("to/fro JSON", () => {
     it("round trip is identity", () => {

--- a/src/core/project_io.test.js
+++ b/src/core/project_io.test.js
@@ -22,10 +22,12 @@ describe("core/project_io", () => {
   const p1: Project = deepFreeze({
     id: "foo/bar",
     repoIds: [foobar],
+    discourseServer: null,
   });
   const p2: Project = deepFreeze({
     id: "@foo",
     repoIds: [foobar, foozod],
+    discourseServer: {serverUrl: "https://example.com", apiUsername: "credbot"},
   });
 
   it("setupProjectDirectory results in a loadable project", async () => {

--- a/src/plugins/github/specToProject.js
+++ b/src/plugins/github/specToProject.js
@@ -36,12 +36,17 @@ export async function specToProject(
     const project: Project = {
       id: spec,
       repoIds: [stringToRepoId(spec)],
+      discourseServer: null,
     };
     return project;
   } else if (spec.match(ownerSpecMatcher)) {
     const owner = spec.slice(1);
     const org = await fetchGithubOrg(owner, token);
-    const project: Project = {id: spec, repoIds: org.repos};
+    const project: Project = {
+      id: spec,
+      repoIds: org.repos,
+      discourseServer: null,
+    };
     return project;
   }
   throw new Error(`invalid spec: ${spec}`);

--- a/src/plugins/github/specToProject.test.js
+++ b/src/plugins/github/specToProject.test.js
@@ -2,6 +2,7 @@
 
 import {specToProject} from "./specToProject";
 import {stringToRepoId} from "../../core/repoId";
+import {type Project} from "../../core/project";
 jest.mock("./fetchGithubOrg", () => ({fetchGithubOrg: jest.fn()}));
 type JestMockFn = $Call<typeof jest.fn>;
 const fetchGithubOrg: JestMockFn = (require("./fetchGithubOrg")
@@ -13,9 +14,10 @@ describe("plugins/github/specToProject", () => {
   });
   it("works for a repoId", async () => {
     const spec = "foo/bar";
-    const expected = {
+    const expected: Project = {
       id: spec,
       repoIds: [stringToRepoId(spec)],
+      discourseServer: null,
     };
     const actual = await specToProject(spec, "FAKE_TOKEN");
     expect(expected).toEqual(actual);
@@ -29,7 +31,7 @@ describe("plugins/github/specToProject", () => {
     fetchGithubOrg.mockResolvedValueOnce(fakeOrg);
     const actual = await specToProject(spec, token);
     expect(fetchGithubOrg).toHaveBeenCalledWith(fakeOrg.name, token);
-    const expected = {id: spec, repoIds: repos};
+    const expected: Project = {id: spec, repoIds: repos, discourseServer: null};
     expect(actual).toEqual(expected);
   });
   describe("fails for malformed spec strings", () => {


### PR DESCRIPTION
This commit modifies the `Project` type so that it allows settings for a
Discourse server, and ensures that `api/load` will appropriately load
the server in question, and include it in the output graph.

Putting the full Discourse declaration directly into the Project type is
an unsustainable development practice—in general, adding plugins should
not require changing core data types. However, at the moment I'm punting
on polishing the plugin system, in favor of adding the Discourse plugin
quickly, so I just put it into Project alongside the repo ids.

In the future, I expect to refactor the plugins around a much cleaner
interface; it's just not a priority as yet. (Tracking: #1120.)

This commit also makes the GitHub token optional in `api/load`, since
now it's very plausible that a user will want to only load a Discourse
server, and therefore not require a GitHub token.

As of this commit, it's still impossible to load Discourse projects, as
the CLI always sets a null Discourse server; and in any case, the
frontend would not properly display the project in question, as any
Discourse types would get filtered out.

Test plan: Mocking unit tests have been added to `api/load.test.js` to
ensure that the Discourse graph is loaded and merged correctly.