### PR TITLE
Support dashes in alias usernames.

### DIFF
--- a/src/plugins/identity/alias.js
+++ b/src/plugins/identity/alias.js
@@ -21,7 +21,7 @@ export function resolveAlias(
   alias: Alias,
   discourseUrl: string | null
 ): NodeAddressT {
-  const re = /(\w+)\/@?(\w+)/g;
+  const re = /(\w+)\/@?([A-Za-z0-9-_]+)/g;
   const match = re.exec(alias);
   if (match == null) {
     throw new Error(`Unable to parse alias: ${alias}`);

--- a/src/plugins/identity/alias.test.js
+++ b/src/plugins/identity/alias.test.js
@@ -30,6 +30,11 @@ describe("src/plugins/identity/alias", () => {
         const expected = githubAddress("login");
         expect(actual).toEqual(expected);
       });
+      it("a github login with underscores and dashes", () => {
+        const actual = resolveAlias("github/login_foo-bar", null);
+        const expected = githubAddress("login_foo-bar");
+        expect(actual).toEqual(expected);
+      });
       it("a discourse login", () => {
         const url = "https://example.com";
         const actual = resolveAlias("discourse/login", url);


### PR DESCRIPTION
This should fix [this issue](https://discourse.sourcecred.io/t/credsperiment-week-3-distribution/282/2?u=beanow) where @s-ben's GitHub username isn't correctly collapsed into the identity.

Test plan: added a unit test with dashes and underscores, which failed before the fix.