### PR TITLE
scores command no longer assumes GitHub plugin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Unreleased]
 
 <!-- Please add new entries just beneath this line. -->
+- Breaking: Change output format for the scores command (#1372)
 - Include top nodes for every type in Timeline Cred (#1358)
 
 ## [0.4.0]

--- a/sharness/__snapshots__/example-github-scores.json
+++ b/sharness/__snapshots__/example-github-scores.json
@@ -1,7 +1,7 @@
 [
   {
     "type": "sourcecred/cli/scores",
-    "version": "0.1.0"
+    "version": "0.2.0"
   },
   {
     "intervals": [
@@ -200,7 +200,13 @@
     ],
     "users": [
       {
-        "id": "decentralion",
+        "address": [
+          "sourcecred",
+          "github",
+          "USERLIKE",
+          "USER",
+          "decentralion"
+        ],
         "intervalCred": [
           9.383869639663432,
           4.691404861944296,
@@ -254,7 +260,13 @@
         "totalCred": 41.343602084119254
       },
       {
-        "id": "wchargin",
+        "address": [
+          "sourcecred",
+          "github",
+          "USERLIKE",
+          "USER",
+          "wchargin"
+        ],
         "intervalCred": [
           3.6161303603365673,
           1.808595138055704,


### PR DESCRIPTION
Previously, the `sourcecred scores` command assumed that all users are
GitHub users, and assigned users an id based on their GitHub login.

Now, the command returns information on all users, regardless of which
plugin provided them. As such, we need to identify users differently.
Instead of a string id, they now have an array of address parts. That
array contains all of the parts of their corresponding node address.

For example, the GitHub user `@Beanow` would correspond to the address
array `["sourcecred", "github", "USERLIKE", "USER", "Beanow"]`

As a general convention, the first two components of any node's address
contain information about the plugin that owns that node. The first
component is the owner of the plugin, and the second is the name of the
plugin. Afterwards, the plugin may represent nodes in whatever manner it
sees fit.

Thanks to @Beanow and @vsoch for some feedback and discussion on this
design.

Test plan: Snapshots have been updated. `yarn test` passes.