### PR TITLE
UniRef: add urlReferenceMap to RelationalView

### DIFF
--- a/src/plugins/github/__snapshots__/relationalView.test.js.snap
+++ b/src/plugins/github/__snapshots__/relationalView.test.js.snap
@@ -824,3 +824,48 @@ Array [
   },
 ]
 `;
+
+exports[`plugins/github/relationalView urlReferenceMap should match example snapshot 1`] = `
+Array [
+  Array [
+    "https://github.com/credbot",
+    "NodeAddress[\\"sourcecred\\",\\"github\\",\\"USERLIKE\\",\\"BOT\\",\\"credbot\\"]",
+  ],
+  Array [
+    "https://github.com/decentralion",
+    "NodeAddress[\\"sourcecred\\",\\"github\\",\\"USERLIKE\\",\\"USER\\",\\"decentralion\\"]",
+  ],
+  Array [
+    "https://github.com/sourcecred-test/example-github",
+    "NodeAddress[\\"sourcecred\\",\\"github\\",\\"REPO\\",\\"sourcecred-test\\",\\"example-github\\"]",
+  ],
+  Array [
+    "https://github.com/sourcecred-test/example-github/commit/0a223346b4e6dec0127b1e6aa892c4ee0424b66a",
+    "NodeAddress[\\"sourcecred\\",\\"github\\",\\"COMMIT\\",\\"MDY6Q29tbWl0MTIzMjU1MDA2OjBhMjIzMzQ2YjRlNmRlYzAxMjdiMWU2YWE4OTJjNGVlMDQyNGI2NmE=\\"]",
+  ],
+  Array [
+    "https://github.com/sourcecred-test/example-github/issues/1",
+    "NodeAddress[\\"sourcecred\\",\\"github\\",\\"ISSUE\\",\\"sourcecred-test\\",\\"example-github\\",\\"1\\"]",
+  ],
+  Array [
+    "https://github.com/sourcecred-test/example-github/issues/2#issuecomment-373768703",
+    "NodeAddress[\\"sourcecred\\",\\"github\\",\\"COMMENT\\",\\"ISSUE\\",\\"sourcecred-test\\",\\"example-github\\",\\"2\\",\\"373768703\\"]",
+  ],
+  Array [
+    "https://github.com/sourcecred-test/example-github/pull/3",
+    "NodeAddress[\\"sourcecred\\",\\"github\\",\\"PULL\\",\\"sourcecred-test\\",\\"example-github\\",\\"3\\"]",
+  ],
+  Array [
+    "https://github.com/sourcecred-test/example-github/pull/3#issuecomment-369162222",
+    "NodeAddress[\\"sourcecred\\",\\"github\\",\\"COMMENT\\",\\"PULL\\",\\"sourcecred-test\\",\\"example-github\\",\\"3\\",\\"369162222\\"]",
+  ],
+  Array [
+    "https://github.com/sourcecred-test/example-github/pull/5#discussion_r171460198",
+    "NodeAddress[\\"sourcecred\\",\\"github\\",\\"COMMENT\\",\\"REVIEW\\",\\"sourcecred-test\\",\\"example-github\\",\\"5\\",\\"100313899\\",\\"171460198\\"]",
+  ],
+  Array [
+    "https://github.com/sourcecred-test/example-github/pull/5#pullrequestreview-100313899",
+    "NodeAddress[\\"sourcecred\\",\\"github\\",\\"REVIEW\\",\\"sourcecred-test\\",\\"example-github\\",\\"5\\",\\"100313899\\"]",
+  ],
+]
+`;

--- a/src/plugins/github/relationalView.test.js
+++ b/src/plugins/github/relationalView.test.js
@@ -1,5 +1,6 @@
 // @flow
 
+import {NodeAddress} from "../../core/graph";
 import * as R from "./relationalView";
 import * as N from "./nodes";
 import {exampleRepository, exampleRelationalView} from "./example/example";
@@ -387,6 +388,40 @@ describe("plugins/github/relationalView", () => {
       const view1 = R.RelationalView.fromJSON(json1);
       const json2 = view1.toJSON();
       expect(json1).toEqual(json2);
+    });
+  });
+
+  describe("urlReferenceMap", () => {
+    it("should match example snapshot", () => {
+      // Given
+      const rv = exampleRelationalView();
+
+      // When
+      const map = rv.urlReferenceMap();
+
+      // Then
+      const snapshotMapWith = (urls: string[]): [string, ?string][] => {
+        // Sort, for less test flakes.
+        // Remove null bytes from NodeAddress.
+        // Generate selective [key, value] tuples.
+        urls.sort();
+        const maybeString = (a) => (a ? NodeAddress.toString(a) : a);
+        return urls.map((url) => [url, maybeString(map.get(url))]);
+      };
+      expect(
+        snapshotMapWith([
+          "https://github.com/decentralion",
+          "https://github.com/credbot",
+          "https://github.com/sourcecred-test/example-github",
+          "https://github.com/sourcecred-test/example-github/issues/1",
+          "https://github.com/sourcecred-test/example-github/pull/3",
+          "https://github.com/sourcecred-test/example-github/pull/5#pullrequestreview-100313899",
+          "https://github.com/sourcecred-test/example-github/issues/2#issuecomment-373768703",
+          "https://github.com/sourcecred-test/example-github/pull/3#issuecomment-369162222",
+          "https://github.com/sourcecred-test/example-github/pull/5#discussion_r171460198",
+          "https://github.com/sourcecred-test/example-github/commit/0a223346b4e6dec0127b1e6aa892c4ee0424b66a",
+        ])
+      ).toMatchSnapshot();
     });
   });
 


### PR DESCRIPTION
`RelationalView` provides easy access to `ReferentEntities`, which we can use for reference detection. The map produced by `urlReferenceMap` can be used easily by a `MappedReferenceDetector`.

As discussed in #1532 we'll use `RelationalView` for this before deprecating it.

Test plan: `yarn unit`