### PR TITLE
Security: force update yarn version in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ RUN mkdir -p /code
 WORKDIR /code
 
 # Install global and local dependencies first so they can be cached.
-RUN npm install -g yarn@^1.17
+RUN npm install -gf yarn@^1.21.1
 COPY package.json yarn.lock /code/
 RUN yarn
 


### PR DESCRIPTION
Note, unless you used the SourceCred Docker image's bundled
npm or yarn to install your own package.json dependencies,
you were not vulnerable. Otherwise the same risk applies as
[in this NPM blog][1].

You can patch the vulnerability by using the latest Docker image
using `docker pull sourcecred/sourcecred` as soon as this commit
is included in the latest release.

## Commit details

In a [recent security issue][1] found in NPM and Yarn, handling
binary file installation has changed. Quoting from there:

> The bin script linking libraries in use in npm v6.13.4 were
> updated such that, when installing binary entries of top-level
> globally installed packages, they will only overwrite existing
> binary files if they are currently installed on behalf of the
> same package being installed.  For example, npm install –global
> foo could overwrite /usr/local/bin/foo if and only if
> /usr/local/bin/foo is currently a link to a previously installed
> version of foo.

In our case, we specifically want this behavior in our Dockerfile.
The node:12 base image comes with an NPM and Yarn version installed.
We're using `npm i -g yarn@<version>` to upgrade the yarn installation
to a predictable minimum, should we have an older version from the
base image. But since they're from different installation sources,
it causes an error as it would overwrite the yarn binary that wasn't
previously owned by npm install.

Our own package.json or yarn.lock did not appear to have any risk
of exploitation. However since we bundle our image with npm and yarn,
people using our image could in theory use it to install their own
packages. Meaning we should include the fixed npm and yarn versions
to protect users in such a scenario.

[1]: https://blog.npmjs.org/post/189618601100/binary-planting-with-the-npm-cli

---

Fixes #1497 #1498 #1499 #1500 #1501 #1502

Test plan:
```sh
# Build with latest node base image.
docker pull node:12
docker build -t sourcecred .

# Expect: 6.13.4 (or greater)
docker run --rm --entrypoint="" sourcecred npm -v

# Expect: 1.21.1 (or greater)
docker run --rm --entrypoint="" sourcecred yarn -v

# Optionally test loading
SOURCECRED_GITHUB_TOKEN="xxxxxxxxxxxxxxxxx" \
  docker run --rm -ti -e SOURCECRED_GITHUB_TOKEN -p 8080:8080 \
  sourcecred dev-preview @sourcecred-test

# Browse through http://localhost:8080/webpack-dev-server/
# Exit with Ctrl+C when done
```