### PR TITLE
Let plugins specify user types

### DIFF
--- a/src/analysis/pluginDeclaration.js
+++ b/src/analysis/pluginDeclaration.js
@@ -11,6 +11,11 @@ export type PluginDeclaration = {|
   +edgePrefix: EdgeAddressT,
   +nodeTypes: $ReadOnlyArray<NodeType>,
   +edgeTypes: $ReadOnlyArray<EdgeType>,
+  // Which node types represent user identities.
+  // Important for computing score and for display in the frontend.
+  // It's expected that the userTypes will also be included in the array of
+  // nodeTypes.
+  +userTypes: $ReadOnlyArray<NodeType>,
 |};
 
 export function combineTypes(

--- a/src/plugins/demo/declaration.js
+++ b/src/plugins/demo/declaration.js
@@ -44,4 +44,5 @@ export const declaration: PluginDeclaration = deepFreeze({
   nodeTypes: [inserterNodeType, machineNodeType],
   edgePrefix: EdgeAddress.fromParts(["factorio"]),
   edgeTypes: [assemblesEdgeType, transportsEdgeType],
+  userTypes: [],
 });

--- a/src/plugins/discourse/declaration.js
+++ b/src/plugins/discourse/declaration.js
@@ -85,4 +85,5 @@ export const declaration: PluginDeclaration = deepFreeze({
     topicContainsPostEdgeType,
     likesEdgeType,
   ],
+  userTypes: [userNodeType],
 });

--- a/src/plugins/git/declaration.js
+++ b/src/plugins/git/declaration.js
@@ -31,4 +31,5 @@ export const declaration: PluginDeclaration = deepFreeze({
   edgePrefix: E.Prefix.base,
   nodeTypes,
   edgeTypes,
+  userTypes: [],
 });

--- a/src/plugins/github/declaration.js
+++ b/src/plugins/github/declaration.js
@@ -199,4 +199,5 @@ export const declaration: PluginDeclaration = deepFreeze({
   edgePrefix: E.Prefix.base,
   nodeTypes: nodeTypes,
   edgeTypes: edgeTypes,
+  userTypes: [userNodeType],
 });


### PR DESCRIPTION
This modifies the pluginDeclaration so that it can specifiy user node
types. This will allow us to replace the TimelineCredConfig type with a
plugin collection instead.

It's expected that the user types will also be present in the node
types, although this isn't validated anywhere at present.

Test plan: `yarn flow`.