### PR TITLE
Create `core/credGraph`

### DIFF
--- a/src/analysis/timeline/timelineCred.js
+++ b/src/analysis/timeline/timelineCred.js
@@ -199,17 +199,20 @@ export class TimelineCred {
       fullParams.intervalDecay,
       fullParams.alpha
     );
-    const cred = distributionToCred(distribution, nodeOrder, scorePrefixes);
+    const credScores = distributionToCred(
+      distribution,
+      nodeOrder,
+      scorePrefixes
+    );
     const addressToCred = new Map();
     for (let i = 0; i < nodeOrder.length; i++) {
       const addr = nodeOrder[i];
-      const addrCred = cred.map(({cred}) => cred[i]);
+      const addrCred = credScores.intervalCredScores.map((cred) => cred[i]);
       addressToCred.set(addr, addrCred);
     }
-    const intervals = cred.map((x) => x.interval);
     return new TimelineCred(
       weightedGraph,
-      intervals,
+      credScores.intervals,
       addressToCred,
       fullParams,
       plugins

--- a/src/core/algorithm/distributionToCred.js
+++ b/src/core/algorithm/distributionToCred.js
@@ -5,6 +5,7 @@
  */
 
 import {sum} from "d3-array";
+import {toCompat, fromCompat, type Compatible} from "../../util/compat";
 import {type Interval} from "../interval";
 import {type TimelineDistributions} from "./timelinePagerank";
 import {NodeAddress, type NodeAddressT} from "../../core/graph";
@@ -78,4 +79,22 @@ export function distributionToCred(
     return cred;
   });
   return {intervalCredScores, intervals};
+}
+
+const COMPAT_INFO = {type: "sourcecred/timelineCredScores", version: "0.1.0"};
+
+export type TimelineCredScoresJSON = Compatible<{|
+  +intervals: $ReadOnlyArray<Interval>,
+  // TODO: Serializing floats as strings is space-inefficient. We can likely
+  // get space savings if we base64 encode a byte representation of the
+  // floats.
+  +intervalCredScores: $ReadOnlyArray<Float64Array>,
+|}>;
+
+export function toJSON(s: TimelineCredScores): TimelineCredScoresJSON {
+  return toCompat(COMPAT_INFO, s);
+}
+
+export function fromJSON(j: TimelineCredScoresJSON): TimelineCredScores {
+  return fromCompat(COMPAT_INFO, j);
 }

--- a/src/core/algorithm/distributionToCred.js
+++ b/src/core/algorithm/distributionToCred.js
@@ -10,25 +10,38 @@ import {type TimelineDistributions} from "./timelinePagerank";
 import {NodeAddress, type NodeAddressT} from "../../core/graph";
 
 /**
- * Represents the full timeline cred for a graph.
+ * Represents cred scores over time.
+ *
+ * It contains an array of intervals, which give timing information, and an
+ * array of CredTimeSlices, which are Float64Arrays. Each CredTimeSlice
+ * contains cred scores for an interval. The cred scores are included in
+ * node-address-sorted order, and as such the CredScores can only be
+ * interpreted in the context of an associated Graph.
+ *
+ * As invariants, it is guaranteed that:
+ * - intervals and intervalCredScores will always have the same length
+ * - all of the intervalCredScores will have a consistent implicit node ordering
+ *
+ * The type is marked opaque so that no-one else can construct instances that
+ * don't conform to these invariants.
  */
