### PR TITLE
discourse: factor out snapshotTestUtil

### DIFF
--- a/src/plugins/discourse/fetch.test.js
+++ b/src/plugins/discourse/fetch.test.js
@@ -1,34 +1,10 @@
 // @flow
 
-import deepFreeze from "deep-freeze";
-import {Fetcher, type DiscourseFetchOptions} from "./fetch";
-import base64url from "base64url";
-import path from "path";
-import fs from "fs-extra";
+import {Fetcher} from "./fetch";
+import {options, snapshotFetcher} from "./mockSnapshotFetcher";
 
 describe("plugins/discourse/fetch", () => {
-  const options: DiscourseFetchOptions = deepFreeze({
-    apiKey: "FAKE_KEY",
-    apiUsername: "credbot",
-    serverUrl: "https://sourcecred-test.discourse.group",
-  });
-
   describe("snapshot testing", () => {
-    async function snapshotFetch(
-      url: string | Request | URL
-    ): Promise<Response> {
-      const snapshotDir = "src/plugins/discourse/snapshots";
-      const filename = base64url(url);
-      const file = path.join(snapshotDir, filename);
-      if (await fs.exists(file)) {
-        const contents = await fs.readFile(file);
-        return new Response(contents, {status: 200});
-      } else {
-        throw new Error(`couldn't load snapshot for ${file}`);
-      }
-    }
-    const snapshotFetcher = () => new Fetcher(options, snapshotFetch, 0);
-
     it("loads LatestTopicId from snapshot", async () => {
       const topicId = await snapshotFetcher().latestTopicId();
       expect(topicId).toMatchInlineSnapshot(`21`);

--- a/src/plugins/discourse/mockSnapshotFetcher.js
+++ b/src/plugins/discourse/mockSnapshotFetcher.js
@@ -1,0 +1,26 @@
+// @flow
+
+import deepFreeze from "deep-freeze";
+import base64url from "base64url";
+import path from "path";
+import fs from "fs-extra";
+import {Fetcher, type DiscourseFetchOptions} from "./fetch";
+
+export const options: DiscourseFetchOptions = deepFreeze({
+  apiKey: "FAKE_KEY",
+  apiUsername: "credbot",
+  serverUrl: "https://sourcecred-test.discourse.group",
+});
+
+async function snapshotFetch(url: string | Request | URL): Promise<Response> {
+  const snapshotDir = "src/plugins/discourse/snapshots";
+  const filename = base64url(url);
+  const file = path.join(snapshotDir, filename);
+  if (await fs.exists(file)) {
+    const contents = await fs.readFile(file);
+    return new Response(contents, {status: 200});
+  } else {
+    throw new Error(`couldn't load snapshot for ${file}`);
+  }
+}
+export const snapshotFetcher = () => new Fetcher(options, snapshotFetch, 0);


### PR DESCRIPTION
I want to have the reference tests depend on real snapshotted data.
Therefore, I'm factoring out the utilities for interacting with the
snapshot data out of fetch.test.js and into snapshotTestUtil.js

Test plan: `yarn test` still passes.