### PR TITLE
Upgrade Flow to v0.111.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     "eslint-plugin-jsx-a11y": "6.2.3",
     "eslint-plugin-react": "7.16.0",
     "file-loader": "^4.0.0",
-    "flow-bin": "^0.110.0",
+    "flow-bin": "^0.111.0",
     "jest": "^24.8.0",
     "jest-fetch-mock": "^2.1.2",
     "prettier": "1.18.2",

--- a/src/analysis/pagerank.js
+++ b/src/analysis/pagerank.js
@@ -28,16 +28,17 @@ import {uniformDistribution} from "../core/attribution/distribution";
 
 export type {NodeDistribution} from "../core/attribution/nodeDistribution";
 export type {PagerankNodeDecomposition} from "./pagerankNodeDecomposition";
-export type PagerankOptions = {|
-  +selfLoopWeight?: number,
-  +verbose?: boolean,
-  +convergenceThreshold?: number,
-  +maxIterations?: number,
+export type FullPagerankOptions = {|
+  +selfLoopWeight: number,
+  +verbose: boolean,
+  +convergenceThreshold: number,
+  +maxIterations: number,
   // Scores will be normalized so that scores sum to totalScore
-  +totalScore?: number,
+  +totalScore: number,
   // Only nodes matching this prefix will count for normalization
-  +totalScoreNodePrefix?: NodeAddressT,
+  +totalScoreNodePrefix: NodeAddressT,
 |};
+export type PagerankOptions = $Shape<FullPagerankOptions>;
 
 export type {EdgeWeight} from "../core/attribution/graphToMarkovChain";
 export type EdgeEvaluator = (Edge) => EdgeWeight;

--- a/src/core/pagerankGraph.js
+++ b/src/core/pagerankGraph.js
@@ -77,15 +77,15 @@ export opaque type PagerankGraphJSON = Compatible<{|
 /**
  * Options to control how PageRank runs and when it stops
  */
-export type PagerankOptions = {|
+export type FullPagerankOptions = {|
   // Maximum number of iterations before we give up on PageRank Convergence
   // Defaults to DEFAULT_MAX_ITERATIONS if not provided.
-  +maxIterations?: number,
+  +maxIterations: number,
 
   // PageRank will stop running once the diff between the previous iteration
   // and the latest is less than this threshold.
   // Defaults to DEFAULT_CONVERGENCE_THRESHOLD if not provided.
-  +convergenceThreshold?: number,
+  +convergenceThreshold: number,
 
   // Specifies a seed vector for PageRank "teleportation".
   // At every step, some proportion `alpha` of the weight will
@@ -99,13 +99,14 @@ export type PagerankOptions = {|
   //
   // Specifying any negative, NaN, or infinite weights is an error.
   // Specifying weights for nodes that are not in the graph is also an error.
-  +seed?: Map<NodeAddressT, number>,
+  +seed: Map<NodeAddressT, number>,
 
   // Specifies the probability with which score 'teleports' to the seed vector.
   // If alpha=0, then the teleportation never happens. If alpha=1, then PageRank
   // always converges to precisely the seed vector. Defaults to DEFAULT_ALPHA.
-  +alpha?: number,
+  +alpha: number,
 |};
+export type PagerankOptions = $Shape<FullPagerankOptions>;
 
 export type PagerankConvergenceReport = {|
   // A quantitative measure of how close to convergence the final distribution was.
@@ -123,7 +124,7 @@ export const DEFAULT_CONVERGENCE_THRESHOLD = 1e-7;
 export const DEFAULT_ALPHA = 0;
 export const DEFAULT_SEED: () => Map<NodeAddressT, number> = () => new Map();
 
-function defaultOptions(): PagerankOptions {
+function defaultOptions(): FullPagerankOptions {
   return {
     maxIterations: DEFAULT_MAX_ITERATIONS,
     convergenceThreshold: DEFAULT_CONVERGENCE_THRESHOLD,

--- a/src/graphql/mirror.js
+++ b/src/graphql/mirror.js
@@ -75,10 +75,8 @@ export class Mirror {
     if (db == null) throw new Error("db: " + String(db));
     if (schema == null) throw new Error("schema: " + String(schema));
     const fullOptions = {
-      ...{
-        blacklistedIds: [],
-        guessTypename: () => null,
-      },
+      blacklistedIds: [],
+      guessTypename: () => null,
       ...(options || {}),
     };
     this._db = db;

--- a/src/graphql/schema.js
+++ b/src/graphql/schema.js
@@ -230,7 +230,9 @@ export function object(fields: {[Fieldname]: FieldType}): NodeType {
   if (fields[ID_FIELD_NAME].type !== "ID") {
     throw new Error(`field "${ID_FIELD_NAME}" must be an ID field`);
   }
-  return {type: "OBJECT", fields: {...fields}};
+  // Workaround for <https://github.com/facebook/flow/issues/7128>.
+  const exactFields: {|[Fieldname]: FieldType|} = ({...fields}: any);
+  return {type: "OBJECT", fields: exactFields};
 }
 
 export function union(clauses: $ReadOnlyArray<Typename>): NodeType {

--- a/src/plugins/git/gitUtils.js
+++ b/src/plugins/git/gitUtils.js
@@ -38,7 +38,8 @@ export function localGit(repositoryPath: string): GitDriver {
       // This post has some useful information on SSH_AUTH_SOCK:
       // http://blog.joncairns.com/2013/12/understanding-ssh-agent-and-ssh-add/
       SSH_AUTH_SOCK: process.env.SSH_AUTH_SOCK,
-      ...(env || {}),
+      // Workaround for <https://github.com/facebook/flow/issues/7128>.
+      ...(((env: any): {|[string]: string|}) || {}),
     };
     const options = {env: fullEnv};
     return execFileSync(

--- a/src/plugins/github/generateGraphqlFlowTypes.js
+++ b/src/plugins/github/generateGraphqlFlowTypes.js
@@ -7,8 +7,8 @@ import schema from "./schema";
 
 export default function generateGraphqlFlowTypes() {
   const prettierOptions = {
-    ...{parser: "babel"},
-    ...(prettier.resolveConfig.sync(__filename) || {}),
+    parser: "babel",
+    ...prettier.resolveConfig.sync(__filename),
   };
   return generateFlowTypes(schema(), prettierOptions);
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -3780,10 +3780,10 @@ flatted@^2.0.0:
   resolved "https://registry.yarnpkg.com/flatted/-/flatted-2.0.1.tgz#69e57caa8f0eacbc281d2e2cb458d46fdb449e08"
   integrity sha512-a1hQMktqW9Nmqr5aktAux3JMNqaucxGcjtjWnZLHX7yyPCmlSV3M54nGYbqT8K+0GhF3NBgmJCc3ma+WOgX8Jg==
 
-flow-bin@^0.110.0:
-  version "0.110.0"
-  resolved "https://registry.yarnpkg.com/flow-bin/-/flow-bin-0.110.0.tgz#c6c140e239f662839d8f61b64b7b911f12d3306c"
-  integrity sha512-mmdEPEMoTuX+mguy/tjRlOlCtPfVdXZQeMgCAsEDVDgWMA5vwWhM2y653OcJiKX38t4gtZ2e/MNVo0qzyYeZDQ==
+flow-bin@^0.111.0:
+  version "0.111.0"
+  resolved "https://registry.yarnpkg.com/flow-bin/-/flow-bin-0.111.0.tgz#dda5d07911df2268ef0f9061fb3c8d71bbb3bc3d"
+  integrity sha512-RQQMJ23r9zdGJjmYDoAoKqFy3TAudqbf/QGpsgsZvzMPg/qgIPK6e0hDLJe4aARR6B1+Gs0xBbVRBcFEFK8jyg==
 
 flush-write-stream@^1.0.0:
   version "1.1.1"


### PR DESCRIPTION
Summary:
The Flow team fixed a lot of bugs related to object spreading recently.
Some of these enable us to simplify our code (`generateGraphqlFlowTypes`
and `mirror`). Some find new genuine errors. Others require suppressions
in place of a larger change.

Test Plan:
Running `yarn flow` now passes.

wchargin-branch: upgrade-flow-v0.111.0