### PR TITLE
Switch to LoadContext based loading

### DIFF
--- a/src/api/load.js
+++ b/src/api/load.js
@@ -23,6 +23,7 @@ import {type Weights as WeightsT} from "../core/weights";
 import {loadWeightedGraph} from "./loadWeightedGraph";
 import {DataDirectory} from "../backend/dataDirectory";
 import {type CacheProvider} from "../backend/cache";
+import {LoadContext} from "../backend/loadContext";
 
 export type LoadOptions = {|
   +project: Project,
@@ -32,6 +33,26 @@ export type LoadOptions = {|
   +sourcecredDirectory: string,
   +githubToken: ?GithubToken,
 |};
+
+export async function loadContext(
+  options: LoadOptions,
+  reporter: TaskReporter
+): Promise<void> {
+  const {
+    sourcecredDirectory,
+    githubToken,
+    project,
+    params,
+    weightsOverrides,
+  } = options;
+  const data = new DataDirectory(sourcecredDirectory);
+  const context = new LoadContext({cache: data, githubToken, reporter});
+  const result = await context.load(project, {
+    params: params || {},
+    weightsOverrides,
+  });
+  data.storeProject(project, result);
+}
 
 /**
  * Loads and computes cred for a project.

--- a/src/cli/discourse.js
+++ b/src/cli/discourse.js
@@ -8,7 +8,7 @@ import {LoggingTaskReporter} from "../util/taskReporter";
 import type {Command} from "./command";
 import * as Common from "./common";
 import * as Weights from "../core/weights";
-import {load} from "../api/load";
+import {loadContext as load} from "../api/load";
 import {declaration as discourseDeclaration} from "../plugins/discourse/declaration";
 import {type Project, createProject} from "../core/project";
 

--- a/src/cli/load.js
+++ b/src/cli/load.js
@@ -7,7 +7,7 @@ import type {Command} from "./command";
 import * as Common from "./common";
 import * as Weights from "../core/weights";
 import {projectFromJSON} from "../core/project";
-import {load} from "../api/load";
+import {loadContext as load} from "../api/load";
 import {specToProject} from "../plugins/github/specToProject";
 import fs from "fs-extra";
 import {type PluginDeclaration} from "../analysis/pluginDeclaration";

--- a/src/cli/load.test.js
+++ b/src/cli/load.test.js
@@ -16,9 +16,9 @@ import {makeRepoId, stringToRepoId} from "../plugins/github/repoId";
 import {validateToken} from "../plugins/github/token";
 import {defaultParams} from "../analysis/timeline/params";
 
-jest.mock("../api/load", () => ({load: jest.fn()}));
+jest.mock("../api/load", () => ({loadContext: jest.fn()}));
 type JestMockFn = $Call<typeof jest.fn>;
-const load: JestMockFn = (require("../api/load").load: any);
+const load: JestMockFn = (require("../api/load").loadContext: any);
 
 describe("cli/load", () => {
   const exampleGithubToken = validateToken("0".repeat(40));


### PR DESCRIPTION
Part of the load refactor #1586
Depends on #1621

This naming is temporary, as the old loading code is removed it will be named load and replace the existing function.

Test plan:
- `yarn test --full`
- Manually `bin/sourcecred.js load` a project