### PR TITLE
Github: switch to CacheProvider for fetchGithubRepo

### DIFF
--- a/src/api/load.js
+++ b/src/api/load.js
@@ -18,6 +18,8 @@ import * as Github from "../plugins/github/loadWeightedGraph";
 import * as WeightedGraph from "../core/weightedGraph";
 import {type Weights as WeightsT} from "../core/weights";
 import {loadWeightedGraph} from "./loadWeightedGraph";
+import {DataDirectory} from "../backend/dataDirectory";
+import {type CacheProvider} from "../backend/cache";
 
 export type LoadOptions = {|
   +project: Project,
@@ -58,6 +60,7 @@ export async function load(
   const fullParams = params == null ? defaultParams() : partialParams(params);
   const loadTask = `load-${options.project.id}`;
   taskReporter.start(loadTask);
+  const dataDirectory = new DataDirectory(sourcecredDirectory);
   const cacheDirectory = path.join(sourcecredDirectory, "cache");
   await fs.mkdirp(cacheDirectory);
 
@@ -77,7 +80,7 @@ export async function load(
     githubOptions = {
       repoIds: project.repoIds,
       token: githubToken,
-      cacheDirectory,
+      cache: (dataDirectory: CacheProvider),
     };
   }
 

--- a/src/api/load.test.js
+++ b/src/api/load.test.js
@@ -26,6 +26,7 @@ import {
   partialParams,
 } from "../analysis/timeline/params";
 import * as WeightedGraph from "../core/weightedGraph";
+import {DataDirectory} from "../backend/dataDirectory";
 
 type JestMockFn = $Call<typeof jest.fn>;
 jest.mock("../plugins/github/loadWeightedGraph", () => ({
@@ -102,11 +103,11 @@ describe("api/load", () => {
   it("calls github githubWeightedGraph with the right options", async () => {
     const {options, taskReporter, sourcecredDirectory} = example();
     await load(options, taskReporter);
-    const cacheDirectory = path.join(sourcecredDirectory, "cache");
+    const cache = new DataDirectory(sourcecredDirectory);
     const expectedLoadGraphOptions: LoadGraphOptions = {
       repoIds: project.repoIds,
       token: exampleGithubToken,
-      cacheDirectory,
+      cache,
     };
     expect(githubWeightedGraph).toHaveBeenCalledWith(
       expectedLoadGraphOptions,

--- a/src/plugins/github/bin/fetchAndPrintGithubRepo.js
+++ b/src/plugins/github/bin/fetchAndPrintGithubRepo.js
@@ -13,10 +13,9 @@
  */
 
 import stringify from "json-stable-stringify";
-import tmp from "tmp";
-
 import fetchGithubRepo from "../fetchGithubRepo";
 import {makeRepoId} from "../repoId";
+import {MemoryCacheProvider} from "../../../backend/memoryCacheProvider";
 
 function parseArgs() {
   const argv = process.argv.slice(2);
@@ -38,7 +37,8 @@ function parseArgs() {
 function main() {
   const args = parseArgs();
   const repoId = makeRepoId(args.owner, args.name);
-  const options = {token: args.githubToken, cacheDirectory: tmp.dirSync().name};
+  const cache = new MemoryCacheProvider();
+  const options = {token: args.githubToken, cache};
   fetchGithubRepo(repoId, options)
     .then((data) => {
       console.log(stringify(data, {space: 4}));

--- a/src/plugins/github/loadGraph.js
+++ b/src/plugins/github/loadGraph.js
@@ -15,11 +15,12 @@ import {RelationalView} from "./relationalView";
 import {type RepoId, repoIdToString} from "./repoId";
 import {Graph} from "../../core/graph";
 import {type GithubToken} from "./token";
+import {type CacheProvider} from "../../backend/cache";
 
 export type Options = {|
   +repoIds: $ReadOnlyArray<RepoId>,
   +token: GithubToken,
-  +cacheDirectory: string,
+  +cache: CacheProvider,
 |};
 
 /**
@@ -42,7 +43,7 @@ export async function loadGraph(
     repositories.push(
       await fetchGithubRepo(repoId, {
         token: options.token,
-        cacheDirectory: options.cacheDirectory,
+        cache: options.cache,
       })
     );
     taskReporter.finish(taskId);


### PR DESCRIPTION
Depends on #1613 
Replaces #1568

Delegating to a `CacheProvider` instance, will limit the number of places where we need to handle filesystem details. It will also allow a mock, or in-memory cache to be provided.

Test plan:
1. `yarn test --full`
Existing flow/eslint coverage should include ` src/plugins/github/bin/*` for correct api usage.
2. Optional: `scripts/update_snapshots.sh` with a `SOURCECRED_GITHUB_TOKEN`.
The updated snapshots should be unchanged.