### PR TITLE
Rename `Weights.defaultWeights` to `Weights.empty`

### DIFF
--- a/src/analysis/timeline/params.js
+++ b/src/analysis/timeline/params.js
@@ -1,12 +1,7 @@
 // @flow
 
-import {
-  type Weights,
-  type WeightsJSON,
-  toJSON as weightsToJSON,
-  fromJSON as weightsFromJSON,
-  defaultWeights,
-} from "../../core/weights";
+import {type Weights as WeightsT, type WeightsJSON} from "../../core/weights";
+import * as Weights from "../../core/weights";
 
 /**
  * Parameters for computing TimelineCred
@@ -29,7 +24,7 @@ export type TimelineCredParameters = {|
   // node types, how cred flows across various edge types, and can specify
   // manual weights directly on individual nodes. See the docs in
   // `analysis/weights` for details.
-  +weights: Weights,
+  +weights: WeightsT,
 |};
 
 export const DEFAULT_ALPHA = 0.2;
@@ -47,7 +42,7 @@ export function paramsToJSON(
   return {
     alpha: p.alpha,
     intervalDecay: p.intervalDecay,
-    weights: weightsToJSON(p.weights),
+    weights: Weights.toJSON(p.weights),
   };
 }
 
@@ -57,7 +52,7 @@ export function paramsFromJSON(
   return {
     alpha: p.alpha,
     intervalDecay: p.intervalDecay,
-    weights: weightsFromJSON(p.weights),
+    weights: Weights.fromJSON(p.weights),
   };
 }
 
@@ -71,7 +66,7 @@ export function defaultParams(): TimelineCredParameters {
   return {
     alpha: DEFAULT_ALPHA,
     intervalDecay: DEFAULT_INTERVAL_DECAY,
-    weights: defaultWeights(),
+    weights: Weights.empty(),
   };
 }
 

--- a/src/analysis/timeline/params.test.js
+++ b/src/analysis/timeline/params.test.js
@@ -9,12 +9,12 @@ import {
   DEFAULT_ALPHA,
   DEFAULT_INTERVAL_DECAY,
 } from "./params";
-import {defaultWeights} from "../../core/weights";
+import * as Weights from "../../core/weights";
 import {NodeAddress} from "../../core/graph";
 
 describe("analysis/timeline/params", () => {
   const customWeights = () => {
-    const weights = defaultWeights();
+    const weights = Weights.empty();
     // Ensure it works with non-default weights
     weights.nodeWeights.set(NodeAddress.empty, 33);
     return weights;
@@ -35,7 +35,7 @@ describe("analysis/timeline/params", () => {
     const expected: TimelineCredParameters = {
       alpha: DEFAULT_ALPHA,
       intervalDecay: DEFAULT_INTERVAL_DECAY,
-      weights: defaultWeights(),
+      weights: Weights.empty(),
     };
     expect(defaultParams()).toEqual(expected);
   });
@@ -46,7 +46,7 @@ describe("analysis/timeline/params", () => {
     });
     it("accepts an alpha override", () => {
       const params = partialParams({alpha: 0.99});
-      expect(params.weights).toEqual(defaultWeights());
+      expect(params.weights).toEqual(Weights.empty());
       expect(params.alpha).toEqual(0.99);
       expect(params.intervalDecay).toEqual(DEFAULT_INTERVAL_DECAY);
     });
@@ -59,7 +59,7 @@ describe("analysis/timeline/params", () => {
     });
     it("accepts intervalDecay override", () => {
       const params = partialParams({intervalDecay: 0.1});
-      expect(params.weights).toEqual(defaultWeights());
+      expect(params.weights).toEqual(Weights.empty());
       expect(params.alpha).toEqual(DEFAULT_ALPHA);
       expect(params.intervalDecay).toEqual(0.1);
     });

--- a/src/analysis/weightEvaluator.test.js
+++ b/src/analysis/weightEvaluator.test.js
@@ -3,7 +3,7 @@
 import deepFreeze from "deep-freeze";
 import {NodeAddress, EdgeAddress} from "../core/graph";
 import {nodeWeightEvaluator, edgeWeightEvaluator} from "./weightEvaluator";
-import {defaultWeights} from "../core/weights";
+import * as Weights from "../core/weights";
 
 describe("src/analysis/weightEvaluator", () => {
   describe("nodeWeightEvaluator", () => {
@@ -30,18 +30,18 @@ describe("src/analysis/weightEvaluator", () => {
     const types = deepFreeze([fooNodeType, fooBarNodeType]);
 
     it("gives every node weight 1 with empty types and weights", () => {
-      const evaluator = nodeWeightEvaluator([], defaultWeights());
+      const evaluator = nodeWeightEvaluator([], Weights.empty());
       expect(evaluator(empty)).toEqual(1);
       expect(evaluator(foo)).toEqual(1);
     });
     it("composes matching weights multiplicatively", () => {
-      const evaluator = nodeWeightEvaluator(types, defaultWeights());
+      const evaluator = nodeWeightEvaluator(types, Weights.empty());
       expect(evaluator(empty)).toEqual(1);
       expect(evaluator(foo)).toEqual(2);
       expect(evaluator(foobar)).toEqual(6);
     });
     it("explicitly set weights on type prefixes override the type weights", () => {
-      const weights = defaultWeights();
+      const weights = Weights.empty();
       weights.nodeWeights.set(foo, 3);
       weights.nodeWeights.set(foobar, 4);
       const evaluator = nodeWeightEvaluator(types, weights);
@@ -50,7 +50,7 @@ describe("src/analysis/weightEvaluator", () => {
       expect(evaluator(foobar)).toEqual(12);
     });
     it("uses manually-specified weights", () => {
-      const weights = defaultWeights();
+      const weights = Weights.empty();
       weights.nodeWeights.set(foo, 3);
       const evaluator = nodeWeightEvaluator([], weights);
       expect(evaluator(empty)).toEqual(1);
@@ -76,13 +76,13 @@ describe("src/analysis/weightEvaluator", () => {
       description: "",
     });
     it("gives default 1,1 weights if no matching type", () => {
-      const evaluator = edgeWeightEvaluator([], defaultWeights());
+      const evaluator = edgeWeightEvaluator([], Weights.empty());
       expect(evaluator(foo)).toEqual({forwards: 1, backwards: 1});
     });
     it("composes weights multiplicatively for all matching types", () => {
       const evaluator = edgeWeightEvaluator(
         [fooType, fooBarType],
-        defaultWeights()
+        Weights.empty()
       );
       expect(evaluator(foo)).toEqual({forwards: 2, backwards: 3});
       expect(evaluator(foobar)).toEqual({forwards: 8, backwards: 15});
@@ -92,7 +92,7 @@ describe("src/analysis/weightEvaluator", () => {
       });
     });
     it("explicit weights override defaults from types", () => {
-      const weights = defaultWeights();
+      const weights = Weights.empty();
       weights.edgeWeights.set(foo, {forwards: 99, backwards: 101});
       const evaluator = edgeWeightEvaluator([fooType, fooBarType], weights);
       expect(evaluator(foo)).toEqual({forwards: 99, backwards: 101});

--- a/src/analysis/weightsToEdgeEvaluator.test.js
+++ b/src/analysis/weightsToEdgeEvaluator.test.js
@@ -2,7 +2,8 @@
 
 import deepFreeze from "deep-freeze";
 import {NodeAddress, EdgeAddress} from "../core/graph";
-import {type Weights, defaultWeights} from "../core/weights";
+import {type Weights as WeightsT} from "../core/weights";
+import * as Weights from "../core/weights";
 import {weightsToEdgeEvaluator} from "./weightsToEdgeEvaluator";
 
 describe("analysis/weightsToEdgeEvaluator", () => {
@@ -39,7 +40,7 @@ describe("analysis/weightsToEdgeEvaluator", () => {
     description: "",
   });
 
-  function evaluateEdge(weights: Weights) {
+  function evaluateEdge(weights: WeightsT) {
     const evaluator = weightsToEdgeEvaluator(weights, {
       nodeTypes: [fallbackNodeType, srcNodeType],
       edgeTypes: [fallbackEdgeType],
@@ -48,17 +49,17 @@ describe("analysis/weightsToEdgeEvaluator", () => {
   }
 
   it("applies default weights when none are specified", () => {
-    expect(evaluateEdge(defaultWeights())).toEqual({forwards: 1, backwards: 2});
+    expect(evaluateEdge(Weights.empty())).toEqual({forwards: 1, backwards: 2});
   });
 
   it("matches all prefixes of the nodes in scope", () => {
-    const weights = defaultWeights();
+    const weights = Weights.empty();
     weights.nodeWeights.set(NodeAddress.empty, 99);
     expect(evaluateEdge(weights)).toEqual({forwards: 99, backwards: 2 * 99});
   });
 
   it("takes manually specified edge type weights into account", () => {
-    const weights = defaultWeights();
+    const weights = Weights.empty();
     // Note that here we grab the fallout edge type. This also verifies that
     // we are doing prefix matching on the types (rather than exact matching).
     weights.edgeWeights.set(EdgeAddress.empty, {
@@ -69,13 +70,13 @@ describe("analysis/weightsToEdgeEvaluator", () => {
   });
 
   it("an explicit weight on a prefix overrides the type weight", () => {
-    const weights = defaultWeights();
+    const weights = Weights.empty();
     weights.nodeWeights.set(src, 1);
     expect(evaluateEdge(weights)).toEqual({forwards: 1, backwards: 1});
   });
 
   it("uses 1 as a default weight for unmatched nodes and edges", () => {
-    const evaluator = weightsToEdgeEvaluator(defaultWeights(), {
+    const evaluator = weightsToEdgeEvaluator(Weights.empty(), {
       nodeTypes: [],
       edgeTypes: [],
     });
@@ -83,8 +84,8 @@ describe("analysis/weightsToEdgeEvaluator", () => {
   });
 
   it("ignores extra weights if they do not apply", () => {
-    const withoutExtraWeights = evaluateEdge(defaultWeights());
-    const extraWeights = defaultWeights();
+    const withoutExtraWeights = evaluateEdge(Weights.empty());
+    const extraWeights = Weights.empty();
     extraWeights.nodeWeights.set(NodeAddress.fromParts(["foo"]), 99);
     extraWeights.nodeWeights.set(NodeAddress.fromParts(["foo"]), 99);
     extraWeights.edgeWeights.set(EdgeAddress.fromParts(["foo"]), {

--- a/src/api/load.test.js
+++ b/src/api/load.test.js
@@ -16,7 +16,7 @@ import {
   loadProject,
 } from "../core/project_io";
 import {makeRepoId} from "../plugins/github/repoId";
-import {defaultWeights} from "../core/weights";
+import * as Weights from "../core/weights";
 import {NodeAddress, Graph} from "../core/graph";
 import {node} from "../core/graphTestUtil";
 import {TestTaskReporter} from "../util/taskReporter";
@@ -67,7 +67,7 @@ describe("api/load", () => {
     discourseServer: {serverUrl: discourseServerUrl},
   });
   deepFreeze(project);
-  const weights = defaultWeights();
+  const weights = Weights.empty();
   // Tweaks the weights so that we can ensure we aren't overriding with default weights
   weights.nodeWeights.set(NodeAddress.empty, 33);
   // Deep freeze will freeze the weights, too

--- a/src/cli/common.test.js
+++ b/src/cli/common.test.js
@@ -3,7 +3,7 @@
 import path from "path";
 import tmp from "tmp";
 import fs from "fs-extra";
-import {defaultWeights, toJSON as weightsToJSON} from "../core/weights";
+import * as Weights from "../core/weights";
 import {NodeAddress} from "../core/graph";
 import {validateToken} from "../plugins/github/token";
 
@@ -69,11 +69,11 @@ describe("cli/common", () => {
       return name;
     }
     it("works in a simple success case", async () => {
-      const weights = defaultWeights();
+      const weights = Weights.empty();
       // Make a modification, just to be sure we aren't always loading the
       // default weights.
       weights.nodeWeights.set(NodeAddress.empty, 3);
-      const weightsJSON = weightsToJSON(weights);
+      const weightsJSON = Weights.toJSON(weights);
       const file = tmpWithContents(weightsJSON);
       const weights_ = await loadWeights(file);
       expect(weights).toEqual(weights_);

--- a/src/cli/discourse.js
+++ b/src/cli/discourse.js
@@ -7,7 +7,7 @@ import dedent from "../util/dedent";
 import {LoggingTaskReporter} from "../util/taskReporter";
 import type {Command} from "./command";
 import * as Common from "./common";
-import {defaultWeights} from "../core/weights";
+import * as Weights from "../core/weights";
 import {load} from "../api/load";
 import {declaration as discourseDeclaration} from "../plugins/discourse/declaration";
 import {type Project, createProject} from "../core/project";
@@ -88,7 +88,7 @@ const command: Command = async (args, std) => {
     discourseServer: {serverUrl},
   });
   const taskReporter = new LoggingTaskReporter();
-  let weights = defaultWeights();
+  let weights = Weights.empty();
   if (weightsPath) {
     weights = await Common.loadWeights(weightsPath);
   }

--- a/src/cli/load.js
+++ b/src/cli/load.js
@@ -5,7 +5,7 @@ import dedent from "../util/dedent";
 import {LoggingTaskReporter} from "../util/taskReporter";
 import type {Command} from "./command";
 import * as Common from "./common";
-import {defaultWeights, fromJSON as weightsFromJSON} from "../core/weights";
+import * as Weights from "../core/weights";
 import {projectFromJSON} from "../core/project";
 import {load} from "../api/load";
 import {specToProject} from "../plugins/github/specToProject";
@@ -107,7 +107,7 @@ const loadCommand: Command = async (args, std) => {
     return die(std, "projects not specified");
   }
 
-  let weights = defaultWeights();
+  let weights = Weights.empty();
   if (weightsPath) {
     weights = await loadWeightOverrides(weightsPath);
   }
@@ -160,7 +160,7 @@ const loadWeightOverrides = async (path: string) => {
   const raw = await fs.readFile(path, "utf-8");
   const weightsJSON = JSON.parse(raw);
   try {
-    return weightsFromJSON(weightsJSON);
+    return Weights.fromJSON(weightsJSON);
   } catch (e) {
     throw new Error(`provided weights file is invalid:\n${e}`);
   }

--- a/src/cli/load.test.js
+++ b/src/cli/load.test.js
@@ -8,7 +8,7 @@ import {NodeAddress} from "../core/graph";
 import {run} from "./testUtil";
 import loadCommand, {help} from "./load";
 import type {LoadOptions} from "../api/load";
-import {defaultWeights, toJSON as weightsToJSON} from "../core/weights";
+import * as Weights from "../core/weights";
 import * as Common from "./common";
 import {defaultParams, partialParams} from "../analysis/timeline/params";
 import {declaration as githubDeclaration} from "../plugins/github/declaration";
@@ -120,9 +120,9 @@ describe("cli/load", () => {
     });
 
     it("loads the weights, if provided", async () => {
-      const weights = defaultWeights();
+      const weights = Weights.empty();
       weights.nodeWeights.set(NodeAddress.empty, 33);
-      const weightsJSON = weightsToJSON(weights);
+      const weightsJSON = Weights.toJSON(weights);
       const weightsFile = tmp.tmpNameSync();
       fs.writeFileSync(weightsFile, JSON.stringify(weightsJSON));
       const invocation = run(loadCommand, [

--- a/src/core/weights.js
+++ b/src/core/weights.js
@@ -32,11 +32,9 @@ export type Weights = {|
 |};
 
 /**
- * Creates default (i.e. empty) weights.
- *
- * When the weights are empty, defaults will be used for every type and node.
+ * Creates new, empty weights.
  */
