### PR TITLE
Enable eslint eqeqeq rule

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -22,6 +22,7 @@ module.exports = {
   ],
   rules: {
     camelcase: ["error", {properties: "never", allow: ["^_unused_.*"]}],
+    eqeqeq: ["error", "always", {null: "ignore"}],
     "no-unused-vars": [
       "warn",
       {

--- a/src/analysis/timeline/distributionToCred.js
+++ b/src/analysis/timeline/distributionToCred.js
@@ -63,7 +63,7 @@ export function distributionToCred(
     );
 
     const intervalNormalizer =
-      intervalTotalScore == 0 ? 0 : intervalWeight / intervalTotalScore;
+      intervalTotalScore === 0 ? 0 : intervalWeight / intervalTotalScore;
     const cred = distribution.map((x) => x * intervalNormalizer);
     return {interval, cred};
   });

--- a/src/cli/discourse.js
+++ b/src/cli/discourse.js
@@ -61,7 +61,7 @@ const command: Command = async (args, std) => {
         return 0;
       }
       case "--weights": {
-        if (weightsPath != undefined)
+        if (weightsPath != null)
           return die(std, "'--weights' given multiple times");
         if (++i >= args.length)
           return die(std, "'--weights' given without value");

--- a/src/cli/genProject.js
+++ b/src/cli/genProject.js
@@ -97,7 +97,7 @@ export const genProject: Command = async (args, std) => {
         break;
       }
       case "--discourse-url": {
-        if (discourseUrl != undefined)
+        if (discourseUrl != null)
           return die(std, "'--discourse-url' given multiple times");
         if (++i >= args.length)
           return die(std, "'--discourse-url' given without value");

--- a/src/cli/load.js
+++ b/src/cli/load.js
@@ -84,7 +84,7 @@ const loadCommand: Command = async (args, std) => {
         return 0;
       }
       case "--weights": {
-        if (weightsPath != undefined)
+        if (weightsPath != null)
           return die(std, "'--weights' given multiple times");
         if (++i >= args.length)
           return die(std, "'--weights' given without value");

--- a/src/plugins/discourse/fetch.js
+++ b/src/plugins/discourse/fetch.js
@@ -298,7 +298,7 @@ export class Fetcher implements Discourse {
       const {topic_list: topicList} = await response.json();
 
       // Having the same amount of results as expected by pagination, assume there's another page.
-      morePages = topicList.per_page == topicList.topics.length;
+      morePages = topicList.per_page === topicList.topics.length;
 
       for (const jsonTopic of topicList.topics) {
         const topic = parseLatestTopic(jsonTopic);

--- a/src/plugins/discourse/mirror.test.js
+++ b/src/plugins/discourse/mirror.test.js
@@ -229,7 +229,7 @@ class MockFetcher implements Discourse {
     this._topicToPostIds.set(topicId, []);
 
     // Add to category.
-    if (categoryId != undefined) {
+    if (categoryId != null) {
       this._topicToCategory.set(topicId, categoryId);
     }
 
@@ -330,7 +330,7 @@ class MockFetcher implements Discourse {
     }
     this._topicToPostIds.set(
       oldPost.topicId,
-      postList.filter((pid) => pid != postId)
+      postList.filter((pid) => pid !== postId)
     );
     this._posts.delete(postId);
   }
@@ -886,7 +886,7 @@ describe("plugins/discourse/mirror", () => {
         targetUsername: string,
         offset: number
       ) => {
-        if (targetUsername == "credbot") return null;
+        if (targetUsername === "credbot") return null;
         return await _likesByUser(targetUsername, offset);
       };
       await mirror.update(reporter);

--- a/src/plugins/github/referenceDetector.js
+++ b/src/plugins/github/referenceDetector.js
@@ -20,7 +20,7 @@ export function fromRelationalViews(
   for (const view of views) {
     for (const [url, addr] of view.urlReferenceMap().entries()) {
       const existing = map.get(url);
-      if (existing && existing != addr) {
+      if (existing && existing !== addr) {
         throw new Error(dedent`\
           An entry for ${url} already existed, but with a different NodeAddressT.
           This is probably a bug with SourceCred. Please report it on GitHub.

--- a/src/plugins/github/relationalView.js
+++ b/src/plugins/github/relationalView.js
@@ -528,7 +528,7 @@ export class RelationalView {
       const addr = N.toRaw(e.address());
       const url = e.url();
       const existing = refToAddress.get(url);
-      if (existing && existing != addr) {
+      if (existing && existing !== addr) {
         throw new Error(dedent`\
           An entry for ${url} already existed, but with a different NodeAddressT.
           This is probably a bug with SourceCred. Please report it on GitHub.

--- a/src/plugins/github/token.js
+++ b/src/plugins/github/token.js
@@ -26,13 +26,13 @@ export function validateToken(token: string): GithubToken {
   if (matches != null) {
     const [_, version, hexCode] = matches;
 
-    if (version != "v1") {
+    if (version !== "v1") {
       console.warn(
         `Warning: GitHub installation access token has an unexpected version "${version}".`
       );
     }
 
-    if (hexCode.length != 40) {
+    if (hexCode.length !== 40) {
       console.warn(
         `Warning: GitHub installation access token has an unexpected hexadecimal component ` +
           `length of ${hexCode.length}.`

--- a/src/plugins/initiatives/discourse.test.js
+++ b/src/plugins/initiatives/discourse.test.js
@@ -131,7 +131,7 @@ class MockDiscourseQueries implements DiscourseQueries {
   }
 
   postsInTopic(topicId: TopicId, numberOfPosts: number): $ReadOnlyArray<Post> {
-    if (numberOfPosts != 1) {
+    if (numberOfPosts !== 1) {
       throw new Error(
         "MockDiscourseQueries doesn't support anything but 1 for numberOfPosts"
       );

--- a/src/util/taskReporter.js
+++ b/src/util/taskReporter.js
@@ -114,11 +114,11 @@ export function formatTimeElapsed(elapsed: MsSinceEpoch): string {
   }
   const seconds = Math.round(elapsed / 1000);
   const minutes = Math.floor(seconds / 60);
-  if (minutes == 0) return `${seconds}s`;
+  if (minutes === 0) return `${seconds}s`;
   const hours = Math.floor(minutes / 60);
-  if (hours == 0) return `${minutes}m ${seconds % 60}s`;
+  if (hours === 0) return `${minutes}m ${seconds % 60}s`;
   const days = Math.floor(hours / 24);
-  if (days == 0) return `${hours}h ${minutes % 60}m`;
+  if (days === 0) return `${hours}h ${minutes % 60}m`;
   return `${days}d ${hours % 24}h`;
 }
 


### PR DESCRIPTION
The [eqeqeq rule][1] allows us to ban potentially confusing usage of the
type-coercing `==` equality operator. I've set it to "smart", so it
allows `== null` checks, as well as directly comparing literals or the
output of `typeof`.

Alongside activating the rule, I've fixed 15 violations. Inspired by
[review of #1560][2].

Test plan: `yarn test` passes.

[1]: https://eslint.org/docs/rules/eqeqeq
[2]: https://github.com/sourcecred/sourcecred/pull/1560#discussion_r368331081