### PR TITLE
Expose some internal APIs in a new bundle

### DIFF
--- a/config/paths.js
+++ b/config/paths.js
@@ -27,6 +27,7 @@ module.exports = {
   // point within the build directory.
   backendEntryPoints: {
     sourcecred: resolveApp("src/cli/main.js"),
+    api: resolveApp("src/api/index.js"),
     //
     generateGithubGraphqlFlowTypes: resolveApp(
       "src/plugins/github/bin/generateGraphqlFlowTypes.js"

--- a/src/api/index.js
+++ b/src/api/index.js
@@ -1,0 +1,44 @@
+// @flow
+
+import deepFreeze from "deep-freeze";
+
+// Exports for calling SourceCred code programmatically. Both the
+// structure and the contents of this API are experimental and subject
+// to change.
+import * as address from "../core/address";
+import * as discourseAddress from "../plugins/discourse/address";
+import * as discourseDeclaration from "../plugins/discourse/declaration";
+import * as githubDeclaration from "../plugins/github/declaration";
+import * as githubEdges from "../plugins/github/edges";
+import * as githubNodes from "../plugins/github/nodes";
+import * as graph from "../core/graph";
+import * as graphToMarkovChain from "../core/attribution/graphToMarkovChain";
+import * as markovChain from "../core/attribution/markovChain";
+import * as timelineCred from "../analysis/timeline/timelineCred";
+
+export default deepFreeze({
+  analysis: {
+    timeline: {
+      timelineCred,
+    },
+  },
+  core: {
+    address,
+    attribution: {
+      markovChain,
+      graphToMarkovChain,
+    },
+    graph,
+  },
+  plugins: {
+    github: {
+      declaration: githubDeclaration,
+      edges: githubEdges,
+      nodes: githubNodes,
+    },
+    discourse: {
+      address: discourseAddress,
+      declaration: discourseDeclaration,
+    },
+  },
+});


### PR DESCRIPTION
Summary:
For convenient import by scripts and Observable notebooks that want to
use SourceCred code outside its normal build system. We export a subset
of the codebase, including some core data structures and algorithms and
also some plugin metadata, but no plugin loading code.

To build, run `yarn backend` (or `yarn backend --watch`), then grab the
new `bin/api.js` file.

Test Plan:
Sample usage, with normal Node:

```javascript
const {
  core: {
    graph: {Graph, NodeAddress, EdgeAddress},
  },
} = require("./api").default;

function node(address) {
  return {
    address,
    description: "blurgh",
    timestampMs: -1,
  };
}

const g = new Graph();
g.addNode(node(NodeAddress.fromParts(["people", "alice"])));
g.addNode(node(NodeAddress.fromParts(["people", "bob"])));
g.addEdge({
  address: EdgeAddress.fromParts(["friendship"]),
  src: NodeAddress.fromParts(["people", "alice"]),
  dst: NodeAddress.fromParts(["people", "bob"]),
  timestampMs: 0,
});

console.log(require("json-stable-stringify")(g));
```

This prints a valid graph JSON object.

wchargin-branch: api-bundle