### PR TITLE
Discourse: adds bumpedMsForTopic and topicsInCategories queries

### DIFF
--- a/src/plugins/discourse/createGraph.test.js
+++ b/src/plugins/discourse/createGraph.test.js
@@ -75,6 +75,11 @@ describe("plugins/discourse/createGraph", () => {
         maxTopicId: this._topics.reduce((max, t) => Math.max(t.id, max), 0),
       };
     }
+    topicsInCategories() {
+      throw new Error(
+        "Method topicsInCategories should be unused for createGraph"
+      );
+    }
   }
 
   function example() {

--- a/src/plugins/discourse/mirrorRepository.test.js
+++ b/src/plugins/discourse/mirrorRepository.test.js
@@ -4,6 +4,7 @@ import Database from "better-sqlite3";
 import fs from "fs";
 import tmp from "tmp";
 import {SqliteMirrorRepository} from "./mirrorRepository";
+import type {Topic} from "./fetch";
 
 describe("plugins/discourse/mirrorRepository", () => {
   it("rejects a different server url without changing the database", () => {
@@ -23,5 +24,118 @@ describe("plugins/discourse/mirrorRepository", () => {
 
     expect(() => new SqliteMirrorRepository(db, url1)).not.toThrow();
     expect(fs.readFileSync(filename).toJSON()).toEqual(data);
+  });
+
+  it("bumpedMsForTopic finds an existing topic's bumpedMs", () => {
+    // Given
+    const db = new Database(":memory:");
+    const url = "http://example.com";
+    const repository = new SqliteMirrorRepository(db, url);
+    const topic: Topic = {
+      id: 123,
+      categoryId: 1,
+      title: "Sample topic",
+      timestampMs: 456789,
+      bumpedMs: 456999,
+      authorUsername: "credbot",
+    };
+
+    // When
+    repository.addTopic(topic);
+    const bumpedMs = repository.bumpedMsForTopic(topic.id);
+
+    // Then
+    expect(bumpedMs).toEqual(topic.bumpedMs);
+  });
+
+  it("bumpedMsForTopic returns null when missing topic", () => {
+    // Given
+    const db = new Database(":memory:");
+    const url = "http://example.com";
+    const repository = new SqliteMirrorRepository(db, url);
+
+    // When
+    const bumpedMs = repository.bumpedMsForTopic(123);
+
+    // Then
+    expect(bumpedMs).toEqual(null);
+  });
+
+  it("topicsInCategories finds an an existing topic by categoryId", () => {
+    // Given
+    const db = new Database(":memory:");
+    const url = "http://example.com";
+    const repository = new SqliteMirrorRepository(db, url);
+    const topic: Topic = {
+      id: 123,
+      categoryId: 42,
+      title: "Sample topic",
+      timestampMs: 456789,
+      bumpedMs: 456999,
+      authorUsername: "credbot",
+    };
+
+    // When
+    repository.addTopic(topic);
+    const topicIds = repository.topicsInCategories([topic.categoryId]);
+
+    // Then
+    expect(topicIds).toEqual([topic.id]);
+  });
+
+  it("topicsInCategories with several categoryIds returns all matching topics", () => {
+    // Given
+    const db = new Database(":memory:");
+    const url = "http://example.com";
+    const repository = new SqliteMirrorRepository(db, url);
+    const topic1: Topic = {
+      id: 123,
+      categoryId: 42,
+      title: "Sample topic 1",
+      timestampMs: 456789,
+      bumpedMs: 456999,
+      authorUsername: "credbot",
+    };
+    const topic2: Topic = {
+      id: 456,
+      categoryId: 16,
+      title: "Sample topic 2",
+      timestampMs: 456789,
+      bumpedMs: 456999,
+      authorUsername: "credbot",
+    };
+
+    // When
+    repository.addTopic(topic1);
+    repository.addTopic(topic2);
+    const topicIds = repository.topicsInCategories([
+      topic1.categoryId,
+      topic2.categoryId,
+    ]);
+
+    // Then
+    expect(topicIds).toEqual([topic1.id, topic2.id]);
+  });
+
+  it("topicsInCategories without categoryIds gives no topicIds", () => {
+    // Given
+    const db = new Database(":memory:");
+    const url = "http://example.com";
+    const repository = new SqliteMirrorRepository(db, url);
+    const topic: Topic = {
+      id: 123,
+      categoryId: 42,
+      title: "Sample topic",
+      timestampMs: 456789,
+      bumpedMs: 456999,
+      authorUsername: "credbot",
+    };
+
+    // When
+    repository.addTopic(topic);
+    const topicIds = repository.topicsInCategories([]);
+
+    // Then
+    expect(topicIds).toEqual([]);
   });
 });


### PR DESCRIPTION
These are to be used by the new mirror code.

Test plan: `yarn unit`
New test cases added.