### PR TITLE
Add non-interactive `sourcecred init` command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Unreleased]
 
 <!-- Please add new entries just beneath this line. -->
+- Add the `sourcecred init` command (#1515)
 - Change default alpha from 0.05 to 0.20 (#1391)
 - Enable viewing and changing alpha in the explorer (#1390)
 - Enable combining different user identities together (#1385)

--- a/scripts/update_snapshots.sh
+++ b/scripts/update_snapshots.sh
@@ -28,6 +28,9 @@ echo "Updating sharness/test_load_example_github.t"
 echo "Updating sharness/test_cli_scores.t"
 (cd sharness; UPDATE_SNAPSHOT=1 ./test_cli_scores.t -l)
 
+echo "Updating sharness/test_cli_init.t"
+(cd sharness; UPDATE_SNAPSHOT=1 ./test_cli_init.t -l)
+
 echo "Updating github/fetchGithubOrgTest.sh"
 ./src/plugins/github/fetchGithubOrgTest.sh -u --no-build
 

--- a/sharness/__snapshots__/empty.json
+++ b/sharness/__snapshots__/empty.json
@@ -1,0 +1,14 @@
+[
+    {
+        "type": "sourcecred/project",
+        "version": "0.4.0"
+    },
+    {
+        "discourseServer": null,
+        "id": "obsolete-id",
+        "identities": [
+        ],
+        "repoIds": [
+        ]
+    }
+]

--- a/sharness/__snapshots__/full.json
+++ b/sharness/__snapshots__/full.json
@@ -1,0 +1,32 @@
+[
+    {
+        "type": "sourcecred/project",
+        "version": "0.4.0"
+    },
+    {
+        "discourseServer": {
+            "serverUrl": "https://discourse.sourcecred.io"
+        },
+        "id": "obsolete-id",
+        "identities": [
+        ],
+        "repoIds": [
+            {
+                "name": "example-github",
+                "owner": "sourcecred-test"
+            },
+            {
+                "name": "example-git-submodule",
+                "owner": "sourcecred-test"
+            },
+            {
+                "name": "example-git",
+                "owner": "sourcecred-test"
+            },
+            {
+                "name": "sourcecred",
+                "owner": "sourcecred"
+            }
+        ]
+    }
+]

--- a/sharness/test_cli_init.t
+++ b/sharness/test_cli_init.t
@@ -1,0 +1,169 @@
+#!/bin/sh
+
+# Disable these lint rules globally:
+#   2034 = unused variable (used by sharness)
+#   2016 = parameter expansion in single quotes
+#   1004 = backslash-newline in single quotes
+# shellcheck disable=SC2034,SC2016,SC1004
+:
+
+test_description='tests for cli/init.js'
+
+export GIT_CONFIG_NOSYSTEM=1
+export GIT_ATTR_NOSYSTEM=1
+
+# shellcheck disable=SC1091
+. ./sharness.sh
+
+test_expect_success "environment and Node linking setup" '
+    toplevel="$(git -C "$(dirname "$0")" rev-parse --show-toplevel)" &&
+    snapshot_directory="${toplevel}/sharness/__snapshots__/" &&
+    if [ -z "${SOURCECRED_BIN}" ]; then
+        printf >&2 "warn: missing environment variable SOURCECRED_BIN\n" &&
+        printf >&2 "warn: using repository bin directory as fallback\n" &&
+        export SOURCECRED_BIN="${toplevel}/bin"
+    fi &&
+    export NODE_PATH="${toplevel}/node_modules${NODE_PATH:+:${NODE_PATH}}" &&
+    test_set_prereq SETUP
+'
+
+run() (
+    set -eu
+    rm -f out err
+    code=0
+    node "${SOURCECRED_BIN}"/sourcecred.js "$@" >out 2>err || code=$?
+    if [ "${code}" -ne 0  ]; then
+        printf '%s failed with %d\n' "sourcecred $*"
+        printf 'stdout:\n'
+        cat out
+        printf 'stderr:\n'
+        cat err
+    fi
+)
+
+# Use this instead of `run` when we are expecting sourcecred to return a
+# non-zero exit code
+run_without_validation() (
+    set -eu
+    rm -f out err
+    node "${SOURCECRED_BIN}"/sourcecred.js "$@" >out 2>err
+)
+
+if [ -n "${SOURCECRED_GITHUB_TOKEN:-}" ]; then
+    test_set_prereq HAVE_GITHUB_TOKEN
+fi
+
+test_expect_success SETUP  "help should print usage info" '
+    run help init &&
+    grep -q "usage: sourcecred init" out
+'
+
+test_expect_success SETUP "--help should print usage info" '
+    run init --help &&
+    grep -q "usage: sourcecred init" out
+'
+
+test_expect_success SETUP "should fail for multiple discourse urls" '
+    test_must_fail run_without_validation init \
+      --discourse https://discourse.sourcecred.io \
+      --discourse https://discourse2.sourcecred.io \
+      &&
+    grep -q "fatal: --discourse given multiple times" err
+'
+
+test_expect_success SETUP "should fail for incomplete discourse args" '
+    test_must_fail run_without_validation init --discourse &&
+    grep -q "fatal: --discourse given without value" err
+'
+
+test_expect_success SETUP "should fail for invalid discourse urls" '
+    test_must_fail run_without_validation init \
+      --discourse discourse.sourcecred.io \
+      &&
+    grep -q "fatal: invalid discourse url: must start with http:// or https://" err
+'
+
+test_expect_success SETUP "should strip trailing slash from discourse url" '
+    run --discourse https://discourse.sourcecred.io --print &&
+    mv out clean &&
+    run --discourse https://discourse.sourcecred.io/ --print &&
+    diff -u clean out
+'
+
+test_expect_success SETUP "should fail for incomplete github args" '
+    test_must_fail run_without_validation init --github &&
+    grep -q "fatal: --github given without value" err
+'
+
+test_expect_success SETUP "should fail if github specs are provided without github token" '
+    (
+      unset SOURCECRED_GITHUB_TOKEN &&
+      test_must_fail run_without_validation init --github foo
+    ) &&
+    grep -q "fatal: tried to load GitHub specs, but no GitHub token provided" err
+'
+
+test_expect_success SETUP "should write the project to sourcecred.json (or to stdout with --print)" '
+    rm -f sourcecred.json &&
+    run init &&
+    run init --print &&
+    diff -u out sourcecred.json &&
+    rm sourcecred.json
+'
+
+test_expect_success SETUP "should refuse to overwrite sourcecred.json without --force" '
+    printf "foo" > sourcecred.json &&
+    test_must_fail run_without_validation init &&
+    grep -q "fatal: refusing to overwrite sourcecred.json without --force" err
+'
+
+test_expect_success SETUP "should overwrite sourcecred.json if --force is provided" '
+    printf "foo" > sourcecred.json &&
+    run init --force &&
+    run init --print &&
+    diff -u out sourcecred.json
+'
+
+test_expect_success SETUP "should not touch sourcecred.json if both --force and --print are provided" '
+    printf "foo" > sourcecred.json &&
+    printf "foo" > expected &&
+    run init --force --print &&
+    mv out out1 &&
+    run init --print &&
+    diff -u out out1 &&
+    diff -u sourcecred.json expected
+'
+
+if [ -n "${UPDATE_SNAPSHOT}" ]; then
+    test_set_prereq UPDATE_SNAPSHOT
+fi
+
+test_expect_success SETUP,UPDATE_SNAPSHOT,HAVE_GITHUB_TOKEN  "should update the snapshots" '
+    run init --print &&
+    mv out "${snapshot_directory}/empty.json" &&
+    run init \
+      --print \
+      --discourse https://discourse.sourcecred.io \
+      --github @sourcecred-test \
+      --github sourcecred/sourcecred \
+      &&
+    mv out "${snapshot_directory}/full.json"
+'
+
+test_expect_success SETUP  "should produce an empty project config when called without args" '
+    run init --print &&
+    diff -u out "${snapshot_directory}/empty.json"
+'
+
+test_expect_success SETUP,HAVE_GITHUB_TOKEN "can include github and discourse specs" '
+    run init \
+      --print \
+      --discourse https://discourse.sourcecred.io \
+      --github @sourcecred-test \
+      --github sourcecred/sourcecred \
+      &&
+    diff -u out "${snapshot_directory}/full.json"
+'
+
+test_done
+# vim: ft=sh

--- a/src/cli/genProject.js
+++ b/src/cli/genProject.js
@@ -4,6 +4,7 @@
 // before we build a more intentional declarative json config approach, as discussed
 // here: https://github.com/sourcecred/sourcecred/issues/1232#issuecomment-519538494
 // This method is untested; please take care when modifying it!
+// This command is deprecated by `sourcecred init` and will shortly be removed.
 
 import dedent from "../util/dedent";
 import type {Command} from "./command";

--- a/src/cli/help.js
+++ b/src/cli/help.js
@@ -9,6 +9,7 @@ import {help as scoresHelp} from "./scores";
 import {help as clearHelp} from "./clear";
 import {help as genProjectHelp} from "./genProject";
 import {help as discourseHelp} from "./discourse";
+import {help as initHelp} from "./init";
 
 const help: Command = async (args, std) => {
   if (args.length === 0) {
@@ -23,6 +24,7 @@ const help: Command = async (args, std) => {
     clear: clearHelp,
     "gen-project": genProjectHelp,
     discourse: discourseHelp,
+    init: initHelp,
   };
   if (subHelps[command] !== undefined) {
     return subHelps[command](args.slice(1), std);
@@ -46,6 +48,7 @@ function usage(print: (string) => void): void {
       scores        print SourceCred scores to stdout
       gen-project   print a SourceCred project config to stdout
       discourse     load a Discourse server into SourceCred
+      init          initialize a SourceCred instance
       help          show this help message
 
     Use 'sourcecred help COMMAND' for help about an individual command.

--- a/src/cli/init.js
+++ b/src/cli/init.js
@@ -3,7 +3,6 @@
 
 import stringify from "json-stable-stringify";
 import dedent from "../util/dedent";
-import {type RepoId} from "../core/repoId";
 import {type Project, projectToJSON, createProject} from "../core/project";
 import type {Command} from "./command";
 import * as Common from "./common";
@@ -11,6 +10,7 @@ import fs from "fs-extra";
 import process from "process";
 import path from "path";
 import {type DiscourseServer} from "../plugins/discourse/loadDiscourse";
+import {type RepoId} from "../plugins/github/repoId";
 import {specToProject} from "../plugins/github/specToProject";
 import * as NullUtil from "../util/null";
 
@@ -106,17 +106,6 @@ const initCommand: Command = async (args, std) => {
         if (++i >= args.length)
           return die(std, "--discourse given without value");
         discourseUrl = args[i];
-        /*
-        if (!discourseUrl.match(new RegExp("^https?://"))) {
-          return die(
-            std,
-            "invalid discourse url: must start with http:// or https://"
-          );
-        }
-        if (discourseUrl.endsWith("/")) {
-          discourseUrl = discourseUrl.slice(0, discourseUrl.length - 1);
-        }
-        */
         break;
       }
       case "--force": {

--- a/src/cli/init.js
+++ b/src/cli/init.js
@@ -1,0 +1,182 @@
+// @flow
+// Implementation of `sourcecred init`
+
+import stringify from "json-stable-stringify";
+import dedent from "../util/dedent";
+import {type RepoId} from "../core/repoId";
+import {type Project, projectToJSON, createProject} from "../core/project";
+import type {Command} from "./command";
+import * as Common from "./common";
+import fs from "fs-extra";
+import process from "process";
+import path from "path";
+import {type DiscourseServer} from "../plugins/discourse/loadDiscourse";
+import {specToProject} from "../plugins/github/specToProject";
+import * as NullUtil from "../util/null";
+
+function usage(print: (string) => void): void {
+  print(
+    dedent`\
+    usage: sourcecred init [--github GITHUB_SPEC [...]]
+                           [--discourse DISCOURSE_URL]
+                           [--force]
+                           [--print]
+           sourcecred init --help
+
+    Sets up a new SourceCred instance, by creating a SourceCred project
+    configuration, and saving it to 'sourcecred.json' within the current
+    directory.
+
+    Zero or more GitHub specs may be provided; each GitHub spec can be of the
+    form OWNER/NAME (as in 'torvalds/linux') for loading a single repository,
+    or @owner (as in '@torvalds') for loading all repositories owned by a given
+    account. If any GitHub specs are present, then the SOURCECRED_GITHUB_TOKEN
+    environment variable is required.
+
+    A discourse url may be provided. The discourse url must be the full url of
+    a valid Discourse server, as in 'https://discourse.sourcecred.io'.
+
+    All of the GitHub specs, and the Discourse specification (if it exists)
+    will be combined into a single project, which is written to
+    sourcecred.json. The file may be manually modified to activate other
+    advanced features, such as identity map resolution.
+
+    Arguments:
+        --github GITHUB_SPEC
+            A specification (in form 'OWNER/NAME' or '@OWNER') of GitHub
+            repositories to load.
+
+        --discourse DISCOURSE_URL
+            The url of a Discourse server to load.
+
+        --force
+            If provided, sourcecred init will overwrite pre-existing
+            sourcecred.json files. Otherwise, the command will refuse to
+            overwite pre-existing files and fail.
+
+        --print
+            If provided, sourcecred init will print the project to stdout
+            rather than writing it to sourcecred.json. Mostly used for testing
+            purposes, as a SourceCred instance is only valid if the file is
+            saved as sourcecred.json. If this flag is set, it supercedes
+            --force.
+
+        --help
+            Show this help message and exit, as 'sourcecred help init'.
+
+    Environment variables:
+        SOURCECRED_GITHUB_TOKEN
+            API token for GitHub. This should be a 40-character hex
+            string. Required if you provide GitHub specs.
+
+            To generate a token, create a "Personal access token" at
+            <https://github.com/settings/tokens>. When loading data for
+            public repositories, no special permissions are required.
+            For private repositories, the 'repo' scope is required.
+    `.trimRight()
+  );
+}
+
+function die(std, message) {
+  std.err("fatal: " + message);
+  std.err("fatal: run 'sourcecred help init' for help");
+  return 1;
+}
+
+const initCommand: Command = async (args, std) => {
+  let withForce = false;
+  let printToStdOut = false;
+  let discourseUrl: ?string;
+  let githubSpecs: string[] = [];
+
+  for (let i = 0; i < args.length; i++) {
+    switch (args[i]) {
+      case "--help": {
+        usage(std.out);
+        return 0;
+      }
+      case "--github": {
+        if (++i >= args.length) return die(std, "--github given without value");
+        githubSpecs.push(args[i]);
+        break;
+      }
+      case "--discourse": {
+        if (discourseUrl != undefined)
+          return die(std, "--discourse given multiple times");
+        if (++i >= args.length)
+          return die(std, "--discourse given without value");
+        discourseUrl = args[i];
+        if (!discourseUrl.match(new RegExp("^https?://"))) {
+          return die(
+            std,
+            "invalid discourse url: must start with http:// or https://"
+          );
+        }
+        if (discourseUrl.endsWith("/")) {
+          discourseUrl = discourseUrl.slice(0, discourseUrl.length - 1);
+        }
+        break;
+      }
+      case "--force": {
+        withForce = true;
+        break;
+      }
+      case "--print": {
+        printToStdOut = true;
+        break;
+      }
+      default: {
+        return die(std, `Unexpected argument ${args[i]}`);
+      }
+    }
+  }
+  const dir = process.cwd();
+  const projectFilePath = path.join(dir, "sourcecred.json");
+  const fileAlreadyExists = await fs.exists(projectFilePath);
+  if (fileAlreadyExists && !(withForce || printToStdOut)) {
+    return die(std, `refusing to overwrite sourcecred.json without --force`);
+  }
+
+  const githubToken = Common.githubToken();
+  if (!githubToken && githubSpecs.length > 0) {
+    return die(std, "tried to load GitHub specs, but no GitHub token provided");
+  }
+  let repoIds: RepoId[] = [];
+  for (const spec of githubSpecs) {
+    const subproject = await specToProject(spec, NullUtil.get(githubToken));
+    repoIds = [...repoIds, ...subproject.repoIds];
+  }
+
+  const discourseServer: DiscourseServer | null = discourseUrl
+    ? {serverUrl: discourseUrl}
+    : null;
+  const project: Project = createProject({
+    // the id field is obsolete in the instance system, and will be
+    // removed once we fully migrate to sourcecred instances.
+    id: "obsolete-id",
+    repoIds,
+    discourseServer,
+  });
+
+  const projectJson = projectToJSON(project);
+  const stringified = stringify(projectJson, {space: 4});
+  if (printToStdOut) {
+    std.out(stringified);
+  } else {
+    await fs.writeFile(projectFilePath, stringified + "\n");
+  }
+
+  return 0;
+};
+
+export const help: Command = async (args, std) => {
+  if (args.length === 0) {
+    usage(std.out);
+    return 0;
+  } else {
+    usage(std.err);
+    return 1;
+  }
+};
+
+export default initCommand;

--- a/src/cli/init.test.js
+++ b/src/cli/init.test.js
@@ -1,0 +1,5 @@
+// @flow
+
+import {genDiscourseServer, genRepoIds, genProject} from "./init";
+
+// TODO: testing

--- a/src/cli/sourcecred.js
+++ b/src/cli/sourcecred.js
@@ -11,6 +11,7 @@ import scores from "./scores";
 import clear from "./clear";
 import genProject from "./genProject";
 import discourse from "./discourse";
+import init from "./init";
 
 const sourcecred: Command = async (args, std) => {
   if (args.length === 0) {
@@ -34,6 +35,8 @@ const sourcecred: Command = async (args, std) => {
       return genProject(args.slice(1), std);
     case "discourse":
       return discourse(args.slice(1), std);
+    case "init":
+      return init(args.slice(1), std);
     default:
       std.err("fatal: unknown command: " + JSON.stringify(args[0]));
       std.err("fatal: run 'sourcecred help' for commands and usage");

--- a/src/core/project.js
+++ b/src/core/project.js
@@ -12,7 +12,7 @@ export type ProjectId = string;
  * A project represents a scope for cred analysis.
  *
  * Right now it has an `id` (which should be unique across a user's projects)
- * and an array of GitHub RepoIds.
+ * and information to configure the GitHub, Discourse, and Identity plugins.
  *
  * In the future, instead of hardcoding support for plugins like GitHub and Discourse,
  * we will have a generic system for storing plugin-specific config, keyed by plugin
@@ -28,6 +28,9 @@ export type Project = Project_v040;
 export type SupportedProject = Project_v030 | Project_v031 | Project_v040;
 
 type Project_v040 = {|
+  // the id field is required for pre-instance SourceCred, when multiple
+  // projects may co-exist in a SourceCred directory. Once we fully migrate
+  // to an instance system, it will be removed.
   +id: ProjectId,
   +repoIds: $ReadOnlyArray<RepoId>,
   +discourseServer: DiscourseServer | null,


### PR DESCRIPTION
The `sourcecred init` command sets up a `sourcecred.json`
file, which is currently just a serialized `Project`. This is based on
work in #1496, but is non-interactive instead.

This is a first step towards implementing the [instance system].

[instance system]: https://discourse.sourcecred.io/t/sourcecred-instance-system/244

Test plan:

This command is thoroughly tested by sharness tests; see
`sharness/test_cli_init.t`.

Thanks to @wchargin for help with the sharness testing.