### PR TITLE
Update projectFromJSON & upgrade function signatures

### DIFF
--- a/src/core/project.js
+++ b/src/core/project.js
@@ -42,7 +42,7 @@ export function projectToJSON(p: Project): ProjectJSON {
   return toCompat(COMPAT_INFO, p);
 }
 
-export function projectFromJSON(j: ProjectJSON): Project {
+export function projectFromJSON(j: Compatible<any>): Project {
   return fromCompat(COMPAT_INFO, j, upgrades);
 }
 
@@ -54,7 +54,7 @@ export function encodeProjectId(id: ProjectId): string {
   return base64url.encode(id);
 }
 
-const upgradeFrom030 = (p) => ({
+const upgradeFrom030 = (p: Project_v030 | Project_v031): Project_v040 => ({
   ...p,
   discourseServer:
     p.discourseServer != null ? {serverUrl: p.discourseServer.serverUrl} : null,


### PR DESCRIPTION
This creates better flow type coverage for the upgrading from older Project types feature.

Note `projectFromJSON`'s function signature changes like this:

```diff
- (Compatible<Project>) => Project
+ (Compatible<any>) => Project
```

And that makes sense, because we use this function to validate an object we parsed from JSON at runtime. It could actually be anything.

Added benefit is that is makes writing unit tests possible. Because now will flow not throw a type error when we provide something other than `Compatible<Project>` as input, to test upgrading or validation functionality.

Note that the underlying utility `fromCompat` already uses `Compatible<any>` for the same object.

This is a replacement for #1491, splitting it into smaller PRs.

Test plan: `yarn flow`