-export type FullTimelineCred = $ReadOnlyArray<{|
-  // The interval for this slice.
-  +interval: Interval,
-  // The cred for each node.
-  // (Uses the graph's canonical node ordering.)
-  +cred: Float64Array,
-|}>;
+export opaque type TimelineCredScores: {|
+  +intervals: $ReadOnlyArray<Interval>,
+  +intervalCredScores: $ReadOnlyArray<Float64Array>,
+|} = {|
+  +intervals: $ReadOnlyArray<Interval>,
+  +intervalCredScores: $ReadOnlyArray<Float64Array>,
+|};
 
 /**
- * Convert a TimelineDistribution into TimelineCred.
+ * Convert a TimelineDistribution into CredScores.
  *
  * The difference between the distribution and cred is that cred has been
  * re-normalized to present human-agreeable scores, rather than a probability
  * distribution.
  *
  * This implementation normalizes the scores so that in each interval, the
- * total score of every node matching scoringNodePrefix is equal to the
+ * total score of every node matching a scoringNodePrefix is equal to the
  * interval's weight.
  *
  * Edge cases:
@@ -42,22 +55,19 @@ export function distributionToCred(
   ds: TimelineDistributions,
   nodeOrder: $ReadOnlyArray<NodeAddressT>,
   scoringNodePrefixes: $ReadOnlyArray<NodeAddressT>
-): FullTimelineCred {
+): TimelineCredScores {
   if (ds.length === 0) {
-    return [];
+    return {intervals: [], intervalCredScores: []};
   }
-  const intervals = ds.map((x) => x.interval);
   const scoringNodeIndices = [];
-  const cred = new Array(nodeOrder.length);
   for (let i = 0; i < nodeOrder.length; i++) {
     const addr = nodeOrder[i];
     if (scoringNodePrefixes.some((x) => NodeAddress.hasPrefix(addr, x))) {
       scoringNodeIndices.push(i);
     }
-    cred[i] = new Array(intervals.length);
   }
-
-  return ds.map(({interval, distribution, intervalWeight}) => {
+  const intervals = ds.map((x) => x.interval);
+  const intervalCredScores = ds.map(({distribution, intervalWeight}) => {
     const intervalTotalScore = sum(
       scoringNodeIndices.map((x) => distribution[x])
     );
@@ -65,6 +75,7 @@ export function distributionToCred(
     const intervalNormalizer =
       intervalTotalScore === 0 ? 0 : intervalWeight / intervalTotalScore;
     const cred = distribution.map((x) => x * intervalNormalizer);
-    return {interval, cred};
+    return cred;
   });
+  return {intervalCredScores, intervals};
 }

--- a/src/core/algorithm/distributionToCred.test.js
+++ b/src/core/algorithm/distributionToCred.test.js
@@ -21,16 +21,16 @@ describe("src/core/algorithm/distributionToCred", () => {
       ];
       const nodeOrder = [na("foo"), na("bar")];
       const actual = distributionToCred(ds, nodeOrder, [NodeAddress.empty]);
-      const expected = [
-        {
-          interval: {startTimeMs: 0, endTimeMs: 10},
-          cred: new Float64Array([1, 1]),
-        },
-        {
-          interval: {startTimeMs: 10, endTimeMs: 20},
-          cred: new Float64Array([9, 1]),
-        },
-      ];
+      const expected = {
+        intervals: [
+          {startTimeMs: 0, endTimeMs: 10},
+          {startTimeMs: 10, endTimeMs: 20},
+        ],
+        intervalCredScores: [
+          new Float64Array([1, 1]),
+          new Float64Array([9, 1]),
+        ],
+      };
       expect(expected).toEqual(actual);
     });
     it("correctly handles multiple scoring prefixes", () => {
@@ -48,16 +48,16 @@ describe("src/core/algorithm/distributionToCred", () => {
       ];
       const nodeOrder = [na("foo"), na("bar")];
       const actual = distributionToCred(ds, nodeOrder, [na("foo"), na("bar")]);
-      const expected = [
-        {
-          interval: {startTimeMs: 0, endTimeMs: 10},
-          cred: new Float64Array([1, 1]),
-        },
-        {
-          interval: {startTimeMs: 10, endTimeMs: 20},
-          cred: new Float64Array([9, 1]),
-        },
-      ];
+      const expected = {
+        intervals: [
+          {startTimeMs: 0, endTimeMs: 10},
+          {startTimeMs: 10, endTimeMs: 20},
+        ],
+        intervalCredScores: [
+          new Float64Array([1, 1]),
+          new Float64Array([9, 1]),
+        ],
+      };
       expect(expected).toEqual(actual);
     });
     it("works in a case where some nodes are scoring", () => {
@@ -75,16 +75,16 @@ describe("src/core/algorithm/distributionToCred", () => {
       ];
       const nodeOrder = [na("foo"), na("bar")];
       const actual = distributionToCred(ds, nodeOrder, [na("bar")]);
-      const expected = [
-        {
-          interval: {startTimeMs: 0, endTimeMs: 10},
-          cred: new Float64Array([2, 2]),
-        },
-        {
-          interval: {startTimeMs: 10, endTimeMs: 20},
-          cred: new Float64Array([90, 10]),
-        },
-      ];
+      const expected = {
+        intervals: [
+          {startTimeMs: 0, endTimeMs: 10},
+          {startTimeMs: 10, endTimeMs: 20},
+        ],
+        intervalCredScores: [
+          new Float64Array([2, 2]),
+          new Float64Array([90, 10]),
+        ],
+      };
       expect(expected).toEqual(actual);
     });
     it("handles the case where no nodes are scoring", () => {
@@ -97,12 +97,10 @@ describe("src/core/algorithm/distributionToCred", () => {
       ];
       const nodeOrder = [na("foo"), na("bar")];
       const actual = distributionToCred(ds, nodeOrder, []);
-      const expected = [
-        {
-          interval: {startTimeMs: 0, endTimeMs: 10},
-          cred: new Float64Array([0, 0]),
-        },
-      ];
+      const expected = {
+        intervals: [{startTimeMs: 0, endTimeMs: 10}],
+        intervalCredScores: [new Float64Array([0, 0])],
+      };
       expect(actual).toEqual(expected);
     });
 
@@ -116,17 +114,18 @@ describe("src/core/algorithm/distributionToCred", () => {
       ];
       const nodeOrder = [na("foo"), na("bar")];
       const actual = distributionToCred(ds, nodeOrder, [na("bar")]);
-      const expected = [
-        {
-          interval: {startTimeMs: 0, endTimeMs: 10},
-          cred: new Float64Array([0, 0]),
-        },
-      ];
+      const expected = {
+        intervals: [{startTimeMs: 0, endTimeMs: 10}],
+        intervalCredScores: [new Float64Array([0, 0])],
+      };
       expect(actual).toEqual(expected);
     });
 
-    it("returns empty array if no intervals are present", () => {
-      expect(distributionToCred([], [], [])).toEqual([]);
+    it("returns empty CredScores if no intervals are present", () => {
+      expect(distributionToCred([], [], [])).toEqual({
+        intervals: [],
+        intervalCredScores: [],
+      });
     });
   });
 });

--- a/src/core/algorithm/distributionToCred.test.js
+++ b/src/core/algorithm/distributionToCred.test.js
@@ -1,7 +1,7 @@
 // @flow
 
 import {NodeAddress} from "../graph";
-import {distributionToCred} from "./distributionToCred";
+import {distributionToCred, toJSON, fromJSON} from "./distributionToCred";
 
 describe("src/core/algorithm/distributionToCred", () => {
   const na = (...parts) => NodeAddress.fromParts(parts);
@@ -126,6 +126,27 @@ describe("src/core/algorithm/distributionToCred", () => {
         intervals: [],
         intervalCredScores: [],
       });
+    });
+  });
+  describe("to/from JSON", () => {
+    it("satisfies round-trip equality", () => {
+      const ds = [
+        {
+          interval: {startTimeMs: 0, endTimeMs: 10},
+          intervalWeight: 2,
+          distribution: new Float64Array([0.5, 0.5]),
+        },
+        {
+          interval: {startTimeMs: 10, endTimeMs: 20},
+          intervalWeight: 10,
+          distribution: new Float64Array([0.9, 0.1]),
+        },
+      ];
+      const nodeOrder = [na("foo"), na("bar")];
+      const before = distributionToCred(ds, nodeOrder, [na("bar")]);
+      const json = toJSON(before);
+      const after = fromJSON(json);
+      expect(before).toEqual(after);
     });
   });
 });

--- a/src/core/credGraph.js
+++ b/src/core/credGraph.js
@@ -1,0 +1,146 @@
+// @flow
+
+/**
+ * This module contains the CredGraph, which is a data structure containing a WeightedGraph,
+ * associated TimelineCredScores, and the parameters used to compute those scores.
+ * It contains (or will contain) methods for generating CredGraphs, methods for fetching
+ * data from them, and methods for analyzing the struture of the cred scores.
+ */
+import {toCompat, fromCompat, type Compatible} from "../util/compat";
+import {type NodeAddressT, NodeAddress} from "./graph";
+import {type WeightedGraph as WeightedGraphT} from "./weightedGraph";
+import * as WeightedGraph from "./weightedGraph";
+import {
+  type TimelineCredScores,
+  distributionToCred,
+  toJSON as timelineCredScoresToJSON,
+  fromJSON as timelineCredScoresFromJSON,
+  type TimelineCredScoresJSON,
+} from "./algorithm/distributionToCred";
+import {timelinePagerank} from "./algorithm/timelinePagerank";
+
+/**
+ * Represents all the parameters associated with computing cred scores for a
+ * WeightedGraph.
+ */
+export type CredParameters = {|
+  +alpha: number,
+  +intervalDecay: number,
+  +scoringNodePrefixes: $ReadOnlyArray<NodeAddressT>,
+|};
+
+/**
+ * Represents a weighted graph with computed cred scores.
+ *
+ * This type contains the WeightedGraph, the TimelineCredScores scores, and the
+ * parameters used to compute those scores. It's an opaque type because to be
+ * a valid CredGraph, the cred scores must be a faithful computation of cred
+ * scores on the included graph, using the included parameters.
+ *
+ * Clients may freely access the fields; they just can't hand-construct new
+ * instances.
+ */
+export opaque type CredGraph: {|
+  +weightedGraph: WeightedGraphT,
+  +timelineCredScores: TimelineCredScores,
+  +params: CredParameters,
+|} = {|
+  +weightedGraph: WeightedGraphT,
+  +timelineCredScores: TimelineCredScores,
+  +params: CredParameters,
+|};
+
+/**
+ * Given a WeightedGraph and CredParameters, compute a CredGraph.
+ *
+ * Under the hood, it uses the timelinePagerank module to partition the graph into time
+ * intervals and assign a raw score to each one. Then, using the scoringNodePrefixes
+ * from the parameters, it converts raw scores to cred scores, ensuring that the total
+ * cred minted in each interval is equal to the total node weight for the interval.
+ *
+ * See the docs on `core/algorithm/timelinePagerank` and
+ * `core/algorithm/distributionToCred` for more details.
+ */
+export async function compute(
+  weightedGraph: WeightedGraphT,
+  params: CredParameters
+): Promise<CredGraph> {
+  const nodeOrder = Array.from(weightedGraph.graph.nodes()).map(
+    (x) => x.address
+  );
+  const distribution = await timelinePagerank(
+    weightedGraph,
+    params.intervalDecay,
+    params.alpha
+  );
+  const timelineCredScores = distributionToCred(
+    distribution,
+    nodeOrder,
+    params.scoringNodePrefixes
+  );
+  return {weightedGraph, timelineCredScores, params};
+}
+
+const COMPAT_INFO = {type: "sourcecred/credGraph", version: "0.1.0"};
+
+export type CredGraphJSON = Compatible<{|
+  +weightedGraphJSON: WeightedGraph.WeightedGraphJSON,
+  +paramsJSON: CredParametersJSON,
+  +timelineCredScoresJSON: TimelineCredScoresJSON,
+|}>;
+
+export function toJSON({
+  timelineCredScores,
+  params,
+  weightedGraph,
+}: CredGraph): CredGraphJSON {
+  return toCompat(COMPAT_INFO, {
+    paramsJSON: paramsToJSON(params),
+    timelineCredScoresJSON: timelineCredScoresToJSON(timelineCredScores),
+    weightedGraphJSON: WeightedGraph.toJSON(weightedGraph),
+  });
+}
+
+export function fromJSON(j: CredGraphJSON): CredGraph {
+  const {timelineCredScoresJSON, paramsJSON, weightedGraphJSON} = fromCompat(
+    COMPAT_INFO,
+    j
+  );
+  return {
+    timelineCredScores: timelineCredScoresFromJSON(timelineCredScoresJSON),
+    params: paramsFromJSON(paramsJSON),
+    weightedGraph: WeightedGraph.fromJSON(weightedGraphJSON),
+  };
+}
+
+type CredParametersJSON = {
+  alpha: number,
+  intervalDecay: number,
+  // Split into address components so we don't have any address separators in
+  // the serialized representation.
+  scoringNodePrefixes: $ReadOnlyArray<$ReadOnlyArray<string>>,
+};
+
+function paramsToJSON({
+  intervalDecay,
+  alpha,
+  scoringNodePrefixes,
+}: CredParameters): CredParametersJSON {
+  return {
+    intervalDecay,
+    alpha,
+    scoringNodePrefixes: scoringNodePrefixes.map(NodeAddress.toParts),
+  };
+}
+
+function paramsFromJSON({
+  intervalDecay,
+  alpha,
+  scoringNodePrefixes,
+}: CredParametersJSON): CredParameters {
+  return {
+    intervalDecay,
+    alpha,
+    scoringNodePrefixes: scoringNodePrefixes.map(NodeAddress.fromParts),
+  };
+}

