### PR TITLE
Frontend gets plugins from disk, not TimelineCred

### DIFF
--- a/src/analysis/timeline/timelineCred.js
+++ b/src/analysis/timeline/timelineCred.js
@@ -76,10 +76,6 @@ export class TimelineCred {
     return this._params;
   }
 
-  plugins(): $ReadOnlyArray<PluginDeclaration> {
-    return this._plugins;
-  }
-
   /**
    * Creates a new TimelineCred based on the new Parameters.
    * Holds the graph and config constant.
@@ -151,7 +147,7 @@ export class TimelineCred {
    * with a type specified as a user type by one of the plugin declarations.
    */
   userNodes(): $ReadOnlyArray<CredNode> {
-    const userTypes = [].concat(...this.plugins().map((p) => p.userTypes));
+    const userTypes = [].concat(...this._plugins.map((p) => p.userTypes));
     return this.credSortedNodes(userTypes.map((x) => x.prefix));
   }
 

--- a/src/explorer/TimelineExplorer.js
+++ b/src/explorer/TimelineExplorer.js
@@ -11,13 +11,17 @@ import {TimelineCredView} from "./TimelineCredView";
 import Link from "../webutil/Link";
 import {WeightConfig} from "./weights/WeightConfig";
 import {WeightsFileManager} from "./weights/WeightsFileManager";
-import {type PluginDeclaration} from "../analysis/pluginDeclaration";
+import {
+  type PluginDeclarations,
+  type PluginDeclaration,
+} from "../analysis/pluginDeclaration";
 import * as NullUtil from "../util/null";
 import {format} from "d3-format";
 
 export type Props = {
   projectId: string,
   initialTimelineCred: TimelineCred,
+  pluginDeclarations: PluginDeclarations,
 };
 
 export type State = {
@@ -89,7 +93,7 @@ export class TimelineExplorer extends React.Component<Props, State> {
     );
     const weightConfig = (
       <WeightConfig
-        declarations={this.state.timelineCred.plugins()}
+        declarations={this.props.pluginDeclarations}
         nodeWeights={this.state.weights.nodeWeights}
         edgeWeights={this.state.weights.edgeWeights}
         onNodeWeightChange={(prefix, weight) => {
@@ -201,7 +205,7 @@ export class TimelineExplorer extends React.Component<Props, State> {
           <option key={"All users"} value={""}>
             All users
           </option>
-          {this.state.timelineCred.plugins().map(optionGroup)}
+          {this.props.pluginDeclarations.map(optionGroup)}
         </select>
       </label>
     );

--- a/src/explorer/legacy/App.js
+++ b/src/explorer/legacy/App.js
@@ -93,7 +93,7 @@ export function createApp(
       );
       let pagerankTable;
       if (appState.type === "PAGERANK_EVALUATED") {
-        const declarations = appState.timelineCred.plugins();
+        const declarations = appState.pluginDeclarations;
         const weightConfig = (
           <WeightConfig
             declarations={declarations}

--- a/src/explorer/legacy/App.test.js
+++ b/src/explorer/legacy/App.test.js
@@ -72,6 +72,7 @@ describe("explorer/legacy/App", () => {
           defaultParams(),
           []
         ),
+        pluginDeclarations: [],
       });
     },
     pagerankEvaluated: (loadingState) => {
@@ -86,6 +87,7 @@ describe("explorer/legacy/App", () => {
           defaultParams(),
           []
         ),
+        pluginDeclarations: [],
         pagerankNodeDecomposition: new Map(),
       });
     },


### PR DESCRIPTION
This commit modifies the frontend so that it now pulls plugin
declarations from disk, rather than from the TimelineCred. This will
allow us to decouple the TimelineCred from the PluginDeclarations, which
is another step towards #1557.

As proof that the frontend no longer gets plugins from the TimelineCred,
I removed the public `plugins()` method on TimelineCred.

Test plan: The frontend is somewhat sketchily tested. `yarn test`
passing is good, manual inspection of the frontend is also necessary;
I've done this.