### PR TITLE
factor loadWeights into Common

### DIFF
--- a/src/cli/common.js
+++ b/src/cli/common.js
@@ -4,6 +4,8 @@
 import os from "os";
 import path from "path";
 import deepFreeze from "deep-freeze";
+import fs from "fs-extra";
+import {type Weights, fromJSON as weightsFromJSON} from "../analysis/weights";
 
 import * as NullUtil from "../util/null";
 
@@ -26,4 +28,17 @@ export function githubToken(): string | null {
 
 export function discourseKey(): string | null {
   return NullUtil.orElse(process.env.SOURCECRED_DISCOURSE_KEY, null);
+}
+
+export async function loadWeights(path: string): Promise<Weights> {
+  if (!(await fs.exists(path))) {
+    throw new Error("Could not find the weights file");
+  }
+  const raw = await fs.readFile(path, "utf-8");
+  const weightsJSON = JSON.parse(raw);
+  try {
+    return weightsFromJSON(weightsJSON);
+  } catch (e) {
+    throw new Error(`provided weights file is invalid:\n${e}`);
+  }
 }

--- a/src/cli/load.js
+++ b/src/cli/load.js
@@ -5,10 +5,9 @@ import dedent from "../util/dedent";
 import {LoggingTaskReporter} from "../util/taskReporter";
 import type {Command} from "./command";
 import * as Common from "./common";
-import {defaultWeights, fromJSON as weightsFromJSON} from "../analysis/weights";
+import {defaultWeights} from "../analysis/weights";
 import {load} from "../api/load";
 import {specToProject} from "../plugins/github/specToProject";
-import fs from "fs-extra";
 import {partialParams} from "../analysis/timeline/params";
 import {DEFAULT_PLUGINS} from "./defaultPlugins";
 
@@ -93,7 +92,7 @@ const loadCommand: Command = async (args, std) => {
 
   let weights = defaultWeights();
   if (weightsPath) {
-    weights = await loadWeightOverrides(weightsPath);
+    weights = await Common.loadWeights(weightsPath);
   }
 
   const githubToken = Common.githubToken();
@@ -122,20 +121,6 @@ const loadCommand: Command = async (args, std) => {
     await load(options, taskReporter);
   }
   return 0;
-};
-
-const loadWeightOverrides = async (path: string) => {
-  if (!(await fs.exists(path))) {
-    throw new Error("Could not find the weights file");
-  }
-
-  const raw = await fs.readFile(path, "utf-8");
-  const weightsJSON = JSON.parse(raw);
-  try {
-    return weightsFromJSON(weightsJSON);
-  } catch (e) {
-    throw new Error(`provided weights file is invalid:\n${e}`);
-  }
 };
 
 export const help: Command = async (args, std) => {


### PR DESCRIPTION
As suggested by @Beanow in [a review comment][1], this commit factors
loading weights from disk into a cli/common utility method.

The actual method is really generic, and we have a number of similar
constructions across the codebase (grep for `JSON.parse` to find them).
I considered factoring out a generic utility for loading and
deserializing JSON data from disk in general, but it didn't seem
valuable enough at this time.

Test plan: Unit tests added, existing tests pass.

[1]: https://github.com/sourcecred/sourcecred/pull/1374#discussion_r323149740