--- a/src/core/credGraph.test.js
+++ b/src/core/credGraph.test.js
@@ -1,0 +1,100 @@
+// @flow
+
+import deepFreeze from "deep-freeze";
+import {NodeAddress} from "./graph";
+import * as CredGraph from "./credGraph";
+import * as WeightedGraph from "./weightedGraph";
+import {weekIntervals} from "./interval";
+
+describe("core/credGraph", () => {
+  const scoreAddress = NodeAddress.fromParts(["score"]);
+  const exampleParams = deepFreeze({
+    alpha: 0.5,
+    intervalDecay: 0,
+    scoringNodePrefixes: [NodeAddress.empty],
+  });
+  function expectScoresClose(
+    as: $ReadOnlyArray<Float64Array>,
+    bs: $ReadOnlyArray<Float64Array>
+  ) {
+    expect(as.length).toEqual(bs.length);
+    for (let i = 0; i < as.length; i++) {
+      expect(as[i].length).toEqual(bs[i].length);
+      for (let j = 0; j < as[i].length; j++) {
+        expect(as[i][j]).toBeCloseTo(bs[i][j]);
+      }
+    }
+  }
+
+  it("is an error to manually construct a CredGraph", () => {
+    const weightedGraph = WeightedGraph.empty();
+    const timelineCredScores = {intervals: [], intervalCredScores: []};
+    const params = {alpha: 0.5, intervalDecay: 0.3, scoringNodePrefixes: []};
+    // $ExpectFlowError
+    const _unused_credGraph: CredGraphT = {
+      weightedGraph,
+      timelineCredScores,
+      params,
+    };
+  });
+
+  // compute has smoke testing -- it is a lightweight composition of other highly-tested
+  // components, so we don't try to hit all the edge cases here.
+  describe("compute", () => {
+    it("produces an empty CredGraph for an empty WeightedGraph", async () => {
+      const empty = WeightedGraph.empty();
+      const result = await CredGraph.compute(empty, exampleParams);
+      expect(result.weightedGraph).toEqual(empty);
+      expect(result.params).toEqual(exampleParams);
+      expect(result.timelineCredScores).toEqual({
+        intervals: [],
+        intervalCredScores: [],
+      });
+    });
+    it("produces a valid CredGraph for a single-node graph", async () => {
+      const wg = WeightedGraph.empty();
+      wg.graph.addNode({
+        address: scoreAddress,
+        timestampMs: 0,
+        description: "node",
+      });
+      wg.weights.nodeWeights.set(scoreAddress, 1337);
+      const credGraph = await CredGraph.compute(wg, exampleParams);
+      expect(credGraph.weightedGraph).toEqual(wg);
+      expect(credGraph.params).toEqual(exampleParams);
+      const {intervals, intervalCredScores} = credGraph.timelineCredScores;
+      expect(intervals).toEqual(weekIntervals(0, 0));
+      expectScoresClose(intervalCredScores, [new Float64Array([1337])]);
+    });
+    it("produces a valid CredGraph for a multi-node, multi-interval graph", async () => {
+      const ts0 = 0;
+      // Get a timestamp in the next week
+      const ts1 = weekIntervals(0, 0)[0].endTimeMs + 100;
+      const wg = WeightedGraph.empty();
+      const otherAddress = NodeAddress.fromParts(["other"]);
+      wg.graph.addNode({
+        address: scoreAddress,
+        timestampMs: ts0,
+        description: "node",
+      });
+      wg.graph.addNode({
+        address: otherAddress,
+        timestampMs: ts1,
+        description: "node",
+      });
+      wg.weights.nodeWeights.set(scoreAddress, 1337);
+      wg.weights.nodeWeights.set(otherAddress, 420);
+      const credGraph = await CredGraph.compute(wg, exampleParams);
+      expect(credGraph.weightedGraph).toEqual(wg);
+      expect(credGraph.params).toEqual(exampleParams);
+      const {intervals, intervalCredScores} = credGraph.timelineCredScores;
+      const expectedIntervals = weekIntervals(ts0, ts1);
+      expect(intervals).toEqual(expectedIntervals);
+      const expectedCredScores = [
+        new Float64Array([0, 1337]),
+        new Float64Array([420, 0]),
+      ];
+      expectScoresClose(intervalCredScores, expectedCredScores);
+    });
+  });
+});


### PR DESCRIPTION
`core/credGraph` is a new module which allows you to compute a
`CredGraph`, which, as the name suggests, contains a `WeightedGraph`,
`TimelineCredScores`, and the `CredParameters` used to generate it.

Thus, you can think of this as a burgeoning replacement for the (ugly
and non-core) TimelineCred module inside `analysis/`.

I intend for this to be the canonical module for generating and
representing cred scores. In followon PRs, I will migrate the
`timelineCred` module to depend on `credGraph`, and will "dissolve" all
of its non-trivial functionality into `credGraph`; e.g. `credGraph` will
have methods for retrieving nodes and edges along with relevant cred
scores and weights.

In the future, I expect we'll also add well-tested and well documented
methods for analyzing cred scores, e.g. for computing cred
decompositions in the style of the `pagerankNodeDecomposition` module,
except with much cleaner APIs that are consistent with the rest of core.

You'll know that this refactor is going well when I entirely remove the
`src/analysis` module. :)

Test plan: Review the code, and observe that I've included smoke unit
tests. `yarn test` passes.