### PR TITLE
Backend: implement PluginLoaders.createPluginGraphs

### DIFF
--- a/src/plugins/github/loader.js
+++ b/src/plugins/github/loader.js
@@ -2,11 +2,19 @@
 
 import {TaskReporter} from "../../util/taskReporter";
 import {type CacheProvider} from "../../backend/cache";
+import {type WeightedGraph} from "../../core/weightedGraph";
 import {type PluginDeclaration} from "../../analysis/pluginDeclaration";
 import {type GithubToken} from "./token";
+import {Graph} from "../../core/graph";
 import {declaration} from "./declaration";
 import {type RepoId, repoIdToString} from "./repoId";
-import {default as fetchGithubRepo} from "./fetchGithubRepo";
+import {createGraph as _createGraph} from "./createGraph";
+import {RelationalView} from "./relationalView";
+import {weightsForDeclaration} from "../../analysis/pluginDeclaration";
+import {
+  default as fetchGithubRepo,
+  fetchGithubRepoFromCache,
+} from "./fetchGithubRepo";
 
 export interface Loader {
   declaration(): PluginDeclaration;
@@ -16,11 +24,17 @@ export interface Loader {
     cache: CacheProvider,
     reporter: TaskReporter
   ): Promise<void>;
+  createGraph(
+    repoIds: $ReadOnlyArray<RepoId>,
+    token: GithubToken,
+    cache: CacheProvider
+  ): Promise<WeightedGraph>;
 }
 
 export default ({
   declaration: () => declaration,
   updateMirror,
+  createGraph,
 }: Loader);
 
 export async function updateMirror(
@@ -38,4 +52,24 @@ export async function updateMirror(
     });
     reporter.finish(taskId);
   }
+}
+
+export async function createGraph(
+  repoIds: $ReadOnlyArray<RepoId>,
+  token: GithubToken,
+  cache: CacheProvider
+): Promise<WeightedGraph> {
+  const repositories = [];
+  for (const repoId of repoIds) {
+    repositories.push(await fetchGithubRepoFromCache(repoId, {token, cache}));
+  }
+  const graph = Graph.merge(
+    repositories.map((r) => {
+      const rv = new RelationalView();
+      rv.addRepository(r);
+      return _createGraph(rv);
+    })
+  );
+  const weights = weightsForDeclaration(declaration);
+  return {graph, weights};
 }


### PR DESCRIPTION
Part of the load refactor #1586
Depends on #1617 and #1569

Similar to CachedProject, we're using an opaque PluginGraphs return type. Because only PluginLoaders can add the semantic of this being all plugin graphs, and to use this semantic in future functions.

Test plan: `yarn test`