### PR TITLE
lint: require camel case variables

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -21,6 +21,7 @@ module.exports = {
     "plugin:flowtype/recommended",
   ],
   rules: {
+    camelcase: ["error", {properties: "never", allow: ["^_unused_.*"]}],
     "no-unused-vars": [
       "warn",
       {

--- a/src/cli/main.js
+++ b/src/cli/main.js
@@ -17,6 +17,7 @@ export default function main(): Promise<void> {
 // Only run in the Webpack bundle, not as a Node module (during tests).
 /* istanbul ignore next */
 /*:: declare var __webpack_require__: mixed; */
+// eslint-disable-next-line camelcase
 if (typeof __webpack_require__ !== "undefined") {
   main();
 }

--- a/src/core/graph.test.js
+++ b/src/core/graph.test.js
@@ -906,10 +906,10 @@ describe("core/graph", () => {
       // It's included so we can verify it has no neighbors.
       const halfIsolated = partsNode(["halfIsolated"]);
 
-      const foo_loop = partsEdge(["foo", "1"], foo, loop);
-      const loop_foo = partsEdge(["foo", "2"], loop, foo);
-      const loop_loop = partsEdge(["loop"], loop, loop);
-      const repeated_loop_foo = partsEdge(["repeated", "foo"], loop, foo);
+      const fooLoop = partsEdge(["foo", "1"], foo, loop);
+      const loopFoo = partsEdge(["foo", "2"], loop, foo);
+      const loopLoop = partsEdge(["loop"], loop, loop);
+      const repeatedLoopFoo = partsEdge(["repeated", "foo"], loop, foo);
       const dangling = partsEdge(
         ["dangling"],
         halfIsolated,
@@ -922,10 +922,10 @@ describe("core/graph", () => {
           .addNode(loop)
           .addNode(isolated)
           .addNode(halfIsolated)
-          .addEdge(foo_loop)
-          .addEdge(loop_foo)
-          .addEdge(loop_loop)
-          .addEdge(repeated_loop_foo)
+          .addEdge(fooLoop)
+          .addEdge(loopFoo)
+          .addEdge(loopLoop)
+          .addEdge(repeatedLoopFoo)
           .addEdge(dangling);
       }
 
@@ -995,8 +995,8 @@ describe("core/graph", () => {
             [],
             [],
             [
-              {node: loop, edge: loop_loop},
-              {node: foo, edge: foo_loop},
+              {node: loop, edge: loopLoop},
+              {node: foo, edge: fooLoop},
             ]
           );
         });
@@ -1006,9 +1006,9 @@ describe("core/graph", () => {
             [],
             [],
             [
-              {node: loop, edge: loop_loop},
-              {node: foo, edge: repeated_loop_foo},
-              {node: foo, edge: loop_foo},
+              {node: loop, edge: loopLoop},
+              {node: foo, edge: repeatedLoopFoo},
+              {node: foo, edge: loopFoo},
             ]
           );
         });
@@ -1019,10 +1019,10 @@ describe("core/graph", () => {
             [],
             [],
             [
-              {node: loop, edge: loop_loop},
-              {node: foo, edge: repeated_loop_foo},
-              {node: foo, edge: loop_foo},
-              {node: foo, edge: foo_loop},
+              {node: loop, edge: loopLoop},
+              {node: foo, edge: repeatedLoopFoo},
+              {node: foo, edge: loopFoo},
+              {node: foo, edge: fooLoop},
             ]
           );
         });
@@ -1041,15 +1041,15 @@ describe("core/graph", () => {
           );
         }
         it("returns nodes exactly matching prefix", () => {
-          nodeExpectNeighbors(["loop"], [{node: loop, edge: loop_loop}]);
+          nodeExpectNeighbors(["loop"], [{node: loop, edge: loopLoop}]);
         });
         it("returns nodes inexactly matching prefix", () => {
           nodeExpectNeighbors(
             ["foo"],
             [
-              {node: foo, edge: loop_foo},
-              {node: foo, edge: foo_loop},
-              {node: foo, edge: repeated_loop_foo},
+              {node: foo, edge: loopFoo},
+              {node: foo, edge: fooLoop},
+              {node: foo, edge: repeatedLoopFoo},
             ]
           );
         });
@@ -1073,15 +1073,15 @@ describe("core/graph", () => {
         it("works for an exact address match", () => {
           edgeExpectNeighbors(
             ["repeated", "foo"],
-            [{node: foo, edge: repeated_loop_foo}]
+            [{node: foo, edge: repeatedLoopFoo}]
           );
         });
         it("works for a proper prefix match", () => {
           edgeExpectNeighbors(
             ["foo"],
             [
-              {node: foo, edge: foo_loop},
-              {node: foo, edge: loop_foo},
+              {node: foo, edge: fooLoop},
+              {node: foo, edge: loopFoo},
             ]
           );
         });
@@ -1098,7 +1098,7 @@ describe("core/graph", () => {
             nodePrefix: NodeAddress.fromParts(["foo"]),
             edgePrefix: EdgeAddress.fromParts(["repeated"]),
           },
-          [{node: foo, edge: repeated_loop_foo}]
+          [{node: foo, edge: repeatedLoopFoo}]
         );
       });
 
@@ -1295,13 +1295,13 @@ describe("core/graph", () => {
         .addNode(bar)
         .addEdge(foobar);
       const g2 = new Graph().addNode(zod);
-      const g3_actual = Graph.merge([g1, g2]);
-      const g3_expected = new Graph()
+      const g3Actual = Graph.merge([g1, g2]);
+      const g3Expected = new Graph()
         .addNode(foo)
         .addNode(bar)
         .addNode(zod)
         .addEdge(foobar);
-      expect(g3_actual.equals(g3_expected)).toBe(true);
+      expect(g3Actual.equals(g3Expected)).toBe(true);
     });
     it("merges two graphs with nontrivial intersection", () => {
       const g1 = new Graph()
@@ -1314,15 +1314,15 @@ describe("core/graph", () => {
         .addNode(zod)
         .addEdge(zodfoo)
         .addEdge(foofoo);
-      const g3_actual = Graph.merge([g1, g2]);
-      const g3_expected = new Graph()
+      const g3Actual = Graph.merge([g1, g2]);
+      const g3Expected = new Graph()
         .addNode(foo)
         .addNode(bar)
         .addNode(zod)
         .addEdge(foobar)
         .addEdge(zodfoo)
         .addEdge(foofoo);
-      expect(g3_actual.equals(g3_expected)).toBe(true);
+      expect(g3Actual.equals(g3Expected)).toBe(true);
     });
     it("merges many graphs", () => {
       const graphs = [];

--- a/src/core/graphTestUtil.js
+++ b/src/core/graphTestUtil.js
@@ -73,7 +73,7 @@ export function advancedGraph() {
   const hom1 = partsEdge(["hom", "1"], src, dst);
   const hom2 = partsEdge(["hom", "2"], src, dst);
   const loop = node("loop");
-  const loop_loop = edge("loop", loop, loop);
+  const loopLoop = edge("loop", loop, loop);
 
   const halfIsolated = node("halfIsolated");
   const phantomNode = node("phantom");
@@ -89,7 +89,7 @@ export function advancedGraph() {
       .addNode(isolated)
       .addEdge(hom1)
       .addEdge(hom2)
-      .addEdge(loop_loop)
+      .addEdge(loopLoop)
       .addNode(halfIsolated)
       .addEdge(halfDanglingEdge)
       .addEdge(fullDanglingEdge);
@@ -156,17 +156,17 @@ export function advancedGraph() {
       .addNode(loop)
       // N: [src, halfIsolated, dst, isolated, loop]
       // E: [halfDanglingEdge, fullDanglingEdge, hom2]
-      .addEdge(loop_loop)
+      .addEdge(loopLoop)
       // N: [src, halfIsolated, dst, isolated, loop]
-      // E: [halfDanglingEdge, fullDanglingEdge, hom2, loop_loop]
+      // E: [halfDanglingEdge, fullDanglingEdge, hom2, loopLoop]
       .addEdge(hom1);
   //     N: [src, halfIsolated, dst, isolated, loop]
-  //     E: [halfDanglingEdge, fullDanglingEdge, hom2, loop_loop, hom1]
+  //     E: [halfDanglingEdge, fullDanglingEdge, hom2, loopLoop, hom1]
   const nodes = {src, dst, loop, isolated, phantomNode, halfIsolated};
   const edges = {
     hom1,
     hom2,
-    loop_loop,
+    loopLoop,
     phantomEdge1,
     phantomEdge2,
     halfDanglingEdge,

--- a/src/core/project.js
+++ b/src/core/project.js
@@ -24,10 +24,10 @@ export type ProjectId = string;
  * the future (e.g. showing the last update time for each of the project's data
  * dependencies).
  */
-export type Project = Project_v040;
-export type SupportedProject = Project_v030 | Project_v031 | Project_v040;
+export type Project = ProjectV040;
+export type SupportedProject = ProjectV030 | ProjectV031 | ProjectV040;
 
-type Project_v040 = {|
+type ProjectV040 = {|
   +id: ProjectId,
   +repoIds: $ReadOnlyArray<RepoId>,
   +discourseServer: DiscourseServer | null,
@@ -72,13 +72,13 @@ export function encodeProjectId(id: ProjectId): string {
   return base64url.encode(id);
 }
 
-const upgradeFrom030 = (p: Project_v030 | Project_v031): Project_v040 => ({
+const upgradeFrom030 = (p: ProjectV030 | ProjectV031): ProjectV040 => ({
   ...p,
   discourseServer:
     p.discourseServer != null ? {serverUrl: p.discourseServer.serverUrl} : null,
 });
 
-type Project_v031 = {|
+type ProjectV031 = {|
   +id: ProjectId,
   +repoIds: $ReadOnlyArray<RepoId>,
   +discourseServer: {|
@@ -88,7 +88,7 @@ type Project_v031 = {|
   +identities: $ReadOnlyArray<Identity>,
 |};
 
-type Project_v030 = {|
+type ProjectV030 = {|
   +id: ProjectId,
   +repoIds: $ReadOnlyArray<RepoId>,
   +discourseServer: {|

--- a/src/tools/execDependencyGraph.js
+++ b/src/tools/execDependencyGraph.js
@@ -6,7 +6,7 @@
 // and we use the Flow comment syntax instead of the inline syntax.
 
 const chalk = require("chalk");
-const child_process = require("child_process");
+const {execFile} = require("child_process");
 
 /*::
 export type TaskId = string;
@@ -219,7 +219,7 @@ function processTask(task /*: Task */) /*: Promise<TaskResult> */ {
   const file = task.cmd[0];
   const args = task.cmd.slice(1);
   return new Promise((resolve, _unused_reject) => {
-    child_process.execFile(file, args, (error, stdout, stderr) => {
+    execFile(file, args, (error, stdout, stderr) => {
       resolve({
         id: task.id,
         success: !error,


### PR DESCRIPTION
Summary:
We’ve had this policy unspoken since the beginning; making it explicit
as a lint rule makes it one less thing to think about. The few existing
offenders can almost all be changed with no value lost; one is an extern
that needs a lint suppression.

Test Plan:
That Flow and tests still pass suffices.

wchargin-branch: lint-camelcase