### PR TITLE
Expose a ReferenceDetector to createPluginGraphs

### DIFF
--- a/src/backend/loadContext.js
+++ b/src/backend/loadContext.js
@@ -67,6 +67,7 @@ export class LoadContext {
   +_declarations = PluginLoaders.declarations;
   +_updateMirror = PluginLoaders.updateMirror;
   +_createPluginGraphs = PluginLoaders.createPluginGraphs;
+  +_createReferenceDetector = PluginLoaders.createReferenceDetector;
   +_contractPluginGraphs = PluginLoaders.contractPluginGraphs;
   +_overrideWeights = WeightedGraph.overrideWeights;
   +_computeTask = ComputeFunction.computeTask;
@@ -97,10 +98,16 @@ export class LoadContext {
       this._options,
       project
     );
-    const pluginGraphs = await this._createPluginGraphs(
+    const referenceDetector = await this._createReferenceDetector(
       this._pluginLoaders,
       this._options,
       cachedProject
+    );
+    const pluginGraphs = await this._createPluginGraphs(
+      this._pluginLoaders,
+      this._options,
+      cachedProject,
+      referenceDetector
     );
     const contractedGraph = await this._contractPluginGraphs(
       this._pluginLoaders,

--- a/src/backend/loadContext.test.js
+++ b/src/backend/loadContext.test.js
@@ -9,6 +9,7 @@ import {LoadContext} from "./loadContext";
 
 const fakes = {
   declarations: ({fake: "declarations"}: any),
+  referenceDetector: ({fake: "referenceDetector"}: any),
   pluginGraphs: ({fake: "pluginGraphs"}: any),
   contractedGraph: ({fake: "contractedGraph"}: any),
   weightedGraph: ({fake: "weightedGraph"}: any),
@@ -42,6 +43,10 @@ const mockProxyMethods = (
     updateMirror: spyBuilder
       .proxyMethod("updateMirror")
       .mockResolvedValueOnce({project, cache}),
+
+    createReferenceDetector: spyBuilder
+      .proxyMethod("createReferenceDetector")
+      .mockResolvedValueOnce(fakes.referenceDetector),
 
     createPluginGraphs: spyBuilder
       .proxyMethod("createPluginGraphs")
@@ -91,6 +96,7 @@ describe("src/backend/loadContext", () => {
           // Methods
           _declarations: expect.anything(),
           _updateMirror: expect.anything(),
+          _createReferenceDetector: expect.anything(),
           _createPluginGraphs: expect.anything(),
           _contractPluginGraphs: expect.anything(),
           _overrideWeights: expect.anything(),
@@ -127,10 +133,16 @@ describe("src/backend/loadContext", () => {
           expectedEnv,
           project
         );
-        expect(spies.createPluginGraphs).toBeCalledWith(
+        expect(spies.createReferenceDetector).toBeCalledWith(
           loadContext._pluginLoaders,
           expectedEnv,
           cachedProject
+        );
+        expect(spies.createPluginGraphs).toBeCalledWith(
+          loadContext._pluginLoaders,
+          expectedEnv,
+          cachedProject,
+          fakes.referenceDetector
         );
         expect(spies.contractPluginGraphs).toBeCalledWith(
           loadContext._pluginLoaders,


### PR DESCRIPTION
Eventually all plugins are expected to use the ReferenceDetector. This commit composes the Github and Discourse detectors we can create, for now exposing it as unused to `createPluginGraphs`.

Test plan: `yarn test`