### PR TITLE
mirror: add default typename-mismatch error message

### DIFF
--- a/src/graphql/mirror.js
+++ b/src/graphql/mirror.js
@@ -365,14 +365,7 @@ export class Mirror {
     +id: Schema.ObjectId,
   |}): void {
     _inTransaction(this._db, () => {
-      this._nontransactionallyRegisterObject(object, (guess) => {
-        const s = JSON.stringify;
-        const message =
-          `object ${s(object.id)} ` +
-          `looks like it should have type ${s(guess)}, ` +
-          `not ${s(object.typename)}`;
-        return message;
-      });
+      this._nontransactionallyRegisterObject(object);
     });
   }
 
@@ -386,10 +379,21 @@ export class Mirror {
       +typename: Schema.Typename,
       +id: Schema.ObjectId,
     |},
-    guessMismatchMessage: (guess: Schema.Typename) => string
+    guessMismatchMessage?: (guess: Schema.Typename) => string
   ): void {
     const db = this._db;
     const {typename, id} = object;
+
+    if (guessMismatchMessage == null) {
+      guessMismatchMessage = (guess) => {
+        const s = JSON.stringify;
+        const message =
+          `object ${s(object.id)} ` +
+          `looks like it should have type ${s(guess)}, ` +
+          `not ${s(object.typename)}`;
+        return message;
+      };
+    }
 
     const existingTypename = db
       .prepare("SELECT typename FROM objects WHERE id = ?")


### PR DESCRIPTION
Summary:
Previously, `_nontransactionallyRegisterObject` differed from its
counterpart `registerObject` in two ways: the former does not enter a
transaction, but it also requires a function to format an error message.
The value provided by `registerObject` to the helper is a suitable
default, so we can use it to decouple the transaction semantics from the
error message.

Test Plan:
Existing tests suffice, retaining full coverage.

wchargin-branch: mirror-default-typename-message