### PR TITLE
TimelineExplorer defaults to showing all users

### DIFF
--- a/src/explorer/TimelineApp.js
+++ b/src/explorer/TimelineApp.js
@@ -4,11 +4,6 @@ import React from "react";
 import type {Assets} from "../webutil/assets";
 import {TimelineExplorer} from "./TimelineExplorer";
 import {TimelineCred} from "../analysis/timeline/timelineCred";
-import {
-  declaration as githubDeclaration,
-  userNodeType,
-  repoNodeType,
-} from "../plugins/github/declaration";
 import {encodeProjectId, type ProjectId} from "../core/project";
 
 export type Props = {|
@@ -72,9 +67,6 @@ export class TimelineApp extends React.Component<Props, State> {
           <TimelineExplorer
             initialTimelineCred={timelineCred}
             projectId={this.props.projectId}
-            declarations={[githubDeclaration]}
-            defaultNodeType={userNodeType}
-            filterableNodeTypes={[userNodeType, repoNodeType]}
           />
         );
       }

--- a/src/explorer/TimelineCredView.js
+++ b/src/explorer/TimelineCredView.js
@@ -10,7 +10,7 @@ import {TimelineCred} from "../analysis/timeline/timelineCred";
 
 export type Props = {|
   +timelineCred: TimelineCred,
-  +selectedNodeFilter: NodeAddressT,
+  +selectedNodeFilter: NodeAddressT | null,
 |};
 
 const MAX_ENTRIES_PER_LIST = 100;
@@ -33,7 +33,13 @@ const DEFAULT_ENTRIES_PER_CHART = 6;
 export class TimelineCredView extends React.Component<Props> {
   render() {
     const {selectedNodeFilter, timelineCred} = this.props;
-    const nodes = timelineCred.credSortedNodes([selectedNodeFilter]);
+    const nodes = (() => {
+      if (selectedNodeFilter == null) {
+        return timelineCred.userNodes();
+      } else {
+        return timelineCred.credSortedNodes([selectedNodeFilter]);
+      }
+    })();
     const tableNodes = nodes.slice(0, MAX_ENTRIES_PER_LIST);
     const chartNodes = nodes
       .slice(0, DEFAULT_ENTRIES_PER_CHART)

--- a/src/explorer/TimelineExplorer.js
+++ b/src/explorer/TimelineExplorer.js
@@ -2,10 +2,7 @@
 
 import React from "react";
 import deepEqual from "lodash.isequal";
-import {
-  type PluginDeclaration,
-  combineTypes,
-} from "../analysis/pluginDeclaration";
+import {combineTypes} from "../analysis/pluginDeclaration";
 import {type Weights, copy as weightsCopy} from "../analysis/weights";
 import {type NodeAddressT} from "../core/graph";
 import {
@@ -16,14 +13,10 @@ import {TimelineCredView} from "./TimelineCredView";
 import Link from "../webutil/Link";
 import {WeightConfig} from "./weights/WeightConfig";
 import {WeightsFileManager} from "./weights/WeightsFileManager";
-import {type NodeType} from "../analysis/types";
 
 export type Props = {
   projectId: string,
   initialTimelineCred: TimelineCred,
-  // TODO: Get this info from the TimelineCred
-  declarations: $ReadOnlyArray<PluginDeclaration>,
-  +defaultNodeType: NodeType,
 };
 
 export type State = {
@@ -33,7 +26,7 @@ export type State = {
   intervalDecay: number,
   loading: boolean,
   showWeightConfig: boolean,
-  selectedNodeTypePrefix: NodeAddressT,
+  selectedNodeTypePrefix: NodeAddressT | null,
 };
 
 /**
@@ -48,9 +41,7 @@ export class TimelineExplorer extends React.Component<Props, State> {
   constructor(props: Props) {
     super(props);
     const timelineCred = props.initialTimelineCred;
-    const {defaultNodeType} = props;
     const {alpha, intervalDecay, weights} = timelineCred.params();
-    const selectedNodeTypePrefix = defaultNodeType.prefix;
     this.state = {
       timelineCred,
       alpha,
@@ -61,7 +52,7 @@ export class TimelineExplorer extends React.Component<Props, State> {
       weights: weightsCopy(weights),
       loading: false,
       showWeightConfig: false,
-      selectedNodeTypePrefix,
+      selectedNodeTypePrefix: null,
     };
   }
 
@@ -90,7 +81,7 @@ export class TimelineExplorer extends React.Component<Props, State> {
     );
     const weightConfig = (
       <WeightConfig
-        declarations={this.props.declarations}
+        declarations={this.state.timelineCred.plugins()}
         nodeTypeWeights={this.state.weights.nodeTypeWeights}
         edgeTypeWeights={this.state.weights.edgeTypeWeights}
         onNodeWeightChange={(prefix, weight) => {
@@ -164,6 +155,9 @@ export class TimelineExplorer extends React.Component<Props, State> {
             this.setState({selectedNodeTypePrefix: e.target.value})
           }
         >
+          <option key={null} value={null}>
+            All users
+          </option>
           {nodeTypes.map(({prefix, pluralName}) => (
             <option key={prefix} value={prefix}>
               {pluralName}


### PR DESCRIPTION
Now instead of always defaulting to GitHub users, it shows all
user-typed nodes. This will make SourceCred work non-hackily when there
is e.g. just a Discourse plugin in scope.

I also fixed an issue where it was loading the GitHub declaration in a
hardcoded way, instead of properly getting it from the TimelineCred's
plugin array.

Test plan: Manual UI inspection.