### PR TITLE
Discourse: add categoryId and bumpedMs to Topic data

### DIFF
--- a/src/plugins/discourse/__snapshots__/fetch.test.js.snap
+++ b/src/plugins/discourse/__snapshots__/fetch.test.js.snap
@@ -47,6 +47,7 @@ Object {
   ],
   "topic": Object {
     "authorUsername": "d11",
+    "categoryId": 1,
     "id": 11,
     "timestampMs": 1564744349408,
     "title": "My First Test Post",

--- a/src/plugins/discourse/createGraph.test.js
+++ b/src/plugins/discourse/createGraph.test.js
@@ -84,6 +84,8 @@ describe("plugins/discourse/createGraph", () => {
       title: "first topic",
       timestampMs: 0,
       authorUsername: "decentralion",
+      categoryId: 1,
+      bumpedMs: 0,
     };
     const post1 = {
       id: 1,

--- a/src/plugins/discourse/fetch.js
+++ b/src/plugins/discourse/fetch.js
@@ -20,11 +20,27 @@ export type PostId = number;
 export type TopicId = number;
 export type CategoryId = number;
 
-export type Topic = {|
+/**
+ * The "view" received from the Discourse API
+ * when getting a topic by ID.
+ *
+ * This filters some relevant data like bumpedMs,
+ * and the type separation makes this distinction clear.
+ */
+export type TopicView = {|
   +id: TopicId,
+  +categoryId: CategoryId,
   +title: string,
   +timestampMs: number,
   +authorUsername: string,
+|};
+
+/**
+ * A complete Topic object.
+ */
+export type Topic = {|
+  ...TopicView,
+  +bumpedMs: number,
 |};
 
 export type Post = {|
@@ -43,7 +59,7 @@ export type Post = {|
 |};
 
 export type TopicWithPosts = {|
-  +topic: Topic,
+  +topic: TopicView,
   // Not guaranteed to contain all the Posts in the topic—clients will need to
   // manually request some posts. The raw response actually includes a list of
   // all the PostIds in the topic, but for now we don't use them.
@@ -182,11 +198,12 @@ export class Fetcher implements Discourse {
     }
     failForNotOk(response);
     const json = await response.json();
-    const posts = json.post_stream.posts.map(parsePost);
-    const topic: Topic = {
+    let posts = json.post_stream.posts.map(parsePost);
+    const topic: TopicView = {
       id: json.id,
+      categoryId: json.category_id,
       title: json.title,
-      timestampMs: +new Date(json.created_at),
+      timestampMs: Date.parse(json.created_at),
       authorUsername: json.details.created_by.username,
     };
     return {topic, posts};

--- a/src/plugins/discourse/mirror.js
+++ b/src/plugins/discourse/mirror.js
@@ -1,7 +1,7 @@
 // @flow
 
 import type {TaskReporter} from "../../util/taskReporter";
-import type {Discourse, CategoryId} from "./fetch";
+import type {Discourse, CategoryId, Topic} from "./fetch";
 import {MirrorRepository} from "./mirrorRepository";
 
 export type MirrorOptions = {|
@@ -117,7 +117,10 @@ export class Mirror {
       const topicWithPosts = await this._fetcher.topicWithPosts(topicId);
       if (topicWithPosts != null) {
         const {topic, posts} = topicWithPosts;
-        this._repo.addTopic(topic);
+        // TODO: Quick hack, as TopicView does not include bumpedMs.
+        // This should be resolved in the new sync logic.
+        const workaroundTopic: Topic = {...topic, bumpedMs: topic.timestampMs};
+        this._repo.addTopic(workaroundTopic);
         for (const post of posts) {
           addPost(post);
         }

--- a/src/plugins/discourse/mirror.test.js
+++ b/src/plugins/discourse/mirror.test.js
@@ -9,6 +9,7 @@ import {
   type TopicId,
   type PostId,
   type Topic,
+  type TopicView,
   type Post,
   type TopicWithPosts,
   type LikeAction,
@@ -64,7 +65,7 @@ class MockFetcher implements Discourse {
     // Only return the first post in the posts array, to ensure that we have to
     // test the functionality where we manually grab posts by ID
     const posts = [firstPost];
-    return {topic: this._topic(id), posts};
+    return {topic: this._topicView(id), posts};
   }
 
   async likesByUser(
@@ -80,7 +81,15 @@ class MockFetcher implements Discourse {
 
   _topic(id: TopicId): Topic {
     return {
+      ...this._topicView(id),
+      bumpedMs: 1000,
+    };
+  }
+
+  _topicView(id: TopicId): TopicView {
+    return {
       id,
+      categoryId: 1,
       title: `topic ${id}`,
       timestampMs: 1000,
       authorUsername: "credbot",


### PR DESCRIPTION
As not all API calls return bumpedMs, make a new type to show the distinction.

Is a separate commit from #1452.

Test plan: `yarn unit`
Snapshots and tests have been updated.