### PR TITLE
Backend: create DataDirectory class

### DIFF
--- a/src/backend/cache.js
+++ b/src/backend/cache.js
@@ -1,0 +1,17 @@
+//@flow
+
+import Database from "better-sqlite3";
+
+/**
+ * A cache abstraction which plugins can use to store mirroring data in.
+ */
+export interface CacheProvider {
+  /**
+   * Opens a new Database handle.
+   * Given the same `id`, an existing Database from the cache *may* be provided.
+   *
+   * Make sure the `id` you're using is both _deterministic_ and doesn't
+   * conflict with other plugins.
+   */
+  database(id: string): Promise<Database>;
+}

--- a/src/backend/dataDirectory.js
+++ b/src/backend/dataDirectory.js
@@ -1,0 +1,50 @@
+// @flow
+
+import path from "path";
+import fs from "fs-extra";
+import Database from "better-sqlite3";
+import stringify from "json-stable-stringify";
+import {type Project, projectToJSON} from "../core/project";
+import {directoryForProjectId} from "../core/project_io";
+import {type CacheProvider} from "./cache";
+import type {
+  ProjectStorageProvider,
+  ProjectStorageExtras,
+} from "./projectStorage";
+
+/**
+ * Represents a SourceCred data directory.
+ */
+export class DataDirectory implements CacheProvider, ProjectStorageProvider {
+  +_sourcecredDirectory: string;
+  +_cacheDirectory: string;
+
+  constructor(sourcecredDirectory: string) {
+    this._sourcecredDirectory = sourcecredDirectory;
+    this._cacheDirectory = path.join(sourcecredDirectory, "cache");
+  }
+
+  async database(id: string): Promise<Database> {
+    await fs.mkdirp(this._cacheDirectory);
+    const file = path.join(this._cacheDirectory, `${id}.db`);
+    return new Database(file);
+  }
+
+  async storeProject(
+    project: Project,
+    {graph, cred}: ProjectStorageExtras
+  ): Promise<void> {
+    const projectDirectory = directoryForProjectId(
+      project.id,
+      this._sourcecredDirectory
+    );
+    await fs.mkdirp(projectDirectory);
+    const writeFile = async (name: string, data: string) => {
+      const fileName = path.join(projectDirectory, name);
+      await fs.writeFile(fileName, data);
+    };
+    writeFile("project.json", stringify(projectToJSON(project)));
+    if (graph) writeFile("graph.json", stringify(graph.toJSON()));
+    if (cred) writeFile("cred.json", stringify(cred.toJSON()));
+  }
+}

