### PR TITLE
Discourse: extend repository

### DIFF
--- a/src/plugins/discourse/mirrorRepository.js
+++ b/src/plugins/discourse/mirrorRepository.js
@@ -3,7 +3,14 @@
 import type {Database} from "better-sqlite3";
 import stringify from "json-stable-stringify";
 import dedent from "../../util/dedent";
-import type {TopicId, PostId, Topic, Post, LikeAction} from "./fetch";
+import type {
+  CategoryId,
+  TopicId,
+  PostId,
+  Topic,
+  Post,
+  LikeAction,
+} from "./fetch";
 
 // The version should be bumped any time the database schema is changed,
 // so that the cache will be properly invalidated.
@@ -63,6 +70,19 @@ export interface MirrorRepository extends ReadRepository {
   addTopic(topic: Topic): AddResult;
   addPost(post: Post): AddResult;
   addLike(like: LikeAction): AddResult;
+
+  /**
+   * For the given topic ID, retrieves the bumpedMs value.
+   * Returns null, when the topic wasn't found.
+   */
+  bumpedMsForTopic(id: TopicId): number | null;
+
+  /**
+   * Finds the TopicIds of topics that have one of the categoryIds as it's category.
+   */
+  topicsInCategories(
+    categoryIds: $ReadOnlyArray<CategoryId>
+  ): $ReadOnlyArray<TopicId>;
 }
 
 function toAddResult({
@@ -291,6 +311,27 @@ export class SqliteMirrorRepository
         username: like.username,
       });
     return toAddResult(res);
