### PR TITLE
Create a node for each Discourse like

### DIFF
--- a/src/plugins/discourse/address.js
+++ b/src/plugins/discourse/address.js
@@ -2,16 +2,32 @@
 
 import {NodeAddress, type NodeAddressT} from "../../core/graph";
 
-import {type PostId, type TopicId} from "./fetch";
+import {type PostId, type TopicId, type LikeAction} from "./fetch";
 
-import {topicNodeType, postNodeType, userNodeType} from "./declaration";
+import {
+  topicNodeType,
+  postNodeType,
+  userNodeType,
+  likeNodeType,
+} from "./declaration";
 
 export function topicAddress(serverUrl: string, id: TopicId): NodeAddressT {
   return NodeAddress.append(topicNodeType.prefix, serverUrl, String(id));
 }
+
 export function postAddress(serverUrl: string, id: PostId): NodeAddressT {
   return NodeAddress.append(postNodeType.prefix, serverUrl, String(id));
 }
+
 export function userAddress(serverUrl: string, username: string): NodeAddressT {
   return NodeAddress.append(userNodeType.prefix, serverUrl, username);
+}
+
+export function likeAddress(serverUrl: string, like: LikeAction): NodeAddressT {
+  return NodeAddress.append(
+    likeNodeType.prefix,
+    serverUrl,
+    like.username,
+    String(like.postId)
+  );
 }

--- a/src/plugins/discourse/declaration.js
+++ b/src/plugins/discourse/declaration.js
@@ -33,6 +33,14 @@ export const userNodeType: NodeType = deepFreeze({
   description: "A user account on a particular Discourse instance.",
 });
 
+export const likeNodeType: NodeType = deepFreeze({
+  name: "Like",
+  pluralName: "Likes",
+  prefix: NodeAddress.append(nodePrefix, "like"),
+  defaultWeight: 4,
+  description: "A like by some user, directed at some post",
+});
+
 export const topicContainsPostEdgeType: EdgeType = deepFreeze({
   forwardName: "contains post",
   backwardName: "is contained by topic",
@@ -65,12 +73,20 @@ export const authorsPostEdgeType: EdgeType = deepFreeze({
   description: "Connects an author to a post they've created.",
 });
 
+export const createsLikeEdgeType: EdgeType = deepFreeze({
+  forwardName: "creates like",
+  backwardName: "like created by",
+  prefix: EdgeAddress.append(edgePrefix, "createsLike"),
+  defaultWeight: {forwards: 1, backwards: 1 / 16},
+  description: "Connects a Discourse user to a like that they created.",
+});
+
 export const likesEdgeType: EdgeType = deepFreeze({
   forwardName: "likes",
   backwardName: "is liked by",
   prefix: EdgeAddress.append(edgePrefix, "likes"),
   defaultWeight: {forwards: 1, backwards: 1 / 16},
-  description: "Connects a Discourse user to a post they liked.",
+  description: "Connects a Discourse like to a post that was liked.",
 });
 
 export const referencesPostEdgeType: EdgeType = deepFreeze({
@@ -101,13 +117,14 @@ export const declaration: PluginDeclaration = deepFreeze({
   name: "Discourse",
   nodePrefix,
   edgePrefix,
-  nodeTypes: [userNodeType, topicNodeType, postNodeType],
+  nodeTypes: [userNodeType, topicNodeType, postNodeType, likeNodeType],
   edgeTypes: [
     postRepliesEdgeType,
     authorsTopicEdgeType,
     authorsPostEdgeType,
     topicContainsPostEdgeType,
     likesEdgeType,
+    createsLikeEdgeType,
     referencesPostEdgeType,
     referencesTopicEdgeType,
     referencesUserEdgeType,


### PR DESCRIPTION
*Let's use the syntax `(node)` to represent some node, and `> edge >` to
represent some edge.*

In the past, for every like, we would create the following graph
structure:

`(user) > likes > (post)`

As of this commit, we instead create:

`(user) > createsLike > (like) > likes > (post)`

We make this change because we want to mint cred for likes. Arguably,
this is more robust than minting cred for activity: something being
liked signals that at least one person in the community found a post
valuable, so you can think of moving cred minting away from raw activity
and towards likes as a sort of implicit "cred review".

Create a node for each like is a somewhat hacky way to do it--in
principle, we should have a heuristic which increases the cred weight of
a post based on the number of likes it has received--but it is expedient
so we can prototype this quickly.

Obviously, this is not robust to Sibyll attacks. If we decide to adopt
this, in the medium term we can add some filtering logic so that e.g. a
user must be whitelisted for their likes to mint cred. (And, in a nice
recursive step, the whitelist can be auto-generated from the last week's
cred scores, so that e.g. every user with at least 50 cred can mint more
cred.) I think it's OK to put in a Sibyll-vulnerable mechanism here
because SourceCred is still being designed for high trust-level
communities, and the existing system of minting cred for raw activity is
also vulnerable to Sibyll and spam attacks.

Test plan: Unit tests updated; also @s-ben can report back on whether
this is useful to him in demo-ing SourceCred [on MakerDAO][1].

If we merge this, we should simultaneously explicitly set the weight to
like nodes to 0 in our cred instance, so that we can separate merging
this feature from actually changing our own cred (which should go
through a separate review).

[1]: https://forum.makerdao.com/t/possible-data-source-for-determining-compensation