### PR TITLE
discourse: factor out address module

### DIFF
--- a/src/plugins/discourse/address.js
+++ b/src/plugins/discourse/address.js
@@ -1,0 +1,17 @@
+// @flow
+
+import {NodeAddress, type NodeAddressT} from "../../core/graph";
+
+import {type PostId, type TopicId} from "./fetch";
+
+import {topicNodeType, postNodeType, userNodeType} from "./declaration";
+
+export function topicAddress(serverUrl: string, id: TopicId): NodeAddressT {
+  return NodeAddress.append(topicNodeType.prefix, serverUrl, String(id));
+}
+export function postAddress(serverUrl: string, id: PostId): NodeAddressT {
+  return NodeAddress.append(postNodeType.prefix, serverUrl, String(id));
+}
+export function userAddress(serverUrl: string, username: string): NodeAddressT {
+  return NodeAddress.append(userNodeType.prefix, serverUrl, username);
+}

--- a/src/plugins/discourse/createGraph.js
+++ b/src/plugins/discourse/createGraph.js
@@ -1,13 +1,6 @@
 // @flow
 
-import {
-  Graph,
-  NodeAddress,
-  EdgeAddress,
-  type Node,
-  type Edge,
-  type NodeAddressT,
-} from "../../core/graph";
+import {Graph, EdgeAddress, type Node, type Edge} from "../../core/graph";
 import {
   type PostId,
   type TopicId,
@@ -17,25 +10,13 @@ import {
 } from "./fetch";
 import {type DiscourseData} from "./mirror";
 import {
-  topicNodeType,
-  postNodeType,
-  userNodeType,
   authorsPostEdgeType,
   authorsTopicEdgeType,
   postRepliesEdgeType,
   topicContainsPostEdgeType,
   likesEdgeType,
 } from "./declaration";
-
-export function topicAddress(serverUrl: string, id: TopicId): NodeAddressT {
-  return NodeAddress.append(topicNodeType.prefix, serverUrl, String(id));
-}
-export function postAddress(serverUrl: string, id: PostId): NodeAddressT {
-  return NodeAddress.append(postNodeType.prefix, serverUrl, String(id));
-}
-export function userAddress(serverUrl: string, username: string): NodeAddressT {
-  return NodeAddress.append(userNodeType.prefix, serverUrl, username);
-}
+import {userAddress, topicAddress, postAddress} from "./address";
 
 export function userNode(serverUrl: string, username: string): Node {
   const url = `${serverUrl}/u/${username}/`;

--- a/src/plugins/discourse/createGraph.test.js
+++ b/src/plugins/discourse/createGraph.test.js
@@ -14,9 +14,10 @@ import {
   topicContainsPostEdge,
   postRepliesEdge,
   likesEdge,
-  userAddress,
-  postAddress,
 } from "./createGraph";
+
+import {userAddress, postAddress} from "./address";
+
 import {
   userNodeType,
   topicNodeType,

--- a/src/plugins/identity/alias.js
+++ b/src/plugins/identity/alias.js
@@ -2,7 +2,7 @@
 
 import {type NodeAddressT} from "../../core/graph";
 import {loginAddress as githubAddress} from "../github/nodes";
-import {userAddress as discourseAddress} from "../discourse/createGraph";
+import {userAddress as discourseAddress} from "../discourse/address";
 
 /** An Alias is a string specification of an identity within another plugin.
  *

--- a/src/plugins/identity/alias.test.js
+++ b/src/plugins/identity/alias.test.js
@@ -2,7 +2,7 @@
 
 import {resolveAlias} from "./alias";
 import {loginAddress as githubAddress} from "../github/nodes";
-import {userAddress as discourseAddress} from "../discourse/createGraph";
+import {userAddress as discourseAddress} from "../discourse/address";
 
 describe("src/plugins/identity/alias", () => {
   describe("resolveAlias", () => {


### PR DESCRIPTION
This will make it possible to depend on addresses in the reference
module.

Test plan: `yarn test` passes.

This is progress towards [Discourse reference and mention detection][1].

[1]: https://discourse.sourcecred.io/t/discourse-reference-mention-detection/270