### PR TITLE
CI: remove broken tag deploy

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -93,28 +93,6 @@ workflows:
 
       - docker/publish:
           image: sourcecred/sourcecred
-          tag: latest
-          requires:
-            - test
-          filters:
-            branches:
-              ignore: /.*/
-            tags:
-              only: /^v.*/
-          extra_build_args: --cache-from=node:12,sourcecred/sourcecred:dev
-          before_build:
-            - pull_cache
-          after_build:
-            - run:
-                name: Publish Docker Tag with Sourcecred Version
-                command: |
-                   DOCKER_TAG=$(docker run sourcecred/sourcecred --version | cut -d' ' -f2)
-                   echo "Version for Docker tag is ${DOCKER_TAG}"
-                   docker tag sourcecred/sourcecred:latest sourcecred/sourcecred:${DOCKER_TAG}
-                   docker push sourcecred/sourcecred
-
-      - docker/publish:
-          image: sourcecred/sourcecred
           extra_build_args: --cache-from=node:12,sourcecred/sourcecred:dev
           before_build:
             - pull_cache


### PR DESCRIPTION
See #1512 for full context.

Short explanation:
Because the job wants to run only on tag pushes, but requires the `test` job (which doesn't run on tag pushes), the job will never run.

Test plan:
Created a test project to demonstrate.
1. [Before configuration](https://github.com/Beanow/circle-tag-filters/tree/v0.1.1), has no `deploy_tag` 
![image](https://user-images.githubusercontent.com/497556/71328391-e33aa100-2516-11ea-90d0-b0c3cd6bf688.png)
2. [After configuration](https://github.com/Beanow/circle-tag-filters/tree/v0.1.2), does have `deploy_tag`
![image](https://user-images.githubusercontent.com/497556/71328415-49272880-2517-11ea-8500-2ead10ab7a37.png)
