### PR TITLE
UniRef: implement Initiatives reference detector

### DIFF
--- a/src/plugins/initiatives/createGraph.js
+++ b/src/plugins/initiatives/createGraph.js
@@ -19,7 +19,7 @@ import {
   championsEdgeType,
 } from "./declaration";
 
-function initiativeAddress(initiative: Initiative): NodeAddressT {
+export function initiativeAddress(initiative: Initiative): NodeAddressT {
   return NodeAddress.append(
     initiativeNodeType.prefix,
     ...NodeAddress.toParts(initiative.tracker)

--- a/src/plugins/initiatives/referenceDetector.js
+++ b/src/plugins/initiatives/referenceDetector.js
@@ -1,0 +1,29 @@
+// @flow
+
+import type {NodeAddressT} from "../../core/graph";
+import type {InitiativeRepository} from "./initiative";
+import {initiativeAddress} from "./createGraph";
+import {
+  type ReferenceDetector,
+  TranslatingReferenceDetector,
+} from "../../core/references";
+
+/**
+ * Creates a TranslatingReferenceDetector which translates the NodeAddressT's
+ * referring to our Initiative.tracker's and translates them to the Initiative's
+ * NodeAddressT.
+ */
+export function fromTrackerTranslation(
+  trackerRefs: ReferenceDetector,
+  repo: InitiativeRepository
+): TranslatingReferenceDetector {
+  // Generate the mapping as: tracker address => initiative address.
+  const map: Map<NodeAddressT, NodeAddressT> = new Map();
+  for (const initiative of repo.initiatives()) {
+    map.set(initiative.tracker, initiativeAddress(initiative));
+  }
+
+  // Use a map lookup as the translation function.
+  const translate = (addr: NodeAddressT): ?NodeAddressT => map.get(addr);
+  return new TranslatingReferenceDetector(trackerRefs, translate);
+}

--- a/src/plugins/initiatives/referenceDetector.test.js
+++ b/src/plugins/initiatives/referenceDetector.test.js
@@ -1,0 +1,69 @@
+// @flow
+
+import {fromTrackerTranslation} from "./referenceDetector";
+import {type InitiativeRepository, type Initiative} from "./initiative";
+import {type NodeAddressT, NodeAddress} from "../../core/graph";
+import {MappedReferenceDetector} from "../../core/references";
+
+const maybeToParts = (a: ?NodeAddressT) => {
+  return a ? NodeAddress.toParts(a) : a;
+};
+
+class MockInitiativeRepository implements InitiativeRepository {
+  _initiatives: Initiative[];
+
+  constructor() {
+    this._initiatives = [];
+  }
+
+  addInitiative(title: string, tracker: NodeAddressT) {
+    this._initiatives.push({
+      title,
+      tracker,
+      timestampMs: 1234,
+      completed: false,
+      dependencies: [],
+      references: [],
+      contributions: [],
+      champions: [],
+    });
+  }
+
+  initiatives(): $ReadOnlyArray<Initiative> {
+    return [...this._initiatives];
+  }
+}
+
+describe("plugins/initiatives/referenceDetector", () => {
+  describe("fromTrackerTranslation", () => {
+    // This is a smoke test, as the underlying TranslatingReferenceDetector
+    // is extensively tested. We're mostly interested in testing whether
+    // it correctly maps based on the InitiativeRepository data.
+    it("should correctly translate a tracker address to initiative address", () => {
+      // Given
+      const nodeA = NodeAddress.fromParts(["TRACKER", "A"]);
+      const url = "http://foo.bar";
+
+      const base = new MappedReferenceDetector(new Map());
+      base.map.set(url, nodeA);
+
+      const repo = new MockInitiativeRepository();
+      repo.addInitiative("Make tests work", nodeA);
+
+      // When
+      const detector = fromTrackerTranslation(base, repo);
+      const result = detector.addressFromUrl(url);
+
+      // Then
+      expect(maybeToParts(result)).toMatchInlineSnapshot(`
+        Array [
+          "sourcecred",
+          "initiatives",
+          "initiative",
+          "TRACKER",
+          "A",
+        ]
+      `);
+    });
+  });
+});


### PR DESCRIPTION
Giving this detector priority, would allow us to consider a Discourse Topic URL (or any other tracker) a reference to an Initiative node, when there is a valid Initiative being linked.

Test plan: `yarn unit`