### PR TITLE
Backend: introduce LoadPlan

### DIFF
--- a/src/backend/cache.js
+++ b/src/backend/cache.js
@@ -1,0 +1,17 @@
+//@flow
+
+import Database from "better-sqlite3";
+
+/**
+ * A cache abstraction which plugins can use to store mirroring data in.
+ */
+export interface CacheProvider {
+  /**
+   * Opens a new Database handle.
+   * Given the same `id`, an existing Database from the cache *may* be provided.
+   *
+   * Make sure the `id` you're using is both _deterministic_ and doesn't
+   * conflict with other plugins.
+   */
+  database(id: string): Promise<Database>;
+}

--- a/src/backend/dataDirectory.js
+++ b/src/backend/dataDirectory.js
@@ -1,0 +1,47 @@
+// @flow
+
+import path from "path";
+import fs from "fs-extra";
+import Database from "better-sqlite3";
+import stringify from "json-stable-stringify";
+import {type Project, projectToJSON} from "../core/project";
+import {directoryForProjectId} from "../core/project_io";
+import {type CacheProvider} from "./cache";
+import type {ProjectStorageProvider, ProjectStorageExtras} from "./project";
+
+/**
+ * Represents a SourceCred data directory.
+ */
+export class DataDirectory implements CacheProvider, ProjectStorageProvider {
+  sourcecredDirectory: string;
+  cacheDirectory: string;
+
+  constructor(sourcecredDirectory: string) {
+    this.sourcecredDirectory = sourcecredDirectory;
+    this.cacheDirectory = path.join(sourcecredDirectory, "cache");
+  }
+
+  async database(id: string): Promise<Database> {
+    await fs.mkdirp(this.cacheDirectory);
+    const file = path.join(this.cacheDirectory, `${id}.db`);
+    return new Database(file);
+  }
+
+  async storeProject(
+    project: Project,
+    {graph, cred}: ProjectStorageExtras
+  ): Promise<void> {
+    const projectDirectory = directoryForProjectId(
+      project.id,
+      this.sourcecredDirectory
+    );
+    await fs.mkdirp(projectDirectory);
+    const writeFile = async (name: string, data: string) => {
+      const fileName = path.join(projectDirectory, name);
+      await fs.writeFile(fileName, data);
+    };
+    writeFile("project.json", stringify(projectToJSON(project)));
+    if (graph) writeFile("graph.json", stringify(graph.toJSON()));
+    if (cred) writeFile("cred.json", stringify(cred.toJSON()));
+  }
+}

--- a/src/backend/dataDirectory.test.js
+++ b/src/backend/dataDirectory.test.js
@@ -1,0 +1,79 @@
+// @flow
+
+import tmp from "tmp";
+import path from "path";
+import fs from "fs-extra";
+import Database from "better-sqlite3";
+import {createProject, projectToJSON, encodeProjectId} from "../core/project";
+import {type CacheProvider} from "./cache";
+import {type ProjectStorageProvider} from "./project";
+import {DataDirectory} from "./dataDirectory";
+
+const project = createProject({id: "testing-project"});
+
+const fakeGraph = ({
+  toJSON: () => ({is: "fake-graph"}),
+}: any);
+
+const fakeCred = ({
+  toJSON: () => ({is: "fake-cred"}),
+}: any);
+
+const fakeExtras = {
+  graph: fakeGraph,
+  cred: fakeCred,
+};
+
+describe("src/backend/dataDirectory", () => {
+  describe("DataDirectory", () => {
+    it("should be a CacheProvider", () => {
+      const _ = (x: DataDirectory): CacheProvider => x;
+    });
+    it("should be a ProjectStorageProvider", () => {
+      const _ = (x: DataDirectory): ProjectStorageProvider => x;
+    });
+
+    describe("DataDirectory.database", () => {
+      it("should create SQLite DB in the cache directory", async () => {
+        // Given
+        const sourcecredDirectory = tmp.dirSync().name;
+        const id = "test-db-id";
+
+        // When
+        const data = new DataDirectory(sourcecredDirectory);
+        const db = await data.database(id);
+
+        // Then
+        expect(db).toBeInstanceOf(Database);
+        const dbFile = path.join(sourcecredDirectory, "cache", `${id}.db`);
+        await fs.stat(dbFile);
+      });
+    });
+
+    describe("DataDirectory.storeProject", () => {
+      it("should populate a project directory", async () => {
+        // Given
+        const sourcecredDirectory = tmp.dirSync().name;
+
+        // When
+        const data = new DataDirectory(sourcecredDirectory);
+        await data.storeProject(project, fakeExtras);
+
+        // Then
+        const expectedProjectDirectory = path.join(
+          sourcecredDirectory,
+          "projects",
+          encodeProjectId(project.id)
+        );
+        const expectJSONFile = async (name: string, expected: any) => {
+          const filePath = path.join(expectedProjectDirectory, name);
+          const actual = JSON.parse(await fs.readFile(filePath));
+          expect(actual).toEqual(expected);
+        };
+        await expectJSONFile("project.json", projectToJSON(project));
+        await expectJSONFile("graph.json", fakeGraph.toJSON());
+        await expectJSONFile("cred.json", fakeCred.toJSON());
+      });
+    });
+  });
+});

