### PR TITLE
github: standardize blacklist URL comments

### DIFF
--- a/src/plugins/github/blacklistedObjectIds.js
+++ b/src/plugins/github/blacklistedObjectIds.js
@@ -64,14 +64,14 @@ export const BLACKLISTED_IDS: $ReadOnlyArray<ObjectId> = deepFreeze([
   "MDM6Qm90NDM4ODA5MDM=", // transifex-integration
 
   // Problematic interactions they did as a user: reactions.
-  "MDg6UmVhY3Rpb24yMTY3ODkyNQ==",
-  "MDg6UmVhY3Rpb240NDMwMzQ1",
-  "MDg6UmVhY3Rpb24xMDI4MzQxOA==",
-  "MDg6UmVhY3Rpb24zNDUxNjA2MQ==",
+  "MDg6UmVhY3Rpb24yMTY3ODkyNQ==", // https://github.com/twbs/bootstrap/issues/11037#issuecomment-105283986
+  "MDg6UmVhY3Rpb240NDMwMzQ1", // https://github.com/twbs/bootstrap/issues/20631#issuecomment-245479378
+  "MDg6UmVhY3Rpb24xMDI4MzQxOA==", // https://github.com/twbs/bootstrap/issues/22683#issuecomment-304187232
+  "MDg6UmVhY3Rpb24zNDUxNjA2MQ==", // https://github.com/quasarframework/quasar-cli/issues/164
   "MDg6UmVhY3Rpb24xNTUyODc3OQ==", // https://github.com/quasarframework/quasar/issues/1064
   "MDg6UmVhY3Rpb24xNjA5NDYyOQ==", // https://github.com/quasarframework/quasar/issues/1123#issuecomment-343846259
   "MDg6UmVhY3Rpb24xNjIxNTMzNQ==", // https://github.com/quasarframework/quasar/pull/1128#issuecomment-344605228
-  "MDg6UmVhY3Rpb24xMjIxMTk2Ng==", //https://github.com/passbolt/passbolt_api/issues/19
+  "MDg6UmVhY3Rpb24xMjIxMTk2Ng==", // https://github.com/passbolt/passbolt_api/issues/19
   "MDg6UmVhY3Rpb24zMTg4NjU3NQ==", // https://github.com/prettier/prettier/issues/40
   "MDg6UmVhY3Rpb24xMzEzNjY5MA==", // https://github.com/prettier/prettier/issues/187
   "MDg6UmVhY3Rpb24xMzEzNjc2OQ==", // https://github.com/prettier/prettier/issues/187#issuecomment-318651633

--- a/src/plugins/github/blacklistedObjectIds.js
+++ b/src/plugins/github/blacklistedObjectIds.js
@@ -7,10 +7,10 @@ export const BLACKLISTED_IDS: $ReadOnlyArray<ObjectId> = deepFreeze([
   // These are `Organization` nodes that are sometimes referenced in a
   // `User` context: in particular, as the author of a reaction.
   // See: https://gist.github.com/wchargin/a2b8561b81bcc932c84e493d2485ea8a
-  "MDEyOk9yZ2FuaXphdGlvbjE3OTUyOTI1",
-  "MDEyOk9yZ2FuaXphdGlvbjI5MTkzOTQ=",
-  "MDEyOk9yZ2FuaXphdGlvbjEyNDE3MDI0",
-  "MDEyOk9yZ2FuaXphdGlvbjQzMDkzODIw",
+  "MDEyOk9yZ2FuaXphdGlvbjE3OTUyOTI1", // webineh
+  "MDEyOk9yZ2FuaXphdGlvbjI5MTkzOTQ=", // ck-ws
+  "MDEyOk9yZ2FuaXphdGlvbjEyNDE3MDI0", // DediData
+  "MDEyOk9yZ2FuaXphdGlvbjQzMDkzODIw", // airgram
   "MDEyOk9yZ2FuaXphdGlvbjEyNDk5MDI=", // techtribe
   "MDEyOk9yZ2FuaXphdGlvbjIxMzQ5NTM=", // nueko
   "MDEyOk9yZ2FuaXphdGlvbjQ0MDU2MDY4", // foodles-tech


### PR DESCRIPTION
Summary:
Most of the blacklisted reactions helpfully link to their original
source, but some don’t. This patch adds the missing links.

Test Plan:
The following command now prints a URL on every line:

```
<src/plugins/github/blacklistedObjectIds.js \
awk '/^[^ ]/ { p = 0 }; p { gsub(".*// ", ""); print }; /reactions/ { p = 1 }'
```

wchargin-branch: blacklist-urls