### PR TITLE
Use createProject to set default values for Project

### DIFF
--- a/src/api/load.test.js
+++ b/src/api/load.test.js
@@ -8,7 +8,7 @@ import fs from "fs-extra";
 import type {Options as LoadGraphOptions} from "../plugins/github/loadGraph";
 import type {Options as LoadDiscourseOptions} from "../plugins/discourse/loadDiscourse";
 import {nodeContractions} from "../plugins/identity/nodeContractions";
-import type {Project} from "../core/project";
+import {type Project, createProject} from "../core/project";
 import {
   directoryForProjectId,
   getProjectIds,
@@ -59,12 +59,11 @@ describe("api/load", () => {
     timelineCredCompute.mockResolvedValue(fakeTimelineCred);
   });
   const discourseServerUrl = "https://example.com";
-  const project: Project = {
+  const project: Project = createProject({
     id: "foo",
     repoIds: [makeRepoId("foo", "bar")],
     discourseServer: {serverUrl: discourseServerUrl},
-    identities: [],
-  };
+  });
   deepFreeze(project);
   const githubToken = "EXAMPLE_TOKEN";
   const weights = defaultWeights();

--- a/src/cli/discourse.js
+++ b/src/cli/discourse.js
@@ -10,7 +10,7 @@ import * as Common from "./common";
 import {defaultWeights} from "../analysis/weights";
 import {load} from "../api/load";
 import {declaration as discourseDeclaration} from "../plugins/discourse/declaration";
-import {type Project} from "../core/project";
+import {type Project, createProject} from "../core/project";
 
 function usage(print: (string) => void): void {
   print(
@@ -83,12 +83,10 @@ const command: Command = async (args, std) => {
     die(std, "expected server url to start with 'https://' or 'http://'");
   }
   const projectId = serverUrl.trim().replace(httpRE, "");
-  const project: Project = {
+  const project: Project = createProject({
     id: projectId,
-    repoIds: [],
     discourseServer: {serverUrl},
-    identities: [],
-  };
+  });
   const taskReporter = new LoggingTaskReporter();
   let weights = defaultWeights();
   if (weightsPath) {

--- a/src/cli/genProject.js
+++ b/src/cli/genProject.js
@@ -9,7 +9,11 @@ import dedent from "../util/dedent";
 import type {Command} from "./command";
 import * as Common from "./common";
 import stringify from "json-stable-stringify";
-import {type Project, projectToJSON} from "../core/project";
+import {
+  type Project,
+  projectToJSON,
+  createProject as defaultProject,
+} from "../core/project";
 import {type RepoId} from "../core/repoId";
 import {specToProject} from "../plugins/github/specToProject";
 import * as NullUtil from "../util/null";
@@ -142,7 +146,7 @@ export async function createProject(opts: {|
     const subproject = await specToProject(spec, NullUtil.get(githubToken));
     repoIds = repoIds.concat(subproject.repoIds);
   }
-  return {id: projectId, repoIds, discourseServer, identities: []};
+  return defaultProject({id: projectId, repoIds, discourseServer});
 }
 
 export default genProject;

--- a/src/cli/load.test.js
+++ b/src/cli/load.test.js
@@ -12,7 +12,7 @@ import {defaultWeights, toJSON as weightsToJSON} from "../analysis/weights";
 import * as Common from "./common";
 import {defaultParams, partialParams} from "../analysis/timeline/params";
 import {declaration as githubDeclaration} from "../plugins/github/declaration";
-
+import {createProject} from "../core/project";
 import {makeRepoId, stringToRepoId} from "../core/repoId";
 
 jest.mock("../api/load", () => ({load: jest.fn()}));
@@ -71,12 +71,10 @@ describe("cli/load", () => {
     it("calls load with a single repo", async () => {
       const invocation = run(loadCommand, ["foo/bar"]);
       const expectedOptions: LoadOptions = {
-        project: {
+        project: createProject({
           id: "foo/bar",
           repoIds: [makeRepoId("foo", "bar")],
-          discourseServer: null,
-          identities: [],
-        },
+        }),
         params: defaultParams(),
         plugins: [githubDeclaration],
         sourcecredDirectory: Common.sourcecredDirectory(),
@@ -96,12 +94,10 @@ describe("cli/load", () => {
     it("calls load with multiple repos", async () => {
       const invocation = run(loadCommand, ["foo/bar", "zoink/zod"]);
       const expectedOptions: (string) => LoadOptions = (projectId: string) => ({
-        project: {
+        project: createProject({
           id: projectId,
           repoIds: [stringToRepoId(projectId)],
-          discourseServer: null,
-          identities: [],
-        },
+        }),
         params: defaultParams(),
         plugins: [githubDeclaration],
         sourcecredDirectory: Common.sourcecredDirectory(),
@@ -134,12 +130,10 @@ describe("cli/load", () => {
         weightsFile,
       ]);
       const expectedOptions: LoadOptions = {
-        project: {
+        project: createProject({
           id: "foo/bar",
           repoIds: [makeRepoId("foo", "bar")],
-          discourseServer: null,
-          identities: [],
-        },
+        }),
         params: partialParams({weights}),
         plugins: [githubDeclaration],
         sourcecredDirectory: Common.sourcecredDirectory(),

--- a/src/core/project.js
+++ b/src/core/project.js
@@ -36,6 +36,24 @@ type Project_v040 = {|
 
 const COMPAT_INFO = {type: "sourcecred/project", version: "0.4.0"};
 
+/**
+ * Creates a new Project instance with default values.
+ *
+ * Note: the `id` field is required, as there's no sensible default.
+ */
+export function createProject(p: $Shape<Project>): Project {
+  if (!p.id) {
+    throw new Error("Project.id must be set");
+  }
+
+  return {
+    repoIds: [],
+    identities: [],
+    discourseServer: null,
+    ...p,
+  };
+}
+
 export type ProjectJSON = Compatible<Project>;
 
 export function projectToJSON(p: Project): ProjectJSON {

--- a/src/core/project.test.js
+++ b/src/core/project.test.js
@@ -7,6 +7,7 @@ import {
   projectFromJSON,
   type Project,
   encodeProjectId,
+  createProject,
 } from "./project";
 
 import {makeRepoId} from "./repoId";
@@ -103,6 +104,56 @@ describe("core/project", () => {
     });
     it("is decodable to identity", () => {
       expect(base64url.decode(encodeProjectId("foo bar"))).toEqual("foo bar");
+    });
+  });
+  describe("createProject", () => {
+    it("requires an id field", () => {
+      // Given
+      const projectShape = {};
+
+      // When
+      const fn = () => createProject(projectShape);
+
+      // Then
+      expect(fn).toThrow("Project.id must be set");
+    });
+    it("adds default values", () => {
+      // Given
+      const projectShape = {
+        id: "minimal-project",
+      };
+
+      // When
+      const project = createProject(projectShape);
+
+      // Then
+      expect(project).toEqual({
+        id: projectShape.id,
+        discourseServer: null,
+        repoIds: [],
+        identities: [],
+      });
+    });
+    it("treats input shape as overrides", () => {
+      // Given
+      // Note: adding Project type annotation to force all fields are used.
+      const projectShape: Project = {
+        id: "@foo",
+        repoIds: [foobar, foozod],
+        discourseServer: {serverUrl: "https://example.com"},
+        identities: [
+          {
+            username: "example",
+            aliases: ["github/example"],
+          },
+        ],
+      };
+
+      // When
+      const project = createProject(projectShape);
+
+      // Then
+      expect(project).toEqual(projectShape);
     });
   });
 });

--- a/src/core/project_io.test.js
+++ b/src/core/project_io.test.js
@@ -5,7 +5,12 @@ import tmp from "tmp";
 import path from "path";
 import fs from "fs-extra";
 
-import {type Project, encodeProjectId, projectToJSON} from "./project";
+import {
+  type Project,
+  encodeProjectId,
+  projectToJSON,
+  createProject,
+} from "./project";
 
 import {
   getProjectIds,
@@ -19,12 +24,14 @@ import {makeRepoId} from "./repoId";
 describe("core/project_io", () => {
   const foobar = deepFreeze(makeRepoId("foo", "bar"));
   const foozod = deepFreeze(makeRepoId("foo", "zod"));
-  const p1: Project = deepFreeze({
-    id: "foo/bar",
-    repoIds: [foobar],
-    discourseServer: null,
-    identities: [],
-  });
+  const p1: Project = deepFreeze(
+    createProject({
+      id: "foo/bar",
+      repoIds: [foobar],
+    })
+  );
+  // Note: the point of P2 is to use all project options.
+  // So we're avoiding createProject, to not forget new options.
   const p2: Project = deepFreeze({
     id: "@foo",
     repoIds: [foobar, foozod],

--- a/src/plugins/github/specToProject.js
+++ b/src/plugins/github/specToProject.js
@@ -1,6 +1,6 @@
 // @flow
 
-import {type Project} from "../../core/project";
+import {type Project, createProject} from "../../core/project";
 import {
   stringToRepoId,
   githubOwnerPattern,
@@ -33,22 +33,18 @@ export async function specToProject(
   );
   const ownerSpecMatcher = new RegExp(`^@${githubOwnerPattern}$`);
   if (spec.match(repoSpecMatcher)) {
-    const project: Project = {
+    const project: Project = createProject({
       id: spec,
       repoIds: [stringToRepoId(spec)],
-      discourseServer: null,
-      identities: [],
-    };
+    });
     return project;
   } else if (spec.match(ownerSpecMatcher)) {
     const owner = spec.slice(1);
     const org = await fetchGithubOrg(owner, token);
-    const project: Project = {
+    const project: Project = createProject({
       id: spec,
       repoIds: org.repos,
-      discourseServer: null,
-      identities: [],
-    };
+    });
     return project;
   }
   throw new Error(`invalid spec: ${spec}`);

--- a/src/plugins/github/specToProject.test.js
+++ b/src/plugins/github/specToProject.test.js
@@ -2,7 +2,7 @@
 
 import {specToProject} from "./specToProject";
 import {stringToRepoId} from "../../core/repoId";
-import {type Project} from "../../core/project";
+import {type Project, createProject} from "../../core/project";
 jest.mock("./fetchGithubOrg", () => ({fetchGithubOrg: jest.fn()}));
 type JestMockFn = $Call<typeof jest.fn>;
 const fetchGithubOrg: JestMockFn = (require("./fetchGithubOrg")
@@ -14,12 +14,10 @@ describe("plugins/github/specToProject", () => {
   });
   it("works for a repoId", async () => {
     const spec = "foo/bar";
-    const expected: Project = {
+    const expected: Project = createProject({
       id: spec,
       repoIds: [stringToRepoId(spec)],
-      discourseServer: null,
-      identities: [],
-    };
+    });
     const actual = await specToProject(spec, "FAKE_TOKEN");
     expect(expected).toEqual(actual);
     expect(fetchGithubOrg).not.toHaveBeenCalled();
@@ -32,12 +30,10 @@ describe("plugins/github/specToProject", () => {
     fetchGithubOrg.mockResolvedValueOnce(fakeOrg);
     const actual = await specToProject(spec, token);
     expect(fetchGithubOrg).toHaveBeenCalledWith(fakeOrg.name, token);
-    const expected: Project = {
+    const expected: Project = createProject({
       id: spec,
       repoIds: repos,
-      discourseServer: null,
-      identities: [],
-    };
+    });
     expect(actual).toEqual(expected);
   });
   describe("fails for malformed spec strings", () => {


### PR DESCRIPTION
Creation of new Project instances is spread out across the code.
So whenever there's a change in it's format, the PR is cluttered
with adding a logical default value in many places. It means
our default values might be inconsistent as well.

For example #1385 adds many `identities: [],` lines.
A similar situation would happen with the planned Initiatives
plugin, adding many `initiatives: null,` lines.

Using this function we can manage what default values to add
from a central place. Avoiding noise and code churn.