### PR TITLE
Add instructions to set up the GitHub API Token

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ git clone https://github.com/sourcecred/sourcecred.git
 cd sourcecred
 yarn install
 yarn backend
+export SOURCECRED_GITHUB_TOKEN=YOUR_GITHUB_TOKEN
 node bin/sourcecred.js load REPO_OWNER/REPO_NAME
 ```
 


### PR DESCRIPTION
The README explains how to set the SOURCECRED_GITHUB_TOKEN, but later in the Docker section. People who aren't using Docker will follow the initial installation instructions. Added the instructions to set that up when users first install and setup SourceCred.