### PR TITLE
identity: forbid underscores in GitHub logins

### DIFF
--- a/src/plugins/identity/alias.js
+++ b/src/plugins/identity/alias.js
@@ -1,6 +1,7 @@
 // @flow
 
 import {type NodeAddressT} from "../../core/graph";
+import {githubOwnerPattern} from "../../core/repoId";
 import {loginAddress as githubAddress} from "../github/nodes";
 import {userAddress as discourseAddress} from "../discourse/address";
 
@@ -18,7 +19,7 @@ import {userAddress as discourseAddress} from "../discourse/address";
 export type Alias = string;
 
 const _VALID_ALIAS = /^(\w+)[/](.*)$/;
-const _VALID_GITHUB_NAME = /^@?([0-9a-z_-]+)$/i;
+const _VALID_GITHUB_NAME = new RegExp(`^@?(${githubOwnerPattern})$`);
 const _VALID_DISCOURSE_NAME = /^@?([0-9a-z_-]+)$/i;
 
 export function resolveAlias(

--- a/src/plugins/identity/alias.test.js
+++ b/src/plugins/identity/alias.test.js
@@ -38,6 +38,11 @@ describe("src/plugins/identity/alias", () => {
           "Invalid GitHub username"
         );
       });
+      it("a github login with underscores", () => {
+        expect(() => resolveAlias("github/foo_bar", null)).toThrow(
+          "Invalid GitHub username"
+        );
+      });
       it("a discourse login with invalid characters", () => {
         expect(() => resolveAlias("discourse/!@#$", "url")).toThrow(
           "Invalid Discourse username"
@@ -50,9 +55,9 @@ describe("src/plugins/identity/alias", () => {
         const expected = githubAddress("login");
         expect(actual).toEqual(expected);
       });
-      it("a github login with underscores and dashes", () => {
-        const actual = resolveAlias("github/login_foo-bar", null);
-        const expected = githubAddress("login_foo-bar");
+      it("a github login with hyphens", () => {
+        const actual = resolveAlias("github/login-foo-bar", null);
+        const expected = githubAddress("login-foo-bar");
         expect(actual).toEqual(expected);
       });
       it("a discourse login", () => {


### PR DESCRIPTION
Summary:
GitHub logins may not have underscores, because underscores are not
valid characters in DNS labels. We already have a good-enough regular
expression for validating GitHub usernames; this commit updates the
alias parser to use that.

Discourse usernames are more permissive than what is listed here, but we
leave that unchanged for now.

Test Plan:
Unit tests updated.

wchargin-branch: alias-no-underscore