### PR TITLE
Improve distributionToCred

### DIFF
--- a/src/analysis/timeline/timelineCred.js
+++ b/src/analysis/timeline/timelineCred.js
@@ -199,17 +199,20 @@ export class TimelineCred {
       fullParams.intervalDecay,
       fullParams.alpha
     );
-    const cred = distributionToCred(distribution, nodeOrder, scorePrefixes);
+    const credScores = distributionToCred(
+      distribution,
+      nodeOrder,
+      scorePrefixes
+    );
     const addressToCred = new Map();
     for (let i = 0; i < nodeOrder.length; i++) {
       const addr = nodeOrder[i];
-      const addrCred = cred.map(({cred}) => cred[i]);
+      const addrCred = credScores.intervalCredScores.map((cred) => cred[i]);
       addressToCred.set(addr, addrCred);
     }
-    const intervals = cred.map((x) => x.interval);
     return new TimelineCred(
       weightedGraph,
-      intervals,
+      credScores.intervals,
       addressToCred,
       fullParams,
       plugins

--- a/src/core/algorithm/distributionToCred.test.js
+++ b/src/core/algorithm/distributionToCred.test.js
@@ -21,16 +21,16 @@ describe("src/core/algorithm/distributionToCred", () => {
       ];
       const nodeOrder = [na("foo"), na("bar")];
       const actual = distributionToCred(ds, nodeOrder, [NodeAddress.empty]);
-      const expected = [
-        {
-          interval: {startTimeMs: 0, endTimeMs: 10},
-          cred: new Float64Array([1, 1]),
-        },
-        {
-          interval: {startTimeMs: 10, endTimeMs: 20},
-          cred: new Float64Array([9, 1]),
-        },
-      ];
+      const expected = {
+        intervals: [
+          {startTimeMs: 0, endTimeMs: 10},
+          {startTimeMs: 10, endTimeMs: 20},
+        ],
+        intervalCredScores: [
+          new Float64Array([1, 1]),
+          new Float64Array([9, 1]),
+        ],
+      };
       expect(expected).toEqual(actual);
     });
     it("correctly handles multiple scoring prefixes", () => {
@@ -48,16 +48,16 @@ describe("src/core/algorithm/distributionToCred", () => {
       ];
       const nodeOrder = [na("foo"), na("bar")];
       const actual = distributionToCred(ds, nodeOrder, [na("foo"), na("bar")]);
-      const expected = [
-        {
-          interval: {startTimeMs: 0, endTimeMs: 10},
-          cred: new Float64Array([1, 1]),
-        },
-        {
-          interval: {startTimeMs: 10, endTimeMs: 20},
-          cred: new Float64Array([9, 1]),
-        },
-      ];
+      const expected = {
+        intervals: [
+          {startTimeMs: 0, endTimeMs: 10},
+          {startTimeMs: 10, endTimeMs: 20},
+        ],
+        intervalCredScores: [
+          new Float64Array([1, 1]),
+          new Float64Array([9, 1]),
+        ],
+      };
       expect(expected).toEqual(actual);
     });
     it("works in a case where some nodes are scoring", () => {
@@ -75,16 +75,16 @@ describe("src/core/algorithm/distributionToCred", () => {
       ];
       const nodeOrder = [na("foo"), na("bar")];
       const actual = distributionToCred(ds, nodeOrder, [na("bar")]);
-      const expected = [
-        {
-          interval: {startTimeMs: 0, endTimeMs: 10},
-          cred: new Float64Array([2, 2]),
-        },
-        {
-          interval: {startTimeMs: 10, endTimeMs: 20},
-          cred: new Float64Array([90, 10]),
-        },
-      ];
+      const expected = {
+        intervals: [
+          {startTimeMs: 0, endTimeMs: 10},
+          {startTimeMs: 10, endTimeMs: 20},
+        ],
+        intervalCredScores: [
+          new Float64Array([2, 2]),
+          new Float64Array([90, 10]),
+        ],
+      };
       expect(expected).toEqual(actual);
     });
     it("handles the case where no nodes are scoring", () => {
@@ -97,12 +97,10 @@ describe("src/core/algorithm/distributionToCred", () => {
       ];
       const nodeOrder = [na("foo"), na("bar")];
       const actual = distributionToCred(ds, nodeOrder, []);
-      const expected = [
-        {
-          interval: {startTimeMs: 0, endTimeMs: 10},
-          cred: new Float64Array([0, 0]),
-        },
-      ];
+      const expected = {
+        intervals: [{startTimeMs: 0, endTimeMs: 10}],
+        intervalCredScores: [new Float64Array([0, 0])],
+      };
       expect(actual).toEqual(expected);
     });
 
@@ -116,17 +114,18 @@ describe("src/core/algorithm/distributionToCred", () => {
       ];
       const nodeOrder = [na("foo"), na("bar")];
       const actual = distributionToCred(ds, nodeOrder, [na("bar")]);
-      const expected = [
-        {
-          interval: {startTimeMs: 0, endTimeMs: 10},
-          cred: new Float64Array([0, 0]),
-        },
-      ];
+      const expected = {
+        intervals: [{startTimeMs: 0, endTimeMs: 10}],
+        intervalCredScores: [new Float64Array([0, 0])],
+      };
       expect(actual).toEqual(expected);
     });
 
-    it("returns empty array if no intervals are present", () => {
-      expect(distributionToCred([], [], [])).toEqual([]);
+    it("returns empty CredScores if no intervals are present", () => {
+      expect(distributionToCred([], [], [])).toEqual({
+        intervals: [],
+        intervalCredScores: [],
+      });
     });
   });
 });


### PR DESCRIPTION
This commit makes several small improvements to the distributionToCred
module:

- We rename the output `FullTimelineCred` data structure to
`TimelineCredScores`, which is more descriptive
- We re-organize that data structure so that rather than being an array
of `{interval, cred}` objects, it has an `intervals` property and a
`intervalCredScores` property, both of which are arrays. This will make
downstream usage cleaner.
- An unused variable is removed.
- We document invariants about the TimelineCredScores data type.
- We mark the TimelineCredScores data type opaque, so that clients
recieving a TimelineCredScores can trust that the invariants are
maintained.

Test plan:
- The rename is robustly tested by `yarn flow`.
- That the refactor lands without changing existing semantics is
robustly tested by `yarn test --full`, since we snapshot a full cred
load; thus we know that cred scores haven't changed. (Also, we have
existing unit tests).
- The newly documented invariants aren't robustly tested by the test
code, but it's easy to see that they hold by reading the algorithm.