### PR TITLE
Refactor Weights into a class

### DIFF
--- a/src/analysis/timeline/params.js
+++ b/src/analysis/timeline/params.js
@@ -1,12 +1,6 @@
 // @flow
 
-import {
-  type Weights,
-  type WeightsJSON,
-  toJSON as weightsToJSON,
-  fromJSON as weightsFromJSON,
-  defaultWeights,
-} from "../weights";
+import {Weights, type WeightsJSON} from "../weights";
 
 /**
  * Parameters for computing TimelineCred
@@ -47,7 +41,7 @@ export function paramsToJSON(
   return {
     alpha: p.alpha,
     intervalDecay: p.intervalDecay,
-    weights: weightsToJSON(p.weights),
+    weights: p.weights.toJSON(),
   };
 }
 
@@ -57,7 +51,7 @@ export function paramsFromJSON(
   return {
     alpha: p.alpha,
     intervalDecay: p.intervalDecay,
-    weights: weightsFromJSON(p.weights),
+    weights: Weights.fromJSON(p.weights),
   };
 }
 
@@ -71,7 +65,7 @@ export function defaultParams(): TimelineCredParameters {
   return {
     alpha: DEFAULT_ALPHA,
     intervalDecay: DEFAULT_INTERVAL_DECAY,
-    weights: defaultWeights(),
+    weights: new Weights(),
   };
 }
 

--- a/src/analysis/timeline/params.test.js
+++ b/src/analysis/timeline/params.test.js
@@ -9,12 +9,12 @@ import {
   DEFAULT_ALPHA,
   DEFAULT_INTERVAL_DECAY,
 } from "./params";
-import {defaultWeights} from "../weights";
+import {Weights} from "../weights";
 import {NodeAddress} from "../../core/graph";
 
 describe("analysis/timeline/params", () => {
   const customWeights = () => {
-    const weights = defaultWeights();
+    const weights = new Weights();
     // Ensure it works with non-default weights
     weights.nodeManualWeights.set(NodeAddress.empty, 33);
     return weights;
@@ -35,7 +35,7 @@ describe("analysis/timeline/params", () => {
     const expected: TimelineCredParameters = {
       alpha: DEFAULT_ALPHA,
       intervalDecay: DEFAULT_INTERVAL_DECAY,
-      weights: defaultWeights(),
+      weights: new Weights(),
     };
     expect(defaultParams()).toEqual(expected);
   });
@@ -46,7 +46,7 @@ describe("analysis/timeline/params", () => {
     });
     it("accepts an alpha override", () => {
       const params = partialParams({alpha: 0.99});
-      expect(params.weights).toEqual(defaultWeights());
+      expect(params.weights).toEqual(new Weights());
       expect(params.alpha).toEqual(0.99);
       expect(params.intervalDecay).toEqual(DEFAULT_INTERVAL_DECAY);
     });
@@ -59,7 +59,7 @@ describe("analysis/timeline/params", () => {
     });
     it("accepts intervalDecay override", () => {
       const params = partialParams({intervalDecay: 0.1});
-      expect(params.weights).toEqual(defaultWeights());
+      expect(params.weights).toEqual(new Weights());
       expect(params.alpha).toEqual(DEFAULT_ALPHA);
       expect(params.intervalDecay).toEqual(0.1);
     });

--- a/src/analysis/weightEvaluator.test.js
+++ b/src/analysis/weightEvaluator.test.js
@@ -3,7 +3,7 @@
 import deepFreeze from "deep-freeze";
 import {NodeAddress, EdgeAddress} from "../core/graph";
 import {nodeWeightEvaluator, edgeWeightEvaluator} from "./weightEvaluator";
-import {defaultWeights} from "./weights";
+import {Weights} from "./weights";
 
 describe("src/analysis/weightEvaluator", () => {
   describe("nodeWeightEvaluator", () => {
@@ -30,18 +30,18 @@ describe("src/analysis/weightEvaluator", () => {
     const types = deepFreeze([fooNodeType, fooBarNodeType]);
 
     it("gives every node weight 1 with empty types and weights", () => {
-      const evaluator = nodeWeightEvaluator([], defaultWeights());
+      const evaluator = nodeWeightEvaluator([], new Weights());
       expect(evaluator(empty)).toEqual(1);
       expect(evaluator(foo)).toEqual(1);
     });
     it("matches the most specific possible node type", () => {
-      const evaluator = nodeWeightEvaluator(types, defaultWeights());
+      const evaluator = nodeWeightEvaluator(types, new Weights());
       expect(evaluator(empty)).toEqual(1);
       expect(evaluator(foo)).toEqual(2);
       expect(evaluator(foobar)).toEqual(3);
     });
     it("uses type weight overrides", () => {
-      const weights = defaultWeights();
+      const weights = new Weights();
       weights.nodeTypeWeights.set(foo, 3);
       weights.nodeTypeWeights.set(foobar, 4);
       const evaluator = nodeWeightEvaluator(types, weights);
@@ -50,7 +50,7 @@ describe("src/analysis/weightEvaluator", () => {
       expect(evaluator(foobar)).toEqual(4);
     });
     it("uses manually-specified weights", () => {
-      const weights = defaultWeights();
+      const weights = new Weights();
       weights.nodeManualWeights.set(foo, 3);
       const evaluator = nodeWeightEvaluator([], weights);
       expect(evaluator(empty)).toEqual(1);
@@ -58,7 +58,7 @@ describe("src/analysis/weightEvaluator", () => {
       expect(evaluator(foobar)).toEqual(1);
     });
     it("composes manual and type weights multiplicatively", () => {
-      const weights = defaultWeights();
+      const weights = new Weights();
       weights.nodeManualWeights.set(foo, 3);
       const evaluator = nodeWeightEvaluator(types, weights);
       weights.nodeManualWeights.set(foo, 3);
@@ -85,13 +85,13 @@ describe("src/analysis/weightEvaluator", () => {
       description: "",
     });
     it("gives default 1,1 weights if no matching type", () => {
-      const evaluator = edgeWeightEvaluator([], defaultWeights());
+      const evaluator = edgeWeightEvaluator([], new Weights());
       expect(evaluator(foo)).toEqual({forwards: 1, backwards: 1});
     });
     it("uses weights for the most specific matching type", () => {
       const evaluator = edgeWeightEvaluator(
         [fooType, fooBarType],
-        defaultWeights()
+        new Weights()
       );
       expect(evaluator(foo)).toEqual({forwards: 2, backwards: 3});
       expect(evaluator(foobar)).toEqual({forwards: 4, backwards: 5});
@@ -101,7 +101,7 @@ describe("src/analysis/weightEvaluator", () => {
       });
     });
     it("uses weight overrides if available", () => {
-      const weights = defaultWeights();
+      const weights = new Weights();
       weights.edgeTypeWeights.set(foo, {forwards: 99, backwards: 101});
       const evaluator = edgeWeightEvaluator([fooType, fooBarType], weights);
       expect(evaluator(foo)).toEqual({forwards: 99, backwards: 101});

--- a/src/analysis/weights.test.js
+++ b/src/analysis/weights.test.js
@@ -2,12 +2,12 @@
 
 import stringify from "json-stable-stringify";
 import {NodeAddress, EdgeAddress} from "../core/graph";
-import {toJSON, fromJSON, defaultWeights, copy} from "./weights";
+import {Weights} from "./weights";
 
 describe("analysis/weights", () => {
   it("copy makes a copy", () => {
-    const w = defaultWeights();
-    const w1 = copy(w);
+    const w = new Weights();
+    const w1 = w.copy();
     w1.nodeTypeWeights.set(NodeAddress.empty, 33);
     w1.edgeTypeWeights.set(EdgeAddress.empty, {forwards: 34, backwards: 39});
     w1.nodeManualWeights.set(NodeAddress.empty, 35);
@@ -18,8 +18,8 @@ describe("analysis/weights", () => {
   });
   describe("toJSON/fromJSON", () => {
     it("works for the default weights", () => {
-      const weights = defaultWeights();
-      const json = toJSON(weights);
+      const weights = new Weights();
+      const json = weights.toJSON();
       const jsonString = stringify(json, {space: 4});
       expect(jsonString).toMatchInlineSnapshot(`
 "[
@@ -37,18 +37,18 @@ describe("analysis/weights", () => {
     }
 ]"
 `);
-      expect(weights).toEqual(fromJSON(json));
+      expect(weights).toEqual(Weights.fromJSON(json));
     });
 
     it("works for non-default weights", () => {
-      const weights = defaultWeights();
+      const weights = new Weights();
       weights.nodeTypeWeights.set(NodeAddress.empty, 32);
       weights.edgeTypeWeights.set(EdgeAddress.empty, {
         forwards: 7,
         backwards: 9,
       });
       weights.nodeManualWeights.set(NodeAddress.fromParts(["foo"]), 42);
-      const json = toJSON(weights);
+      const json = weights.toJSON();
       const jsonString = stringify(json, {space: 4});
       expect(jsonString).toMatchInlineSnapshot(`
 "[
@@ -72,7 +72,7 @@ describe("analysis/weights", () => {
     }
 ]"
 `);
-      expect(weights).toEqual(fromJSON(json));
+      expect(weights).toEqual(Weights.fromJSON(json));
     });
   });
 });

--- a/src/analysis/weightsToEdgeEvaluator.test.js
+++ b/src/analysis/weightsToEdgeEvaluator.test.js
@@ -2,7 +2,7 @@
 
 import deepFreeze from "deep-freeze";
 import {NodeAddress, EdgeAddress} from "../core/graph";
-import {type Weights, defaultWeights} from "./weights";
+import {Weights} from "./weights";
 import {weightsToEdgeEvaluator} from "./weightsToEdgeEvaluator";
 
 describe("analysis/weightsToEdgeEvaluator", () => {
@@ -48,17 +48,17 @@ describe("analysis/weightsToEdgeEvaluator", () => {
   }
 
   it("applies default weights when none are specified", () => {
-    expect(evaluateEdge(defaultWeights())).toEqual({forwards: 1, backwards: 2});
+    expect(evaluateEdge(new Weights())).toEqual({forwards: 1, backwards: 2});
   });
 
   it("only matches the most specific node types", () => {
-    const weights = defaultWeights();
+    const weights = new Weights();
     weights.nodeTypeWeights.set(NodeAddress.empty, 99);
     expect(evaluateEdge(weights)).toEqual({forwards: 99, backwards: 2});
   });
 
   it("takes manually specified edge type weights into account", () => {
-    const weights = defaultWeights();
+    const weights = new Weights();
     // Note that here we grab the fallout edge type. This also verifies that
     // we are doing prefix matching on the types (rather than exact matching).
     weights.edgeTypeWeights.set(EdgeAddress.empty, {
@@ -69,13 +69,13 @@ describe("analysis/weightsToEdgeEvaluator", () => {
   });
 
   it("takes manually specified per-node weights into account", () => {
-    const weights = defaultWeights();
+    const weights = new Weights();
     weights.nodeManualWeights.set(src, 10);
     expect(evaluateEdge(weights)).toEqual({forwards: 1, backwards: 20});
   });
 
   it("uses 1 as a default weight for unmatched nodes and edges", () => {
-    const evaluator = weightsToEdgeEvaluator(defaultWeights(), {
+    const evaluator = weightsToEdgeEvaluator(new Weights(), {
       nodeTypes: [],
       edgeTypes: [],
     });
@@ -83,8 +83,8 @@ describe("analysis/weightsToEdgeEvaluator", () => {
   });
 
   it("ignores extra weights if they do not apply", () => {
-    const withoutExtraWeights = evaluateEdge(defaultWeights());
-    const extraWeights = defaultWeights();
+    const withoutExtraWeights = evaluateEdge(new Weights());
+    const extraWeights = new Weights();
     extraWeights.nodeManualWeights.set(NodeAddress.fromParts(["foo"]), 99);
     extraWeights.nodeTypeWeights.set(NodeAddress.fromParts(["foo"]), 99);
     extraWeights.edgeTypeWeights.set(EdgeAddress.fromParts(["foo"]), {

--- a/src/api/load.test.js
+++ b/src/api/load.test.js
@@ -15,7 +15,7 @@ import {
   loadProject,
 } from "../core/project_io";
 import {makeRepoId} from "../core/repoId";
-import {defaultWeights} from "../analysis/weights";
+import {Weights} from "../analysis/weights";
 import {NodeAddress, Graph} from "../core/graph";
 import {node} from "../core/graphTestUtil";
 import {TestTaskReporter} from "../util/taskReporter";
@@ -66,7 +66,7 @@ describe("api/load", () => {
   });
   deepFreeze(project);
   const githubToken = "EXAMPLE_TOKEN";
-  const weights = defaultWeights();
+  const weights = new Weights();
   // Tweaks the weights so that we can ensure we aren't overriding with default weights
   weights.nodeManualWeights.set(NodeAddress.empty, 33);
   // Deep freeze will freeze the weights, too

--- a/src/cli/common.js
+++ b/src/cli/common.js
@@ -5,7 +5,7 @@ import os from "os";
 import path from "path";
 import deepFreeze from "deep-freeze";
 import fs from "fs-extra";
-import {type Weights, fromJSON as weightsFromJSON} from "../analysis/weights";
+import {Weights} from "../analysis/weights";
 
 import * as NullUtil from "../util/null";
 
@@ -33,7 +33,7 @@ export async function loadWeights(path: string): Promise<Weights> {
   const raw = await fs.readFile(path, "utf-8");
   const weightsJSON = JSON.parse(raw);
   try {
-    return weightsFromJSON(weightsJSON);
+    return Weights.fromJSON(weightsJSON);
   } catch (e) {
     throw new Error(`provided weights file is invalid:\n${e}`);
   }

--- a/src/cli/common.test.js
+++ b/src/cli/common.test.js
@@ -3,7 +3,7 @@
 import path from "path";
 import tmp from "tmp";
 import fs from "fs-extra";
-import {defaultWeights, toJSON as weightsToJSON} from "../analysis/weights";
+import {Weights} from "../analysis/weights";
 import {NodeAddress} from "../core/graph";
 
 import {
@@ -67,11 +67,11 @@ describe("cli/common", () => {
       return name;
     }
     it("works in a simple success case", async () => {
-      const weights = defaultWeights();
+      const weights = new Weights();
       // Make a modification, just to be sure we aren't always loading the
       // default weights.
       weights.nodeManualWeights.set(NodeAddress.empty, 3);
-      const weightsJSON = weightsToJSON(weights);
+      const weightsJSON = weights.toJSON();
       const file = tmpWithContents(weightsJSON);
       const weights_ = await loadWeights(file);
       expect(weights).toEqual(weights_);

--- a/src/cli/discourse.js
+++ b/src/cli/discourse.js
@@ -7,7 +7,7 @@ import dedent from "../util/dedent";
 import {LoggingTaskReporter} from "../util/taskReporter";
 import type {Command} from "./command";
 import * as Common from "./common";
-import {defaultWeights} from "../analysis/weights";
+import {Weights} from "../analysis/weights";
 import {load} from "../api/load";
 import {declaration as discourseDeclaration} from "../plugins/discourse/declaration";
 import {type Project, createProject} from "../core/project";
@@ -88,7 +88,7 @@ const command: Command = async (args, std) => {
     discourseServer: {serverUrl},
   });
   const taskReporter = new LoggingTaskReporter();
-  let weights = defaultWeights();
+  let weights = new Weights();
   if (weightsPath) {
     weights = await Common.loadWeights(weightsPath);
   }

--- a/src/cli/load.js
+++ b/src/cli/load.js
@@ -5,7 +5,7 @@ import dedent from "../util/dedent";
 import {LoggingTaskReporter} from "../util/taskReporter";
 import type {Command} from "./command";
 import * as Common from "./common";
-import {defaultWeights, fromJSON as weightsFromJSON} from "../analysis/weights";
+import {Weights} from "../analysis/weights";
 import {projectFromJSON} from "../core/project";
 import {load} from "../api/load";
 import {specToProject} from "../plugins/github/specToProject";
@@ -107,7 +107,7 @@ const loadCommand: Command = async (args, std) => {
     return die(std, "projects not specified");
   }
 
-  let weights = defaultWeights();
+  let weights = new Weights();
   if (weightsPath) {
     weights = await loadWeightOverrides(weightsPath);
   }
@@ -160,7 +160,7 @@ const loadWeightOverrides = async (path: string) => {
   const raw = await fs.readFile(path, "utf-8");
   const weightsJSON = JSON.parse(raw);
   try {
-    return weightsFromJSON(weightsJSON);
+    return Weights.fromJSON(weightsJSON);
   } catch (e) {
     throw new Error(`provided weights file is invalid:\n${e}`);
   }

--- a/src/cli/load.test.js
+++ b/src/cli/load.test.js
@@ -8,7 +8,7 @@ import {NodeAddress} from "../core/graph";
 import {run} from "./testUtil";
 import loadCommand, {help} from "./load";
 import type {LoadOptions} from "../api/load";
-import {defaultWeights, toJSON as weightsToJSON} from "../analysis/weights";
+import {Weights} from "../analysis/weights";
 import * as Common from "./common";
 import {defaultParams, partialParams} from "../analysis/timeline/params";
 import {declaration as githubDeclaration} from "../plugins/github/declaration";
@@ -119,9 +119,9 @@ describe("cli/load", () => {
     });
 
     it("loads the weights, if provided", async () => {
-      const weights = defaultWeights();
+      const weights = new Weights();
       weights.nodeTypeWeights.set(NodeAddress.empty, 33);
-      const weightsJSON = weightsToJSON(weights);
+      const weightsJSON = weights.toJSON();
       const weightsFile = tmp.tmpNameSync();
       fs.writeFileSync(weightsFile, JSON.stringify(weightsJSON));
       const invocation = run(loadCommand, [

--- a/src/explorer/TimelineExplorer.js
+++ b/src/explorer/TimelineExplorer.js
@@ -2,7 +2,7 @@
 
 import React from "react";
 import deepEqual from "lodash.isequal";
-import {type Weights, copy as weightsCopy} from "../analysis/weights";
+import {Weights} from "../analysis/weights";
 import {type NodeAddressT} from "../core/graph";
 import {TimelineCred} from "../analysis/timeline/timelineCred";
 import {type TimelineCredParameters} from "../analysis/timeline/params";
@@ -49,7 +49,7 @@ export class TimelineExplorer extends React.Component<Props, State> {
       // Set the weights to a copy, to ensure we don't mutate the weights in the
       // initialTimelineCred. This enables e.g. disabling the analyze button
       // when the parameters are unchanged.
-      weights: weightsCopy(weights),
+      weights: weights.copy(),
       loading: false,
       showWeightConfig: false,
       selectedNodeTypePrefix: null,
@@ -60,7 +60,7 @@ export class TimelineExplorer extends React.Component<Props, State> {
     const {alpha, intervalDecay, weights} = this.state;
     // Set the weights to a copy, to ensure that the weights we pass into e.g.
     // analyzeCred are a distinct reference from the one we keep in our state.
-    return {alpha, intervalDecay, weights: weightsCopy(weights)};
+    return {alpha, intervalDecay, weights: weights.copy()};
   }
 
   async analyzeCred() {

--- a/src/explorer/legacy/App.js
+++ b/src/explorer/legacy/App.js
@@ -12,7 +12,7 @@ import {type NodeAddressT} from "../../core/graph";
 import {PagerankTable} from "./pagerankTable/Table";
 import {WeightConfig} from "../weights/WeightConfig";
 import {WeightsFileManager} from "../weights/WeightsFileManager";
-import {type Weights, defaultWeights} from "../../analysis/weights";
+import {Weights} from "../../analysis/weights";
 import {Prefix as GithubPrefix} from "../../plugins/github/nodes";
 import {
   createStateTransitionMachine,
@@ -72,7 +72,7 @@ export function createApp(
       super(props);
       this.state = {
         appState: initialState(this.props.projectId),
-        weights: defaultWeights(),
+        weights: new Weights(),
       };
       this.stateTransitionMachine = createSTM(
         () => this.state.appState,

--- a/src/explorer/legacy/state.test.js
+++ b/src/explorer/legacy/state.test.js
@@ -5,7 +5,7 @@ import {StateTransitionMachine, type AppState} from "./state";
 import {Graph, NodeAddress} from "../../core/graph";
 import {Assets} from "../../webutil/assets";
 import {type EdgeEvaluator} from "../../analysis/pagerank";
-import {defaultWeights} from "../../analysis/weights";
+import {Weights} from "../../analysis/weights";
 import type {
   PagerankNodeDecomposition,
   PagerankOptions,
@@ -147,7 +147,7 @@ describe("explorer/legacy/state", () => {
       const badState = readyToLoadGraph();
       const {stm} = example(badState);
       await expect(
-        stm.runPagerank(defaultWeights(), NodeAddress.empty)
+        stm.runPagerank(new Weights(), NodeAddress.empty)
       ).rejects.toThrow("incorrect state");
     });
     it("can be run when READY_TO_RUN_PAGERANK or PAGERANK_EVALUATED", async () => {
@@ -156,7 +156,7 @@ describe("explorer/legacy/state", () => {
         const {stm, getState, pagerankMock} = example(g);
         const pnd = pagerankNodeDecomposition();
         pagerankMock.mockReturnValue(Promise.resolve(pnd));
-        await stm.runPagerank(defaultWeights(), NodeAddress.empty);
+        await stm.runPagerank(new Weights(), NodeAddress.empty);
         const state = getState();
         if (state.type !== "PAGERANK_EVALUATED") {
           throw new Error("Impossible");
@@ -168,13 +168,13 @@ describe("explorer/legacy/state", () => {
     it("immediately sets loading status", () => {
       const {getState, stm} = example(readyToRunPagerank());
       expect(loading(getState())).toBe("NOT_LOADING");
-      stm.runPagerank(defaultWeights(), NodeAddress.empty);
+      stm.runPagerank(new Weights(), NodeAddress.empty);
       expect(loading(getState())).toBe("LOADING");
     });
     it("calls pagerank with the totalScoreNodePrefix option", async () => {
       const {pagerankMock, stm} = example(readyToRunPagerank());
       const foo = NodeAddress.fromParts(["foo"]);
-      await stm.runPagerank(defaultWeights(), foo);
+      await stm.runPagerank(new Weights(), foo);
       const args = pagerankMock.mock.calls[0];
       expect(args[2].totalScoreNodePrefix).toBe(foo);
     });
@@ -184,7 +184,7 @@ describe("explorer/legacy/state", () => {
       // $ExpectFlowError
       console.error = jest.fn();
       pagerankMock.mockReturnValue(Promise.reject(error));
-      await stm.runPagerank(defaultWeights(), NodeAddress.empty);
+      await stm.runPagerank(new Weights(), NodeAddress.empty);
       const state = getState();
       expect(loading(state)).toBe("FAILED");
       expect(state.type).toBe("READY_TO_RUN_PAGERANK");
@@ -201,7 +201,7 @@ describe("explorer/legacy/state", () => {
       stm.loadTimelineCred.mockResolvedValue(true);
       const assets = new Assets("/gateway/");
       const prefix = NodeAddress.fromParts(["bar"]);
-      const wt = defaultWeights();
+      const wt = new Weights();
       await stm.loadTimelineCredAndRunPagerank(assets, wt, prefix);
       expect(stm.loadTimelineCred).toHaveBeenCalledTimes(1);
       expect(stm.loadTimelineCred).toHaveBeenCalledWith(assets);
@@ -215,11 +215,7 @@ describe("explorer/legacy/state", () => {
       stm.loadTimelineCred.mockResolvedValue(false);
       const assets = new Assets("/gateway/");
       const prefix = NodeAddress.fromParts(["bar"]);
-      await stm.loadTimelineCredAndRunPagerank(
-        assets,
-        defaultWeights(),
-        prefix
-      );
+      await stm.loadTimelineCredAndRunPagerank(assets, new Weights(), prefix);
       expect(stm.loadTimelineCred).toHaveBeenCalledTimes(1);
       expect(stm.runPagerank).toHaveBeenCalledTimes(0);
     });
@@ -228,7 +224,7 @@ describe("explorer/legacy/state", () => {
       (stm: any).loadTimelineCred = jest.fn();
       (stm: any).runPagerank = jest.fn();
       const prefix = NodeAddress.fromParts(["bar"]);
-      const wt = defaultWeights();
+      const wt = new Weights();
       await stm.loadTimelineCredAndRunPagerank(
         new Assets("/gateway/"),
         wt,
@@ -243,7 +239,7 @@ describe("explorer/legacy/state", () => {
       (stm: any).loadTimelineCred = jest.fn();
       (stm: any).runPagerank = jest.fn();
       const prefix = NodeAddress.fromParts(["bar"]);
-      const wt = defaultWeights();
+      const wt = new Weights();
       await stm.loadTimelineCredAndRunPagerank(
         new Assets("/gateway/"),
         wt,

--- a/src/explorer/weights/WeightsFileManager.js
+++ b/src/explorer/weights/WeightsFileManager.js
@@ -5,7 +5,7 @@ import React from "react";
 import {FileUploader} from "../../util/FileUploader";
 import Link from "../../webutil/Link";
 import {MdFileDownload, MdFileUpload} from "react-icons/md";
-import {type Weights, toJSON, fromJSON} from "../../analysis/weights";
+import {Weights} from "../../analysis/weights";
 
 export type Props = {|
   +weights: Weights,
@@ -13,8 +13,9 @@ export type Props = {|
 |};
 export class WeightsFileManager extends React.Component<Props> {
   render() {
-    const weightsJSON = stringify(toJSON(this.props.weights));
-    const onUpload = (json) => this.props.onWeightsChange(fromJSON(json));
+    const weightsJSON = stringify(this.props.weights.toJSON());
+    const onUpload = (json) =>
+      this.props.onWeightsChange(Weights.fromJSON(json));
     return (
       <div>
         <Link


### PR DESCRIPTION
Currently, Weights are tracked as a raw object, and there are a lot of
'floating' functions in the weights module which allow copying or
serializing them. This commit reorganizes the module around a Weights
class, which has attached methods instead of floating functions.

The resulting APIs are isomorphic, but consumers of Weights need only
import a single class rather than a smattering of functions.

This commit is a prelude to future work around packaging Weights with
Graphs, both to make it possible to compute scores without needing
plugin declarations, and so that plugins can specify weights for
specific nodes (e.g. initiatives).

Test plan: `yarn test` is sufficient for this refactor.