### PR TITLE
Check typesafety of `NullUtil.filterList`

### DIFF
--- a/src/util/null.js
+++ b/src/util/null.js
@@ -89,5 +89,8 @@ export function orElse<T>(x: ?T, defaultValue: T): T {
  * in a type-aware way.
  */
 export function filterList<T>(xs: $ReadOnlyArray<?T>): T[] {
-  return (xs.filter((x) => x != null): any);
+  // A type-safe way to implement this would be:
+  /*:: (xs.flatMap((x) => x == null ? [] : [x]): T[]); */
+  // For performance, we instead take an unsafe route.
+  return ((xs.filter((x) => x != null): any): T[]);
 }


### PR DESCRIPTION
Summary:
The current implementation of `NullUtil.filterList` uses an `any`-cast.
This is fine as long as the definition is actually typesafe; we should
take a least a little care to ensure that it is. This commit adds a
typesafe version, commented out but still typechecked, and refines the
type around the `any`-cast to make the cast slightly more robust.

Test Plan:
Note that changing `$ReadOnlyArray<?T>` to `$ReadOnlyArray<?T | number>`
in the declaration of `filterList` caused no Flow error prior to this
commit, but now causes one.

wchargin-branch: filter-list-typecheck