### PR TITLE
Add to/fromJSON for plugin declarations

### DIFF
--- a/src/analysis/__snapshots__/pluginDeclaration.test.js.snap
+++ b/src/analysis/__snapshots__/pluginDeclaration.test.js.snap
@@ -1,0 +1,5 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`analysis/pluginDeclaration to/fromJSON snapshots on an empty declaration 1`] = `"[{\\"type\\":\\"sourcecred/pluginDeclarations\\",\\"version\\":\\"0.1.0\\"},[{\\"edgePrefix\\":\\"E\\\\u0000\\",\\"edgeTypes\\":[],\\"name\\":\\"empty\\",\\"nodePrefix\\":\\"N\\\\u0000\\",\\"nodeTypes\\":[],\\"userTypes\\":[]}]]"`;
+
+exports[`analysis/pluginDeclaration to/fromJSON snapshots on an non-empty declaration 1`] = `"[{\\"type\\":\\"sourcecred/pluginDeclarations\\",\\"version\\":\\"0.1.0\\"},[{\\"edgePrefix\\":\\"E\\\\u0000\\",\\"edgeTypes\\":[{\\"backwardName\\":\\"is pointed to\\",\\"defaultWeight\\":{\\"backwards\\":3,\\"forwards\\":2},\\"description\\":\\"a type\\",\\"forwardName\\":\\"points\\",\\"prefix\\":\\"E\\\\u0000edge\\\\u0000\\"}],\\"name\\":\\"non-empty\\",\\"nodePrefix\\":\\"N\\\\u0000\\",\\"nodeTypes\\":[{\\"defaultWeight\\":2,\\"description\\":\\"a type\\",\\"name\\":\\"node\\",\\"pluralName\\":\\"nodes\\",\\"prefix\\":\\"N\\\\u0000node\\\\u0000\\"}],\\"userTypes\\":[]}]]"`;

--- a/src/analysis/pluginDeclaration.js
+++ b/src/analysis/pluginDeclaration.js
@@ -4,6 +4,9 @@ import {type NodeAddressT, type EdgeAddressT} from "../core/graph";
 import type {EdgeType, NodeType, NodeAndEdgeTypes} from "./types";
 import * as Weights from "../core/weights";
 import {type Weights as WeightsT} from "../core/weights";
+import {toCompat, fromCompat, type Compatible} from "../util/compat";
+
+const COMPAT_INFO = {type: "sourcecred/pluginDeclarations", version: "0.1.0"};
 
 // TODO(@decentralion): Maybe merge this file with analysis/types
 
@@ -22,6 +25,18 @@ export type PluginDeclaration = {|
   // user type weights.
   +userTypes: $ReadOnlyArray<NodeType>,
 |};
+
+export type PluginDeclarations = $ReadOnlyArray<PluginDeclaration>;
+
+export function toJSON(decs: PluginDeclarations): PluginDeclarationsJSON {
+  return toCompat(COMPAT_INFO, decs);
+}
+
+export function fromJSON(json: PluginDeclarationsJSON): PluginDeclarations {
+  return fromCompat(COMPAT_INFO, json);
+}
+
+export type PluginDeclarationsJSON = Compatible<PluginDeclarations>;
 
 export function combineTypes(
   decs: $ReadOnlyArray<PluginDeclaration>

--- a/src/analysis/pluginDeclaration.test.js
+++ b/src/analysis/pluginDeclaration.test.js
@@ -1,11 +1,14 @@
 // @flow
 
+import stringify from "json-stable-stringify";
 import deepFreeze from "deep-freeze";
 import {NodeAddress, EdgeAddress} from "../core/graph";
 import {type NodeType, type EdgeType} from "./types";
 import {
   weightsForDeclaration,
   type PluginDeclaration,
+  toJSON,
+  fromJSON,
 } from "./pluginDeclaration";
 import * as Weights from "../core/weights";
 
@@ -50,6 +53,27 @@ describe("analysis/pluginDeclaration", () => {
       expected.edgeWeights.set(edgeType.prefix, edgeType.defaultWeight);
       const actual = weightsForDeclaration(nonEmptyDeclaration);
       expect(expected).toEqual(actual);
+    });
+  });
+
+  describe("to/fromJSON", () => {
+    it("works round-trip on an empty declaration", () => {
+      const json = toJSON([emptyDeclaration]);
+      const result = fromJSON(json);
+      expect(result).toEqual([emptyDeclaration]);
+    });
+    it("snapshots on an empty declaration", () => {
+      // stringify to avoid having literal NUL bytes in our source.
+      expect(stringify(toJSON([emptyDeclaration]))).toMatchSnapshot();
+    });
+    it("works round-trip on an non-empty declaration", () => {
+      const json = toJSON([nonEmptyDeclaration]);
+      const result = fromJSON(json);
+      expect(result).toEqual([nonEmptyDeclaration]);
+    });
+    it("snapshots on an non-empty declaration", () => {
+      // stringify to avoid having literal NUL bytes in our source.
+      expect(stringify(toJSON([nonEmptyDeclaration]))).toMatchSnapshot();
     });
   });
 });


### PR DESCRIPTION
This commit adds a simple method for (de-)serializing arrays of
PluginDeclarations. This will allow us to save PluginDeclarations for
consumption by the frontend, without having them bundled with cred
results in TimelineCred. Thus, we can simplify and clean up TimelineCred
as described in #1557.

Test plan: Inspect unit tests and snapshots; `yarn test` passes.