### PR TITLE
Allow `while(true)` loops

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -29,6 +29,7 @@ module.exports = {
         caughtErrorsIgnorePattern: "^_$|^_unused_",
       },
     ],
+    "no-constant-condition": ["warn", {checkLoops: false}],
     "no-use-before-define": ["off"],
     "no-useless-constructor": ["off"],
     "no-case-declarations": ["off"],


### PR DESCRIPTION
The eslint no-constant-condition rule disallows while(true) loops,
since the true is a constant condition. However, I find the allowed
alternative (`for (;;)`) less readable, so I am adding the sub-rule that
allows constant conditions for loops.

Test plan: Add a `while (true)` loop somewhere in the codebase.
Before this commit, it will generate a lint error; afterwards, it is fine.