### PR TITLE
Initiatives: add InitiativeOptions to project spec

### DIFF
--- a/sharness/__snapshots__/example-github-load/projects/c291cmNlY3JlZC10ZXN0L2V4YW1wbGUtZ2l0aHVi/project.json
+++ b/sharness/__snapshots__/example-github-load/projects/c291cmNlY3JlZC10ZXN0L2V4YW1wbGUtZ2l0aHVi/project.json
@@ -1,1 +1,1 @@
-[{"type":"sourcecred/project","version":"0.4.0"},{"discourseServer":null,"id":"sourcecred-test/example-github","identities":[],"repoIds":[{"name":"example-github","owner":"sourcecred-test"}]}]
+[{"type":"sourcecred/project","version":"0.5.0"},{"discourseServer":null,"id":"sourcecred-test/example-github","identities":[],"initiatives":null,"repoIds":[{"name":"example-github","owner":"sourcecred-test"}]}]

--- a/src/core/project.test.js
+++ b/src/core/project.test.js
@@ -21,6 +21,7 @@ describe("core/project", () => {
     repoIds: [foobar],
     discourseServer: null,
     identities: [],
+    initiatives: null,
   });
   const p2: Project = deepFreeze({
     id: "@foo",
@@ -32,6 +33,10 @@ describe("core/project", () => {
         aliases: ["github/example"],
       },
     ],
+    initiatives: {
+      discourseCategoryId: 12,
+      topicBlacklist: [666],
+    },
   });
   describe("to/from JSON", () => {
     it("round trip is identity", () => {
@@ -67,6 +72,8 @@ describe("core/project", () => {
         ...body,
         // It should strip the apiUsername field, keeping just serverUrl.
         discourseServer: {serverUrl: "https://example.com"},
+        // It should default to not using the Initiatives plugin.
+        initiatives: null,
       });
     });
     it("should upgrade from 0.3.1 formatting", () => {
@@ -93,6 +100,33 @@ describe("core/project", () => {
         ...body,
         // It should strip the apiUsername field, keeping just serverUrl.
         discourseServer: {serverUrl: "https://example.com"},
+        // It should default to not using the Initiatives plugin.
+        initiatives: null,
+      });
+    });
+    it("should upgrade from 0.4.0 formatting", () => {
+      // Given
+      const body = {
+        id: "example-040",
+        repoIds: [foobar, foozod],
+        discourseServer: {
+          serverUrl: "https://example.com",
+        },
+        identities: [],
+      };
+      const compat = toCompat(
+        {type: "sourcecred/project", version: "0.4.0"},
+        body
+      );
+
+      // When
+      const project = projectFromJSON(compat);
+
+      // Then
+      expect(project).toEqual({
+        ...body,
+        // It should default to not using the Initiatives plugin.
+        initiatives: null,
       });
     });
   });
@@ -127,12 +161,15 @@ describe("core/project", () => {
       const project = createProject(projectShape);
 
       // Then
-      expect(project).toEqual({
+      // Note: adding Project type annotation to force all fields are used.
+      const expectedProject: Project = {
         id: projectShape.id,
         discourseServer: null,
         repoIds: [],
         identities: [],
-      });
+        initiatives: null,
+      };
+      expect(project).toEqual(expectedProject);
     });
     it("treats input shape as overrides", () => {
       // Given
@@ -147,6 +184,10 @@ describe("core/project", () => {
             aliases: ["github/example"],
           },
         ],
+        initiatives: {
+          discourseCategoryId: 12,
+          topicBlacklist: [666],
+        },
       };
 
       // When

--- a/src/core/project_io.test.js
+++ b/src/core/project_io.test.js
@@ -37,6 +37,7 @@ describe("core/project_io", () => {
     repoIds: [foobar, foozod],
     discourseServer: {serverUrl: "https://example.com"},
     identities: [{username: "foo", aliases: ["github/foo", "discourse/foo"]}],
+    initiatives: null,
   });
 
   it("setupProjectDirectory results in a loadable project", async () => {

--- a/src/plugins/initiatives/loadInitiatives.js
+++ b/src/plugins/initiatives/loadInitiatives.js
@@ -1,0 +1,19 @@
+// @flow
+
+import type {CategoryId, TopicId} from "../discourse/fetch";
+
+export type InitiativeOptions = {|
+  /**
+   * The Discourse category from which to parse Topics as Initiatives.
+   */
+  +discourseCategoryId: CategoryId,
+
+  /**
+   * Topics that should be skipped for Initiative parsing if encountered.
+   *
+   * Useful mainly for ignoring Topics in the initiatives category that
+   * we know are not intended as an Initiative. Such as the "about" topic,
+   * or perhaps a discussion / announcement topics surrounding initiatives.
+   */
+  +topicBlacklist: $ReadOnlyArray<TopicId>,
+|};


### PR DESCRIPTION
Depends on #1492, #1517, #1518 and #1519 for tests and proper Project formatting.

These will be used for example as arguments for #1483's DiscourseInitiativeRepositoryOptions.

Test plan: `yarn test`