### PR TITLE
Enable and add upgrade testing for projectFromJSON

### DIFF
--- a/src/core/project.js
+++ b/src/core/project.js
@@ -44,13 +44,11 @@ const upgrades = {
   "0.3.1": upgradeFrom030,
 };
 
-export type ProjectJSON = Compatible<Project>;
-
-export function projectToJSON(p: Project): ProjectJSON {
+export function projectToJSON(p: Project): Compatible<Project> {
   return toCompat(COMPAT_INFO, p);
 }
 
-export function projectFromJSON(j: ProjectJSON): Project {
+export function projectFromJSON(j: Compatible<any>): Project {
   return fromCompat(COMPAT_INFO, j, upgrades);
 }
 

--- a/src/core/project.js
+++ b/src/core/project.js
@@ -24,16 +24,35 @@ export type ProjectId = string;
  * the future (e.g. showing the last update time for each of the project's data
  * dependencies).
  */
-export type Project = {|
+export type Project = Project_v040;
+export type SupportedProject = Project_v030 | Project_v031 | Project_v040;
+
+type Project_v040 = {|
   +id: ProjectId,
   +repoIds: $ReadOnlyArray<RepoId>,
   +discourseServer: DiscourseServer | null,
   +identities: $ReadOnlyArray<Identity>,
 |};
 
+type Project_v031 = {|
+  ...Project_v040,
+  +discourseServer: {|
+    +serverUrl: string,
+    +apiUsername?: string,
+  |} | null,
+|};
+
+type Project_v030 = {|
+  ...Project_v040,
+  +discourseServer: {|
+    +serverUrl: string,
+    +apiUsername: string,
+  |} | null,
+|};
+
 const COMPAT_INFO = {type: "sourcecred/project", version: "0.4.0"};
 
-const upgradeFrom030 = (p) => ({
+const upgradeFrom030 = (p: Project_v030 | Project_v031): Project_v040 => ({
   ...p,
   discourseServer:
     p.discourseServer != null ? {serverUrl: p.discourseServer.serverUrl} : null,
@@ -48,7 +67,7 @@ export function projectToJSON(p: Project): Compatible<Project> {
   return toCompat(COMPAT_INFO, p);
 }
 
-export function projectFromJSON(j: Compatible<any>): Project {
+export function projectFromJSON(j: Compatible<SupportedProject>): Project {
   return fromCompat(COMPAT_INFO, j, upgrades);
 }
 

--- a/src/core/project.test.js
+++ b/src/core/project.test.js
@@ -8,8 +8,8 @@ import {
   type Project,
   encodeProjectId,
 } from "./project";
-
 import {makeRepoId} from "./repoId";
+import {toCompat} from "../util/compat";
 
 describe("core/project", () => {
   const foobar = deepFreeze(makeRepoId("foo", "bar"));
@@ -40,6 +40,58 @@ describe("core/project", () => {
       }
       check(p1);
       check(p2);
+    });
+    it("should upgrade from 0.3.0 formatting", () => {
+      // Given
+      const body = {
+        id: "example-030",
+        repoIds: [foobar, foozod],
+        discourseServer: {
+          serverUrl: "https://example.com",
+          apiUsername: "hello-test",
+        },
+        identities: [],
+      };
+      const compat = toCompat(
+        {type: "sourcecred/project", version: "0.3.0"},
+        body
+      );
+
+      // When
+      const project = projectFromJSON(compat);
+
+      // Then
+      expect(project).toEqual({
+        ...body,
+        // It should strip the apiUsername field, keeping just serverUrl.
+        discourseServer: {serverUrl: "https://example.com"},
+      });
+    });
+    it("should upgrade from 0.3.1 formatting", () => {
+      // Given
+      const body = {
+        id: "example-031",
+        repoIds: [foobar, foozod],
+        discourseServer: {
+          serverUrl: "https://example.com",
+          apiUsername: "hello-test",
+        },
+        identities: [],
+      };
+      const compat = toCompat(
+        {type: "sourcecred/project", version: "0.3.1"},
+        body
+      );
+
+      // When
+      const project = projectFromJSON(compat);
+
+      // Then
+      expect(project).toEqual({
+        ...body,
+        // It should strip the apiUsername field, keeping just serverUrl.
+        discourseServer: {serverUrl: "https://example.com"},
+      });
     });
   });
   describe("encodeProjectId", () => {

--- a/src/core/project.test.js
+++ b/src/core/project.test.js
@@ -6,10 +6,15 @@ import {
   projectToJSON,
   projectFromJSON,
   type Project,
+  type SupportedProject,
   encodeProjectId,
 } from "./project";
 import {makeRepoId} from "./repoId";
-import {toCompat} from "../util/compat";
+import {toCompat, type Compatible} from "../util/compat";
+
+function castType<T>(cp: Compatible<any>): Compatible<T> {
+  return [cp[0], cp[1]];
+}
 
 describe("core/project", () => {
   const foobar = deepFreeze(makeRepoId("foo", "bar"));
@@ -35,7 +40,8 @@ describe("core/project", () => {
     it("round trip is identity", () => {
       function check(p: Project) {
         const json = projectToJSON(p);
-        const p_ = projectFromJSON(json);
+        const supportedJson = castType<SupportedProject>(json);
+        const p_ = projectFromJSON(supportedJson);
         expect(p).toEqual(p_);
       }
       check(p1);

--- a/src/util/compat.js
+++ b/src/util/compat.js
@@ -1,6 +1,6 @@
 // @flow
 
-export opaque type Compatible<T> = [CompatInfo, T];
+export type Compatible<T> = [CompatInfo, T];
 type CompatInfo = {|
   +type: string,
   +version: string,


### PR DESCRIPTION
Same as the underlying util `fromCompat`, the object isn't statically typed, but parsed from JSON at runtime. Hence it's marked as `Compatible<any>`, to become `Compatible<T>` after validation.

Recognizing this potential difference at runtime, the new signature allows differently structured objects to be given as input for tests without flow errors. Allowing us to test the upgrade functionality.

Test plan: `yarn test` (unit and flow in particular)