### PR TITLE
legacy app state includes TimelineCred

### DIFF
--- a/src/explorer/legacy/App.js
+++ b/src/explorer/legacy/App.js
@@ -121,7 +121,7 @@ export function createApp(
             weightFileManager={weightFileManager}
             manualWeights={this.state.weights.nodeManualWeights}
             declarations={[githubDeclaration]}
-            graph={appState.graph}
+            graph={appState.timelineCred.graph()}
             onManualWeightsChange={(addr: NodeAddressT, weight: number) =>
               this.setState(({weights}) => {
                 weights.nodeManualWeights.set(addr, weight);
@@ -156,7 +156,7 @@ export function createApp(
               appState.loading === "LOADING"
             }
             onClick={() =>
-              this.stateTransitionMachine.loadGraphAndRunPagerank(
+              this.stateTransitionMachine.loadTimelineCredAndRunPagerank(
                 this.props.assets,
                 this.state.weights,
                 {

--- a/src/explorer/legacy/App.test.js
+++ b/src/explorer/legacy/App.test.js
@@ -9,23 +9,25 @@ import testLocalStore from "../../webutil/testLocalStore";
 
 import {PagerankTable} from "./pagerankTable/Table";
 import {createApp, LoadingIndicator, ProjectDetail} from "./App";
+import {TimelineCred} from "../../analysis/timeline/timelineCred";
+import {defaultParams} from "../../analysis/timeline/params";
 
 require("../../webutil/testUtil").configureEnzyme();
 
 describe("explorer/legacy/App", () => {
   function example() {
     let setState, getState;
-    const loadGraph = jest.fn();
+    const loadTimelineCred = jest.fn();
     const runPagerank = jest.fn();
-    const loadGraphAndRunPagerank = jest.fn();
+    const loadTimelineCredAndRunPagerank = jest.fn();
     const localStore = testLocalStore();
     function createMockSTM(_getState, _setState) {
       setState = _setState;
       getState = _getState;
       return {
-        loadGraph,
+        loadTimelineCred,
         runPagerank,
-        loadGraphAndRunPagerank,
+        loadTimelineCredAndRunPagerank,
       };
     }
     const App = createApp(createMockSTM);
@@ -43,9 +45,9 @@ describe("explorer/legacy/App", () => {
       el,
       setState,
       getState,
-      loadGraph,
+      loadTimelineCred,
       runPagerank,
-      loadGraphAndRunPagerank,
+      loadTimelineCredAndRunPagerank,
       localStore,
     };
   }
@@ -63,7 +65,13 @@ describe("explorer/legacy/App", () => {
         type: "READY_TO_RUN_PAGERANK",
         projectId: "foo/bar",
         loading: loadingState,
-        graph: new Graph(),
+        timelineCred: new TimelineCred(
+          new Graph(),
+          [],
+          new Map(),
+          defaultParams(),
+          []
+        ),
       });
     },
     pagerankEvaluated: (loadingState) => {
@@ -71,7 +79,13 @@ describe("explorer/legacy/App", () => {
         type: "PAGERANK_EVALUATED",
         projectId: "foo/bar",
         loading: loadingState,
-        graph: new Graph(),
+        timelineCred: new TimelineCred(
+          new Graph(),
+          [],
+          new Map(),
+          defaultParams(),
+          []
+        ),
         pagerankNodeDecomposition: new Map(),
       });
     },
@@ -123,7 +137,7 @@ describe("explorer/legacy/App", () => {
     function testAnalyzeCredButton(stateFn, {disabled}) {
       const adjective = disabled ? "disabled" : "working";
       it(`has a ${adjective} analyze cred button`, () => {
-        const {el, loadGraphAndRunPagerank, setState} = example();
+        const {el, loadTimelineCredAndRunPagerank, setState} = example();
         setState(stateFn());
         el.update();
         const button = el.findWhere(
@@ -134,7 +148,7 @@ describe("explorer/legacy/App", () => {
         } else {
           expect(button.props().disabled).toBe(false);
           button.simulate("click");
-          expect(loadGraphAndRunPagerank).toBeCalledTimes(1);
+          expect(loadTimelineCredAndRunPagerank).toBeCalledTimes(1);
         }
       });
     }


### PR DESCRIPTION
By keeping the TimelineCred in state instead of the Graph, we can access
the plugin information (and potentially other config) from TimelineCred.
Note that the legacy app does still use old-style cred calculation (no
time weighting).

Test plan: `yarn test`. It's just a refactor.

Part of https://discourse.sourcecred.io/t/fixup-legacy-explorer/316