### PR TITLE
Add `sourcecred init` command

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "react-icons": "^3.7.0",
     "react-markdown": "^4.0.8",
     "react-router": "^3.2.1",
+    "read": "^1.0.7",
     "recharts": "^1.6.2",
     "remove-markdown": "^0.3.0",
     "retry": "^0.12.0",

--- a/src/cli/help.js
+++ b/src/cli/help.js
@@ -9,6 +9,7 @@ import {help as scoresHelp} from "./scores";
 import {help as clearHelp} from "./clear";
 import {help as genProjectHelp} from "./genProject";
 import {help as discourseHelp} from "./discourse";
+import {help as initHelp} from "./init";
 
 const help: Command = async (args, std) => {
   if (args.length === 0) {
@@ -23,6 +24,7 @@ const help: Command = async (args, std) => {
     clear: clearHelp,
     "gen-project": genProjectHelp,
     discourse: discourseHelp,
+    init: initHelp,
   };
   if (subHelps[command] !== undefined) {
     return subHelps[command](args.slice(1), std);
@@ -46,6 +48,7 @@ function usage(print: (string) => void): void {
       scores        print SourceCred scores to stdout
       gen-project   print a SourceCred project config to stdout
       discourse     load a Discourse server into SourceCred
+      init          initialize a SourceCred instance
       help          show this help message
 
     Use 'sourcecred help COMMAND' for help about an individual command.

--- a/src/cli/init.js
+++ b/src/cli/init.js
@@ -1,0 +1,158 @@
+// @flow
+// Implementation of `sourcecred init`
+
+import dedent from "../util/dedent";
+import {type RepoId, stringToRepoId} from "../core/repoId";
+import {type Project, projectToJSON} from "../core/project";
+import type {Command} from "./command";
+import * as Common from "./common";
+import fs from "fs-extra";
+import process from "process";
+import read from "read";
+import path from "path";
+import {fetchGithubOrg} from "../plugins/github/fetchGithubOrg";
+import {type DiscourseServer} from "../plugins/discourse/loadDiscourse";
+
+function usage(print: (string) => void): void {
+  print(
+    dedent`\
+    usage: sourcecred init
+           sourcecred init --help
+
+    Sets up a new SourceCred instance, by interactively creating a SourceCred
+    project configuration, and saving it to 'sourcecred.json'.
+
+    Arguments:
+        --help
+            Show this help message and exit, as 'sourcecred help init'.
+
+    Environment variables:
+        SOURCECRED_GITHUB_TOKEN
+            API token for GitHub. This should be a 40-character hex
+            string. Required if you want to load whole GitHub orgs.
+
+            To generate a token, create a "Personal access token" at
+            <https://github.com/settings/tokens>. When loading data for
+            public repositories, no special permissions are required.
+            For private repositories, the 'repo' scope is required.
+    `.trimRight()
+  );
+}
+
+function die(std, message) {
+  std.err("fatal: " + message);
+  std.err("fatal: run 'sourcecred help init' for help");
+  return 1;
+}
+
+const initCommand: Command = async (args, std) => {
+  for (let i = 0; i < args.length; i++) {
+    switch (args[i]) {
+      case "--help": {
+        usage(std.out);
+        return 0;
+      }
+      default: {
+        return die(std, `Unexpected argument ${args[i]}`);
+      }
+    }
+  }
+  const dir = process.cwd();
+  const projectFilePath = path.join(dir, "sourcecred.json");
+  if (await fs.exists(projectFilePath)) {
+    return die(std, `Refusing to overwrite sourcecred.json file in ${dir}`);
+  }
+  const basename = path.basename(dir);
+  const name = await aread({
+    prompt: "Choose an instance name:",
+    default: basename,
+  });
+  std.out("");
+
+  let repoIds: RepoId[] = [];
+  const githubToken = Common.githubToken();
+  if (githubToken == null) {
+    std.out("Skipping organization loading, as no GitHub token available.");
+  } else {
+    std.out("Now you can add any GitHub organizations you want to load.");
+    std.out("You'll have the option to load multiple orgs, one at a time.");
+    std.out("Leave a blank response when done adding orgs.");
+    std.out("You'll have the option to add individual repos next.");
+    while (true) {
+      const nextOrg = await aread({prompt: "The name of an org to add:"});
+      if (nextOrg === "") {
+        break;
+      } else {
+        const {repos} = await fetchGithubOrg(nextOrg, githubToken);
+        repoIds = [...repoIds, ...repos];
+      }
+    }
+  }
+  std.out("");
+
+  std.out("Now you can add individual GitHub repositories.");
+  std.out("Add them in format OWNER/NAME, like in torvalds/linux.");
+  std.out("Leave a blank response when done adding repos.");
+  while (true) {
+    const nextRepo = await aread({prompt: "The name of a repo to add:"});
+    if (nextRepo === "") {
+      break;
+    }
+    const repoId = stringToRepoId(nextRepo);
+    repoIds.push(repoId);
+  }
+  std.out("");
+
+  let discourseServer: DiscourseServer | null = null;
+  std.out("Now you can add a Discourse server url.");
+  std.out("It should begin with http:// or https://");
+  std.out("Leave blank if you don't want to add a Discourse server.");
+  let serverUrl = await aread({prompt: "Discourse server url, or blank"});
+  if (serverUrl !== "") {
+    if (!serverUrl.startsWith("https://") && !serverUrl.startsWith("http://")) {
+      return die(std, "serverUrl should start with http:// or https://");
+    }
+    if (serverUrl.endsWith("/")) {
+      serverUrl = serverUrl.slice(0, serverUrl.length - 1);
+    }
+    discourseServer = {serverUrl};
+  }
+
+  const project: Project = {
+    id: name,
+    repoIds,
+    discourseServer,
+    identities: [],
+  };
+
+  const projectJson = projectToJSON(project);
+  await fs.writeFile(projectFilePath, JSON.stringify(projectJson, null, 2));
+
+  std.out("Done. Inspect `sourcecred.json` for results.");
+
+  return 0;
+};
+
+// Async version of `read`
+function aread(options): Promise<string> {
+  return new Promise((resolve, reject) => {
+    read(options, (error, result) => {
+      if (error) {
+        reject(error);
+      }
+      resolve(result);
+    });
+  });
+}
+
+export const help: Command = async (args, std) => {
+  if (args.length === 0) {
+    usage(std.out);
+    return 0;
+  } else {
+    usage(std.err);
+    return 1;
+  }
+};
+
+export default initCommand;

--- a/src/cli/sourcecred.js
+++ b/src/cli/sourcecred.js
@@ -11,6 +11,7 @@ import scores from "./scores";
 import clear from "./clear";
 import genProject from "./genProject";
 import discourse from "./discourse";
+import init from "./init";
 
 const sourcecred: Command = async (args, std) => {
   if (args.length === 0) {
@@ -34,6 +35,8 @@ const sourcecred: Command = async (args, std) => {
       return genProject(args.slice(1), std);
     case "discourse":
       return discourse(args.slice(1), std);
+    case "init":
+      return init(args.slice(1), std);
     default:
       std.err("fatal: unknown command: " + JSON.stringify(args[0]));
       std.err("fatal: run 'sourcecred help' for commands and usage");

--- a/yarn.lock
+++ b/yarn.lock
@@ -5946,7 +5946,7 @@ mute-stream@0.0.7:
   resolved "https://registry.yarnpkg.com/mute-stream/-/mute-stream-0.0.7.tgz#3075ce93bc21b8fab43e1bc4da7e8115ed1e7bab"
   integrity sha1-MHXOk7whuPq0PhvE2n6BFe0ee6s=
 
-mute-stream@0.0.8:
+mute-stream@0.0.8, mute-stream@~0.0.4:
   version "0.0.8"
   resolved "https://registry.yarnpkg.com/mute-stream/-/mute-stream-0.0.8.tgz#1630c42b2251ff81e2a283de96a5497ea92e5e0d"
   integrity sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA==
@@ -7179,6 +7179,13 @@ read-pkg@^3.0.0:
     load-json-file "^4.0.0"
     normalize-package-data "^2.3.2"
     path-type "^3.0.0"
+
+read@^1.0.7:
+  version "1.0.7"
+  resolved "https://registry.yarnpkg.com/read/-/read-1.0.7.tgz#b3da19bd052431a97671d44a42634adf710b40c4"
+  integrity sha1-s9oZvQUkMal2cdRKQmNK33ELQMQ=
+  dependencies:
+    mute-stream "~0.0.4"
 
 "readable-stream@1 || 2", readable-stream@^2.0.0, readable-stream@^2.0.1, readable-stream@^2.0.2, readable-stream@^2.0.6, readable-stream@^2.1.5, readable-stream@^2.2.2, readable-stream@^2.3.3, readable-stream@^2.3.6, readable-stream@~2.3.6:
   version "2.3.6"


### PR DESCRIPTION
The `sourcecred init` command interactively sets up a `sourcecred.json`
file, which is currently just a serialized `Project`.

The command guides the user through common options like adding GitHub
repos or orgs, and adding a Discourse server.

This is intended as a first step towards having an instance system.

Test plan:
This is an interactive tool which has relatively little room for
subtle/hard to track down bugs (either it produces a valid project
config or it doesn't). As such, I've decided not to write automated
tests.

I manually tested its common cases (loading orgs, adding repos, adding a
Discourse server), and verified that it will conservatively refuse to
overwrite an existing `sourcecred.json` file.