### PR TITLE
add TimelineCred.userNodes

### DIFF
--- a/src/analysis/timeline/timelineCred.js
+++ b/src/analysis/timeline/timelineCred.js
@@ -157,6 +157,17 @@ export class TimelineCred {
   }
 
   /**
+   * Returns all user-typed nodes, sorted by their total cred (descending).
+   *
+   * A node is considered a user-type node if its address has a prefix match
+   * with a type specified as a user type by one of the plugin declarations.
+   */
+  userNodes(): $ReadOnlyArray<CredNode> {
+    const userTypes = [].concat(...this.plugins().map((p) => p.userTypes));
+    return this.credSortedNodes(userTypes.map((x) => x.prefix));
+  }
+
+  /**
    * Create a new, filtered TimelineCred, by removing low-scored nodes.
    *
    * Cred Graphs may have a huge number of small contributions, like comments,

--- a/src/analysis/timeline/timelineCred.test.js
+++ b/src/analysis/timeline/timelineCred.test.js
@@ -192,6 +192,11 @@ describe("src/analysis/timeline/timelineCred", () => {
     });
   });
 
+  it("userNodes returns the credSortedNodes for user types", () => {
+    const tc = exampleTimelineCred();
+    expect(tc.userNodes()).toEqual(tc.credSortedNodes([userPrefix]));
+  });
+
   it("credNode returns undefined for absent nodes", () => {
     const tc = exampleTimelineCred();
     expect(tc.credNode(NodeAddress.fromParts(["baz"]))).toBe(undefined);


### PR DESCRIPTION
This is a convenience method that extracts cred for all the user-typed
nodes. It's basically an abstraction over calling `credSortedNodes` with
the right set of prefixes.

I forsee using it in at least two places (score retrieval in the CLI and
score display in the frontend) so I decided to make it a method.

Test plan: A very simple unit test was added. (It's a very simple
wrapper function.)