### PR TITLE
Move timeline pagerank code to core/algorithm

### DIFF
--- a/src/analysis/timeline/timelineCred.js
+++ b/src/analysis/timeline/timelineCred.js
@@ -5,9 +5,9 @@ import sortBy from "lodash.sortby";
 import * as NullUtil from "../../util/null";
 import * as MapUtil from "../../util/map";
 import {toCompat, fromCompat, type Compatible} from "../../util/compat";
-import {type Interval} from "./interval";
-import {timelinePagerank} from "./timelinePagerank";
-import {distributionToCred} from "./distributionToCred";
+import {type Interval} from "../../core/interval";
+import {timelinePagerank} from "../../core/algorithm/timelinePagerank";
+import {distributionToCred} from "../../core/algorithm/distributionToCred";
 import {type PluginDeclaration} from "../pluginDeclaration";
 import {type NodeAddressT, NodeAddress, type Node} from "../../core/graph";
 import * as WeightedGraph from "../../core/weightedGraph";
@@ -25,7 +25,7 @@ import {
   defaultParams,
 } from "./params";
 
-export type {Interval} from "./interval";
+export type {Interval} from "../../core/interval";
 
 /**
  * A Graph Node wrapped with cred information.

--- a/src/analysis/weightsToEdgeEvaluator.js
+++ b/src/analysis/weightsToEdgeEvaluator.js
@@ -3,7 +3,10 @@
 import type {Edge} from "../core/graph";
 import type {Weights} from "../core/weights";
 import type {EdgeEvaluator} from "./pagerank";
-import {nodeWeightEvaluator, edgeWeightEvaluator} from "./weightEvaluator";
+import {
+  nodeWeightEvaluator,
+  edgeWeightEvaluator,
+} from "../core/algorithm/weightEvaluator";
 
 /**
  * Given the weight choices and the node and edge types, produces an edge

--- a/src/core/algorithm/distributionToCred.js
+++ b/src/core/algorithm/distributionToCred.js
@@ -5,7 +5,7 @@
  */
 
 import {sum} from "d3-array";
-import {type Interval} from "./interval";
+import {type Interval} from "../interval";
 import {type TimelineDistributions} from "./timelinePagerank";
 import {NodeAddress, type NodeAddressT} from "../../core/graph";
 

--- a/src/core/algorithm/distributionToCred.test.js
+++ b/src/core/algorithm/distributionToCred.test.js
@@ -1,9 +1,9 @@
 // @flow
 
-import {NodeAddress} from "../../core/graph";
+import {NodeAddress} from "../graph";
 import {distributionToCred} from "./distributionToCred";
 
