### PR TITLE
Initiatives: replace trackers with InitiativeIds

### DIFF
--- a/src/plugins/initiatives/createGraph.js
+++ b/src/plugins/initiatives/createGraph.js
@@ -11,8 +11,8 @@ import {
 } from "../../core/graph";
 import type {ReferenceDetector, URL} from "../../core/references";
 import type {Initiative, InitiativeRepository} from "./initiative";
+import {addressFromId} from "./initiative";
 import {
-  initiativeNodeType,
   dependsOnEdgeType,
   referencesEdgeType,
   contributesToEdgeType,
@@ -20,10 +20,7 @@ import {
 } from "./declaration";
 
 function initiativeAddress(initiative: Initiative): NodeAddressT {
-  return NodeAddress.append(
-    initiativeNodeType.prefix,
-    ...NodeAddress.toParts(initiative.tracker)
-  );
+  return addressFromId(initiative.id);
 }
 
 function initiativeNode(initiative: Initiative): Node {
@@ -71,9 +68,6 @@ export function createGraph(
   for (const initiative of repo.initiatives()) {
     // Adds the Initiative node.
     graph.addNode(initiativeNode(initiative));
-
-    // Consider the tracker a contribution.
-    graph.addEdge(contributionEdge(initiative, initiative.tracker));
 
     // Generic approach to adding edges when the reference detector has a hit.
     const edgeHandler = (

--- a/src/plugins/initiatives/discourse.js
+++ b/src/plugins/initiatives/discourse.js
@@ -2,11 +2,13 @@
 
 import type {Topic, Post, CategoryId, TopicId} from "../discourse/fetch";
 import type {Initiative, URL, InitiativeRepository} from "./initiative";
+import {createId} from "./initiative";
 import {
   parseCookedHtml,
   type HtmlTemplateInitiativePartial,
 } from "./htmlTemplate";
-import {topicAddress} from "../discourse/address";
+
+export const DISCOURSE_TOPIC_SUBTYPE = "DISCOURSE_TOPIC";
 
 /**
  * A subset of queries we need for our plugin.
@@ -130,11 +132,10 @@ export function initiativeFromDiscourseTracker(
       );
     }
 
-    const tracker = topicAddress(serverUrl, topic.id);
     const partial = parseCookedHtml(openingPost.cooked);
     return {
+      id: createId(DISCOURSE_TOPIC_SUBTYPE, serverUrl, String(topic.id)),
       title,
-      tracker,
       timestampMs,
       completed: partial.completed,
       dependencies: absoluteURLs(serverUrl, partial.dependencies),

--- a/src/plugins/initiatives/discourse.test.js
+++ b/src/plugins/initiatives/discourse.test.js
@@ -6,10 +6,8 @@ import {
   DiscourseInitiativeRepository,
   type DiscourseQueries,
 } from "./discourse";
-import {type Initiative} from "./initiative";
 import type {ReadRepository} from "../discourse/mirrorRepository";
 import type {Topic, Post, CategoryId, TopicId} from "../discourse/fetch";
-import {NodeAddress} from "../../core/graph";
 import dedent from "../../util/dedent";
 
 function givenParseError(message: string) {
@@ -26,13 +24,6 @@ function mockParseCookedHtml(
   fn: () => HtmlTemplateInitiativePartial
 ): (cookedHTML: string) => HtmlTemplateInitiativePartial {
   return jest.fn().mockImplementation(fn);
-}
-
-function snapshotInitiative(initiative: Initiative): Object {
-  return {
-    ...initiative,
-    tracker: NodeAddress.toParts(initiative.tracker),
-  };
 }
 
 function exampleTopic(overrides?: $Shape<Topic>): Topic {
@@ -241,43 +232,39 @@ describe("plugins/initiatives/discourse", () => {
       const initiatives = repo.initiatives();
 
       // Then
-      expect(initiatives.map(snapshotInitiative)).toMatchInlineSnapshot(`
+      expect(initiatives).toMatchInlineSnapshot(`
         Array [
           Object {
             "champions": Array [],
             "completed": false,
             "contributions": Array [],
             "dependencies": Array [],
+            "id": Array [
+              "DISCOURSE_TOPIC",
+              "https://foo.bar",
+              "40",
+            ],
             "references": Array [
               "https://example.org/references/included",
             ],
             "timestampMs": 1571498171951,
             "title": "Example initiative",
-            "tracker": Array [
-              "sourcecred",
-              "discourse",
-              "topic",
-              "https://foo.bar",
-              "40",
-            ],
           },
           Object {
             "champions": Array [],
             "completed": false,
             "contributions": Array [],
             "dependencies": Array [],
+            "id": Array [
+              "DISCOURSE_TOPIC",
+              "https://foo.bar",
+              "42",
+            ],
             "references": Array [
               "https://example.org/references/included",
             ],
             "timestampMs": 1571498171951,
             "title": "Example initiative",
-            "tracker": Array [
-              "sourcecred",
-              "discourse",
-              "topic",
-              "https://foo.bar",
-              "42",
-            ],
           },
         ]
       `);
@@ -397,7 +384,7 @@ describe("plugins/initiatives/discourse", () => {
       expect(initiative.timestampMs).toEqual(firstPost.timestampMs);
     });
 
-    it("derives the tracker address from topic ID", () => {
+    it("derives the id from topic ID", () => {
       // Given
       const serverUrl = "https://foo.bar";
       const topic = exampleTopic({
@@ -418,10 +405,8 @@ describe("plugins/initiatives/discourse", () => {
       );
 
       // Then
-      expect(NodeAddress.toParts(initiative.tracker)).toEqual([
-        "sourcecred",
-        "discourse",
-        "topic",
+      expect(initiative.id).toEqual([
+        "DISCOURSE_TOPIC",
         serverUrl,
         String(topic.id),
       ]);

--- a/src/plugins/initiatives/initiative.js
+++ b/src/plugins/initiatives/initiative.js
@@ -36,10 +36,10 @@ export function addressFromId(id: InitiativeId): NodeAddressT {
  * See https://discourse.sourcecred.io/t/write-the-initiatives-plugin/269/6
  */
 export type Initiative = {|
+  +id: InitiativeId,
   +title: string,
   +timestampMs: number,
   +completed: boolean,
-  +tracker: NodeAddressT,
   +dependencies: $ReadOnlyArray<URL>,
   +references: $ReadOnlyArray<URL>,
   +contributions: $ReadOnlyArray<URL>,


### PR DESCRIPTION
Depends on #1646 

"Trackers" were an idea to let Initiatives be aware of the medium that
declares it. Such as a Discourse topic or file.

With Discourse in mind this was really useful. We could add an automatic
contribution edge, enhance reference detection to "upgrade" a URL pointing
to that Topic to resolve to the Initiative instead, etc.

Using files as the only source of Initiatives this becomes less relevant.
So in the interest of reducing complexity, we'll remove tracker awareness.

Test plan: `yarn test`