### PR TITLE
Add `Weights.equals`

### DIFF
--- a/src/core/weights.js
+++ b/src/core/weights.js
@@ -1,6 +1,7 @@
 // @flow
 
 import * as MapUtil from "../util/map";
+import deepEqual from "lodash.isequal";
 import {
   type NodeAddressT,
   type EdgeAddressT,
@@ -87,6 +88,18 @@ export function merge(ws: $ReadOnlyArray<Weights>): Weights {
     }
   }
   return weights;
+}
+
+/**
+ * Returns whether two weights are equal.
+ *
+ * This is actually just a deep equality check, but is provided as
+ * an explicit function for consistency with other modules (e.g. Graph),
+ * and ensures that the interface is robust to future changes in how
+ * we represent the weights.
+ */
+export function equals(a: Weights, b: Weights): boolean {
+  return deepEqual(a, b);
 }
 
 export type WeightsJSON = Compatible<{|


### PR DESCRIPTION
This adds an `equals` method to the Weights module, which reports
whether two weights are equal. This is really just a wrapper around
calling `deepEqual` (since the Weights are just an object consisting of
two maps). However, this makes the module more consistent with `Graph`
(which provides an `equals` method), and ensures that clients can
confidently check equality without needing to reason about how Weights
are implemented.

Test plan: This commit adds an extremely simple wrapper function, with
added unit tests. `yarn test` passes.