### PR TITLE
Replace `PartialTimelineCredParams` with `$Shape`

### DIFF
--- a/src/analysis/timeline/params.js
+++ b/src/analysis/timeline/params.js
@@ -35,17 +35,6 @@ export type TimelineCredParameters = {|
 export const DEFAULT_ALPHA = 0.05;
 export const DEFAULT_INTERVAL_DECAY = 0.5;
 
-/**
- * The PartialTimelineCredParameters are a version of TimelineCredParameters
- * where every field has been marked optional, to make it convenient for API
- * clients to override just the parameters they want to.
- */
-export type PartialTimelineCredParameters = {|
-  +alpha?: number,
-  +intervalDecay?: number,
-  +weights?: Weights,
-|};
-
 export type TimelineCredParametersJSON = {|
   +alpha: number,
   +intervalDecay: number,
@@ -87,16 +76,10 @@ export function defaultParams(): TimelineCredParameters {
 }
 
 /**
- * Promote PartialTimelineCredParameters to TimelineCredParameters.
- *
- * This takes PartialTimelineCredParameters and mixes them with the
- * default parameters to provide a full TimelineCredParameters.
- *
- * End consumers of SourceCred will not need to depend on this; it's
- * provided for implementation of SourceCred's APIs.
+ * Fill in default values for timeline cred parameters.
  */
 export function partialParams(
-  partial: PartialTimelineCredParameters
+  partial: $Shape<TimelineCredParameters>
 ): TimelineCredParameters {
   return {...defaultParams(), ...partial};
 }

--- a/src/analysis/timeline/timelineCred.js
+++ b/src/analysis/timeline/timelineCred.js
@@ -21,7 +21,6 @@ import {
   paramsToJSON,
   paramsFromJSON,
   type TimelineCredParametersJSON,
-  type PartialTimelineCredParameters,
   partialParams,
   defaultParams,
 } from "./params";
@@ -88,7 +87,7 @@ export class TimelineCred {
    * This returns a new TimelineCred; it does not modify the existing one.
    */
   async reanalyze(
-    newParams: PartialTimelineCredParameters
+    newParams: $Shape<TimelineCredParameters>
   ): Promise<TimelineCred> {
     return await TimelineCred.compute({
       graph: this._graph,
@@ -227,7 +226,7 @@ export class TimelineCred {
 
   static async compute(opts: {|
     graph: Graph,
-    params?: PartialTimelineCredParameters,
+    params?: $Shape<TimelineCredParameters>,
     plugins: $ReadOnlyArray<PluginDeclaration>,
   |}): Promise<TimelineCred> {
     const {graph, params, plugins} = opts;

--- a/src/api/load.js
+++ b/src/api/load.js
@@ -8,7 +8,7 @@ import {Graph} from "../core/graph";
 import {loadGraph} from "../plugins/github/loadGraph";
 import {TimelineCred} from "../analysis/timeline/timelineCred";
 import {defaultParams, partialParams} from "../analysis/timeline/params";
-import {type PartialTimelineCredParameters} from "../analysis/timeline/params";
+import {type TimelineCredParameters} from "../analysis/timeline/params";
 
 import {type Project} from "../core/project";
 import {setupProjectDirectory} from "../core/project_io";
@@ -18,7 +18,7 @@ import * as NullUtil from "../util/null";
 
 export type LoadOptions = {|
   +project: Project,
-  +params: ?PartialTimelineCredParameters,
+  +params: ?$Shape<TimelineCredParameters>,
   +plugins: $ReadOnlyArray<PluginDeclaration>,
   +sourcecredDirectory: string,
   +githubToken: string | null,

--- a/src/api/load.test.js
+++ b/src/api/load.test.js
@@ -20,7 +20,7 @@ import {node} from "../core/graphTestUtil";
 import {TestTaskReporter} from "../util/taskReporter";
 import {load, type LoadOptions} from "./load";
 import {
-  type PartialTimelineCredParameters,
+  type TimelineCredParameters,
   partialParams,
 } from "../analysis/timeline/params";
 
@@ -74,7 +74,7 @@ describe("api/load", () => {
   // Tweaks the weights so that we can ensure we aren't overriding with default weights
   weights.nodeManualWeights.set(NodeAddress.empty, 33);
   // Deep freeze will freeze the weights, too
-  const params: PartialTimelineCredParameters = {weights};
+  const params: $Shape<TimelineCredParameters> = {weights};
   const plugins = deepFreeze([]);
   const example = () => {
     const sourcecredDirectory = tmp.dirSync().name;


### PR DESCRIPTION
Summary:
Flow provides a utility type for this purpose; there’s no need to
implement, document, and keep it in sync ourselves:
<https://flow.org/en/docs/types/utilities/#toc-shape>

Test Plan:
As written, `yarn flow` passes. Changing the definition of `params` on
line 77 of `load.test.js` to add a key `foo: "wat"` or change the value
of `weights` to `{hmm: "hmm"}` yield appropriate type errors.

wchargin-branch: use-shape