### PR TITLE
Discourse: add mirror findUsername

### DIFF
--- a/src/plugins/discourse/createGraph.test.js
+++ b/src/plugins/discourse/createGraph.test.js
@@ -80,6 +80,9 @@ describe("plugins/discourse/createGraph", () => {
         "Method topicsInCategories should be unused for createGraph"
       );
     }
+    findUsername() {
+      throw new Error("Method findUsername should be unused by createGraph");
+    }
   }
 
   function example() {

--- a/src/plugins/discourse/mirrorRepository.js
+++ b/src/plugins/discourse/mirrorRepository.js
@@ -60,6 +60,13 @@ export interface ReadRepository {
   topicsInCategories(
     categoryIds: $ReadOnlyArray<CategoryId>
   ): $ReadOnlyArray<TopicId>;
+
+  /**
+   * Gets the username of a user, if it exists.
+   *
+   * Note: input username is case-insensitive.
+   */
+  findUsername(username: string): ?string;
 }
 
 export type SyncHeads = {|
@@ -302,6 +309,19 @@ export class SqliteMirrorRepository
       .prepare("SELECT username FROM users")
       .pluck()
       .all();
+  }
+
+  findUsername(username: string): ?string {
+    return this._db
+      .prepare(
+        dedent`\
+          SELECT username
+          FROM users
+          WHERE username = :username COLLATE NOCASE
+        `
+      )
+      .pluck()
+      .get({username});
   }
 
   likes(): $ReadOnlyArray<LikeAction> {

--- a/src/plugins/discourse/mirrorRepository.test.js
+++ b/src/plugins/discourse/mirrorRepository.test.js
@@ -26,6 +26,23 @@ describe("plugins/discourse/mirrorRepository", () => {
     expect(fs.readFileSync(filename).toJSON()).toEqual(data);
   });
 
+  it("findUsername does a case-insensitive query", () => {
+    // Given
+    const db = new Database(":memory:");
+    const url = "http://example.com";
+    const username = "PascalFan1988";
+    const repository = new SqliteMirrorRepository(db, url);
+
+    // When
+    repository.addUser(username);
+    const result1 = repository.findUsername("pascalfan1988");
+    const result2 = repository.findUsername(username);
+
+    // Then
+    expect(result1).toEqual(username);
+    expect(result2).toEqual(username);
+  });
+
   it("bumpedMsForTopic finds an existing topic's bumpedMs", () => {
     // Given
     const db = new Database(":memory:");


### PR DESCRIPTION
Gets the username of a user, if it exists. Helpful for fixing capitalization issues such as #1479, and verifying the user exists for reference detection.

Test plan: `yarn unit`