### PR TITLE
Initiatives: add conversion functions for InitiativesMap

### DIFF
--- a/src/plugins/initiatives/__snapshots__/initiativesMap.test.js.snap
+++ b/src/plugins/initiatives/__snapshots__/initiativesMap.test.js.snap
@@ -1,0 +1,75 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`plugins/initiatives/initiativesMap smoke test should handle a full round-trip 1`] = `
+"[
+  {
+    \\"champions\\": [
+      \\"https://github.com/Beanow\\"
+    ],
+    \\"completed\\": false,
+    \\"contributions\\": [
+    ],
+    \\"dependencies\\": [
+      \\"https://discourse.sourcecred.io/t/write-the-initiatives-plugin/269\\"
+    ],
+    \\"references\\": [
+      \\"https://github.com/sourcecred/sourcecred/pull/1493\\"
+    ],
+    \\"timestampMs\\": 1578520917751,
+    \\"title\\": \\"Hello prototype!\\",
+    \\"tracker\\": \\"N\\\\u0000sourcecred\\\\u0000initiativesMap\\\\u0000make-prototype-happen\\\\u0000\\"
+  },
+  {
+    \\"champions\\": [
+    ],
+    \\"completed\\": false,
+    \\"contributions\\": [
+    ],
+    \\"dependencies\\": [
+    ],
+    \\"references\\": [
+      \\"https://discourse.sourcecred.io/t/draft-initiatives-guide/525\\"
+    ],
+    \\"timestampMs\\": 1578520917752,
+    \\"title\\": \\"Another prototype :o\\",
+    \\"tracker\\": \\"N\\\\u0000sourcecred\\\\u0000initiativesMap\\\\u0000another-one\\\\u0000\\"
+  }
+]"
+`;
+
+exports[`plugins/initiatives/initiativesMap smoke test should handle a full round-trip 2`] = `
+Array [
+  Object {
+    "type": "sourcecred/initiatives",
+    "version": "0.1.0",
+  },
+  Object {
+    "2020-01-08_another-prototype-o": Object {
+      "champions": Array [],
+      "completed": false,
+      "contributions": Array [],
+      "dependencies": Array [],
+      "references": Array [
+        "https://discourse.sourcecred.io/t/draft-initiatives-guide/525",
+      ],
+      "timestampMs": 1578520917752,
+      "title": "Another prototype :o",
+    },
+    "2020-01-08_hello-prototype": Object {
+      "champions": Array [
+        "https://github.com/Beanow",
+      ],
+      "completed": false,
+      "contributions": Array [],
+      "dependencies": Array [
+        "https://discourse.sourcecred.io/t/write-the-initiatives-plugin/269",
+      ],
+      "references": Array [
+        "https://github.com/sourcecred/sourcecred/pull/1493",
+      ],
+      "timestampMs": 1578520917751,
+      "title": "Hello prototype!",
+    },
+  },
+]
+`;

--- a/src/plugins/initiatives/example/initiatives.json
+++ b/src/plugins/initiatives/example/initiatives.json
@@ -1,0 +1,34 @@
+[
+  {
+    "type": "sourcecred/initiatives",
+    "version": "0.1.0"
+  },
+  {
+    "make-prototype-happen": {
+      "title": "Hello prototype!",
+      "timestampMs": 1578520917751,
+      "completed": false,
+      "dependencies": [
+        "https://discourse.sourcecred.io/t/write-the-initiatives-plugin/269"
+      ],
+      "references": [
+        "https://github.com/sourcecred/sourcecred/pull/1493"
+      ],
+      "contributions": [],
+      "champions": [
+        "https://github.com/Beanow"
+      ]
+    },
+    "another-one": {
+      "title": "Another prototype :o",
+      "timestampMs": 1578520917752,
+      "completed": false,
+      "dependencies": [],
+      "references": [
+        "https://discourse.sourcecred.io/t/draft-initiatives-guide/525"
+      ],
+      "contributions": [],
+      "champions": []
+    }
+  }
+]

--- a/src/plugins/initiatives/initiativesMap.js
+++ b/src/plugins/initiatives/initiativesMap.js
@@ -1,7 +1,10 @@
 // @flow
 
+import {type NodeAddressT, NodeAddress} from "../../core/graph";
 import {type Compatible, fromCompat, toCompat} from "../../util/compat";
-import {type URL} from "./initiative";
+import type {Initiative, URL} from "./initiative";
+
+const trackerPrefix = NodeAddress.fromParts(["sourcecred", "initiativesMap"]);
 
 const COMPAT_INFO = {type: "sourcecred/initiatives", version: "0.1.0"};
 
