### PR TITLE
Github: add fetchGithubRepoFromCache

### DIFF
--- a/src/plugins/github/loadGraph.js
+++ b/src/plugins/github/loadGraph.js
@@ -10,7 +10,10 @@
 
 import {TaskReporter} from "../../util/taskReporter";
 import {createGraph} from "./createGraph";
-import fetchGithubRepo from "./fetchGithubRepo";
+import {
+  default as fetchGithubRepo,
+  fetchGithubRepoFromCache,
+} from "./fetchGithubRepo";
 import {RelationalView} from "./relationalView";
 import {type RepoId, repoIdToString} from "./repoId";
 import {Graph} from "../../core/graph";
@@ -44,7 +47,12 @@ export async function loadGraph(
       await fetchGithubRepo(repoId, {
         token: options.token,
         cache: options.cache,
-      })
+      }).then((_) =>
+        fetchGithubRepoFromCache(repoId, {
+          token: options.token,
+          cache: options.cache,
+        })
+      )
     );
     taskReporter.finish(taskId);
   }


### PR DESCRIPTION
Depends on #1614

Updating the mirror and using the mirror data should be separated. As unified reference detection requires the mirror of all plugins are updated. Upcoming refactors to the load system will solidify this.

While this refactor is ongoing, we will ignore the fetchGithubRepo return value, using it as a mirror update only. And use this new function to extract the data as needed in other loading steps.

Test plan: `yarn test --full`
As the existing `fetchGithubRepo` didn't have unit testing (and would require a lot of module mocking), instead I'm using the new function in `loadGraph`, which will be invoked by a full test.