### PR TITLE
mirror: guess typenames and warn on mismatch

### DIFF
--- a/src/plugins/github/fetchGithubRepo.js
+++ b/src/plugins/github/fetchGithubRepo.js
@@ -91,7 +91,7 @@ const GITHUB_ID_TYPENAME_PATTERN = /^[0-9]*:([A-Za-z0-9_-]*[A-Za-z_-])[0-9]+(?:[
 export function _guessTypename(
   objectId: Schema.ObjectId
 ): Schema.Typename | null {
-  const decodedId = new Buffer(objectId, "base64").toString("utf-8");
+  const decodedId = Buffer.from(objectId, "base64").toString("utf-8");
   const match = decodedId.match(GITHUB_ID_TYPENAME_PATTERN);
   return match ? match[1] : null;
 }

--- a/src/plugins/github/fetchGithubRepo.js
+++ b/src/plugins/github/fetchGithubRepo.js
@@ -86,7 +86,7 @@ export default async function fetchGithubRepo(
 // further section like ":commithash" for commits.
 //
 // See tests for `_guessTypename` for some example object IDs.
-const GITHUB_ID_TYPENAME_PATTERN = /^[0-9]*:([A-Za-z0-9_-]*[A-Za-z_-])[0-9]+(?:[^A-Za-z0-9_-].*)?$/;
+const GITHUB_ID_TYPENAME_PATTERN = /^[0-9]*:([a-z0-9_-]*[a-z_-])[0-9]+(?:[^a-z0-9_-].*)?$/i;
 
 export function _guessTypename(
   objectId: Schema.ObjectId

--- a/src/plugins/github/fetchGithubRepo.test.js
+++ b/src/plugins/github/fetchGithubRepo.test.js
@@ -1,0 +1,29 @@
+// @flow
+
+import {_guessTypename} from "./fetchGithubRepo";
+
+describe("plugins/github/fetchGithubRepo", () => {
+  describe("_guessTypename", () => {
+    it("guesses a User typename", () => {
+      // Simple case.
+      const id = "MDQ6VXNlcjQzMTc4MDY=";
+      expect(_guessTypename(id)).toEqual("User");
+    });
+    it("guesses a Commit typename", () => {
+      // Multiple decoded parts.
+      const id =
+        "MDY6Q29tbWl0MTIwMTQ1NTcwOjljYmEwZTllMjEyYTI4N2NlMjZlOGQ3YzJkMjczZTEwMjVjOWY5YmY=";
+      expect(_guessTypename(id)).toEqual("Commit");
+    });
+    it("guesses an X509Certificate typename", () => {
+      // Numbers in the middle of the typename.
+      // (I made this object ID up; I couldn't find a real one.)
+      const id = "MDEyOlg1MDlDZXJ0aWZpY2F0ZTEyMzQ1";
+      expect(_guessTypename(id)).toEqual("X509Certificate");
+    });
+    it("fails cleanly on an unknown ID format", () => {
+      const id = ":spooky:";
+      expect(_guessTypename(id)).toBe(null);
+    });
+  });
+});


### PR DESCRIPTION
Summary:
The format of GitHub’s GraphQL object IDs is explicitly opaque, and so
we must not introspect them in any way that would influence our results.
But it seems reasonable to introspect these IDs solely for diagnostic
purposes, enabling us to proactively detect GitHub’s contract violations
while we still have useful information about the root cause.

This commit adds an optional `guessTypename` option to the Mirror
constructor, which accepts a function that attempts to guess an object’s
typename based on its ID. If the guess differs from what the server
claims, we continue on as before, but omit a console warning to help
diagnose the issue more quickly.

Resolves #1336. See that issue for details.

Test Plan:
Unit tests for `mirror.js` updated, retaining full coverage. To test
manually, revert #1335, then load `quasarframework/quasar-cli`. Note
that it emits the following warning before failing:

> Warning: when setting Reaction["MDg6UmVhY3Rpb24zNDUxNjA2MQ=="].user:
> object "MDEyOk9yZ2FuaXphdGlvbjQzMDkzODIw" looks like it should have
> type "Organization", but the server claims that it has type "User"

Unit tests for the GitHub typename guesser added as well.

Running `yarn test --full` passes.

wchargin-branch: mirror-guess-typenames