### PR TITLE
identity: require aliases to be anchored

### DIFF
--- a/src/plugins/identity/alias.js
+++ b/src/plugins/identity/alias.js
@@ -17,26 +17,36 @@ import {userAddress as discourseAddress} from "../discourse/address";
  */
 export type Alias = string;
 
+const _VALID_ALIAS = /^(\w+)[/](.*)$/;
+const _VALID_GITHUB_NAME = /^@?([0-9a-z_-]+)$/i;
+const _VALID_DISCOURSE_NAME = /^@?([0-9a-z_-]+)$/i;
+
 export function resolveAlias(
   alias: Alias,
   discourseUrl: string | null
 ): NodeAddressT {
-  const re = /(\w+)\/@?([A-Za-z0-9-_]+)/g;
-  const match = re.exec(alias);
+  const match = alias.match(_VALID_ALIAS);
   if (match == null) {
     throw new Error(`Unable to parse alias: ${alias}`);
   }
-  const prefix = match[1];
-  const name = match[2];
+  const [_, prefix, name] = match;
   switch (prefix) {
     case "github": {
-      return githubAddress(name);
+      const match = name.match(_VALID_GITHUB_NAME);
+      if (!match) {
+        throw new Error(`Invalid GitHub username: ${name}`);
+      }
+      return githubAddress(match[1]);
     }
     case "discourse": {
       if (discourseUrl == null) {
         throw new Error(`Can't parse alias ${alias} without Discourse url`);
       }
-      return discourseAddress(discourseUrl, name);
+      const match = name.match(_VALID_DISCOURSE_NAME);
+      if (!match) {
+        throw new Error(`Invalid Discourse username: ${name}`);
+      }
+      return discourseAddress(discourseUrl, match[1]);
     }
     default:
       throw new Error(`Unknown type for alias: ${alias}`);

--- a/src/plugins/identity/alias.test.js
+++ b/src/plugins/identity/alias.test.js
@@ -13,6 +13,16 @@ describe("src/plugins/identity/alias", () => {
       it("an alias without a /-delimited prefix", () => {
         expect(() => resolveAlias("@credbot", null)).toThrow("Unable to parse");
       });
+      it("an alias not anchored to start of string", () => {
+        expect(() => resolveAlias("my github/@credbot", null)).toThrow(
+          "Unable to parse"
+        );
+      });
+      it("an alias not anchored to end of string", () => {
+        expect(() => resolveAlias("github/@credbot friend", null)).toThrow(
+          "Invalid GitHub username"
+        );
+      });
       it("an alias with an unknown prefix", () => {
         expect(() => resolveAlias("foo/bar", null)).toThrow(
           "Unknown type for alias"
@@ -21,6 +31,16 @@ describe("src/plugins/identity/alias", () => {
       it("a discourse alias without a url", () => {
         expect(() => resolveAlias("discourse/foo", null)).toThrow(
           "without Discourse url"
+        );
+      });
+      it("a github login with invalid characters", () => {
+        expect(() => resolveAlias("github/!@#$", null)).toThrow(
+          "Invalid GitHub username"
+        );
+      });
+      it("a discourse login with invalid characters", () => {
+        expect(() => resolveAlias("discourse/!@#$", "url")).toThrow(
+          "Invalid Discourse username"
         );
       });
     });


### PR DESCRIPTION
Summary:
All the documentation and tests seem to be assuming that aliases must be
anchored: `github/torvalds`, but not `some github/torvalds stuff`.
JavaScript regular expressions aren’t anchored by default; this commit
adds explicit anchoring and adds tests.

Test Plan:
Unit tests added.

wchargin-branch: alias-anchor