### PR TITLE
Initiatives: add initiativesMap type

### DIFF
--- a/src/plugins/initiatives/initiativesMap.js
+++ b/src/plugins/initiatives/initiativesMap.js
@@ -1,0 +1,32 @@
+// @flow
+
+import {type Compatible, fromCompat, toCompat} from "../../util/compat";
+import {type URL} from "./initiative";
+
+const COMPAT_INFO = {type: "sourcecred/initiatives", version: "0.1.0"};
+
+/**
+ * JSON (compat) representation of an Initiative.
+ *
+ * Major difference is that instead of using tracker addresses, we use object
+ * keys as an ID, and derive the tracker address from that.
+ */
+export type InitiativesMap = {[entryKey: string]: InitiativeEntry};
+
+type InitiativeEntry = {|
+  +title: string,
+  +timestampMs: number,
+  +completed: boolean,
+  +dependencies: $ReadOnlyArray<URL>,
+  +references: $ReadOnlyArray<URL>,
+  +contributions: $ReadOnlyArray<URL>,
+  +champions: $ReadOnlyArray<URL>,
+|};
+
+export function fromJSON(j: Compatible<any>): InitiativesMap {
+  return fromCompat(COMPAT_INFO, j);
+}
+
+export function toJSON(m: InitiativesMap): Compatible<InitiativesMap> {
+  return toCompat(COMPAT_INFO, m);
+}

--- a/src/plugins/initiatives/initiativesMap.test.js
+++ b/src/plugins/initiatives/initiativesMap.test.js
@@ -1,0 +1,29 @@
+// @flow
+
+import {fromJSON, toJSON} from "./initiativesMap";
+
+describe("plugins/initiatives/initiativesMap", () => {
+  const exampleMap = {
+    "2020-01-08_sample-initiative": {
+      title: "Sample initiative",
+      timestampMs: 1578520917766,
+      completed: false,
+      champions: [],
+      contributions: [],
+      dependencies: [],
+      references: [],
+    },
+  };
+
+  describe("toJSON/fromJSON", () => {
+    it("should handle an example map round-trip", () => {
+      // Given
+
+      // When
+      const actual = fromJSON(toJSON(exampleMap));
+
+      // Then
+      expect(actual).toEqual(exampleMap);
+    });
+  });
+});


### PR DESCRIPTION
Based on [forum discussion][1], Initiatives should be tracked as in files.

There's one main issue with storing the existing Initiative type as
JSON in a file, there's no natural NodeAddress for a file-based tracker.
This type resolves that by using the keys of a JSON object as a unique
reference within that file.

Test plan: `yarn test`

[1]: https://discourse.sourcecred.io/t/576