@@ -29,4 +32,91 @@ export function fromJSON(j: Compatible<any>): InitiativesMap {
 
 export function toJSON(m: InitiativesMap): Compatible<InitiativesMap> {
   return toCompat(COMPAT_INFO, m);
+}
+
+/**
+ * Creates Initiatives from a InitiativesMap.
+ */
+export function mapToInitiatives(
+  initiativesMap: InitiativesMap
+): $ReadOnlyArray<Initiative> {
+  const initiatives = [];
+  for (const entryKey in initiativesMap) {
+    const addr = _trackerAddress(entryKey);
+    initiatives.push({
+      ...initiativesMap[entryKey],
+      tracker: addr,
+    });
+  }
+  return initiatives;
+}
+
+export function _trackerAddress(entryKey: string): NodeAddressT {
+  return NodeAddress.append(trackerPrefix, entryKey);
+}
+
+/**
+ * Creates an InitiativesMap from Initiatives. Warning: this is a lossy
+ * operation, as the original tracker address will be dropped!
+ *
+ * You might use this to take Initiatives from a different source, like an
+ * editor, and format the Initiatives to be stored in a file.
+ */
+export function initiativesToMap(
+  initiatives: $ReadOnlyArray<Initiative>
+): InitiativesMap {
+  const map: InitiativesMap = {};
+
+  for (const initiative of initiatives) {
+    const [baseKey, entry] = _initiativeToEntry(initiative);
+
+    let i = 1;
+    let key = baseKey;
+    const maxAttempts = 100;
+    while (map[key] && i < maxAttempts) {
+      i++;
+      key = `${baseKey}-${i}`;
+    }
+
+    if (map[key]) {
+      throw new Error(
+        `Couldn't generate an appropriate key in ${maxAttempts} attempts ` +
+          `for initiative "${initiative.title}" (${isoDate(
+            initiative.timestampMs
+          )})`
+      );
+    }
+
+    map[key] = entry;
+  }
+
+  return map;
+}
+
+export function _initiativeToEntry(
+  initiative: Initiative
+): [string, InitiativeEntry] {
+  const entry = ({...initiative}: Object);
+  delete entry.tracker;
+  return [_keySlug(initiative), entry];
+}
+
+/**
+ * Creates a normalized key in a "yyyy-mm-dd_initiative-title-here" format.
+ * Note: these are URL friendly.
+ */
+export function _keySlug(initiative: Initiative): string {
+  const titleSlug = initiative.title
+    .toLowerCase()
+    .replace(/\s/g, "-")
+    .replace(/[^a-z0-9-]/g, "")
+    .replace(/-+/g, "-")
+    .replace(/^-+/, "")
+    .replace(/-+$/, "");
+  return `${isoDate(initiative.timestampMs)}_${titleSlug}`;
+}
+
+function isoDate(timestampMs: number): string {
+  const [isoDate, _] = new Date(timestampMs).toISOString().split("T");
+  return isoDate;
 }

--- a/src/plugins/initiatives/initiativesMap.test.js
+++ b/src/plugins/initiatives/initiativesMap.test.js
@@ -1,8 +1,19 @@
 // @flow
 
-import {fromJSON, toJSON} from "./initiativesMap";
+import stringify from "json-stable-stringify";
+import {NodeAddress} from "../../core/graph";
+import {
+  mapToInitiatives,
+  initiativesToMap,
+  fromJSON,
+  toJSON,
+  _trackerAddress,
+  _keySlug,
+  _initiativeToEntry,
+} from "./initiativesMap";
 
 describe("plugins/initiatives/initiativesMap", () => {
+  const exampleJSON = require("./example/initiatives.json");
   const exampleMap = {
     "2020-01-08_sample-initiative": {
       title: "Sample initiative",
@@ -14,6 +25,136 @@ describe("plugins/initiatives/initiativesMap", () => {
       references: [],
     },
   };
+  const exampleInitiative = {
+    title: "Sample initiative",
+    timestampMs: 1578520917766,
+    tracker: NodeAddress.fromParts([
+      "sourcecred",
+      "initiativesMap",
+      "2020-01-08_sample-initiative",
+    ]),
+    completed: false,
+    champions: [],
+    contributions: [],
+    dependencies: [],
+    references: [],
+  };
+
+  describe("_keySlug", () => {
+    it("should construct the correct key", () => {
+      // Given
+
+      // When
+      const key = _keySlug(exampleInitiative);
+
+      // Then
+      expect(key).toEqual("2020-01-08_sample-initiative");
+    });
+
+    it("should only produce infix dashes, without duplicates", () => {
+      // Given
+      const initiative = {
+        ...exampleInitiative,
+        title: "# Foo - & - Bar ?",
+      };
+
+      // When
+      const key = _keySlug(initiative);
+
+      // Then
+      expect(key).toEqual("2020-01-08_foo-bar");
+    });
+  });
+
+  describe("_initiativeToEntry", () => {
+    it("should construct the correct entry", () => {
+      // Given
+
+      // When
+      const [key, entry] = _initiativeToEntry(exampleInitiative);
+
+      // Then
+      expect(key).toEqual("2020-01-08_sample-initiative");
+      expect(entry).toEqual({
+        title: "Sample initiative",
+        timestampMs: 1578520917766,
+        completed: false,
+        champions: [],
+        contributions: [],
+        dependencies: [],
+        references: [],
+      });
+    });
+  });
+
+  describe("_trackerAddress", () => {
+    it("should construct the correct NodeAddress", () => {
+      // Given
+      const key = "hello-test";
+
+      // When
+      const trackerAddress = _trackerAddress(key);
+
+      // Then
+      expect(trackerAddress).toEqual(
+        NodeAddress.fromParts(["sourcecred", "initiativesMap", key])
+      );
+    });
+  });
+
+  describe("mapToInitiatives", () => {
+    it("should handle an example map", () => {
+      // Given
+
+      // When
+      const initiatives = mapToInitiatives(exampleMap);
+
+      // Then
+      expect(initiatives).toEqual([exampleInitiative]);
+    });
+  });
+
+  describe("initiativesToMap", () => {
+    it("should handle an example initiative", () => {
+      // Given
+
+      // When
+      const actual = initiativesToMap([exampleInitiative]);
+
+      // Then
+      expect(actual).toEqual(exampleMap);
+    });
+
+    it("should handle conflicting keys by incrementing a suffix", () => {
+      // Given
+      const initiatives = Array(4).fill(exampleInitiative);
+
+      // When
+      const actual = initiativesToMap(initiatives);
+
+      // Then
+      expect(Object.keys(actual)).toEqual([
+        "2020-01-08_sample-initiative",
+        "2020-01-08_sample-initiative-2",
+        "2020-01-08_sample-initiative-3",
+        "2020-01-08_sample-initiative-4",
+      ]);
+    });
+
+    it("throws at 100+ conflicting keys", () => {
+      // Given
+      const initiatives = Array(101).fill(exampleInitiative);
+
+      // When
+      const fn = () => initiativesToMap(initiatives);
+
+      // Then
+      expect(fn).toThrow(
+        "Couldn't generate an appropriate key in 100 attempts " +
+          'for initiative "Sample initiative" (2020-01-08)'
+      );
+    });
+  });
 
   describe("toJSON/fromJSON", () => {
     it("should handle an example map round-trip", () => {
@@ -24,6 +165,34 @@ describe("plugins/initiatives/initiativesMap", () => {
 
       // Then
       expect(actual).toEqual(exampleMap);
+    });
+  });
+
+  describe("smoke test", () => {
+    it("should handle a full round-trip", () => {
+      // Given
+
+      // When
+      const initiatives = mapToInitiatives(fromJSON(exampleJSON));
+      const json = toJSON(initiativesToMap(initiatives));
+
+      // Then
+      // Note: stringify avoids binary snapshots.
+      expect(stringify(initiatives, {space: 2})).toMatchSnapshot();
+      expect(json).toMatchSnapshot();
+    });
+
+    it("should normalize the keys through a round-trip", () => {
+      // Given
+
+      // When
+      const round0 = fromJSON(exampleJSON);
+      const round1 = initiativesToMap(mapToInitiatives(round0));
+      const round2 = initiativesToMap(mapToInitiatives(round1));
+
+      // Then
+      expect(Object.keys(round1)).not.toEqual(Object.keys(round0));
+      expect(Object.keys(round2)).toEqual(Object.keys(round1));
     });
   });
 });


### PR DESCRIPTION
Depends on #1638 

These functions provide a general purpose conversion between
InitiativesMap and $ReadOnlyArray<Initiative>.

By normalizing the format of the `entryKey` we produce, it allows for a
lot of operations, without needing to come up with your own unique IDs.
Such as merging several InitiativesMaps or loading Initiatives from a
different source, such as Discourse, to store them in files instead.

Test plan: `yarn test`