### PR TITLE
Capitalize Discourse plugin name

### DIFF
--- a/src/plugins/discourse/declaration.js
+++ b/src/plugins/discourse/declaration.js
@@ -74,7 +74,7 @@ export const likesEdgeType: EdgeType = deepFreeze({
 });
 
 export const declaration: PluginDeclaration = deepFreeze({
-  name: "discourse",
+  name: "Discourse",
   nodePrefix,
   edgePrefix,
   nodeTypes: [userNodeType, topicNodeType, postNodeType],


### PR DESCRIPTION
This ensures consistency with GitHub, and will allow us to use plugin
names in the UI.

Test plan: Not needed, trivial change.