### PR TITLE
Show all plugins' types in legacy ui

### DIFF
--- a/src/explorer/legacy/App.js
+++ b/src/explorer/legacy/App.js
@@ -8,7 +8,6 @@ import CheckedLocalStore from "../../webutil/checkedLocalStore";
 import BrowserLocalStore from "../../webutil/browserLocalStore";
 import Link from "../../webutil/Link";
 import {type NodeAddressT} from "../../core/graph";
-import {declaration as githubDeclaration} from "../../plugins/github/declaration";
 
 import {PagerankTable} from "./pagerankTable/Table";
 import {WeightConfig} from "../weights/WeightConfig";
@@ -84,25 +83,6 @@ export function createApp(
 
     render() {
       const {appState} = this.state;
-      const weightConfig = (
-        <WeightConfig
-          declarations={[githubDeclaration]}
-          nodeTypeWeights={this.state.weights.nodeTypeWeights}
-          edgeTypeWeights={this.state.weights.edgeTypeWeights}
-          onNodeWeightChange={(prefix, weight) => {
-            this.setState(({weights}) => {
-              weights.nodeTypeWeights.set(prefix, weight);
-              return {weights};
-            });
-          }}
-          onEdgeWeightChange={(prefix, weight) => {
-            this.setState(({weights}) => {
-              weights.edgeTypeWeights.set(prefix, weight);
-              return {weights};
-            });
-          }}
-        />
-      );
       const weightFileManager = (
         <WeightsFileManager
           weights={this.state.weights}
@@ -113,6 +93,26 @@ export function createApp(
       );
       let pagerankTable;
       if (appState.type === "PAGERANK_EVALUATED") {
+        const declarations = appState.timelineCred.plugins();
+        const weightConfig = (
+          <WeightConfig
+            declarations={declarations}
+            nodeTypeWeights={this.state.weights.nodeTypeWeights}
+            edgeTypeWeights={this.state.weights.edgeTypeWeights}
+            onNodeWeightChange={(prefix, weight) => {
+              this.setState(({weights}) => {
+                weights.nodeTypeWeights.set(prefix, weight);
+                return {weights};
+              });
+            }}
+            onEdgeWeightChange={(prefix, weight) => {
+              this.setState(({weights}) => {
+                weights.edgeTypeWeights.set(prefix, weight);
+                return {weights};
+              });
+            }}
+          />
+        );
         const pnd = appState.pagerankNodeDecomposition;
         pagerankTable = (
           <PagerankTable
@@ -120,7 +120,7 @@ export function createApp(
             weightConfig={weightConfig}
             weightFileManager={weightFileManager}
             manualWeights={this.state.weights.nodeManualWeights}
-            declarations={[githubDeclaration]}
+            declarations={declarations}
             graph={appState.timelineCred.graph()}
             onManualWeightsChange={(addr: NodeAddressT, weight: number) =>
               this.setState(({weights}) => {
@@ -159,10 +159,6 @@ export function createApp(
               this.stateTransitionMachine.loadTimelineCredAndRunPagerank(
                 this.props.assets,
                 this.state.weights,
-                {
-                  nodeTypes: githubDeclaration.nodeTypes.slice(),
-                  edgeTypes: githubDeclaration.edgeTypes.slice(),
-                },
                 GithubPrefix.user
               )
             }

--- a/src/explorer/legacy/state.test.js
+++ b/src/explorer/legacy/state.test.js
@@ -76,9 +76,6 @@ describe("explorer/legacy/state", () => {
   function pagerankNodeDecomposition() {
     return new Map();
   }
-  function defaultTypes() {
-    return {nodeTypes: [], edgeTypes: []};
-  }
   function loading(state: AppState) {
     return state.loading;
   }
@@ -150,7 +147,7 @@ describe("explorer/legacy/state", () => {
       const badState = readyToLoadGraph();
       const {stm} = example(badState);
       await expect(
-        stm.runPagerank(defaultWeights(), defaultTypes(), NodeAddress.empty)
+        stm.runPagerank(defaultWeights(), NodeAddress.empty)
       ).rejects.toThrow("incorrect state");
     });
     it("can be run when READY_TO_RUN_PAGERANK or PAGERANK_EVALUATED", async () => {
@@ -159,11 +156,7 @@ describe("explorer/legacy/state", () => {
         const {stm, getState, pagerankMock} = example(g);
         const pnd = pagerankNodeDecomposition();
         pagerankMock.mockReturnValue(Promise.resolve(pnd));
-        await stm.runPagerank(
-          defaultWeights(),
-          defaultTypes(),
-          NodeAddress.empty
-        );
+        await stm.runPagerank(defaultWeights(), NodeAddress.empty);
         const state = getState();
         if (state.type !== "PAGERANK_EVALUATED") {
           throw new Error("Impossible");
@@ -175,13 +168,13 @@ describe("explorer/legacy/state", () => {
     it("immediately sets loading status", () => {
       const {getState, stm} = example(readyToRunPagerank());
       expect(loading(getState())).toBe("NOT_LOADING");
-      stm.runPagerank(defaultWeights(), defaultTypes(), NodeAddress.empty);
+      stm.runPagerank(defaultWeights(), NodeAddress.empty);
       expect(loading(getState())).toBe("LOADING");
     });
     it("calls pagerank with the totalScoreNodePrefix option", async () => {
       const {pagerankMock, stm} = example(readyToRunPagerank());
       const foo = NodeAddress.fromParts(["foo"]);
-      await stm.runPagerank(defaultWeights(), defaultTypes(), foo);
+      await stm.runPagerank(defaultWeights(), foo);
       const args = pagerankMock.mock.calls[0];
       expect(args[2].totalScoreNodePrefix).toBe(foo);
     });
@@ -191,11 +184,7 @@ describe("explorer/legacy/state", () => {
       // $ExpectFlowError
       console.error = jest.fn();
       pagerankMock.mockReturnValue(Promise.reject(error));
-      await stm.runPagerank(
-        defaultWeights(),
-        defaultTypes(),
-        NodeAddress.empty
-      );
+      await stm.runPagerank(defaultWeights(), NodeAddress.empty);
       const state = getState();
       expect(loading(state)).toBe("FAILED");
       expect(state.type).toBe("READY_TO_RUN_PAGERANK");
@@ -212,13 +201,12 @@ describe("explorer/legacy/state", () => {
       stm.loadTimelineCred.mockResolvedValue(true);
       const assets = new Assets("/gateway/");
       const prefix = NodeAddress.fromParts(["bar"]);
-      const types = defaultTypes();
       const wt = defaultWeights();
-      await stm.loadTimelineCredAndRunPagerank(assets, wt, types, prefix);
+      await stm.loadTimelineCredAndRunPagerank(assets, wt, prefix);
       expect(stm.loadTimelineCred).toHaveBeenCalledTimes(1);
       expect(stm.loadTimelineCred).toHaveBeenCalledWith(assets);
       expect(stm.runPagerank).toHaveBeenCalledTimes(1);
-      expect(stm.runPagerank).toHaveBeenCalledWith(wt, types, prefix);
+      expect(stm.runPagerank).toHaveBeenCalledWith(wt, prefix);
     });
     it("does not run pagerank if loadTimelineCred did not succeed", async () => {
       const {stm} = example(readyToLoadGraph());
@@ -230,7 +218,6 @@ describe("explorer/legacy/state", () => {
       await stm.loadTimelineCredAndRunPagerank(
         assets,
         defaultWeights(),
-        defaultTypes(),
         prefix
       );
       expect(stm.loadTimelineCred).toHaveBeenCalledTimes(1);
@@ -242,16 +229,14 @@ describe("explorer/legacy/state", () => {
       (stm: any).runPagerank = jest.fn();
       const prefix = NodeAddress.fromParts(["bar"]);
       const wt = defaultWeights();
-      const types = defaultTypes();
       await stm.loadTimelineCredAndRunPagerank(
         new Assets("/gateway/"),
         wt,
-        types,
         prefix
       );
       expect(stm.loadTimelineCred).toHaveBeenCalledTimes(0);
       expect(stm.runPagerank).toHaveBeenCalledTimes(1);
-      expect(stm.runPagerank).toHaveBeenCalledWith(wt, types, prefix);
+      expect(stm.runPagerank).toHaveBeenCalledWith(wt, prefix);
     });
     it("when PAGERANK_EVALUATED, runs pagerank", async () => {
       const {stm} = example(pagerankEvaluated());
@@ -259,16 +244,14 @@ describe("explorer/legacy/state", () => {
       (stm: any).runPagerank = jest.fn();
       const prefix = NodeAddress.fromParts(["bar"]);
       const wt = defaultWeights();
-      const types = defaultTypes();
       await stm.loadTimelineCredAndRunPagerank(
         new Assets("/gateway/"),
         wt,
-        types,
         prefix
       );
       expect(stm.loadTimelineCred).toHaveBeenCalledTimes(0);
       expect(stm.runPagerank).toHaveBeenCalledTimes(1);
-      expect(stm.runPagerank).toHaveBeenCalledWith(wt, types, prefix);
+      expect(stm.runPagerank).toHaveBeenCalledWith(wt, prefix);
     });
   });
 });


### PR DESCRIPTION
This commit upgrades the legacy explorer to now properly include types
from all loaded plugins, rather than just the GitHub plugin. This makes
the legacy UI much more usable for inspecting SourceCred's own
(multi-plugin) cred.

Test plan: Manual inspection of the frontend. `yarn test` passes.

Part of https://discourse.sourcecred.io/t/fixup-legacy-explorer/316