-describe("src/analysis/timeline/distributionToCred", () => {
+describe("src/core/algorithm/distributionToCred", () => {
   const na = (...parts) => NodeAddress.fromParts(parts);
   describe("distributionToCred", () => {
     it("works in a case where all nodes are scoring", () => {

--- a/src/core/algorithm/timelinePagerank.js
+++ b/src/core/algorithm/timelinePagerank.js
@@ -6,26 +6,26 @@
 import deepFreeze from "deep-freeze";
 import {sum} from "d3-array";
 import * as NullUtil from "../../util/null";
-import {Graph, type NodeAddressT, type Edge, type Node} from "../../core/graph";
-import {type WeightedGraph} from "../../core/weightedGraph";
-import {type Interval, partitionGraph} from "./interval";
+import {Graph, type NodeAddressT, type Edge, type Node} from "../graph";
+import {type WeightedGraph} from "../weightedGraph";
+import {type Interval, partitionGraph} from "../interval";
 import {
   nodeWeightEvaluator,
   edgeWeightEvaluator,
   type NodeWeightEvaluator,
   type EdgeWeightEvaluator,
-} from "../weightEvaluator";
-import {weightedDistribution} from "../../core/algorithm/nodeDistribution";
-import {type Distribution} from "../../core/algorithm/distribution";
+} from "./weightEvaluator";
+import {weightedDistribution} from "./nodeDistribution";
+import {type Distribution} from "./distribution";
 import {
   createOrderedSparseMarkovChain,
   createConnections,
-} from "../../core/algorithm/graphToMarkovChain";
+} from "./graphToMarkovChain";
 import {
   findStationaryDistribution,
   type PagerankParams,
   type SparseMarkovChain,
-} from "../../core/algorithm/markovChain";
+} from "./markovChain";
 
 /**
  * Represents raw PageRank distributions on a graph over time.

--- a/src/core/algorithm/timelinePagerank.test.js
+++ b/src/core/algorithm/timelinePagerank.test.js
@@ -2,17 +2,17 @@
 
 import {sum} from "d3-array";
 import * as NullUtil from "../../util/null";
-import {node, edge} from "../../core/graphTestUtil";
-import {Graph, type EdgeAddressT, type Edge} from "../../core/graph";
+import {node, edge} from "../graphTestUtil";
+import {Graph, type EdgeAddressT, type Edge} from "../graph";
 import {_timelineNodeWeights, _timelineMarkovChain} from "./timelinePagerank";
 import {
   createConnections,
   createOrderedSparseMarkovChain,
   type EdgeWeight,
-} from "../../core/algorithm/graphToMarkovChain";
-import {type SparseMarkovChain} from "../../core/algorithm/markovChain";
+} from "./graphToMarkovChain";
+import {type SparseMarkovChain} from "./markovChain";
 
-describe("src/analysis/timeline/timelinePagerank", () => {
+describe("src/core/algorithm/timelinePagerank", () => {
   describe("_timelineNodeWeights", () => {
     it("works in a simple case", () => {
       const foo = node("foo");

--- a/src/core/algorithm/weightEvaluator.js
+++ b/src/core/algorithm/weightEvaluator.js
@@ -1,12 +1,8 @@
 // @flow
 
-import type {NodeAddressT, EdgeAddressT} from "../core/graph";
-import type {
-  Weights as WeightsT,
-  EdgeWeight,
-  NodeWeight,
-} from "../core/weights";
-import {NodeTrie, EdgeTrie} from "../core/trie";
+import type {NodeAddressT, EdgeAddressT} from "../graph";
+import type {Weights as WeightsT, EdgeWeight, NodeWeight} from "../weights";
+import {NodeTrie, EdgeTrie} from "../trie";
 
 export type NodeWeightEvaluator = (NodeAddressT) => NodeWeight;
 export type EdgeWeightEvaluator = (EdgeAddressT) => EdgeWeight;

--- a/src/core/algorithm/weightEvaluator.test.js
+++ b/src/core/algorithm/weightEvaluator.test.js
@@ -1,10 +1,10 @@
 // @flow
 
-import {NodeAddress, EdgeAddress} from "../core/graph";
+import {NodeAddress, EdgeAddress} from "../graph";
 import {nodeWeightEvaluator, edgeWeightEvaluator} from "./weightEvaluator";
-import * as Weights from "../core/weights";
+import * as Weights from "../weights";
 
-describe("src/analysis/weightEvaluator", () => {
+describe("src/core/algorithm/weightEvaluator", () => {
   describe("nodeWeightEvaluator", () => {
     const empty = NodeAddress.fromParts([]);
     const foo = NodeAddress.fromParts(["foo"]);

--- a/src/core/interval.js
+++ b/src/core/interval.js
@@ -3,8 +3,8 @@
 import {max, min} from "d3-array";
 import sortBy from "lodash.sortby";
 import {utcWeek} from "d3-time";
-import * as NullUtil from "../../util/null";
-import type {Node, Edge, Graph} from "../../core/graph";
+import * as NullUtil from "../util/null";
+import type {Node, Edge, Graph} from "./graph";
 
 /**
  * Represents a time interval

--- a/src/core/interval.test.js
+++ b/src/core/interval.test.js
@@ -1,11 +1,11 @@
 // @flow
 
 import {utcWeek} from "d3-time";
-import {node, edge} from "../../core/graphTestUtil";
-import {Graph} from "../../core/graph";
+import {node, edge} from "./graphTestUtil";
+import {Graph} from "./graph";
 import {partitionGraph, graphIntervals, weekIntervals} from "./interval";
 
-describe("src/analysis/timeline/interval", () => {
+describe("src/core/interval", () => {
   const WEEK_MID = 1562501362239;
   const WEEK_START = +utcWeek.floor(WEEK_MID);
   const WEEK_END = +utcWeek.ceil(WEEK_MID);


### PR DESCRIPTION
This commit moves a lot of code and algorithms for computing timeline
cred scores into `core/algorithm`. The `TimelineCred` module hasn't been
moved, because it isn't clean enough for core -- it has dependencies on
analysis and types, for example.

This is another material step towards consolidating all of the
SourceCred algorithm logic into `core/algorithm`, although there's still
more to be done.

Test plan: It's just a code reorg; `yarn test` is sufficient.