--- a/src/backend/dataDirectory.test.js
+++ b/src/backend/dataDirectory.test.js
@@ -1,0 +1,157 @@
+// @flow
+
+import tmp from "tmp";
+import path from "path";
+import fs from "fs-extra";
+import Database from "better-sqlite3";
+import {createProject, projectToJSON, encodeProjectId} from "../core/project";
+import {type CacheProvider} from "./cache";
+import {type ProjectStorageProvider} from "./projectStorage";
+import {DataDirectory} from "./dataDirectory";
+
+const project = createProject({id: "testing-project"});
+
+const fakeGraph = ({
+  toJSON: () => ({is: "fake-graph"}),
+}: any);
+
+const fakeCred = ({
+  toJSON: () => ({is: "fake-cred"}),
+}: any);
+
+const fakeExtras = {
+  graph: fakeGraph,
+  cred: fakeCred,
+};
+
+describe("src/backend/dataDirectory", () => {
+  describe("DataDirectory", () => {
+    it("should be a CacheProvider", () => {
+      const _ = (x: DataDirectory): CacheProvider => x;
+    });
+    it("should be a ProjectStorageProvider", () => {
+      const _ = (x: DataDirectory): ProjectStorageProvider => x;
+    });
+
+    describe("DataDirectory.database", () => {
+      it("should create SQLite DB in the cache directory", async () => {
+        // Given
+        const sourcecredDirectory = tmp.dirSync().name;
+        const id = "test-db-id";
+
+        // When
+        const data = new DataDirectory(sourcecredDirectory);
+        const db = await data.database(id);
+
+        // Then
+        expect(db).toBeInstanceOf(Database);
+        const dbFile = path.join(sourcecredDirectory, "cache", `${id}.db`);
+        await fs.stat(dbFile);
+      });
+
+      it("should work when sourcecredDirectory doesn't exist", async () => {
+        // Given
+        const sourcecredDirectory = path.join(
+          tmp.dirSync().name,
+          "sourcecred_data_test"
+        );
+        const id = "test-db-id";
+
+        // When
+        const data = new DataDirectory(sourcecredDirectory);
+        const db = await data.database(id);
+
+        // Then
+        expect(db).toBeInstanceOf(Database);
+        const dbFile = path.join(sourcecredDirectory, "cache", `${id}.db`);
+        await fs.stat(dbFile);
+      });
+
+      it("should fail when sourcecredDirectory is a file", async () => {
+        // Given
+        const sourcecredDirectory = path.join(
+          tmp.dirSync().name,
+          "sourcecred_data_test"
+        );
+        await fs.writeFile(sourcecredDirectory, "blocking file");
+        const id = "test-db-id";
+
+        // When
+        const data = new DataDirectory(sourcecredDirectory);
+        const p = data.database(id);
+
+        // Then
+        await expect(p).rejects.toThrow("ENOTDIR:");
+      });
+    });
+
+    describe("DataDirectory.storeProject", () => {
+      it("should populate a project directory", async () => {
+        // Given
+        const sourcecredDirectory = tmp.dirSync().name;
+
+        // When
+        const data = new DataDirectory(sourcecredDirectory);
+        await data.storeProject(project, fakeExtras);
+
+        // Then
+        const expectedProjectDirectory = path.join(
+          sourcecredDirectory,
+          "projects",
+          encodeProjectId(project.id)
+        );
+        const expectJSONFile = async (name: string, expected: any) => {
+          const filePath = path.join(expectedProjectDirectory, name);
+          const actual = JSON.parse(await fs.readFile(filePath));
+          expect(actual).toEqual(expected);
+        };
+        await expectJSONFile("project.json", projectToJSON(project));
+        await expectJSONFile("graph.json", fakeGraph.toJSON());
+        await expectJSONFile("cred.json", fakeCred.toJSON());
+      });
+
+      it("should work when sourcecredDirectory doesn't exist", async () => {
+        // Given
+        const sourcecredDirectory = path.join(
+          tmp.dirSync().name,
+          "sourcecred_data_test"
+        );
+
+        // When
+        const data = new DataDirectory(sourcecredDirectory);
+        await data.storeProject(project, fakeExtras);
+
+        // Then
+        const expectedProjectDirectory = path.join(
+          sourcecredDirectory,
+          "projects",
+          encodeProjectId(project.id)
+        );
+        const expectJSONFile = async (name: string, expected: any) => {
+          const filePath = path.join(expectedProjectDirectory, name);
+          const actual = JSON.parse(await fs.readFile(filePath));
+          expect(actual).toEqual(expected);
+        };
+        await expectJSONFile("project.json", projectToJSON(project));
+        await expectJSONFile("graph.json", fakeGraph.toJSON());
+        await expectJSONFile("cred.json", fakeCred.toJSON());
+      });
+
+      it("should fail when sourcecredDirectory is a file", async () => {
+        // Given
+        const sourcecredDirectory = path.join(
+          tmp.dirSync().name,
+          "sourcecred_data_test"
+        );
+        await fs.writeFile(sourcecredDirectory, "blocking file");
+
+        // When
+        const data = new DataDirectory(sourcecredDirectory);
+        const p = data.storeProject(project, fakeExtras);
+
+        // Then
+        await expect(p).rejects.toThrow("ENOTDIR:");
+      });
+    });
+  });
+});

--- a/src/backend/projectStorage.js
+++ b/src/backend/projectStorage.js
@@ -1,0 +1,14 @@
+//@flow
+
+import {Graph} from "../core/graph";
+import {TimelineCred} from "../analysis/timeline/timelineCred";
+import {type Project} from "../core/project";
+
+export type ProjectStorageExtras = {
+  +graph?: Graph,
+  +cred?: TimelineCred,
+};
+
+export interface ProjectStorageProvider {
+  storeProject(project: Project, extras: ProjectStorageExtras): Promise<void>;
+}


### PR DESCRIPTION
Currently the responsibility for the SourceCred directory
is spread out in different places. Some in core/project_io
some in api/load, some in the plugins.

This class is intended to centralize that IO using simple
interfaces we can depend on (and mock) instead.