### PR TITLE
timelineCred.credSortedNodes takes prefixes

### DIFF
--- a/src/cli/scores.js
+++ b/src/cli/scores.js
@@ -101,7 +101,7 @@ export const scores: Command = async (args, std) => {
   const credJSON = JSON.parse(credBlob.toString());
   const timelineCred = TimelineCred.fromJSON(credJSON);
   const userOutput: NodeOutput[] = timelineCred
-    .credSortedNodes(userNodeType.prefix)
+    .credSortedNodes([userNodeType.prefix])
     .map((n: CredNode) => {
       const address = n.node.address;
       const structuredAddress = GN.fromRaw((address: any));

--- a/src/explorer/TimelineCredView.js
+++ b/src/explorer/TimelineCredView.js
@@ -33,7 +33,7 @@ const DEFAULT_ENTRIES_PER_CHART = 6;
 export class TimelineCredView extends React.Component<Props> {
   render() {
     const {selectedNodeFilter, timelineCred} = this.props;
-    const nodes = timelineCred.credSortedNodes(selectedNodeFilter);
+    const nodes = timelineCred.credSortedNodes([selectedNodeFilter]);
     const tableNodes = nodes.slice(0, MAX_ENTRIES_PER_LIST);
     const chartNodes = nodes
       .slice(0, DEFAULT_ENTRIES_PER_CHART)


### PR DESCRIPTION
This lets us filter by a group of prefixes simultaneously, which enables
e.g. seeing all user node types at once.

I also tweaked the API to make it a bit more convenient, you can now
pass no arguments and get all nodes in sorted order.

Test plan: Unit tests updated.