### PR TITLE
adding jq and updates to container base

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,6 +5,9 @@ FROM node:12
 RUN mkdir -p /code
 WORKDIR /code
 
+# Updates and install jq for downstream actions
+RUN apt-get update && apt-get install -y jq
+
 # Install global and local dependencies first so they can be cached.
 RUN npm install -gf yarn@^1.21.1
 COPY package.json yarn.lock /code/


### PR DESCRIPTION
This pull request will serve two purposes, both related to updating the sourcecred/sourcecred:dev image:

 - add an apt-get update so that we install security updates. While there is a tradeoff between running updates and build time, I think the 20 seconds or so are worth it in favor of security
 - adding jq to the base container. This is a relatively small package, and will allow for speeding up of the [cred-action](https://github.com/vsoch/cred-action) as it won't be required to run apt-get update and then install jq - we can just grab the base container and it's ready to go!

I mentioned this in https://github.com/sourcecred/cred/pull/17

Signed-off-by: vsoch <vsochat@stanford.edu>