+  }
+
+  topicsInCategories(
+    categoryIds: $ReadOnlyArray<CategoryId>
+  ): $ReadOnlyArray<TopicId> {
+    return this._db
+      .prepare(
+        dedent`\
+          SELECT id FROM topics
+          WHERE category_id IN (${categoryIds.map((_) => "?").join(",")})
+        `
+      )
+      .all(...categoryIds)
+      .map((t) => t.id);
+  }
+
+  bumpedMsForTopic(id: TopicId): number | null {
+    const res = this._db
+      .prepare(`SELECT bumped_ms FROM topics WHERE id = :id`)
+      .get({id});
+    return res != null ? res.bumped_ms : null;
   }
 
   addPost(post: Post): AddResult {

--- a/src/plugins/discourse/mirrorRepository.js
+++ b/src/plugins/discourse/mirrorRepository.js
@@ -78,6 +78,13 @@ export interface MirrorRepository extends ReadRepository {
   bumpedMsForTopic(id: TopicId): number | null;
 
   /**
+   * Idempotent insert/replace of a Topic, including all it's Posts.
+   *
+   * Note: this will insert new posts, update existing posts and delete old posts.
+   * As these are separate queries, we use a transaction here.
+   */
+  replaceTopicTransaction(topic: Topic, posts: $ReadOnlyArray<Post>): void;
+  /**
    * Finds the TopicIds of topics that have one of the categoryIds as it's category.
    */
   topicsInCategories(
@@ -102,12 +109,19 @@ export class SqliteMirrorRepository
   constructor(db: Database, serverUrl: string) {
     if (db == null) throw new Error("db: " + String(db));
     this._db = db;
+    this._transaction(() => {
+      this._initialize(serverUrl);
+    });
+  }
+
+  _transaction(queries: () => void) {
+    const db = this._db;
     if (db.inTransaction) {
       throw new Error("already in transaction");
     }
     try {
       db.prepare("BEGIN").run();
-      this._initialize(serverUrl);
+      queries();
       if (db.inTransaction) {
         db.prepare("COMMIT").run();
       }
@@ -311,6 +325,32 @@ export class SqliteMirrorRepository
         username: like.username,
       });
     return toAddResult(res);
+  }
+
+  replaceTopicTransaction(topic: Topic, posts: $ReadOnlyArray<Post>) {
+    this._transaction(() => {
+      this.addTopic(topic);
+      for (const post of posts) {
+        this.addPost(post);
+      }
+      this.deleteUnexpectedPosts(
+        topic.id,
+        posts.map((p) => p.id)
+      );
+    });
+  }
+
+  deleteUnexpectedPosts(topicId: TopicId, expected: PostId[]): number {
+    const res = this._db
+      .prepare(
+        dedent`\
+          DELETE FROM posts
+          WHERE topic_id = ?
+          AND id NOT IN (${expected.map((_) => "?").join(",")})
+        `
+      )
+      .run(topicId, ...expected);
+    return res.changes;
   }
 
   topicsInCategories(

--- a/src/plugins/discourse/mirrorRepository.test.js
+++ b/src/plugins/discourse/mirrorRepository.test.js
@@ -4,7 +4,7 @@ import Database from "better-sqlite3";
 import fs from "fs";
 import tmp from "tmp";
 import {SqliteMirrorRepository} from "./mirrorRepository";
-import type {Topic} from "./fetch";
+import type {Topic, Post} from "./fetch";
 
 describe("plugins/discourse/mirrorRepository", () => {
   it("rejects a different server url without changing the database", () => {
@@ -81,5 +81,109 @@ describe("plugins/discourse/mirrorRepository", () => {
 
     // Then
     expect(topicIds).toEqual([topic.id]);
+  });
+
+  it("replaceTopicTransaction finds and prunes old posts", () => {
+    // Given
+    const db = new Database(":memory:");
+    const url = "http://example.com";
+    const repository = new SqliteMirrorRepository(db, url);
+    const topic: Topic = {
+      id: 123,
+      categoryId: 1,
+      title: "Sample topic",
+      timestampMs: 456789,
+      bumpedMs: 456789,
+      authorUsername: "credbot",
+    };
+    const p1: Post = {
+      id: 100,
+      topicId: 123,
+      indexWithinTopic: 0,
+      replyToPostIndex: null,
+      timestampMs: 456789,
+      authorUsername: "credbot",
+      cooked: "<p>Valid post</p>",
+    };
+    const p2: Post = {
+      id: 101,
+      topicId: 123,
+      indexWithinTopic: 1,
+      replyToPostIndex: null,
+      timestampMs: 456789,
+      authorUsername: "credbot",
+      cooked: "<p>Follow up 1</p>",
+    };
+    const p3: Post = {
+      id: 102,
+      topicId: 123,
+      indexWithinTopic: 1,
+      replyToPostIndex: null,
+      timestampMs: 456789,
+      authorUsername: "credbot",
+      cooked: "<p>Follow up, replacement</p>",
+    };
+
+    // When
+    repository.replaceTopicTransaction(topic, [p1, p2]);
+    repository.replaceTopicTransaction(topic, [p1, p3]);
+    const topics = repository.topics();
+    const posts = repository.posts();
+
+    // Then
+    expect(topics).toEqual([topic]);
+    expect(posts).toEqual([p1, p3]);
+  });
+
+  it("throws and rolls back a replaceTopicTransaction error", () => {
+    // Given
+    const db = new Database(":memory:");
+    const url = "http://example.com";
+    const repository = new SqliteMirrorRepository(db, url);
+    const topic: Topic = {
+      id: 123,
+      categoryId: 1,
+      title: "Sample topic",
+      timestampMs: 456789,
+      bumpedMs: 456789,
+      authorUsername: "credbot",
+    };
+    const posts: Post[] = [
+      {
+        id: 456,
+        topicId: 123,
+        indexWithinTopic: 0,
+        replyToPostIndex: null,
+        timestampMs: 456789,
+        authorUsername: "credbot",
+        cooked: "<p>Valid post</p>",
+      },
+      {
+        id: 456,
+        topicId: 666,
+        indexWithinTopic: 0,
+        replyToPostIndex: null,
+        timestampMs: 456789,
+        authorUsername: "credbot",
+        cooked: "<p>Invalid post, topic ID foreign key constraint.</p>",
+      },
+    ];
+
+    // When
+    let error: Error | null = null;
+    try {
+      repository.replaceTopicTransaction(topic, posts);
+    } catch (e) {
+      error = e;
+    }
+    const actualTopics = repository.topics();
+    const actualPosts = repository.posts();
+
+    // Then
+    expect(actualTopics).toEqual([]);
+    expect(actualPosts).toEqual([]);
+    expect(() => {
+      if (error) throw error;
+    }).toThrow("FOREIGN KEY constraint failed");
   });
 });

--- a/src/plugins/discourse/mirrorRepository.test.js
+++ b/src/plugins/discourse/mirrorRepository.test.js
@@ -48,6 +48,49 @@ describe("plugins/discourse/mirrorRepository", () => {
     expect(bumpedMs).toEqual(topic.bumpedMs);
   });
 
+  it("syncHeads finds an an existing topic's bumpedMs", () => {
+    // Given
+    const db = new Database(":memory:");
+    const url = "http://example.com";
+    const repository = new SqliteMirrorRepository(db, url);
+    const topic: Topic = {
+      id: 123,
+      categoryId: 1,
+      title: "Sample topic",
+      timestampMs: 456789,
+      bumpedMs: 456789,
+      authorUsername: "credbot",
+    };
+
+    // When
+    repository.addTopic(topic);
+    const syncHeads = repository.syncHeads();
+
+    // Then
+    expect(syncHeads).toEqual({
+      definitionCheckMs: 0,
+      topicBumpMs: topic.bumpedMs,
+    });
+  });
+
+  it("syncHeads stores and recalls a bumpDefinitionTopicCheck", () => {
+    // Given
+    const db = new Database(":memory:");
+    const url = "http://example.com";
+    const repository = new SqliteMirrorRepository(db, url);
+    const definitionCheckMs = 617283;
+
+    // When
+    repository.bumpDefinitionTopicCheck(definitionCheckMs);
+    const syncHeads = repository.syncHeads();
+
+    // Then
+    expect(syncHeads).toEqual({
+      definitionCheckMs,
+      topicBumpMs: 0,
+    });
+  });
+
   it("bumpedMsForTopic returns null when missing topic", () => {
     // Given
     const db = new Database(":memory:");

--- a/src/plugins/discourse/mirrorRepository.test.js
+++ b/src/plugins/discourse/mirrorRepository.test.js
@@ -4,6 +4,7 @@ import Database from "better-sqlite3";
 import fs from "fs";
 import tmp from "tmp";
 import {SqliteMirrorRepository} from "./mirrorRepository";
+import type {Topic} from "./fetch";
 
 describe("plugins/discourse/mirrorRepository", () => {
   it("rejects a different server url without changing the database", () => {
@@ -23,5 +24,62 @@ describe("plugins/discourse/mirrorRepository", () => {
 
     expect(() => new SqliteMirrorRepository(db, url1)).not.toThrow();
     expect(fs.readFileSync(filename).toJSON()).toEqual(data);
+  });
+
+  it("bumpedMsForTopic finds an existing topic's bumpedMs", () => {
+    // Given
+    const db = new Database(":memory:");
+    const url = "http://example.com";
+    const repository = new SqliteMirrorRepository(db, url);
+    const topic: Topic = {
+      id: 123,
+      categoryId: 1,
+      title: "Sample topic",
+      timestampMs: 456789,
+      bumpedMs: 456789,
+      authorUsername: "credbot",
+    };
+
+    // When
+    repository.addTopic(topic);
+    const bumpedMs = repository.bumpedMsForTopic(topic.id);
+
+    // Then
+    expect(bumpedMs).toEqual(topic.bumpedMs);
+  });
+
+  it("bumpedMsForTopic returns null when missing topic", () => {
+    // Given
+    const db = new Database(":memory:");
+    const url = "http://example.com";
+    const repository = new SqliteMirrorRepository(db, url);
+
+    // When
+    const bumpedMs = repository.bumpedMsForTopic(123);
+
+    // Then
+    expect(bumpedMs).toEqual(null);
+  });
+
+  it("topicsInCategories finds an an existing topic by categoryId", () => {
+    // Given
+    const db = new Database(":memory:");
+    const url = "http://example.com";
+    const repository = new SqliteMirrorRepository(db, url);
+    const topic: Topic = {
+      id: 123,
+      categoryId: 42,
+      title: "Sample topic",
+      timestampMs: 456789,
+      bumpedMs: 456789,
+      authorUsername: "credbot",
+    };
+
+    // When
+    repository.addTopic(topic);
+    const topicIds = repository.topicsInCategories([topic.categoryId]);
+
+    // Then
+    expect(topicIds).toEqual([topic.id]);
   });
 });


### PR DESCRIPTION
Continues from #1452

These are additions to the MirrorRepository, including feedback from #1434.
If it helps to review, each commit can be viewed in isolation.

Test plan: `yarn unit`