### PR TITLE
de-noise scripts/update_snapshots.sh

### DIFF
--- a/scripts/update_snapshots.sh
+++ b/scripts/update_snapshots.sh
@@ -1,6 +1,10 @@
 #!/bin/sh
 
-# Automatically update all SourceCred snapshot data.
+# Automatically update SourceCred snapshot data.
+# This deliberately does not update Discourse API snapshots,
+# because they are very noisy. If you want to update Discourse
+# snapshots, run ./src/plugins/discourse/update_discourse_api_snapshots.sh
+
 set -eu
 
 toplevel="$(git -C "$(dirname "$0")" rev-parse --show-toplevel)"
@@ -33,13 +37,6 @@ echo "Updating github/fetchGithubOrgTest.sh"
 
 echo "Updating github/fetchGithubRepoTest.sh"
 ./src/plugins/github/fetchGithubRepoTest.sh -u --no-build
-
-if [ -n "${DISCOURSE_TEST_API_KEY:-}" ]; then
-  echo "Updating Discourse API snapshots"
-  ./src/plugins/discourse/update_discourse_api_snapshots.sh
-else
-  echo "Not updating Discourse API snapshots (need DISCOURSE_TEST_API_KEY)"
-fi
 
 echo "Updating Jest snapshots"
 yarn unit -u


### PR DESCRIPTION
scripts/update_snapshots.sh is intended as a general-purpose snapshot
updater for SourceCred. Currently, it includes updating Discourse
snapshots, but only if an obsolete Discourse API key is present.

Updating Discourse snapshots is very noisy, because the API responses
are not stable (they include the view count, which increments when
making API requests). Also, most times when we want to update our
snapshots, it's because we changed some core data structure, not because
we actually want new data from Discourse. Therefore, we should
disconnect the Discourse snapshot update process from the general
snapshot updating script.

Test plan:
Run `./scripts/update_snapshots.sh` and verify that it does not produce
Discourse update churn. Run
`./src/plugins/discourse/update_discourse_api_snapshots.sh` and verify
that it does update all the Discourse snapshots.