### PR TITLE
Fix console errors from state.test.js

### DIFF
--- a/src/explorer/legacy/state.test.js
+++ b/src/explorer/legacy/state.test.js
@@ -15,7 +15,20 @@ import {TimelineCred} from "../../analysis/timeline/timelineCred";
 import {defaultParams} from "../../analysis/timeline/params";
 import {type LoadSuccess} from "../TimelineApp";
 
+jest.spyOn(console, "log").mockImplementation(() => {});
+jest.spyOn(console, "error").mockImplementation(() => {});
+const logMock: JestMockFn<any, void> = console.log;
+const errorMock: JestMockFn<any, void> = console.error;
+
 describe("explorer/legacy/state", () => {
+  beforeEach(() => {
+    logMock.mockClear();
+    errorMock.mockClear();
+  });
+  afterEach(() => {
+    expect(errorMock).not.toHaveBeenCalled();
+    expect(logMock).not.toHaveBeenCalled();
+  });
   function example(startingState: AppState) {
     const stateContainer = {appState: startingState};
     const getState = () => stateContainer.appState;
@@ -26,6 +39,13 @@ describe("explorer/legacy/state", () => {
       [Assets, string],
       Promise<LoadSuccess>
     > = jest.fn();
+    loadMock.mockImplementation(() =>
+      Promise.resolve({
+        pluginDeclarations: [],
+        timelineCred: (null: any),
+        type: "SUCCESS",
+      })
+    );
 
     const pagerankMock: JestMockFn<
       [Graph, EdgeEvaluator, PagerankOptions],


### PR DESCRIPTION
This commit fixes an issue introduced in #1625, which caused the
`state.test.js` file to print some unhandled console errors when
running `yarn unit`.

First, this commit changes the file so that it properly errors if any
unexpected console errors are printed. Then it fixes the erroring tests.

Test plan: `yarn test` passes; `yarn unit --watch legacy/state.test.js`
no longer prints any error messages to console.