### PR TITLE
CI: add tagged-release workflow

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -111,6 +111,43 @@ workflows:
             branches:
               only: master
 
+  # Separate workflow just for version tag releases.
+  tagged-release:
+    jobs:
+      - test:
+          filters: &version-tag-only
+            branches:
+              ignore: /.*/
+            tags:
+              only: /^v.*/
+
+      - test_full:
+          filters: *version-tag-only
+
+      - test_full_10:
+          filters: *version-tag-only
+
+      - docker/publish:
+          filters: *version-tag-only
+          requires:
+            - test
+            - test_full
+            - test_full_10
+          deploy: false
+          image: sourcecred/sourcecred
+          tag: latest
+          extra_build_args: --cache-from=node:12,sourcecred/sourcecred:dev
+          before_build:
+            - pull_cache
+          after_build:
+            - run:
+                name: Publish Docker Tag with Sourcecred Version
+                command: |
+                   DOCKER_TAG=$(docker run sourcecred/sourcecred --version | cut -d' ' -f2)
+                   echo "Version for Docker tag is ${DOCKER_TAG}"
+                   docker tag sourcecred/sourcecred:latest sourcecred/sourcecred:${DOCKER_TAG}
+                   docker push sourcecred/sourcecred:${DOCKER_TAG}
+                   docker push sourcecred/sourcecred:latest
 
   nightly:
     triggers:


### PR DESCRIPTION
Continues from #1513
Fixes #1512

In contrast with our previous "tags only" deploy job, this configuration makes sure all it's preceding jobs are also set to a "tags only" filter in order to run.

Test plan:
Created a test project to demonstrate.
1. [Before configuration](https://github.com/Beanow/circle-tag-filters/tree/v0.1.1), has no `deploy_tag` 
![image](https://user-images.githubusercontent.com/497556/71328391-e33aa100-2516-11ea-90d0-b0c3cd6bf688.png)
2. [After configuration](https://github.com/Beanow/circle-tag-filters/tree/v0.1.2), does have `deploy_tag`
![image](https://user-images.githubusercontent.com/497556/71328415-49272880-2517-11ea-8500-2ead10ab7a37.png)
