### PR TITLE
Discourse: add replaceTopicTransaction method to repo

### DIFF
--- a/src/plugins/discourse/mirrorRepository.test.js
+++ b/src/plugins/discourse/mirrorRepository.test.js
@@ -4,7 +4,7 @@ import Database from "better-sqlite3";
 import fs from "fs";
 import tmp from "tmp";
 import {SqliteMirrorRepository} from "./mirrorRepository";
-import type {Topic} from "./fetch";
+import type {Topic, Post} from "./fetch";
 
 describe("plugins/discourse/mirrorRepository", () => {
   it("rejects a different server url without changing the database", () => {
@@ -137,5 +137,109 @@ describe("plugins/discourse/mirrorRepository", () => {
 
     // Then
     expect(topicIds).toEqual([]);
+  });
+
+  it("replaceTopicTransaction finds and prunes old posts", () => {
+    // Given
+    const db = new Database(":memory:");
+    const url = "http://example.com";
+    const repository = new SqliteMirrorRepository(db, url);
+    const topic: Topic = {
+      id: 123,
+      categoryId: 1,
+      title: "Sample topic",
+      timestampMs: 456789,
+      bumpedMs: 456999,
+      authorUsername: "credbot",
+    };
+    const p1: Post = {
+      id: 100,
+      topicId: 123,
+      indexWithinTopic: 0,
+      replyToPostIndex: null,
+      timestampMs: 456789,
+      authorUsername: "credbot",
+      cooked: "<p>Valid post</p>",
+    };
+    const p2: Post = {
+      id: 101,
+      topicId: 123,
+      indexWithinTopic: 1,
+      replyToPostIndex: null,
+      timestampMs: 456888,
+      authorUsername: "credbot",
+      cooked: "<p>Follow up 1</p>",
+    };
+    const p3: Post = {
+      id: 102,
+      topicId: 123,
+      indexWithinTopic: 1,
+      replyToPostIndex: null,
+      timestampMs: 456999,
+      authorUsername: "credbot",
+      cooked: "<p>Follow up, replacement</p>",
+    };
+
+    // When
+    repository.replaceTopicTransaction(topic, [p1, p2]);
+    repository.replaceTopicTransaction(topic, [p1, p3]);
+    const topics = repository.topics();
+    const posts = repository.posts();
+
+    // Then
+    expect(topics).toEqual([topic]);
+    expect(posts).toEqual([p1, p3]);
+  });
+
+  it("throws and rolls back a replaceTopicTransaction error", () => {
+    // Given
+    const db = new Database(":memory:");
+    const url = "http://example.com";
+    const repository = new SqliteMirrorRepository(db, url);
+    const topic: Topic = {
+      id: 123,
+      categoryId: 1,
+      title: "Sample topic",
+      timestampMs: 456789,
+      bumpedMs: 456999,
+      authorUsername: "credbot",
+    };
+    const posts: Post[] = [
+      {
+        id: 456,
+        topicId: 123,
+        indexWithinTopic: 0,
+        replyToPostIndex: null,
+        timestampMs: 456789,
+        authorUsername: "credbot",
+        cooked: "<p>Valid post</p>",
+      },
+      {
+        id: 456,
+        topicId: 666,
+        indexWithinTopic: 0,
+        replyToPostIndex: null,
+        timestampMs: 456999,
+        authorUsername: "credbot",
+        cooked: "<p>Invalid post, topic ID foreign key constraint.</p>",
+      },
+    ];
+
+    // When
+    let error: Error | null = null;
+    try {
+      repository.replaceTopicTransaction(topic, posts);
+    } catch (e) {
+      error = e;
+    }
+    const actualTopics = repository.topics();
+    const actualPosts = repository.posts();
+
+    // Then
+    expect(actualTopics).toEqual([]);
+    expect(actualPosts).toEqual([]);
+    expect(() => {
+      if (error) throw error;
+    }).toThrow("FOREIGN KEY constraint failed");
   });
 });


### PR DESCRIPTION
As the new mirroring will fetch all posts of a topic, inserting them through a DB transaction makes it atomic.

Test plan: `yarn unit`
New test cases added.