### PR TITLE
add `loadWeightedGraph` methods for plugins

### DIFF
--- a/src/plugins/discourse/loadDiscourse.js
+++ b/src/plugins/discourse/loadDiscourse.js
@@ -1,5 +1,13 @@
 // @flow
 
+// This module is deprecated, and is being replaced by
+// discourse/loadWeightedGraph. Over the course of finishing #1557,
+// @decentralion will remove this module and merge its implementation into
+// loadWeightedGraph.
+//
+// This module is untested, because it is an IO-heavy composition of pieces of
+// functionality which are individually quite well tested.
+
 import Database from "better-sqlite3";
 import base64url from "base64url";
 import {Fetcher} from "./fetch";

--- a/src/plugins/discourse/loadWeightedGraph.js
+++ b/src/plugins/discourse/loadWeightedGraph.js
@@ -1,0 +1,24 @@
+// @flow
+//
+// This module is the entry point for clients of the Discourse plugin that
+// want to load a completed WeightedGraph containing Discourse data.
+//
+// This module is untested, because it is an IO-heavy composition of pieces of
+// functionality which are individually quite well tested.
+
+import {loadDiscourse, type Options} from "./loadDiscourse";
+import {TaskReporter} from "../../util/taskReporter";
+import {weightsForDeclaration} from "../../analysis/pluginDeclaration";
+import {type WeightedGraph} from "../../core/weightedGraph";
+import {declaration} from "./declaration";
+
+export type {Options} from "./loadDiscourse";
+
+export async function loadWeightedGraph(
+  options: Options,
+  reporter: TaskReporter
+): Promise<WeightedGraph> {
+  const graph = await loadDiscourse(options, reporter);
+  const weights = weightsForDeclaration(declaration);
+  return {graph, weights};
+}

--- a/src/plugins/github/loadGraph.js
+++ b/src/plugins/github/loadGraph.js
@@ -1,5 +1,13 @@
 // @flow
 
+// This module is deprecated, and is being replaced by
+// github/loadWeightedGraph. Over the course of finishing #1557,
+// @decentralion will remove this module and merge its implementation into
+// loadWeightedGraph.
+//
+// This module is untested, because it is an IO-heavy composition of pieces of
+// functionality which are individually quite well tested.
+
 import {TaskReporter} from "../../util/taskReporter";
 import {createGraph} from "./createGraph";
 import fetchGithubRepo from "./fetchGithubRepo";

--- a/src/plugins/github/loadWeightedGraph.js
+++ b/src/plugins/github/loadWeightedGraph.js
@@ -1,0 +1,24 @@
+// @flow
+//
+// This module is the entry point for clients of the GitHub plugin that
+// want to load a completed WeightedGraph containing GitHub data.
+//
+// This module is untested, because it is an IO-heavy composition of pieces of
+// functionality which are individually quite well tested.
+
+import {loadGraph, type Options} from "./loadGraph";
+import {TaskReporter} from "../../util/taskReporter";
+import {weightsForDeclaration} from "../../analysis/pluginDeclaration";
+import {type WeightedGraph} from "../../core/weightedGraph";
+import {declaration} from "./declaration";
+
+export type {Options} from "./loadGraph";
+
+export async function loadWeightedGraph(
+  options: Options,
+  reporter: TaskReporter
+): Promise<WeightedGraph> {
+  const graph = await loadGraph(options, reporter);
+  const weights = weightsForDeclaration(declaration);
+  return {graph, weights};
+}


### PR DESCRIPTION
This commit adds `loadWeightedGraph` functions for both the GitHub and
Discourse plugins. They will replacing existing (and inconsistently
named) methods which load regular graphs, and they set weights according
to the plugins' default type weights.

The soon-to-be-replaced methods have been marked deprecated.

Another small and vital step towards #1557.

Test plan: The functions that these functions replace are not tested,
because they are IO-heavy composition methods which are painful to test
themselves, and directly depend on well-tested behavior. For the same
reason, no unit tests have been added.