### PR TITLE
ci: run advisory full tests on every PR

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -64,6 +64,13 @@ workflows:
   commit:
     jobs:
       - test
+      # We also run full-tests on each commit, but they're not configured as
+      # blocking checks. Thus, in the case that they complete before you want
+      # to merge your pull request, they provide information, and otherwise
+      # they don't get in your way.
+      - test_full
+      - test_full_10
+
       - docker/publish:
           deploy: false
           image: sourcecred/sourcecred
@@ -105,20 +112,6 @@ workflows:
                    echo "Version for Docker tag is ${DOCKER_TAG}"
                    docker tag sourcecred/sourcecred:latest sourcecred/sourcecred:${DOCKER_TAG}
                    docker push sourcecred/sourcecred
-
-      - test_full:
-          filters:
-            branches:
-              only:
-                - master
-                - /ci-.*/
-
-      - test_full_10:
-          filters:
-            branches:
-              only:
-                - master
-                - /ci-.*/
 
       - docker/publish:
           image: sourcecred/sourcecred


### PR DESCRIPTION
Summary:
We’ve hitherto only run `yarn test` on each commit, to reduce latency.
This commit introduces an advisory (non-blocking) `yarn test --full`
run. Our GitHub branch protection rule is configured to only require
that the `test` task pass before blessing the PR, which is why the
Docker tag preview job doesn’t also block merging. In the case that a
commit is approved quickly and needs to be merged immediately, this
doesn’t get in your way. In all other cases, this can help prevent
breakages.

Test Plan:
Watch the CI run for this commit. Note that all jobs are running, but
only the `test` job is marked as required; see [screenshot][1].

[1]: https://user-images.githubusercontent.com/4317806/68623255-edce3900-0488-11ea-948f-a0cab5174a35.png

wchargin-branch: ci-advisory-full