### PR TITLE
Add `core.weights` and `core.weightedGraph` to api

### DIFF
--- a/src/api/index.js
+++ b/src/api/index.js
@@ -12,6 +12,8 @@ import * as githubDeclaration from "../plugins/github/declaration";
 import * as githubEdges from "../plugins/github/edges";
 import * as githubNodes from "../plugins/github/nodes";
 import * as graph from "../core/graph";
+import * as weightedGraph from "../core/weightedGraph";
+import * as weights from "../core/weights";
 import * as graphToMarkovChain from "../core/algorithm/graphToMarkovChain";
 import * as markovChain from "../core/algorithm/markovChain";
 import * as timelineCred from "../analysis/timeline/timelineCred";
@@ -29,6 +31,8 @@ export default deepFreeze({
       graphToMarkovChain,
     },
     graph,
+    weightedGraph,
+    weights,
   },
   plugins: {
     github: {


### PR DESCRIPTION
This commit modifies the api declaration file so that it includes
`core.weights` and `core.weightedGraph`. These are both important
modules for interfacing with Cred (loading a WeightedGraph, and defining
custom weights), so it's natural for them to be included in the API.

Test plan: Change is a trivial extension of the pattern in api.js. `yarn
flow` passes, and I believe no further testing is _required_; however, I
will use this in an Observable notebook prior to merging.