### PR TITLE
Backend: implement PluginLoaders.contractPluginGraphs

### DIFF
--- a/src/plugins/identity/loader.js
+++ b/src/plugins/identity/loader.js
@@ -1,12 +1,20 @@
 // @flow
 
 import {type PluginDeclaration} from "../../analysis/pluginDeclaration";
+import {type WeightedGraph} from "../../core/weightedGraph";
+import {type IdentitySpec} from "./identity";
+import {contractIdentities} from "./contractIdentities";
 import {declaration} from "./declaration";
 
 export interface Loader {
   declaration(): PluginDeclaration;
+  contractIdentities(
+    weightedGraph: WeightedGraph,
+    identitySpec: IdentitySpec
+  ): WeightedGraph;
 }
 
 export default ({
   declaration: () => declaration,
+  contractIdentities,
 }: Loader);


### PR DESCRIPTION
Part of the load refactor #1586
Depends on #1618 

Note: this doesn't include a `WeightedGraph.overrideWeights` step. Because overriding weights isn't related to plugins, this will be handled as a separate feature, later in the load pipeline.

Test plan: `yarn test`