### PR TITLE
Implement Discourse initiative tracker parsing.

### DIFF
--- a/sharness/test_no_raw_anchor_elements.t
+++ b/sharness/test_no_raw_anchor_elements.t
@@ -25,6 +25,7 @@ test_expect_success "application components must use <Link> instead of <a>" '
         ":(exclude,top)*/snapshots/*" \
         ":(exclude,top)src/plugins/discourse/references.test.js" \
         ":(exclude,top)src/plugins/discourse/createGraph.test.js" \
+        ":(exclude,top)src/plugins/initiatives/discourse.test.js" \
         ":(exclude,top)src/webutil/Link.js" \
         ;
 '

--- a/src/plugins/initiatives/README.md
+++ b/src/plugins/initiatives/README.md
@@ -1,0 +1,11 @@
+# The initiatives plugin
+
+Initiatives are proposals to improve SourceCred in some way.
+Initiatives will be a focal point for minting new cred and flowing it to contributors.
+
+The current format for them is as a Discourse topic, set as a wiki.
+Using a specific template to format them, the wiki is used to link to it's own status and edges.
+
+More information:
+- [The initiatives category](https://discourse.sourcecred.io/c/the-credsperiment/initiatives)
+- [About the Initiatives category](https://discourse.sourcecred.io/t/about-the-initiatives-category/242/1)

--- a/src/plugins/initiatives/declaration.js
+++ b/src/plugins/initiatives/declaration.js
@@ -1,0 +1,112 @@
+// @flow
+
+import deepFreeze from "deep-freeze";
+import type {PluginDeclaration} from "../../analysis/pluginDeclaration";
+import type {NodeType, EdgeType} from "../../analysis/types";
+import {NodeAddress, EdgeAddress} from "../../core/graph";
+
+export const nodePrefix = NodeAddress.fromParts(["sourcecred", "initiatives"]);
+export const edgePrefix = EdgeAddress.fromParts(["sourcecred", "initiatives"]);
+
+export const initiativeNodeType: NodeType = deepFreeze({
+  name: "Initiative",
+  pluralName: "Initiatives",
+  prefix: NodeAddress.append(nodePrefix, "initiative"),
+  defaultWeight: 1,
+  description:
+    "An initiative, formatted as a Discourse wiki topic using a fixed template.",
+});
+
+/*
+	Note on the forward and backward naming convention.
+	It follows the core/graph.js documentation to use
+	a <subject> <verb> <object> format to figure out
+	the directionality.
+*/
+
+/**
+ * A Discourse topic (src) TRACKS (verb) an initiative (dst).
+ * Forward: separate in terms of cred flow for now
+ * Backward: separate in terms of cred flow for now
+ */
+export const discourseTopicTracksInitiativeEdgeType: EdgeType = deepFreeze({
+  forwardName: "tracks",
+  backwardName: "is tracked by",
+  prefix: EdgeAddress.append(edgePrefix, "discourseTopicTracksInitiative"),
+  defaultWeight: {forwards: 0, backwards: 0},
+  description: "Connects an initiative to the Discourse topic that tracks it.",
+});
+
+/**
+ * An initiative (src) DEPENDS ON (verb) a dependency (dst).
+ * Forward: depending on something flows significant cred to the dependency.
+ * Backward: having a dependency does not flow much cred to the iniative,
+ * though does flow some to incentivize reuse and attribution.
+ */
+export const dependsOnEdgeType: EdgeType = deepFreeze({
+  forwardName: "depends on",
+  backwardName: "is a dependency for",
+  prefix: EdgeAddress.append(edgePrefix, "dependsOn"),
+  defaultWeight: {forwards: 1, backwards: 1 / 16},
+  description: "Connects an initiative to it's dependencies.",
+});
+
+/**
+ * An initiative (src) REFERENCES (verb) a reference (dst).
+ * Forward: reference for an initiative flows medium cred to the reference.
+ * Backward: having reference material does not flow much cred to the iniative,
+ * though does flow some to incentivize using existing research and attribution.
+ */
+export const referencesEdgeType: EdgeType = deepFreeze({
+  forwardName: "references",
+  backwardName: "is referenced for",
+  prefix: EdgeAddress.append(edgePrefix, "references"),
+  defaultWeight: {forwards: 1 / 2, backwards: 1 / 16},
+  description: "Connects an initiative to it's references.",
+});
+
+/**
+ * A contribution (src) CONTRIBUTES TO (verb) an initiative (dst).
+ * Forward: a contribution flows a medium amount of cred to the initiative.
+ * Backward: an initiative flows significant cred to it's contributions.
+ */
+export const contributesToEdgeType: EdgeType = deepFreeze({
+  forwardName: "contributes to",
+  backwardName: "is contributed to by",
+  prefix: EdgeAddress.append(edgePrefix, "contributesTo"),
+  defaultWeight: {forwards: 1 / 4, backwards: 1},
+  description: "Connects an initiative to it's contributions.",
+});
+
+/**
+ * A user (src) CHAMPIONS (verb) an initiative (dst).
+ * Meaning forward is the user claiming and committing they will champion an initiative.
+ * and backward is the return of cred based on the completion and succesful championing of the ininiative.
+ * Forward and backward weights depend on the status of the iniative and success of the champion.
+ * The weights represent a successful champion for a completed iniative.
+ *
+ * Forward: having a champion flows significant cred to the iniative.
+ * Backward: being a successful champion for an iniative flows massive cred to the user.
+ */
+export const championsEdgeType: EdgeType = deepFreeze({
+  forwardName: "champions",
+  backwardName: "is championed by",
+  prefix: EdgeAddress.append(edgePrefix, "champions"),
+  defaultWeight: {forwards: 1, backwards: 4},
+  description: "Connects an initiative to users who champion it.",
+});
+
+export const declaration: PluginDeclaration = deepFreeze({
+  name: "Initiatives",
+  nodePrefix,
+  edgePrefix,
+  nodeTypes: [initiativeNodeType],
+  edgeTypes: [
+    discourseTopicTracksInitiativeEdgeType,
+    dependsOnEdgeType,
+    referencesEdgeType,
+    contributesToEdgeType,
+    championsEdgeType,
+  ],
+  userTypes: [],
+});

--- a/src/plugins/initiatives/discourse.js
+++ b/src/plugins/initiatives/discourse.js
@@ -1,0 +1,145 @@
+// @flow
+
+import {DomHandler, DomUtils, Parser} from "htmlparser2";
+
+import {type Topic, type Post} from "../discourse/fetch";
+import {type Initiative, type URL} from "./initiative";
+import {topicAddress} from "../discourse/address";
+
+type HeaderToURLsMap = Map<string, $ReadOnlyArray<URL>>;
+
+export async function initiativeFromDiscourseTracker(
+  serverUrl: string,
+  topic: Topic,
+  firstPost: Post
+): Promise<Initiative> {
+  if (firstPost.topicId !== topic.id) {
+    throw new Error("Post is from a different topic");
+  }
+
+  if (firstPost.indexWithinTopic !== 1) {
+    throw new Error("Post is not the first post in the topic");
+  }
+
+  const {title} = topic;
+  const {timestampMs} = firstPost;
+  const tracker = topicAddress(serverUrl, topic.id);
+
+  const htu: HeaderToURLsMap = await groupURLsByHeader(firstPost.cooked);
+  const completed = findCompletionStatus(htu);
+  const champions = singleMatch(htu, new RegExp(/^Champions?/i));
+  const contributions = singleMatch(htu, new RegExp(/^Contributions?/i));
+  const dependencies = singleMatch(htu, new RegExp(/^Dependenc(y|ies)/i));
+  const references = singleMatch(htu, new RegExp(/^References?/i));
+
+  const missing = [];
+  if (completed === null) missing.push("status");
+  if (!champions) missing.push("champions");
+  if (!contributions) missing.push("contributions");
+  if (!dependencies) missing.push("dependencies");
+  if (!references) missing.push("references");
+
+  if (
+    completed == null ||
+    champions == null ||
+    contributions == null ||
+    dependencies == null ||
+    references == null
+  ) {
+    missing.sort();
+    const missingStr = JSON.stringify(missing);
+    throw new Error(
+      `Missing or malformed headers ${missingStr} for initiative topic "${title}" (${topic.id})`
+    );
+  }
+
+  return {
+    title,
+    tracker,
+    timestampMs,
+    completed,
+    champions,
+    contributions,
+    dependencies,
+    references,
+  };
+}
+
+function findCompletionStatus(map: HeaderToURLsMap): boolean | null {
+  const pattern = new RegExp(/^Status:(.*)/i);
+  const headers = Array.from(map.keys())
+    .map((k) => k.trim())
+    .filter((k) => pattern.test(k));
+
+  if (headers.length !== 1) {
+    return null;
+  }
+
+  const matches = headers[0].match(pattern);
+  if (matches == null) {
+    return null;
+  }
+
+  const completedRE = new RegExp(/^completed?$/i);
+  return completedRE.test(matches[1].trim());
+}
+
+function singleMatch(
+  map: HeaderToURLsMap,
+  pattern: RegExp
+): $ReadOnlyArray<URL> | null {
+  const headers = Array.from(map.keys()).filter((k) => pattern.test(k.trim()));
+
+  if (headers.length !== 1) {
+    return null;
+  }
+
+  return map.get(headers[0]) || null;
+}
+
+export async function groupURLsByHeader(
+  cookedHTML: string
+): Promise<HeaderToURLsMap> {
+  const map: HeaderToURLsMap = new Map();
+  const dom = await promiseDOM(cookedHTML);
+
+  let currentHeader: string | null = null;
+  for (const rootEl of dom) {
+    switch (rootEl.name) {
+      case "h1":
+      case "h2":
+      case "h3":
+      case "h4":
+      case "h5":
+      case "h6":
+        currentHeader = DomUtils.getText(rootEl);
+        // We're also interested in just headers, so make sure an entry exists.
+        map.set(currentHeader, []);
+        break;
+      case "p":
+      case "ul":
+      case "ol":
+        if (currentHeader === null) break;
+        const existing = map.get(currentHeader) || [];
+        const anchors = DomUtils.findAll((el) => el.name === "a", [rootEl]).map(
+          (a) => a.attribs.href
+        );
+        map.set(currentHeader, [...existing, ...anchors]);
+        break;
+    }
+  }
+
+  return map;
+}
+
+function promiseDOM(cookedHTML: string): Promise<Object> {
+  return new Promise((res, rej) => {
+    const domHandler = new DomHandler((err, dom) => {
+      if (err) rej(err);
+      res(dom);
+    });
+    const htmlParser = new Parser(domHandler);
+    htmlParser.write(cookedHTML);
+    htmlParser.end();
+  });
+}

--- a/src/plugins/initiatives/discourse.test.js
+++ b/src/plugins/initiatives/discourse.test.js
@@ -1,0 +1,285 @@
+// @flow
+
+import {groupURLsByHeader, initiativeFromDiscourseTracker} from "./discourse";
+import {NodeAddress} from "../../core/graph";
+
+function exampleTopic(overrides: ?Object) {
+  return {
+    id: 123,
+    categoryId: 42,
+    title: "Example initiative",
+    timestampMs: 1571498171951,
+    authorUsername: "TestUser",
+    ...overrides,
+  };
+}
+
+function examplePost(cooked) {
+  return {
+    id: 432,
+    topicId: 123,
+    indexWithinTopic: 1,
+    replyToPostIndex: null,
+    timestampMs: 1571498171951,
+    authorUsername: "TestUser",
+    cooked,
+  };
+}
+
+function nonBinaryInitiative(object) {
+  return {
+    ...object,
+    tracker: NodeAddress.toParts(object.tracker),
+  };
+}
+
+describe("plugins/initiatives/discourse", () => {
+  describe("initiativeFromDiscourseTracker", () => {
+    it("handles an example tracker", async () => {
+      // Given
+      const serverUrl = "https://foo.bar";
+      const topic = exampleTopic();
+      const firstPost = examplePost(`
+        <h1>Example initiative</h1>
+        <h2>Status: Testing</h2>
+        <h2>Champion<a href="https://foo.bar/t/dont-include/10"><sup>?</sup></a>:</h2>
+        <p>
+          <a class="mention" href="/u/ChampUser">@ChampUser</a>
+        </p>
+        <h2>Dependencies:</h2>
+        <ul>
+          <li><a href="https://foo.bar/t/dependency/1">Thing we need</a></li>
+          <li><a href="https://foo.bar/t/dependency/2">Thing we need</a></li>
+          <li><a href="https://foo.bar/t/dependency/3">Thing we need</a></li>
+        </ul>
+        <h2>References:</h2>
+        <ul>
+          <li><a href="https://foo.bar/t/reference/4">Some reference</a></li>
+          <li><a href="https://foo.bar/t/reference/5/2">Some reference</a></li>
+          <li><a href="https://foo.bar/t/reference/6/4">Some reference</a></li>
+        </ul>
+        <h2>Contributions:</h2>
+        <ul>
+          <li><a href="https://foo.bar/t/contribution/7">Some contribution</a></li>
+          <li><a href="https://foo.bar/t/contribution/8/2">Some contribution</a></li>
+          <li><a href="https://github.com/sourcecred/sourcecred/pull/1416">Some contribution</a></li>
+        </ul>
+      `);
+
+      // When
+      const initiative = await initiativeFromDiscourseTracker(
+        serverUrl,
+        topic,
+        firstPost
+      );
+
+      // Then
+      expect(initiative.completed).toEqual(false);
+      expect(nonBinaryInitiative(initiative)).toMatchInlineSnapshot(`
+        Object {
+          "champions": Array [
+            "/u/ChampUser",
+          ],
+          "completed": false,
+          "contributions": Array [
+            "https://foo.bar/t/contribution/7",
+            "https://foo.bar/t/contribution/8/2",
+            "https://github.com/sourcecred/sourcecred/pull/1416",
+          ],
+          "dependencies": Array [
+            "https://foo.bar/t/dependency/1",
+            "https://foo.bar/t/dependency/2",
+            "https://foo.bar/t/dependency/3",
+          ],
+          "references": Array [
+            "https://foo.bar/t/reference/4",
+            "https://foo.bar/t/reference/5/2",
+            "https://foo.bar/t/reference/6/4",
+          ],
+          "timestampMs": 1571498171951,
+          "title": "Example initiative",
+          "tracker": Array [
+            "sourcecred",
+            "discourse",
+            "topic",
+            "https://foo.bar",
+            "123",
+          ],
+        }
+      `);
+    });
+
+    it("handles a completed status", async () => {
+      // Given
+      const serverUrl = "https://foo.bar";
+      const topic = exampleTopic();
+      const firstPost = examplePost(`
+        <h1>Example initiative</h1>
+        <h2>Status: Complete</h2>
+        <h2>Champion:</h2>
+        <h2>Dependencies:</h2>
+        <h2>References:</h2>
+        <h2>Contributions:</h2>
+      `);
+
+      // When
+      const initiative = await initiativeFromDiscourseTracker(
+        serverUrl,
+        topic,
+        firstPost
+      );
+
+      // Then
+      expect(initiative.completed).toEqual(true);
+      expect(nonBinaryInitiative(initiative)).toMatchInlineSnapshot(`
+        Object {
+          "champions": Array [],
+          "completed": true,
+          "contributions": Array [],
+          "dependencies": Array [],
+          "references": Array [],
+          "timestampMs": 1571498171951,
+          "title": "Example initiative",
+          "tracker": Array [
+            "sourcecred",
+            "discourse",
+            "topic",
+            "https://foo.bar",
+            "123",
+          ],
+        }
+      `);
+    });
+
+    it("considers blank status incomplete", async () => {
+      // Given
+      const serverUrl = "https://foo.bar";
+      const topic = exampleTopic();
+      const firstPost = examplePost(`
+        <h1>Example initiative</h1>
+        <h2>Status:</h2>
+        <h2>Champion:</h2>
+        <h2>Dependencies:</h2>
+        <h2>References:</h2>
+        <h2>Contributions:</h2>
+      `);
+
+      // When
+      const initiative = await initiativeFromDiscourseTracker(
+        serverUrl,
+        topic,
+        firstPost
+      );
+
+      // Then
+      expect(initiative.completed).toEqual(false);
+    });
+
+    it("crashes when missing headers", async () => {
+      // Given
+      const serverUrl = "https://foo.bar";
+      const topic = exampleTopic();
+      const firstPost = examplePost(`<h1>Example initiative</h1>`);
+
+      // When
+      const initiativeP = initiativeFromDiscourseTracker(
+        serverUrl,
+        topic,
+        firstPost
+      );
+
+      // Then
+      await expect(initiativeP).rejects.toThrow(
+        'Missing or malformed headers ["champions","contributions","dependencies","references","status"] for initiative topic "Example initiative" (123)'
+      );
+    });
+
+    it("crashes on duplicate headers", async () => {
+      // Given
+      const serverUrl = "https://foo.bar";
+      const topic = exampleTopic();
+      const firstPost = examplePost(`
+        <h1>Example initiative</h1>
+        <h2>Status: Complete</h2>
+        <h2>Champion:</h2>
+        <h2>Champions:</h2>
+        <h2>Dependencies:</h2>
+        <h2>References:</h2>
+        <h2>Contributions:</h2>
+      `);
+
+      // When
+      const initiativeP = initiativeFromDiscourseTracker(
+        serverUrl,
+        topic,
+        firstPost
+      );
+
+      // Then
+      await expect(initiativeP).rejects.toThrow(
+        'Missing or malformed headers ["champions"] for initiative topic "Example initiative" (123)'
+      );
+    });
+  });
+
+  describe("groupURLsByHeader", () => {
+    it("handles an example text", async () => {
+      // Given
+      const sample = `
+      <h1>This is a title</h1>
+      <p>
+        Things to talk about.
+        <a href="https://foo.bar/1">With links</a>
+      </p>
+      <a href="https://foo.bar/baz">Seems unmarkdownly formatted</a>
+      <h2>Some <i>funky</i> section:</h2>
+      <p>
+        <a href="https://foo.bar/2">With</a>
+        <strong><a href="https://foo.bar/3">More</a></strong>
+      </p>
+      <p>
+        <a href="https://foo.bar/4">Links</a>
+      </p>
+      <h2>Listed things<a href="https://foo.bar/t/dont-include/10"><sup>?</sup></a>:</h2>
+      <ul>
+        <li><a href="https://foo.bar/5">Yet</a></li>
+        <li><a href="https://foo.bar/6">More</a></li>
+        <li><a href="https://foo.bar/7">Links</a></li>
+      </ul>
+      <h2>Ordered things:</h2>
+      <ol>
+        <li><a href="https://foo.bar/8">Yet</a></li>
+        <li><a href="https://foo.bar/9">More</a></li>
+        <li><a href="https://foo.bar/10">Links</a></li>
+      </ol>
+      `;
+
+      // When
+      const map = await groupURLsByHeader(sample);
+
+      // Then
+      expect(map).toMatchInlineSnapshot(`
+        Map {
+          "This is a title" => Array [
+            "https://foo.bar/1",
+          ],
+          "Some funky section:" => Array [
+            "https://foo.bar/2",
+            "https://foo.bar/3",
+            "https://foo.bar/4",
+          ],
+          "Listed things?:" => Array [
+            "https://foo.bar/5",
+            "https://foo.bar/6",
+            "https://foo.bar/7",
+          ],
+          "Ordered things:" => Array [
+            "https://foo.bar/8",
+            "https://foo.bar/9",
+            "https://foo.bar/10",
+          ],
+        }
+      `);
+    });
+  });
+});

--- a/src/plugins/initiatives/initiative.js
+++ b/src/plugins/initiatives/initiative.js
@@ -1,0 +1,29 @@
+// @flow
+
+export type URL = string;
+import {type NodeAddressT} from "../../core/graph";
+
+/**
+ * This makes the assumption a Champion cannot fail in championing.
+ * Instead of a success status, they should be removed if unsuccessful.
+ *
+ * There is also no timestamp for completion or each edge.
+ * They will all use the initiative creation date instead.
+ * We can support accurate edge timestamps by interpreting wiki histories.
+ * However the additional complexity and requirements put on the tracker
+ * don't seem worthwhile right now.
+ * Especially because cred can flow even before bounties are released.
+ * See https://discourse.sourcecred.io/t/write-the-initiatives-plugin/269/6
+ * This will likely create dangling edges, as the initiative may be created
+ * before some of it's contributions/references/dependencies exist as a node.
+ */
+export type Initiative = {|
+  +title: string,
+  +timestampMs: number,
+  +completed: boolean,
+  +tracker: NodeAddressT,
+  +dependencies: $ReadOnlyArray<URL>,
+  +references: $ReadOnlyArray<URL>,
+  +contributions: $ReadOnlyArray<URL>,
+  +champions: $ReadOnlyArray<URL>,
+|};


### PR DESCRIPTION
Continues from #1417 
This has a strict header format and crashes when it's not followed.

Initially I experimented with a very forgiving detection to get a best-effort result.
But considering the CredSperiment is the first and only target of this plugin right now, I believe crashing and forcing to update the wiki to match the expected format will produce more consistent results.

The expected pattern is:

```
All headers are case-insensitive and can be h1-h6.
Headers can appear in any order.
A matching header for each field must appear exactly once.

---

## Status: complete

Status value must be in the header, prefixed by "Status:".
Either "complete" or "completed". A missing status value,
or any other value is considered incomplete.

## Champions:

- [@Beanow](/u/beanow)

Any URLs that appear in the content below the "Champion" or "Champions" header.
No filters on user-like types applied here, that's left for after reference detection.

## Dependencies:

- [Dependency](/t/topic/123)

Any URLs that appear in the content below the "Dependency" or "Dependencies" header.

## References:

- [Reference](/t/topic/123)

Any URLs that appear in the content below the "Reference" or "References" header.

## Contributions:

- [Contribution](/t/topic/123)

Any URLs that appear in the content below the "Contribution" or "Contributions" header.
```