-export function defaultWeights(): Weights {
+export function empty(): Weights {
   return {
     nodeWeights: new Map(),
     edgeWeights: new Map(),

--- a/src/core/weights.test.js
+++ b/src/core/weights.test.js
@@ -2,12 +2,12 @@
 
 import stringify from "json-stable-stringify";
 import {NodeAddress, EdgeAddress} from "../core/graph";
-import {toJSON, fromJSON, defaultWeights, copy} from "./weights";
+import * as Weights from "./weights";
 
 describe("core/weights", () => {
   it("copy makes a copy", () => {
-    const w = defaultWeights();
-    const w1 = copy(w);
+    const w = Weights.empty();
+    const w1 = Weights.copy(w);
     w1.nodeWeights.set(NodeAddress.empty, 33);
     w1.edgeWeights.set(EdgeAddress.empty, {forwards: 34, backwards: 39});
     w1.nodeWeights.set(NodeAddress.empty, 35);
@@ -18,8 +18,8 @@ describe("core/weights", () => {
   });
   describe("toJSON/fromJSON", () => {
     it("works for the default weights", () => {
-      const weights = defaultWeights();
-      const json = toJSON(weights);
+      const weights = Weights.empty();
+      const json = Weights.toJSON(weights);
       const jsonString = stringify(json, {space: 4});
       expect(jsonString).toMatchInlineSnapshot(`
         "[
@@ -35,17 +35,17 @@ describe("core/weights", () => {
             }
         ]"
       `);
-      expect(weights).toEqual(fromJSON(json));
+      expect(weights).toEqual(Weights.fromJSON(json));
     });
 
     it("works for non-default weights", () => {
-      const weights = defaultWeights();
+      const weights = Weights.empty();
       weights.nodeWeights.set(NodeAddress.empty, 32);
       weights.edgeWeights.set(EdgeAddress.empty, {
         forwards: 7,
         backwards: 9,
       });
-      const json = toJSON(weights);
+      const json = Weights.toJSON(weights);
       const jsonString = stringify(json, {space: 4});
       expect(jsonString).toMatchInlineSnapshot(`
         "[
@@ -66,7 +66,7 @@ describe("core/weights", () => {
             }
         ]"
       `);
-      expect(weights).toEqual(fromJSON(json));
+      expect(weights).toEqual(Weights.fromJSON(json));
     });
   });
 });

--- a/src/explorer/legacy/App.js
+++ b/src/explorer/legacy/App.js
@@ -12,7 +12,8 @@ import {type NodeAddressT} from "../../core/graph";
 import {PagerankTable} from "./pagerankTable/Table";
 import {WeightConfig} from "../weights/WeightConfig";
 import {WeightsFileManager} from "../weights/WeightsFileManager";
-import {type Weights, defaultWeights} from "../../core/weights";
+import * as Weights from "../../core/weights";
+import {type Weights as WeightsT} from "../../core/weights";
 import {Prefix as GithubPrefix} from "../../plugins/github/nodes";
 import {
   createStateTransitionMachine,
@@ -56,7 +57,7 @@ type Props = {|
 |};
 type State = {|
   appState: AppState,
-  weights: Weights,
+  weights: WeightsT,
 |};
 
 export function createApp(
@@ -72,7 +73,7 @@ export function createApp(
       super(props);
       this.state = {
         appState: initialState(this.props.projectId),
-        weights: defaultWeights(),
+        weights: Weights.empty(),
       };
       this.stateTransitionMachine = createSTM(
         () => this.state.appState,
@@ -85,7 +86,7 @@ export function createApp(
       const weightFileManager = (
         <WeightsFileManager
           weights={this.state.weights}
-          onWeightsChange={(weights: Weights) => {
+          onWeightsChange={(weights: WeightsT) => {
             this.setState({weights});
           }}
         />

--- a/src/explorer/legacy/state.test.js
+++ b/src/explorer/legacy/state.test.js
@@ -5,7 +5,7 @@ import {StateTransitionMachine, type AppState} from "./state";
 import {Graph, NodeAddress} from "../../core/graph";
 import {Assets} from "../../webutil/assets";
 import {type EdgeEvaluator} from "../../analysis/pagerank";
-import {defaultWeights} from "../../core/weights";
+import * as Weights from "../../core/weights";
 import type {
   PagerankNodeDecomposition,
   PagerankOptions,
@@ -147,7 +147,7 @@ describe("explorer/legacy/state", () => {
       const badState = readyToLoadGraph();
       const {stm} = example(badState);
       await expect(
-        stm.runPagerank(defaultWeights(), NodeAddress.empty)
+        stm.runPagerank(Weights.empty(), NodeAddress.empty)
       ).rejects.toThrow("incorrect state");
     });
     it("can be run when READY_TO_RUN_PAGERANK or PAGERANK_EVALUATED", async () => {
@@ -156,7 +156,7 @@ describe("explorer/legacy/state", () => {
         const {stm, getState, pagerankMock} = example(g);
         const pnd = pagerankNodeDecomposition();
         pagerankMock.mockReturnValue(Promise.resolve(pnd));
-        await stm.runPagerank(defaultWeights(), NodeAddress.empty);
+        await stm.runPagerank(Weights.empty(), NodeAddress.empty);
         const state = getState();
         if (state.type !== "PAGERANK_EVALUATED") {
           throw new Error("Impossible");
@@ -168,13 +168,13 @@ describe("explorer/legacy/state", () => {
     it("immediately sets loading status", () => {
       const {getState, stm} = example(readyToRunPagerank());
       expect(loading(getState())).toBe("NOT_LOADING");
-      stm.runPagerank(defaultWeights(), NodeAddress.empty);
+      stm.runPagerank(Weights.empty(), NodeAddress.empty);
       expect(loading(getState())).toBe("LOADING");
     });
     it("calls pagerank with the totalScoreNodePrefix option", async () => {
       const {pagerankMock, stm} = example(readyToRunPagerank());
       const foo = NodeAddress.fromParts(["foo"]);
-      await stm.runPagerank(defaultWeights(), foo);
+      await stm.runPagerank(Weights.empty(), foo);
       const args = pagerankMock.mock.calls[0];
       expect(args[2].totalScoreNodePrefix).toBe(foo);
     });
@@ -184,7 +184,7 @@ describe("explorer/legacy/state", () => {
       // $ExpectFlowError
       console.error = jest.fn();
       pagerankMock.mockReturnValue(Promise.reject(error));
-      await stm.runPagerank(defaultWeights(), NodeAddress.empty);
+      await stm.runPagerank(Weights.empty(), NodeAddress.empty);
       const state = getState();
       expect(loading(state)).toBe("FAILED");
       expect(state.type).toBe("READY_TO_RUN_PAGERANK");
@@ -201,7 +201,7 @@ describe("explorer/legacy/state", () => {
       stm.loadTimelineCred.mockResolvedValue(true);
       const assets = new Assets("/gateway/");
       const prefix = NodeAddress.fromParts(["bar"]);
-      const wt = defaultWeights();
+      const wt = Weights.empty();
       await stm.loadTimelineCredAndRunPagerank(assets, wt, prefix);
       expect(stm.loadTimelineCred).toHaveBeenCalledTimes(1);
       expect(stm.loadTimelineCred).toHaveBeenCalledWith(assets);
@@ -215,11 +215,7 @@ describe("explorer/legacy/state", () => {
       stm.loadTimelineCred.mockResolvedValue(false);
       const assets = new Assets("/gateway/");
       const prefix = NodeAddress.fromParts(["bar"]);
-      await stm.loadTimelineCredAndRunPagerank(
-        assets,
-        defaultWeights(),
-        prefix
-      );
+      await stm.loadTimelineCredAndRunPagerank(assets, Weights.empty(), prefix);
       expect(stm.loadTimelineCred).toHaveBeenCalledTimes(1);
       expect(stm.runPagerank).toHaveBeenCalledTimes(0);
     });
@@ -228,7 +224,7 @@ describe("explorer/legacy/state", () => {
       (stm: any).loadTimelineCred = jest.fn();
       (stm: any).runPagerank = jest.fn();
       const prefix = NodeAddress.fromParts(["bar"]);
-      const wt = defaultWeights();
+      const wt = Weights.empty();
       await stm.loadTimelineCredAndRunPagerank(
         new Assets("/gateway/"),
         wt,
@@ -243,7 +239,7 @@ describe("explorer/legacy/state", () => {
       (stm: any).loadTimelineCred = jest.fn();
       (stm: any).runPagerank = jest.fn();
       const prefix = NodeAddress.fromParts(["bar"]);
-      const wt = defaultWeights();
+      const wt = Weights.empty();
       await stm.loadTimelineCredAndRunPagerank(
         new Assets("/gateway/"),
         wt,


### PR DESCRIPTION
`empty` is a more descriptive name for a `Weights` object that has no
weights set, rather than `defaultWeights`.

In every case where we were importing `defaultWeights` as a direct
symbol, I switched to importing the whole module, as usage of
`Weights.empty` makes it clear that the empty object returned will be an
empty weights (as opposed to an empty list or some other empty type).
This is as proposed in the reviews from #1538.

Test plan: It's just a rename and change to imports, so `yarn flow`
would catch any issues. `yarn test` passes.