### PR TITLE
GitHub: update token validation function

### DIFF
--- a/src/plugins/github/token.js
+++ b/src/plugins/github/token.js
@@ -1,0 +1,47 @@
+// @flow
+
+/**
+ * Validates a token against know formatting.
+ * Throws an error if it appears invalid.
+ *
+ * Personal access token
+ * https://help.github.com/en/github/authenticating-to-github/creating-a-personal-access-token-for-the-command-line
+ *
+ * Installation access token
+ * https://developer.github.com/v3/apps/#create-a-new-installation-token
+ */
+export function validateToken(token: string) {
+  const personalAccessTokenRE = /^[A-Fa-f0-9]{40}$/;
+  if (personalAccessTokenRE.test(token)) {
+    return;
+  }
+
+  // We're currently being lenient with installation tokens, since we're not completely
+  // sure on the exact format. We're only warning on unexpected values but leave it up
+  // to the GitHub API to reject the token if it's actually invalid.
+  const installationAccessTokenRE = /^(v\d+)\.([A-Fa-f0-9]+)$/;
+  const matches = installationAccessTokenRE.exec(token);
+  if (matches != null) {
+    const [_, version, hexCode] = matches;
+
+    if (version != "v1") {
+      console.warn(
+        `Warning: GitHub installation access token has an unexpected version "${version}".`
+      );
+    }
+
+    if (hexCode.length != 16) {
+      console.warn(
+        `Warning: GitHub installation access token has an unexpected hexadecimal component ` +
+          `length of ${hexCode.length}.`
+      );
+    }
+
+    return;
+  }
+
+  throw new Error(
+    `The token supplied to $SOURCECRED_GITHUB_TOKEN doesn't match any format known to work.\n` +
+      `Please verify the token "${token}" is correct, or report a bug if you think it should work.`
+  );
+}

--- a/src/plugins/github/token.test.js
+++ b/src/plugins/github/token.test.js
@@ -1,0 +1,101 @@
+// @flow
+
+import {validateToken} from "./token";
+
+describe("plugins/github/token", () => {
+  describe("validateToken", () => {
+    function spyWarn(): JestMockFn<[string], void> {
+      return ((console.warn: any): JestMockFn<any, void>);
+    }
+    beforeEach(() => {
+      jest.spyOn(console, "warn").mockImplementation(() => {});
+    });
+    afterEach(() => {
+      try {
+        expect(console.warn).not.toHaveBeenCalled();
+      } finally {
+        spyWarn().mockRestore();
+      }
+    });
+
+    it("should throw on empty tokens", () => {
+      // Given
+      const token = "";
+
+      // When
+      const fn = () => validateToken(token);
+
+      // Then
+      expect(fn).toThrow(
+        "The token supplied to $SOURCECRED_GITHUB_TOKEN doesn't match any format known to work.\n" +
+          'Please verify the token "" is correct, or report a bug if you think it should work.'
+      );
+    });
+
+    it("should throw on an unknown format token", () => {
+      // Given
+      const token = "EXAMPLE-INVALID-TOKEN-1082369";
+
+      // When
+      const fn = () => validateToken(token);
+
+      // Then
+      expect(fn).toThrow(
+        "The token supplied to $SOURCECRED_GITHUB_TOKEN doesn't match any format known to work.\n" +
+          'Please verify the token "EXAMPLE-INVALID-TOKEN-1082369" is correct, or report a bug if you think it should work.'
+      );
+    });
+
+    it("should accept a personal access token format", () => {
+      // Given
+      const token = "1bfb713d900c4962586ec615260b3902438b1d3c";
+
+      // When
+      validateToken(token);
+
+      // Then
+      // Shouldn't throw.
+    });
+
+    it("should accept an installation access token format", () => {
+      // Given
+      const token = "v1.1bfb713d900c4962";
+
+      // When
+      validateToken(token);
+
+      // Then
+      // Shouldn't throw.
+    });
+
+    it("should warn when installation access token has an unexpected version", () => {
+      // Given
+      const token = "v5.1bfb713d900c4962";
+
+      // When
+      validateToken(token);
+
+      // Then
+      expect(console.warn).toHaveBeenCalledWith(
+        'Warning: GitHub installation access token has an unexpected version "v5".'
+      );
+      expect(console.warn).toHaveBeenCalledTimes(1);
+      spyWarn().mockReset();
+    });
+
+    it("should warn when installation access token has an unexpected length", () => {
+      // Given
+      const token = "v1.1bfb713d900c49621bfb713d900c4962";
+
+      // When
+      validateToken(token);
+
+      // Then
+      expect(console.warn).toHaveBeenCalledWith(
+        "Warning: GitHub installation access token has an unexpected hexadecimal component length of 32."
+      );
+      expect(console.warn).toHaveBeenCalledTimes(1);
+      spyWarn().mockReset();
+    });
+  });
+});


### PR DESCRIPTION
Previously an inline check was used for this.
It only accepted the personal access token format.
This adds installation tokens as requested in #1461.

With more complex logic, we'd benefit from tests.
Therefore it's a separate function with a test suite.

Test plan:
- `yarn unit` for the test suite added.
- `SOURCECRED_GITHUB_TOKEN="personal-access-token" node bin/sourcecred.js load sourcecred/sourcecred` to validate existing tokens are not broken.

As mentioned in #1461, manually validating the new installation tokens is a bit involved.
So I'd like to ask if @vsoch can help test it with GitHub actions. ~I'll make a docker build for this.~
The docker image pushed for this is `sourcecred/sourcecred:pr-1471`.