### PR TITLE
Discourse: default to update mode 2

### DIFF
--- a/src/plugins/discourse/mirror.js
+++ b/src/plugins/discourse/mirror.js
@@ -75,7 +75,7 @@ export class Mirror {
       ...defaultOptions,
       ...(options || {}),
     };
-    this._mode = mode || "MODE_1_ITERATE_BY_ID";
+    this._mode = mode || "MODE_2_LOAD_BUMPED_TOPICS";
   }
 
   async update(reporter: TaskReporter) {


### PR DESCRIPTION
Flips the switch, so the new update mode (#1464) is used.

Test plan: `node bin/sourcecred.js discourse https://sourcecred-test.discourse.group`
On an empty cache, manual runs such as these should load correctly and have 100% coverage of all public content. An easy way to spot if mode 2 is being used, is the lack of a `discourse/posts` step in the CLI.