### PR TITLE
GitHub plugin: Expose user addresses

### DIFF
--- a/src/plugins/github/nodes.js
+++ b/src/plugins/github/nodes.js
@@ -2,6 +2,7 @@
 
 import deepFreeze from "deep-freeze";
 import {NodeAddress, type NodeAddressT} from "../../core/graph";
+import {botSet} from "./bots";
 
 export opaque type RawAddress: NodeAddressT = NodeAddressT;
 
@@ -35,6 +36,26 @@ export const Prefix = deepFreeze({
   issueComment: _githubAddress(COMMENT_TYPE, ISSUE_TYPE),
   pullComment: _githubAddress(COMMENT_TYPE, PULL_TYPE),
 });
+
+/**
+ * Return the address corresponding to a GitHub login.
+ *
+ * If the login is considered a bot, then a bot address is returned. Otherwise,
+ * a regular user address is returned. The method does not attempt to find out
+ * whether the address should actually be an organization address, as we don't
+ * yet handle organization addresses.
+ *
+ * Note: The signature will need to be refactored when we make the list of bots
+ * a configuration option rather than a hardcoded constant.
+ */
+export function loginAddress(username: string): RawAddress {
+  const bots = botSet();
+  if (bots.has(username)) {
+    return NodeAddress.append(Prefix.bot, username);
+  } else {
+    return NodeAddress.append(Prefix.user, username);
+  }
+}
 
 export type RepoAddress = {|
   +type: typeof REPO_TYPE,

--- a/src/plugins/github/nodes.test.js
+++ b/src/plugins/github/nodes.test.js
@@ -2,7 +2,7 @@
 
 import {NodeAddress} from "../../core/graph";
 import * as GN from "./nodes";
-import {fromRaw, toRaw} from "./nodes";
+import {fromRaw, toRaw, type UserlikeAddress, loginAddress} from "./nodes";
 
 describe("plugins/github/nodes", () => {
   const repo = (): GN.RepoAddress => ({
@@ -241,6 +241,31 @@ describe("plugins/github/nodes", () => {
           toRaw({type: "COMMENT", parent: {type: "ICE_CREAM"}});
         }).toThrow("Bad comment parent type");
       });
+    });
+  });
+
+  describe("loginAddress", () => {
+    it("works for a regular user", () => {
+      const username = "foo";
+      const structured: UserlikeAddress = {
+        type: "USERLIKE",
+        subtype: "USER",
+        login: username,
+      };
+      const actual = loginAddress(username);
+      const expected = toRaw(structured);
+      expect(actual).toEqual(expected);
+    });
+    it("works for a bot", () => {
+      const username = "credbot";
+      const structured: UserlikeAddress = {
+        type: "USERLIKE",
+        subtype: "BOT",
+        login: username,
+      };
+      const actual = loginAddress(username);
+      const expected = toRaw(structured);
+      expect(actual).toEqual(expected);
     });
   });
 });


### PR DESCRIPTION
Allow getting the node address for a user, given the user's login. This
will be needed by the upcoming identity plugin.

If the login in question corresponds to a bot, then a bot address will
be returned. When we make the bot-set configuration (rather than
hardcoded), we'll need to change the signature of this function; I think
that's fine.

Test plan: Unit tests added. (Also, it's really simple.)