### PR TITLE
cli load uses discourse key

### DIFF
--- a/src/cli/common.js
+++ b/src/cli/common.js
@@ -23,3 +23,7 @@ export function sourcecredDirectory(): string {
 export function githubToken(): string | null {
   return NullUtil.orElse(process.env.SOURCECRED_GITHUB_TOKEN, null);
 }
+
+export function discourseKey(): string | null {
+  return NullUtil.orElse(process.env.SOURCECRED_DISCOURSE_KEY, null);
+}

--- a/src/cli/common.test.js
+++ b/src/cli/common.test.js
@@ -7,6 +7,7 @@ import {
   defaultSourcecredDirectory,
   sourcecredDirectory,
   githubToken,
+  discourseKey,
 } from "./common";
 
 describe("cli/common", () => {
@@ -52,6 +53,17 @@ describe("cli/common", () => {
     it("returns `null` if the environment variable is not set", () => {
       delete process.env.SOURCECRED_GITHUB_TOKEN;
       expect(githubToken()).toBe(null);
+    });
+  });
+
+  describe("discourseKey", () => {
+    it("uses the environment variable when available", () => {
+      process.env.SOURCECRED_DISCOURSE_KEY = "010101";
+      expect(discourseKey()).toEqual("010101");
+    });
+    it("returns `null` if the environment variable is not set", () => {
+      delete process.env.SOURCECRED_DISCOURSE_KEY;
+      expect(discourseKey()).toBe(null);
     });
   });
 });

--- a/src/cli/load.js
+++ b/src/cli/load.js
@@ -110,7 +110,7 @@ const loadCommand: Command = async (args, std) => {
     params,
     sourcecredDirectory: Common.sourcecredDirectory(),
     githubToken,
-    discourseKey: null,
+    discourseKey: Common.discourseKey(),
   }));
   // Deliberately load in serial because GitHub requests that their API not
   // be called concurrently

--- a/src/cli/load.test.js
+++ b/src/cli/load.test.js
@@ -27,10 +27,12 @@ describe("cli/load", () => {
   });
 
   const fakeGithubToken = "....".replace(/./g, "0123456789");
+  const fakeDiscourseKey = "abcdefg";
   function newSourcecredDirectory() {
     const dirname = tmp.dirSync().name;
     process.env.SOURCECRED_DIRECTORY = dirname;
     process.env.SOURCECRED_GITHUB_TOKEN = fakeGithubToken;
+    process.env.SOURCECRED_DISCOURSE_KEY = fakeDiscourseKey;
     return dirname;
   }
 
@@ -77,7 +79,7 @@ describe("cli/load", () => {
         params: {alpha: 0.05, intervalDecay: 0.5, weights: defaultWeights()},
         sourcecredDirectory: Common.sourcecredDirectory(),
         githubToken: fakeGithubToken,
-        discourseKey: null,
+        discourseKey: fakeDiscourseKey,
       };
       expect(await invocation).toEqual({
         exitCode: 0,
@@ -101,7 +103,7 @@ describe("cli/load", () => {
         params: {alpha: 0.05, intervalDecay: 0.5, weights: defaultWeights()},
         sourcecredDirectory: Common.sourcecredDirectory(),
         githubToken: fakeGithubToken,
-        discourseKey: null,
+        discourseKey: fakeDiscourseKey,
       });
       expect(await invocation).toEqual({
         exitCode: 0,
@@ -138,7 +140,7 @@ describe("cli/load", () => {
         params: {alpha: 0.05, intervalDecay: 0.5, weights},
         sourcecredDirectory: Common.sourcecredDirectory(),
         githubToken: fakeGithubToken,
-        discourseKey: null,
+        discourseKey: fakeDiscourseKey,
       };
       expect(await invocation).toEqual({
         exitCode: 0,


### PR DESCRIPTION
This commit modifies `cli/load` to appropriately load a Discourse key
from the environment, if it is available.

The mechanics are basically the same as with the GitHub token.

Test plan: Unit tests added. `yarn test` passes.