### PR TITLE
Adding small changes to use docker layers for cache

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -33,6 +33,11 @@ commands:
           paths:
             - node_modules
           key: v1-dependencies-{{ checksum "package.json" }}
+  pull_cache:
+    description: Pulls docker images usable for our cache
+    steps:
+      - run: docker pull sourcecred/sourcecred:dev
+      - run: docker pull node:12
 
 jobs:
   test:
@@ -69,6 +74,9 @@ workflows:
             branches:
               ignore: 
                 - master
+          extra_build_args: --cache-from=node:12,sourcecred/sourcecred:dev
+          before_build:
+            - pull_cache
           after_build:
             - run:
                 name: Preview Docker Tag for Build
@@ -86,6 +94,9 @@ workflows:
               ignore: /.*/
             tags:
               only: /^v.*/
+          extra_build_args: --cache-from=node:12,sourcecred/sourcecred:dev
+          before_build:
+            - pull_cache
           after_build:
             - run:
                 name: Publish Docker Tag with Sourcecred Version
@@ -111,6 +122,9 @@ workflows:
 
       - docker/publish:
           image: sourcecred/sourcecred
+          extra_build_args: --cache-from=node:12,sourcecred/sourcecred:dev
+          before_build:
+            - pull_cache
           requires:
             - test
             - test_full


### PR DESCRIPTION
This pull request will pull sourcecred/sourcecred:latest first and then use the layers for cache as extra build args.  @Beanow figured out all the logistics for sourcecred/widgets, and as promised, I'm following up on the merge of #1320.

Signed-off-by: Vanessa Sochat <vsochat@stanford.edu>