### PR TITLE
Remove TimelineCred.reduceSize

### DIFF
--- a/src/analysis/timeline/timelineCred.test.js
+++ b/src/analysis/timeline/timelineCred.test.js
@@ -4,7 +4,7 @@ import deepFreeze from "deep-freeze";
 import {sum} from "d3-array";
 import sortBy from "lodash.sortby";
 import {utcWeek} from "d3-time";
-import {NodeAddress, type NodeAddressT, EdgeAddress} from "../../core/graph";
+import {NodeAddress, EdgeAddress} from "../../core/graph";
 import * as WeightedGraph from "../../core/weightedGraph";
 import {TimelineCred} from "./timelineCred";
 import {defaultParams} from "./params";
@@ -139,58 +139,6 @@ describe("src/analysis/timeline/timelineCred", () => {
     for (const node of nodes) {
       expect(node.total).toEqual(sum(node.cred));
     }
-  });
-
-  describe("reduceSize", () => {
-    it("chooses top nodes for each type prefix", () => {
-      const nodesPerType = 3;
-      const tc = exampleTimelineCred();
-      const filtered = tc.reduceSize({
-        typePrefixes: [userPrefix, fooPrefix],
-        nodesPerType,
-        fullInclusionPrefixes: [],
-      });
-
-      const checkPrefix = (p: NodeAddressT) => {
-        const fullNodes = tc.credSortedNodes([p]);
-        const truncatedNodes = filtered.credSortedNodes([p]);
-        expect(truncatedNodes).toHaveLength(nodesPerType);
-        expect(fullNodes.slice(0, nodesPerType)).toEqual(truncatedNodes);
-      };
-      checkPrefix(userPrefix);
-      checkPrefix(fooPrefix);
-    });
-
-    it("can keep only scoring nodes", () => {
-      const nodesPerType = 3;
-      const tc = exampleTimelineCred();
-      const filtered = tc.reduceSize({
-        typePrefixes: [],
-        nodesPerType,
-        fullInclusionPrefixes: [userPrefix],
-      });
-      const fullUserNodes = tc.credSortedNodes([userPrefix]);
-      const truncatedUserNodes = filtered.credSortedNodes([userPrefix]);
-      expect(fullUserNodes).toEqual(truncatedUserNodes);
-      const truncatedFoo = filtered.credSortedNodes([fooPrefix]);
-      expect(truncatedFoo).toHaveLength(0);
-    });
-
-    it("keeps all scoring nodes (with multiple scoring types)", () => {
-      const nodesPerType = 3;
-      const tc = exampleTimelineCred();
-      const filtered = tc.reduceSize({
-        typePrefixes: [userPrefix, NodeAddress.fromParts(["nope"])],
-        nodesPerType,
-        fullInclusionPrefixes: [userPrefix, fooPrefix],
-      });
-      const fullUserNodes = tc.credSortedNodes([userPrefix]);
-      const truncatedUserNodes = filtered.credSortedNodes([userPrefix]);
-      expect(fullUserNodes).toEqual(truncatedUserNodes);
-      const fullFoo = tc.credSortedNodes([fooPrefix]);
-      const truncatedFoo = filtered.credSortedNodes([fooPrefix]);
-      expect(fullFoo).toEqual(truncatedFoo);
-    });
   });
 
   it("userNodes returns the credSortedNodes for user types", () => {


### PR DESCRIPTION
TimelineCred has a `reduceSize` method which discards cred for most
nodes, keeping only cred for the top nodes of each type across all time.
I've wanted to remove this for a while, because it is a bad fit for the
kind of experimentation we're starting to do with showing the top nodes
for recent activity periods. Since the recent nodes haven't had much
time to accumulate cred, they are almost all discarded by reduceSize. As
an added inducement, I want to get rid of reduceSize for #1557 because
it requires type information.

`reduceSize` still serves one function, which is enabling the frontend
to load faster because it only loads a smaller amount of data which is
discoverable in the UI. However, it doesn't make sense to discard most
of the data just for a fast UI load--we can later make another data
structure which is tuned for the needs of the frontend, and have that
data structure include only summary statistics.

This will make the cred.json file much larger for large repos, e.g. I
expect that loading tensorflow/tensorflow would now go over the 100MB
hard cap for GitHub pages. However, right now we're prioritizing using
SourceCred for medium-small projects (e.g. SourceCred itself, and maybe
Maker), so this isn't a current concern.

Test plan: `yarn test --full` passes.