### PR TITLE
test: fix `example-github-load` snaphshot test

### DIFF
--- a/sharness/__snapshots__/example-github-load/projects/c291cmNlY3JlZC10ZXN0L2V4YW1wbGUtZ2l0aHVi/project.json
+++ b/sharness/__snapshots__/example-github-load/projects/c291cmNlY3JlZC10ZXN0L2V4YW1wbGUtZ2l0aHVi/project.json
@@ -1,1 +1,1 @@
-[{"type":"sourcecred/project","version":"0.3.0"},{"discourseServer":null,"id":"sourcecred-test/example-github","identities":[],"repoIds":[{"name":"example-github","owner":"sourcecred-test"}]}]
+[{"type":"sourcecred/project","version":"0.3.1"},{"discourseServer":null,"id":"sourcecred-test/example-github","identities":[],"repoIds":[{"name":"example-github","owner":"sourcecred-test"}]}]


### PR DESCRIPTION
Summary:
Generated with `./scripts/update_snapshots.sh`. This fixes failures
introduced in #1431.

Test Plan:
Running `yarn test --full` now passes. Inspecting the diff shows that
this only includes a compat version number change, which is appropriate.

wchargin-branch: fix-1431-failures