### PR TITLE
UniRef: declare ReferenceDetector interface

### DIFF
--- a/src/core/references/index.js
+++ b/src/core/references/index.js
@@ -1,0 +1,3 @@
+//@flow
+
+export type {URL, ReferenceDetector} from "./referenceDetector";

--- a/src/core/references/referenceDetector.js
+++ b/src/core/references/referenceDetector.js
@@ -1,0 +1,19 @@
+//@flow
+
+import type {NodeAddressT} from "../graph";
+
+export type URL = string;
+
+/**
+ * A service which provides reference detection features.
+ */
+export interface ReferenceDetector {
+  /**
+   * Tries to infer the node address from an absolute URL.
+   * Returning undefined when the detector isn't aware of how to resolve this URL.
+   *
+   * Note: the detector should only return results that have been verified to exist
+   * in it's respective data layer.
+   */
+  addressFromUrl(url: URL): ?NodeAddressT;
+}


### PR DESCRIPTION
The core declaration of the `ReferenceDetector` interface.
As previously discussed in #1477 and https://discourse.sourcecred.io/t/unified-reference-detection/301

Reason I'm adding an `index.js` file is to allow (core) classes that implement this interface to have separate files, while keeping redundancy out of the import statements.

Test plan: none