--- a/src/backend/loadPlan.js
+++ b/src/backend/loadPlan.js
@@ -1,0 +1,50 @@
+//@flow
+
+import {Graph} from "../core/graph";
+import {type Project} from "../core/project";
+import {type TimelineCredParameters} from "../analysis/timeline/params";
+import {TimelineCred} from "../analysis/timeline/timelineCred";
+
+/**
+ * This file introduces a "plan" concept.
+ *
+ * A plan allows us to separate the large amount of dependency injection that's
+ * necessary to load a SourceCred instance. It makes a hard distinction between
+ * which arguments are environment-bound (like the TaskReporter, CacheProvider,
+ * and GithubToken) and which are parameters for the load (like Project).
+ *
+ * A <Something>Plan type only includes the later *parameters for loading*,
+ * because this Plan is typically the output of a factory function which curried
+ * the environment-bound arguments for us.
+ */
+
+export type MirrorPlan = (project: Project) => Promise<void>;
+
+export type GraphPlan = (project: Project) => Promise<Graph>;
+
+export type CredComputationPlan = (
+  graph: Graph,
+  params: ?$Shape<TimelineCredParameters>
+) => Promise<TimelineCred>;
+
+export type LoadPlan = {|
+  +mirror: MirrorPlan,
+  +createGraph: GraphPlan,
+  +computeCred: CredComputationPlan,
+|};
+
+export type LoadResult = {|
+  +graph: Graph,
+  +cred: TimelineCred,
+|};
+
+export async function executePlan(
+  plan: LoadPlan,
+  project: Project,
+  params: ?$Shape<TimelineCredParameters>
+): Promise<LoadResult> {
+  await plan.mirror(project);
+  const graph = await plan.createGraph(project);
+  const cred = await plan.computeCred(graph, params);
+  return {graph, cred};
+}

--- a/src/backend/loadPlan.test.js
+++ b/src/backend/loadPlan.test.js
@@ -1,0 +1,91 @@
+// @flow
+
+import {createProject} from "../core/project";
+import {type LoadPlan, executePlan} from "./loadPlan";
+
+type JestMockFn = $Call<typeof jest.fn>;
+
+const fakeGraph = ({is: "fake-graph"}: any);
+const fakeCred = ({is: "fake-cred"}: any);
+
+const mockLoadPlan = (): LoadPlan => {
+  const mirror = jest.fn();
+  const createGraph = jest.fn();
+  const computeCred = jest.fn();
+  createGraph.mockResolvedValue(fakeGraph);
+  computeCred.mockResolvedValue(fakeCred);
+  return {mirror, createGraph, computeCred};
+};
+
+describe("src/backend/loadPlan", () => {
+  describe("executePlan", () => {
+    const project = createProject({id: "testing-project"});
+    const params = {alpha: 0.123};
+
+    it("should call it's LoadPlan components in order", async () => {
+      // Given
+      const loadPlan = mockLoadPlan();
+
+      // When
+      const update = await executePlan(loadPlan, project, params);
+
+      // Then
+      expect(update).toEqual({graph: fakeGraph, cred: fakeCred});
+      const {mirror, createGraph, computeCred} = loadPlan;
+      expect(mirror).toBeCalledTimes(1);
+      expect(mirror).toBeCalledWith(project);
+      expect(createGraph).toBeCalledTimes(1);
+      expect(createGraph).toBeCalledWith(project);
+      expect(computeCred).toBeCalledTimes(1);
+      expect(computeCred).toBeCalledWith(fakeGraph, params);
+    });
+
+    it("should call mirror first", async () => {
+      // Given
+      const loadPlan = mockLoadPlan();
+      const {mirror, createGraph, computeCred} = loadPlan;
+      (mirror: JestMockFn).mockRejectedValue(new Error("mirror"));
+
+      // When
+      const p = executePlan(loadPlan, project, params);
+
+      // Then
+      await expect(p).rejects.toThrow("mirror");
+      expect(mirror).toBeCalledTimes(1);
+      expect(createGraph).toBeCalledTimes(0);
+      expect(computeCred).toBeCalledTimes(0);
+    });
+
+    it("should call createGraph second", async () => {
+      // Given
+      const loadPlan = mockLoadPlan();
+      const {mirror, createGraph, computeCred} = loadPlan;
+      (createGraph: JestMockFn).mockRejectedValue(new Error("createGraph"));
+
+      // When
+      const p = executePlan(loadPlan, project, params);
+
+      // Then
+      await expect(p).rejects.toThrow("createGraph");
+      expect(mirror).toBeCalledTimes(1);
+      expect(createGraph).toBeCalledTimes(1);
+      expect(computeCred).toBeCalledTimes(0);
+    });
+
+    it("should call computeCred last", async () => {
+      // Given
+      const loadPlan = mockLoadPlan();
+      const {mirror, createGraph, computeCred} = loadPlan;
+      (computeCred: JestMockFn).mockRejectedValue(new Error("computeCred"));
+
+      // When
+      const p = executePlan(loadPlan, project, params);
+
+      // Then
+      await expect(p).rejects.toThrow("computeCred");
+      expect(mirror).toBeCalledTimes(1);
+      expect(createGraph).toBeCalledTimes(1);
+      expect(computeCred).toBeCalledTimes(1);
+    });
+  });
+});

--- a/src/backend/project.js
+++ b/src/backend/project.js
@@ -1,0 +1,14 @@
+//@flow
+
+import {Graph} from "../core/graph";
+import {TimelineCred} from "../analysis/timeline/timelineCred";
+import {type Project} from "../core/project";
+
+export type ProjectStorageExtras = {
+  +graph?: Graph,
+  +cred?: TimelineCred,
+};
+
+export interface ProjectStorageProvider {
+  storeProject(project: Project, extras: ProjectStorageExtras): Promise<void>;
+}


### PR DESCRIPTION
Part of #1559 suggested refactor.

LoadPlan is the key concept which allows us to simplify APIs,
the smaller argument lists make change (and testing) easier.
Additionally since it's DI based, should remove the need for
mocking external modules.