### PR TITLE
Backend: implement PluginLoaders.declarations

### DIFF
--- a/src/backend/pluginLoaders.js
+++ b/src/backend/pluginLoaders.js
@@ -1,0 +1,39 @@
+//@flow
+
+import {type Project} from "../core/project";
+import {type PluginDeclaration} from "../analysis/pluginDeclaration";
+import {type Loader as GithubLoader} from "../plugins/github/loader";
+import {type Loader as IdentityLoader} from "../plugins/identity/loader";
+import {type Loader as DiscourseLoader} from "../plugins/discourse/loader";
+
+/**
+ * A type combining all known plugin Loader interfaces.
+ *
+ * Using this allows us to define "for all plugins" semantics, while keeping
+ * each underlying plugin's interface flexible.
+ */
+export type PluginLoaders = {|
+  +github: GithubLoader,
+  +discourse: DiscourseLoader,
+  +identity: IdentityLoader,
+|};
+
+/**
+ * Gets all relevant PluginDeclarations for a given Project.
+ */
+export function declarations(
+  {github, discourse, identity}: PluginLoaders,
+  project: Project
+): $ReadOnlyArray<PluginDeclaration> {
+  const plugins: PluginDeclaration[] = [];
+  if (project.repoIds.length) {
+    plugins.push(github.declaration());
+  }
+  if (project.discourseServer != null) {
+    plugins.push(discourse.declaration());
+  }
+  if (project.identities.length) {
+    plugins.push(identity.declaration());
+  }
+  return plugins;
+}

--- a/src/backend/pluginLoaders.test.js
+++ b/src/backend/pluginLoaders.test.js
@@ -1,0 +1,72 @@
+// @flow
+
+import {createProject} from "../core/project";
+import {makeRepoId} from "../plugins/github/repoId";
+import * as PluginLoaders from "./pluginLoaders";
+
+const fakeGithubDec = ("fake-github-dec": any);
+const fakeDiscourseDec = ("fake-discourse-dec": any);
+const fakeIdentityDec = ("fake-identity-dec": any);
+
+const mockPluginLoaders = () => ({
+  github: {
+    declaration: jest.fn().mockReturnValue(fakeGithubDec),
+  },
+  discourse: {
+    declaration: jest.fn().mockReturnValue(fakeDiscourseDec),
+  },
+  identity: {
+    declaration: jest.fn().mockReturnValue(fakeIdentityDec),
+  },
+});
+
+describe("src/backend/pluginLoaders", () => {
+  const exampleRepoId = makeRepoId("sourcecred-test", "example-github");
+
+  describe("declarations", () => {
+    it("should include discourse declaration", async () => {
+      // Given
+      const loaders = mockPluginLoaders();
+      const project = createProject({
+        id: "has-discourse",
+        discourseServer: {serverUrl: "http://foo.bar"},
+      });
+
+      // When
+      const decs = PluginLoaders.declarations(loaders, project);
+
+      // Then
+      expect(decs).toEqual([fakeDiscourseDec]);
+    });
+
+    it("should include github declaration", async () => {
+      // Given
+      const loaders = mockPluginLoaders();
+      const project = createProject({
+        id: "has-github",
+        repoIds: [exampleRepoId],
+      });
+
+      // When
+      const decs = PluginLoaders.declarations(loaders, project);
+
+      // Then
+      expect(decs).toEqual([fakeGithubDec]);
+    });
+
+    it("should include identity declaration", async () => {
+      // Given
+      const loaders = mockPluginLoaders();
+      const project = createProject({
+        id: "has-identity",
+        identities: [{username: "foo", aliases: ["github/foo"]}],
+      });
+
+      // When
+      const decs = PluginLoaders.declarations(loaders, project);
+
+      // Then
+      expect(decs).toEqual([fakeIdentityDec]);
+    });
+  });
+});

--- a/src/plugins/discourse/loader.js
+++ b/src/plugins/discourse/loader.js
@@ -1,0 +1,12 @@
+// @flow
+
+import {type PluginDeclaration} from "../../analysis/pluginDeclaration";
+import {declaration} from "./declaration";
+
+export interface Loader {
+  declaration(): PluginDeclaration;
+}
+
+export default ({
+  declaration: () => declaration,
+}: Loader);

--- a/src/plugins/github/loader.js
+++ b/src/plugins/github/loader.js
@@ -1,0 +1,12 @@
+// @flow
+
+import {type PluginDeclaration} from "../../analysis/pluginDeclaration";
+import {declaration} from "./declaration";
+
+export interface Loader {
+  declaration(): PluginDeclaration;
+}
+
+export default ({
+  declaration: () => declaration,
+}: Loader);

--- a/src/plugins/identity/loader.js
+++ b/src/plugins/identity/loader.js
@@ -1,0 +1,12 @@
+// @flow
+
+import {type PluginDeclaration} from "../../analysis/pluginDeclaration";
+import {declaration} from "./declaration";
+
+export interface Loader {
+  declaration(): PluginDeclaration;
+}
+
+export default ({
+  declaration: () => declaration,
+}: Loader);


### PR DESCRIPTION
Part of the load refactor #1586

This is the first of several commits to create the PluginLoaders abstraction. Using this allows us to define "for all plugins" semantics, while keeping each underlying plugin interface flexible.

Test plan: `yarn test`