### PR TITLE
CI: separate node10 and 12 cache

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,17 +22,22 @@ executors:
 commands:
   set_up_node_modules:
     description: "load node_modules, updating and storing back into cache if necessary"
+    parameters:
+      node_version:
+        description: Which node version we're caching packages for
+        type: integer
+        default: 12
     steps:
       - restore_cache:
           keys:
-            - v1-dependencies-{{ checksum "package.json" }}
+            - v1-node<< parameters.node_version >>-dependencies-{{ checksum "package.json" }}
             # fall back to using the latest cache if no exact match is found
-            - v1-dependencies-
+            - v1-node<< parameters.node_version >>-dependencies-
       - run: yarn install
       - save_cache:
           paths:
             - node_modules
-          key: v1-dependencies-{{ checksum "package.json" }}
+          key: v1-node<< parameters.node_version >>-dependencies-{{ checksum "package.json" }}
   pull_cache:
     description: Pulls docker images usable for our cache
     steps:
@@ -56,7 +61,8 @@ jobs:
     executor: node10
     steps:
       - checkout
-      - set_up_node_modules
+      - set_up_node_modules:
+          node_version: 10
       - run: yarn test --full --ci
 
 workflows:


### PR DESCRIPTION
Previously both node versions would share the same cache. This caused one of the two versions to always rebuild the `better-sqlite3` package, costing about 1 min per job.

Now we're using a different cache key for each version, rebuilding a cached `better-sqlite3` should no longer be necessary.

Test plan:
Run the CI worflow for this PR twice.
The second run should cache and not need build time for either version.