### PR TITLE
Add more bots.

### DIFF
--- a/src/plugins/github/bots.js
+++ b/src/plugins/github/bots.js
@@ -5,9 +5,11 @@
 export function botSet(): Set<string> {
   return new Set([
     "codecov",
+    "codecov-io",
     "credbot",
     "facebook-github-bot",
     "gitcoinbot",
+    "gitter-badger",
     "googlebot",
     "greenkeeper",
     "greenkeeperio-bot",


### PR DESCRIPTION
Fixes #1381

Loading a repository with those bots worked on `@fluture-js` so not added to the blacklist.