### PR TITLE
Backend: implement createPlan

### DIFF
--- a/src/backend/loadPlan.js
+++ b/src/backend/loadPlan.js
@@ -4,6 +4,15 @@ import {Graph} from "../core/graph";
 import {type Project} from "../core/project";
 import {type TimelineCredParameters} from "../analysis/timeline/params";
 import {TimelineCred} from "../analysis/timeline/timelineCred";
+import {type PluginDeclaration} from "../analysis/pluginDeclaration";
+import {type GithubToken} from "../plugins/github/token";
+import {type CacheProvider} from "./cache";
+import {timelineCredPlan} from "./timelineCredPlan";
+import {pluginMirrorPlan, pluginGraphPlan} from "./pluginPlan";
+import {TaskReporter} from "../util/taskReporter";
+import {githubLoader} from "../plugins/github/loader";
+import {identityLoader} from "../plugins/identity/loader";
+import {discourseLoader} from "../plugins/discourse/loader";
 
 /**
  * This file introduces a "plan" concept.
@@ -37,6 +46,27 @@ export type LoadResult = {|
   +graph: Graph,
   +cred: TimelineCred,
 |};
+
+export function createPlan(
+  cache: CacheProvider,
+  githubToken: ?GithubToken,
+  pluginDeclarations: $ReadOnlyArray<PluginDeclaration>,
+  reporter: TaskReporter
+): LoadPlan {
+  const loaders = {
+    github: githubLoader,
+    discourse: discourseLoader,
+    identity: identityLoader,
+  };
+  const mirror = pluginMirrorPlan(loaders, githubToken, cache, reporter);
+  const createGraph = pluginGraphPlan(loaders, githubToken, cache);
+  const computeCred = timelineCredPlan(
+    pluginDeclarations,
+    reporter,
+    TimelineCred.compute
+  );
+  return {mirror, createGraph, computeCred};
+}
 
 export async function executePlan(
   plan: LoadPlan,

--- a/src/backend/loadPlan.test.js
+++ b/src/backend/loadPlan.test.js
@@ -1,7 +1,10 @@
 // @flow
 
+import tmp from "tmp";
+import {TestTaskReporter} from "../util/taskReporter";
+import {validateToken} from "../plugins/github/token";
 import {createProject} from "../core/project";
-import {type LoadPlan, executePlan} from "./loadPlan";
+import {type LoadPlan, createPlan, executePlan} from "./loadPlan";
 
 type JestMockFn = $Call<typeof jest.fn>;
 
@@ -18,6 +21,21 @@ const mockLoadPlan = (): LoadPlan => {
 };
 
 describe("src/backend/loadPlan", () => {
+  describe("createPlan", () => {
+    it("should not throw errors", () => {
+      const sourcecredDirectory = tmp.dirSync().name;
+      const token = validateToken("0".repeat(40));
+      const reporter = new TestTaskReporter();
+      const plugins = [];
+      const _: LoadPlan = createPlan(
+        sourcecredDirectory,
+        token,
+        plugins,
+        reporter
+      );
+    });
+  });
+
   describe("executePlan", () => {
     const project = createProject({id: "testing-project"});
     const params = {alpha: 0.123};


### PR DESCRIPTION
Ties together the underlying plans and APIs exposed by preceding PRs and uses them to create our full `LoadPlan`.