### PR TITLE
Discourse plugin now properly detects mentions

### DIFF
--- a/src/plugins/discourse/createGraph.js
+++ b/src/plugins/discourse/createGraph.js
@@ -190,7 +190,9 @@ class _GraphCreator {
     this.graph.addEdge(topicContainsPostEdge(this.serverUrl, post));
     this.maybeAddPostRepliesEdge(post);
 
-    const discourseReferences = linksToReferences(parseLinks(post.cooked));
+    const discourseReferences = linksToReferences(
+      parseLinks(post.cooked, this.serverUrl)
+    );
     for (const reference of discourseReferences) {
       const edge = this.referenceEdge(post, reference);
       if (edge != null) {
@@ -225,7 +227,10 @@ class _GraphCreator {
   }
 
   referenceEdge(post: Post, reference: DiscourseReference): Edge | null {
-    if (reference.serverUrl.toLowerCase() !== this.serverUrl.toLowerCase()) {
+    if (
+      reference.serverUrl != null &&
+      reference.serverUrl.toLowerCase() !== this.serverUrl.toLowerCase()
+    ) {
       // Don't attempt to make cross-instance links for now, since we only
       // load one Discourse forum in a given instance.
       return null;

--- a/src/plugins/discourse/createGraph.test.js
+++ b/src/plugins/discourse/createGraph.test.js
@@ -92,7 +92,7 @@ describe("plugins/discourse/createGraph", () => {
       // A reference to a post (the slug doesn't matter)
       <a href="https://url.com/t/irrelevant-slug/1/2?u=bla">Second post</a>
       // A reference to a user
-      <a href="https://url.com/u/decentralion">@decentralion</a>
+      <a href="/u/decentralion">@decentralion</a>
       // A non-reference as the url is wrong
       <a href="https://boo.com/t/first-topic/1/3">Wrong url</a>
       // No post matching this index in topic, so no reference


### PR DESCRIPTION
As suggested in #1420, heretofore the Discourse plugin wasn't actually
picking up mentions. The issue is that the (thoroughly tested) mention
detection logic assumed that mention urls took the form
`$SERVERURL/u/$USERNAME`, but actually they are encoded as a relative link,
as in `/u/$USERNAME`. As such, the logic was internally consistent but
never detected any actual mentions!

It's a good case study in the need for integration tests and not just
unit tests. I've updaded the code so we do have a proper integration
test: references.test.js validates that a topic reference, post
reference, and user mention are all properly detected in the real output
from a Discoures topic.

Test plan: `yarn test` passes; inspect updated snapshots and tests.

Fixes #1420.