### PR TITLE
add discourse references to the graph

### DIFF
--- a/sharness/test_no_raw_anchor_elements.t
+++ b/sharness/test_no_raw_anchor_elements.t
@@ -24,6 +24,7 @@ test_expect_success "application components must use <Link> instead of <a>" '
         ":(exclude,top)*/__snapshots__/*" \
         ":(exclude,top)*/snapshots/*" \
         ":(exclude,top)src/plugins/discourse/references.test.js" \
+        ":(exclude,top)src/plugins/discourse/createGraph.test.js" \
         ":(exclude,top)src/webutil/Link.js" \
         ;
 '


### PR DESCRIPTION
This commit modifies `discourse/createGraph` so that it finds all of the
same-server Discourse references in Discourse posts, and creates
appropriately typed references edges in response.

The unit tests have been updated with cases for both references that
should exist, and references that shouldn't (e.g. post index out of
bounds, or a reference to the wrong server).

Test plan: `yarn test --full` along with snapshot update.