### PR TITLE
Add command line option to remove projects  

### DIFF
--- a/src/cli/clear.js
+++ b/src/cli/clear.js
@@ -61,7 +61,8 @@ export function makeClear(
   repoCacheFilename: (
     repoId: RepoId,
     token: string
-  ) => Promise<{|+dbFilename: string, +resolvedId: Schema.ObjectId|}>
+  ) => Promise<{|+dbFilename: string, +resolvedId: Schema.ObjectId|}>,
+  token: string
 ): Command {
   return async function clear(args, std) {
     const sourcecredDirectory = Common.sourcecredDirectory();
@@ -78,12 +79,6 @@ export function makeClear(
 
     async function rmProject(repoArg, projectPath) {
       const repoId = stringToRepoId(repoArg);
-      let token = null;
-      try {
-        token = validateGithubToken();
-      } catch (error) {
-        return die(std, `${error}`);
-      }
       const {dbFilename} = await repoCacheFilename(repoId, token);
       try {
         await removeDir(path.join(cacheDirectory, dbFilename));
@@ -164,6 +159,10 @@ export function validateGithubToken(): string {
   return token;
 }
 
-export const clear = makeClear(removeDir, repoCacheFilename);
+export const clear = makeClear(
+  removeDir,
+  repoCacheFilename,
+  validateGithubToken()
+);
 
 export default clear;

--- a/src/cli/clear.test.js
+++ b/src/cli/clear.test.js
@@ -38,7 +38,7 @@ describe("cli/clear", () => {
 
   describe("'makeClear' command", () => {
     it("prints usage with '--help'", async () => {
-      const clear = makeClear(jest.fn(), jest.fn());
+      const clear = makeClear(jest.fn(), jest.fn(), "token");
       expect(await run(clear, ["--help"])).toEqual({
         exitCode: 0,
         stdout: expect.arrayContaining([
@@ -49,7 +49,7 @@ describe("cli/clear", () => {
     });
 
     it("fails when no arguments specified", async () => {
-      const clear = makeClear(jest.fn(), jest.fn());
+      const clear = makeClear(jest.fn(), jest.fn(), "token");
       expect(await run(clear, [])).toEqual({
         exitCode: 1,
         stdout: [],
@@ -61,7 +61,7 @@ describe("cli/clear", () => {
     });
 
     it("fails when an invalid argument is specified", async () => {
-      const clear = makeClear(jest.fn(), jest.fn());
+      const clear = makeClear(jest.fn(), jest.fn(), "token");
       expect(await run(clear, ["invalid"])).toEqual({
         exitCode: 1,
         stdout: [],
@@ -73,7 +73,7 @@ describe("cli/clear", () => {
     });
 
     it("fails when more than one argument specified", async () => {
-      const clear = makeClear(jest.fn(), jest.fn());
+      const clear = makeClear(jest.fn(), jest.fn(), "token");
       expect(await run(clear, ["1", "2"])).toEqual({
         exitCode: 1,
         stdout: [],
@@ -86,21 +86,21 @@ describe("cli/clear", () => {
 
     it("passes correct param to removeDir with `--all`", async () => {
       const rmDir = jest.fn();
-      const clear = makeClear(rmDir, jest.fn());
+      const clear = makeClear(rmDir, jest.fn(), "token");
       await run(clear, ["--all"]);
       expect(rmDir).toHaveBeenCalledWith(Common.sourcecredDirectory());
     });
 
     it("passes correct param to removeDir with `--cache`", async () => {
       const rmDir = jest.fn();
-      const clear = makeClear(rmDir, jest.fn());
+      const clear = makeClear(rmDir, jest.fn(), "token");
       await run(clear, ["--cache"]);
       const cacheDir = path.join(Common.sourcecredDirectory(), "cache");
       expect(rmDir).toHaveBeenCalledWith(cacheDir);
     });
 
     it("--all returns error if removeDir errors", async () => {
-      const clear = makeClear(throwError, jest.fn());
+      const clear = makeClear(throwError, jest.fn(), "token");
       expect(await run(clear, ["--all"])).toEqual({
         exitCode: 1,
         stdout: [],
@@ -112,7 +112,7 @@ describe("cli/clear", () => {
     });
 
     it("--cache returns error if removeDir errors", async () => {
-      const clear = makeClear(throwError, jest.fn());
+      const clear = makeClear(throwError, jest.fn(), "token");
       expect(await run(clear, ["--cache"])).toEqual({
         exitCode: 1,
         stdout: [],
@@ -133,7 +133,7 @@ describe("cli/clear", () => {
         );
       });
 
-      const clear = makeClear(rmDir, cachePath);
+      const clear = makeClear(rmDir, cachePath, "token");
       const projectPath = directoryForProjectId(
         "foo/bar",
         Common.sourcecredDirectory()
@@ -150,7 +150,7 @@ describe("cli/clear", () => {
         name: "bar",
         owner: "foo",
       });
-      expect(cachePath.mock.calls[0][1]).toStrictEqual(Common.githubToken());
+      expect(cachePath.mock.calls[0][1]).toStrictEqual("token");
     });
 
     it("returns an error if removing the cache file errors", async () => {
@@ -159,7 +159,7 @@ describe("cli/clear", () => {
           resolve({dbFilename: "foobuzz", resolvedId: "foobuzz"})
         );
       });
-      const clear = makeClear(throwError, cachePath);
+      const clear = makeClear(throwError, cachePath, "token");
       const projectPath = directoryForProjectId(
         "foo/bar",
         Common.sourcecredDirectory()

--- a/src/cli/clear.test.js
+++ b/src/cli/clear.test.js
@@ -7,8 +7,13 @@ import fs from "fs";
 import {makeClear, removeDir, help} from "./clear";
 import {run} from "./testUtil";
 import * as Common from "./common";
+import {directoryForProjectId} from "../core/project_io";
 
 describe("cli/clear", () => {
+  function throwError() {
+    return Promise.reject(new Error("test error"));
+  }
+
   describe("'help' command", () => {
     it("prints usage when given no arguments", async () => {
       expect(await run(help, [])).toEqual({
@@ -33,7 +38,7 @@ describe("cli/clear", () => {
 
   describe("'makeClear' command", () => {
     it("prints usage with '--help'", async () => {
-      const clear = makeClear(jest.fn());
+      const clear = makeClear(jest.fn(), jest.fn());
       expect(await run(clear, ["--help"])).toEqual({
         exitCode: 0,
         stdout: expect.arrayContaining([
@@ -44,7 +49,7 @@ describe("cli/clear", () => {
     });
 
     it("fails when no arguments specified", async () => {
-      const clear = makeClear(jest.fn());
+      const clear = makeClear(jest.fn(), jest.fn());
       expect(await run(clear, [])).toEqual({
         exitCode: 1,
         stdout: [],
@@ -56,7 +61,7 @@ describe("cli/clear", () => {
     });
 
     it("fails when an invalid argument is specified", async () => {
-      const clear = makeClear(jest.fn());
+      const clear = makeClear(jest.fn(), jest.fn());
       expect(await run(clear, ["invalid"])).toEqual({
         exitCode: 1,
         stdout: [],
@@ -68,7 +73,7 @@ describe("cli/clear", () => {
     });
 
     it("fails when more than one argument specified", async () => {
-      const clear = makeClear(jest.fn());
+      const clear = makeClear(jest.fn(), jest.fn());
       expect(await run(clear, ["1", "2"])).toEqual({
         exitCode: 1,
         stdout: [],
@@ -81,25 +86,21 @@ describe("cli/clear", () => {
 
     it("passes correct param to removeDir with `--all`", async () => {
       const rmDir = jest.fn();
-      const clear = makeClear(rmDir);
+      const clear = makeClear(rmDir, jest.fn());
       await run(clear, ["--all"]);
       expect(rmDir).toHaveBeenCalledWith(Common.sourcecredDirectory());
     });
 
     it("passes correct param to removeDir with `--cache`", async () => {
       const rmDir = jest.fn();
-      const clear = makeClear(rmDir);
+      const clear = makeClear(rmDir, jest.fn());
       await run(clear, ["--cache"]);
       const cacheDir = path.join(Common.sourcecredDirectory(), "cache");
       expect(rmDir).toHaveBeenCalledWith(cacheDir);
     });
 
-    function throwError() {
-      return Promise.reject(new Error("test error"));
-    }
-
     it("--all returns error if removeDir errors", async () => {
-      const clear = makeClear(throwError);
+      const clear = makeClear(throwError, jest.fn());
       expect(await run(clear, ["--all"])).toEqual({
         exitCode: 1,
         stdout: [],
@@ -111,8 +112,60 @@ describe("cli/clear", () => {
     });
 
     it("--cache returns error if removeDir errors", async () => {
-      const clear = makeClear(throwError);
+      const clear = makeClear(throwError, jest.fn());
       expect(await run(clear, ["--cache"])).toEqual({
+        exitCode: 1,
+        stdout: [],
+        stderr: [
+          "fatal: Error: test error",
+          "fatal: run 'sourcecred help clear' for help",
+        ],
+      });
+    });
+  });
+
+  describe("removing projects", () => {
+    it("passes correct params to removeDir if file exists", async () => {
+      const rmDir = jest.fn();
+      const cachePath = jest.fn(() => {
+        return new Promise((resolve) =>
+          resolve({dbFilename: "foobuzz", resolvedId: "foobuzz"})
+        );
+      });
+
+      const clear = makeClear(rmDir, cachePath);
+      const projectPath = directoryForProjectId(
+        "foo/bar",
+        Common.sourcecredDirectory()
+      );
+      await fs.writeFile(projectPath, "", function() {});
+      await run(clear, ["foo/bar"]);
+      expect(rmDir).toHaveBeenCalledWith(projectPath);
+      const mockCachePath = path.join(
+        Common.sourcecredDirectory(),
+        "cache/foobuzz"
+      );
+      expect(rmDir).toHaveBeenCalledWith(mockCachePath);
+      expect(cachePath.mock.calls[0][0]).toStrictEqual({
+        name: "bar",
+        owner: "foo",
+      });
+      expect(cachePath.mock.calls[0][1]).toStrictEqual(Common.githubToken());
+    });
+
+    it("returns an error if removing the cache file errors", async () => {
+      const cachePath = jest.fn(() => {
+        return new Promise((resolve) =>
+          resolve({dbFilename: "foobuzz", resolvedId: "foobuzz"})
+        );
+      });
+      const clear = makeClear(throwError, cachePath);
+      const projectPath = directoryForProjectId(
+        "foo/bar",
+        Common.sourcecredDirectory()
+      );
+      await fs.writeFile(projectPath, "", function() {});
+      expect(await run(clear, ["foo/bar"])).toEqual({
         exitCode: 1,
         stdout: [],
         stderr: [


### PR DESCRIPTION
Resolves #1137

This should let users remove individual projects to avoid
re-downloading all their projects if they only want to remove one.

Command looks like: `node bin/sourcecred.js clear owner/repo`.

Test plan:

Added tests to verify that the correct parameters are passed to
the `removeDir` function, and that an error propogates if that function
errs.

You can also verify, after loading `sourcecred/pm`, that
`node bin/sourcecred.js clear sourcecred/pm` removes the appropriate
files from the `cache` and `projects` directory.

Reviewers, if the command depends on `Common.githubToken()`,
should that be in the `Environment Variables` section of the
help message?

I'm open to adding more tests, restructuing functions, re-formatting
the command line arg, etc.