### PR TITLE
Backport docker security patches: v0.4.1

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,6 +5,10 @@
 #
 version: 2.1
 
+orbs:
+  # https://circleci.com/orbs/registry/orb/circleci/docker
+  docker: circleci/docker@0.5.13
+
 executors:
   node10:
     docker:
@@ -51,22 +55,72 @@ jobs:
       - run: yarn test --full --ci
 
 workflows:
-  version: 2
+  version: 2.0
   commit:
     jobs:
       - test
+      - docker/publish:
+          deploy: false
+          image: sourcecred/sourcecred
+          tag: latest
+          requires:
+            - test
+          filters:
+            branches:
+              ignore: 
+                - master
+          after_build:
+            - run:
+                name: Preview Docker Tag for Build
+                command: |
+                   DOCKER_TAG=$(docker run sourcecred/sourcecred --version | cut -d' ' -f2)
+                   echo "Version that would be used for Docker tag is ${DOCKER_TAG}"
+
+      - docker/publish:
+          image: sourcecred/sourcecred
+          tag: latest
+          requires:
+            - test
+          filters:
+            branches:
+              ignore: /.*/
+            tags:
+              only: /^v.*/
+          after_build:
+            - run:
+                name: Publish Docker Tag with Sourcecred Version
+                command: |
+                   DOCKER_TAG=$(docker run sourcecred/sourcecred --version | cut -d' ' -f2)
+                   echo "Version for Docker tag is ${DOCKER_TAG}"
+                   docker tag sourcecred/sourcecred:latest sourcecred/sourcecred:${DOCKER_TAG}
+                   docker push sourcecred/sourcecred
+
       - test_full:
           filters:
             branches:
               only:
                 - master
                 - /ci-.*/
+
       - test_full_10:
           filters:
             branches:
               only:
                 - master
                 - /ci-.*/
+
+      - docker/publish:
+          image: sourcecred/sourcecred
+          requires:
+            - test
+            - test_full
+            - test_full_10
+          tag: dev
+          filters:
+            branches:
+              only: master
+
+
   nightly:
     triggers:
       - schedule:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -33,6 +33,11 @@ commands:
           paths:
             - node_modules
           key: v1-dependencies-{{ checksum "package.json" }}
+  pull_cache:
+    description: Pulls docker images usable for our cache
+    steps:
+      - run: docker pull sourcecred/sourcecred:dev
+      - run: docker pull node:12
 
 jobs:
   test:
@@ -69,6 +74,9 @@ workflows:
             branches:
               ignore: 
                 - master
+          extra_build_args: --cache-from=node:12,sourcecred/sourcecred:dev
+          before_build:
+            - pull_cache
           after_build:
             - run:
                 name: Preview Docker Tag for Build
@@ -86,6 +94,9 @@ workflows:
               ignore: /.*/
             tags:
               only: /^v.*/
+          extra_build_args: --cache-from=node:12,sourcecred/sourcecred:dev
+          before_build:
+            - pull_cache
           after_build:
             - run:
                 name: Publish Docker Tag with Sourcecred Version
@@ -111,6 +122,9 @@ workflows:
 
       - docker/publish:
           image: sourcecred/sourcecred
+          extra_build_args: --cache-from=node:12,sourcecred/sourcecred:dev
+          before_build:
+            - pull_cache
           requires:
             - test
             - test_full

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@
 
 <!-- Please add new entries just beneath this line. -->
 
+## [0.4.1]
+
+_Note: this is a backport release to include #1503._
+
+- Adding Docker container with instructions for running sourcecred (#1288)
+- Security: force update yarn version in Dockerfile (#1503)
+
 ## [0.4.0]
 
 - Enable viewing cred over time for GitHub repos (#1268)

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ RUN mkdir -p /code
 WORKDIR /code
 
 # Install global and local dependencies first so they can be cached.
-RUN npm install -g yarn@^1.17
+RUN npm install -gf yarn@^1.21.1
 COPY package.json yarn.lock /code/
 RUN yarn
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sourcecred",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "private": false,
   "dependencies": {
     "aphrodite": "^2.1.0",

--- a/src/core/version.js
+++ b/src/core/version.js
@@ -61,7 +61,7 @@ const environment = parseEnvironment(process.env.NODE_ENV);
 export const VERSION_INFO: VersionInfo = deepFreeze({
   major: 0,
   minor: 4,
-  patch: 0,
+  patch: 1,
   gitState,
   environment,
 });


### PR DESCRIPTION
Depends on #1503

As explained in #1331 we don't currently have a backport of our docker builds for v0.4.0. However we do have a `:latest` docker image which is going to be the default way for people to try out the docker image for the first time. That is based on the 08408a9 commit.

However, considering the #1503 security patch for our docker image, I would like to make sure the `:latest` tag receives this patch as well. The most straightforward way is to create a `v0.4.1` patch release.

This PR proposes we take the 08408a9 commit which was used for that latest image as a base. Then backport the commits (seen in this PR) to create a v0.4.1 release.

Test plan:
```sh
# Build with latest node base image.
docker pull node:12
docker build -t sourcecred .

# Expect: sourcecred v0.4.1
docker run --rm sourcecred --version

# Expect: 6.13.4 (or greater)
docker run --rm --entrypoint="" sourcecred npm -v

# Expect: 1.21.1 (or greater)
docker run --rm --entrypoint="" sourcecred yarn -v

# Manually test loading
SOURCECRED_GITHUB_TOKEN="xxxxxxxxxxxxxxxxx" \
  docker run --rm -ti -e SOURCECRED_GITHUB_TOKEN -p 8080:8080 \
  sourcecred dev-preview @sourcecred-test

# Browse through http://localhost:8080/webpack-dev-server/
# Exit with Ctrl+C when done
```