### PR TITLE
Fix failing snapshot test

### DIFF
--- a/sharness/__snapshots__/example-github-load/projects/c291cmNlY3JlZC10ZXN0L2V4YW1wbGUtZ2l0aHVi/project.json
+++ b/sharness/__snapshots__/example-github-load/projects/c291cmNlY3JlZC10ZXN0L2V4YW1wbGUtZ2l0aHVi/project.json
@@ -1,1 +1,1 @@
-[{"type":"sourcecred/project","version":"0.1.0"},{"id":"sourcecred-test/example-github","repoIds":[{"name":"example-github","owner":"sourcecred-test"}]}]
+[{"type":"sourcecred/project","version":"0.2.0"},{"discourseServer":null,"id":"sourcecred-test/example-github","repoIds":[{"name":"example-github","owner":"sourcecred-test"}]}]

--- a/src/core/project.js
+++ b/src/core/project.js
@@ -31,7 +31,7 @@ export type Project = {|
   |} | null,
 |};
 
-const COMPAT_INFO = {type: "sourcecred/project", version: "0.1.0"};
+const COMPAT_INFO = {type: "sourcecred/project", version: "0.2.0"};
 
 export type ProjectJSON = Compatible<Project>;
 


### PR DESCRIPTION
PR #1325 introduced a failing snapshot test, which was promptly caught
by @wchargin. This commit fixes it by running
`./scripts/update_snapshots.sh`. Also, I bumped the project JSON version
number, which also should have happened in #1325.

Test plan: `yarn test --full` passes.