### PR TITLE
CI: make sure we log in for tagged-releases

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -124,7 +124,6 @@ workflows:
             - test
             - test_full
             - test_full_10
-          deploy: false
           image: sourcecred/sourcecred
           tag: latest
           cache_from: node:12,sourcecred/sourcecred:dev


### PR DESCRIPTION
Over at https://github.com/sourcecred/sourcecred/pull/1514#discussion_r365443659
I suggested adding `deploy: false` to be less surprising with the tags we're pushing to DockerHub.
As mentioned in #1512, we actually need `publish: true` to log in with DockerHub.

Test plan:
Compare with a push to `master`, to see our credentials are correct for pushing `:dev`.
https://circleci.com/gh/sourcecred/sourcecred/4422

With the tagged deploy.
https://circleci.com/gh/sourcecred/sourcecred/4426