### PR TITLE
Add transifex-integration bot

### DIFF
--- a/src/plugins/github/blacklistedObjectIds.js
+++ b/src/plugins/github/blacklistedObjectIds.js
@@ -61,6 +61,7 @@ export const BLACKLISTED_IDS: $ReadOnlyArray<ObjectId> = deepFreeze([
   "MDM6Qm90Mjc4NTYyOTc=", // dependabot-preview
   "MDM6Qm90MzY3NzE0MDE=", // azure-pipelines
   "MDM6Qm90NDE4OTgyODI=", // github-actions
+  "MDM6Qm90NDM4ODA5MDM=", // transifex-integration
 
   // Problematic interactions they did as a user: reactions.
   "MDg6UmVhY3Rpb24yMTY3ODkyNQ==",

--- a/src/plugins/github/bots.js
+++ b/src/plugins/github/bots.js
@@ -20,5 +20,6 @@ export function botSet(): Set<string> {
     "tensorflow-jenkins",
     "tensorflowbutler",
     "github-actions",
+    "transifex-integration",
   ]);
 }


### PR DESCRIPTION
See https://github.com/simpledotorg/simple-android/pull/816/commits/9d48a5fca6b5c4ee0e7584e4f8400ed761dc0196
as an example of the bot acting as a user.

Testing it without this change:
```
  GO   github/simpledotorg/simple-android
Error: Inconsistent type for ID "MDM6Qm90NDM4ODA5MDM=": expected "Bot", got "User"
```