### PR TITLE
Make Discourse robust to 404s on user actions

### DIFF
--- a/src/plugins/discourse/mirror.js
+++ b/src/plugins/discourse/mirror.js
@@ -456,7 +456,7 @@ export class Mirror implements DiscourseData {
     })();
 
     reporter.start("discourse/likes");
-    for (const user of this.users()) {
+    const addUserLikes = async (user: string) => {
       let offset = 0;
       let upToDate = false;
       while (!upToDate) {
@@ -472,6 +472,16 @@ export class Mirror implements DiscourseData {
           upToDate = true;
         }
         offset += likeActions.length;
+      }
+    };
+    for (const user of this.users()) {
+      try {
+        await addUserLikes(user);
+      } catch (e) {
+        console.warn(
+          `Warning: Encountered error '${e.message}' ` +
+            `while processing likes for ${user}; skipping this user.`
+        );
       }
     }
     reporter.finish("discourse/likes");


### PR DESCRIPTION
This fixes the non-recoverable error in #1440; namely SourceCred
crashing when the Discourse server returns 404 for a user's actions. I'm
not sure why this happens (maybe DB is in an inconsistent state?) but
missing the likes for a particular user is less frustrating than not
being able to load cred at all.

I've also added a unit test which verifies this behavior; I've confirmed
that before applying the fix, test test fails.

Test plan: `yarn test`