### PR TITLE
Change default alpha to 0.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Unreleased]
 
 <!-- Please add new entries just beneath this line. -->
+- Change default alpha from 0.05 to 0.20 (#1391)
 - Enable viewing and changing alpha in the explorer (#1390)
 - Enable combining different user identities together (#1385)
 - Add `sourcecred discourse` for loading Discourse servers (#1374)

--- a/src/analysis/timeline/params.js
+++ b/src/analysis/timeline/params.js
@@ -32,7 +32,7 @@ export type TimelineCredParameters = {|
   +weights: Weights,
 |};
 
-export const DEFAULT_ALPHA = 0.05;
+export const DEFAULT_ALPHA = 0.2;
 export const DEFAULT_INTERVAL_DECAY = 0.5;
 
 export type TimelineCredParametersJSON = {|


### PR DESCRIPTION
SourceCred is currently quite sensitive to inadvertent 'tight loops' in
the cred, where (e.g.) one user recieves cred but doesn't have many out
edges, resulting in a feedback loop where that person gets
disproportinate cred. See [1] and [2] for some examples.

Per a [suggestion] from @mzargham, I'm going to bandaid this issue by
increasing the alpha parameter; I've increased it 4x from 0.05 to 0.2.
Subjectively, I think this improves the cred quality.

[1]: https://discourse.sourcecred.io/t/sneak-peek-sourcecred-discourse-plugin/171
[2]: https://discourse.sourcecred.io/t/preliminary-credsperiment-cred/219
[suggestion]: https://discourse.sourcecred.io/t/preliminary-credsperiment-cred/219/16?u=decentralion