### PR TITLE
Initiatives: add Project parameters

### DIFF
--- a/sharness/__snapshots__/example-github-load/projects/c291cmNlY3JlZC10ZXN0L2V4YW1wbGUtZ2l0aHVi/project.json
+++ b/sharness/__snapshots__/example-github-load/projects/c291cmNlY3JlZC10ZXN0L2V4YW1wbGUtZ2l0aHVi/project.json
@@ -1,1 +1,1 @@
-[{"type":"sourcecred/project","version":"0.4.0"},{"discourseServer":null,"id":"sourcecred-test/example-github","identities":[],"repoIds":[{"name":"example-github","owner":"sourcecred-test"}]}]
+[{"type":"sourcecred/project","version":"0.5.0"},{"discourseServer":null,"id":"sourcecred-test/example-github","identities":[],"initiatives":null,"repoIds":[{"name":"example-github","owner":"sourcecred-test"}]}]

--- a/src/core/project.js
+++ b/src/core/project.js
@@ -3,6 +3,7 @@
 import base64url from "base64url";
 import {type RepoId} from "../plugins/github/repoId";
 import {toCompat, fromCompat, type Compatible} from "../util/compat";
+import {type ProjectParameters as Initiatives} from "../plugins/initiatives/params";
 import {type Identity} from "../plugins/identity/identity";
 import {type DiscourseServer} from "../plugins/discourse/server";
 
@@ -24,17 +25,22 @@ export type ProjectId = string;
  * the future (e.g. showing the last update time for each of the project's data
  * dependencies).
  */
-export type Project = ProjectV040;
-export type SupportedProject = ProjectV030 | ProjectV031 | ProjectV040;
+export type Project = ProjectV050;
+export type SupportedProject =
+  | ProjectV030
+  | ProjectV031
+  | ProjectV040
+  | ProjectV050;
 
-type ProjectV040 = {|
+export type ProjectV050 = {|
   +id: ProjectId,
+  +initiatives: Initiatives | null,
   +repoIds: $ReadOnlyArray<RepoId>,
   +discourseServer: DiscourseServer | null,
   +identities: $ReadOnlyArray<Identity>,
 |};
 
-const COMPAT_INFO = {type: "sourcecred/project", version: "0.4.0"};
+const COMPAT_INFO = {type: "sourcecred/project", version: "0.5.0"};
 
 /**
  * Creates a new Project instance with default values.
@@ -50,6 +56,7 @@ export function createProject(p: $Shape<Project>): Project {
     repoIds: [],
     identities: [],
     discourseServer: null,
+    initiatives: null,
     ...p,
   };
 }
@@ -72,13 +79,28 @@ export function encodeProjectId(id: ProjectId): string {
   return base64url.encode(id);
 }
 
-const upgradeFrom030 = (p: ProjectV030 | ProjectV031): ProjectV040 => ({
+const upgradeFrom040 = (p: ProjectV040): ProjectV050 => ({
   ...p,
-  discourseServer:
-    p.discourseServer != null ? {serverUrl: p.discourseServer.serverUrl} : null,
+  initiatives: null,
 });
 
-type ProjectV031 = {|
+export type ProjectV040 = {|
+  +id: ProjectId,
+  +repoIds: $ReadOnlyArray<RepoId>,
+  +discourseServer: DiscourseServer | null,
+  +identities: $ReadOnlyArray<Identity>,
+|};
+
+const upgradeFrom030 = (p: ProjectV030 | ProjectV031) =>
+  upgradeFrom040({
+    ...p,
+    discourseServer:
+      p.discourseServer != null
+        ? {serverUrl: p.discourseServer.serverUrl}
+        : null,
+  });
+
+export type ProjectV031 = {|
   +id: ProjectId,
   +repoIds: $ReadOnlyArray<RepoId>,
   +discourseServer: {|
@@ -88,7 +110,7 @@ type ProjectV031 = {|
   +identities: $ReadOnlyArray<Identity>,
 |};
 
-type ProjectV030 = {|
+export type ProjectV030 = {|
   +id: ProjectId,
   +repoIds: $ReadOnlyArray<RepoId>,
   +discourseServer: {|
@@ -101,4 +123,5 @@ type ProjectV030 = {|
 const upgrades = {
   "0.3.0": upgradeFrom030,
   "0.3.1": upgradeFrom030,
+  "0.4.0": upgradeFrom040,
 };

--- a/src/core/project_io.test.js
+++ b/src/core/project_io.test.js
@@ -37,6 +37,7 @@ describe("core/project_io", () => {
     repoIds: [foobar, foozod],
     discourseServer: {serverUrl: "https://example.com"},
     identities: [{username: "foo", aliases: ["github/foo", "discourse/foo"]}],
+    initiatives: {remoteUrl: "https://example.com/initiatives"},
   });
 
   it("setupProjectDirectory results in a loadable project", async () => {

--- a/src/plugins/initiatives/params.js
+++ b/src/plugins/initiatives/params.js
@@ -1,0 +1,11 @@
+// @flow
+
+/**
+ * Options to add to Project spec.
+ * Assumes we're loading an InitiativesDirectory. We're not including the local
+ * path here, as this is environment dependent. It should be passed as an ENV
+ * or CLI parameter instead.
+ */
+export type ProjectParameters = {|
+  +remoteUrl: string,
+|};


### PR DESCRIPTION
Adding parameters to Project.

Assumes we're loading an InitiativesDirectory. We're not including the local path here, as this is environment dependent. It should be passed as an ENV or CLI parameter instead.

Test plan: `yarn test --full`