### PR TITLE
Initiatives: define weights to allow Cred minting

### DIFF
--- a/src/plugins/initiatives/__snapshots__/initiativesDirectory.test.js.snap
+++ b/src/plugins/initiatives/__snapshots__/initiativesDirectory.test.js.snap
@@ -18,6 +18,10 @@ Map {
     ],
     "timestampIso": "2020-01-08T22:01:57.711Z",
     "title": "Initiative A",
+    "weight": Object {
+      "complete": 100,
+      "incomplete": 0,
+    },
   },
   "initiative-B.json" => Object {
     "champions": Array [
@@ -35,6 +39,10 @@ Map {
     ],
     "timestampIso": "2020-01-08T22:01:57.722Z",
     "title": "Initiative B",
+    "weight": Object {
+      "complete": 69,
+      "incomplete": 42,
+    },
   },
 }
 `;
@@ -74,7 +82,11 @@ exports[`plugins/initiatives/initiativesDirectory loadDirectory should handle an
       \\"http://foo.bar/A/ref\\"
     ],
     \\"timestampMs\\": 1578520917711,
-    \\"title\\": \\"Initiative A\\"
+    \\"title\\": \\"Initiative A\\",
+    \\"weight\\": {
+      \\"complete\\": 100,
+      \\"incomplete\\": 0
+    }
   },
   {
     \\"champions\\": [
@@ -96,7 +108,11 @@ exports[`plugins/initiatives/initiativesDirectory loadDirectory should handle an
       \\"http://foo.bar/B/ref\\"
     ],
     \\"timestampMs\\": 1578520917722,
-    \\"title\\": \\"Initiative B\\"
+    \\"title\\": \\"Initiative B\\",
+    \\"weight\\": {
+      \\"complete\\": 69,
+      \\"incomplete\\": 42
+    }
   }
 ]"
 `;

--- a/src/plugins/initiatives/createGraph.js
+++ b/src/plugins/initiatives/createGraph.js
@@ -1,7 +1,6 @@
 // @flow
 
 import {
-  Graph,
   EdgeAddress,
   NodeAddress,
   type Edge,
@@ -9,6 +8,9 @@ import {
   type EdgeAddressT,
   type NodeAddressT,
 } from "../../core/graph";
+import {type WeightedGraph as WeightedGraphT} from "../../core/weightedGraph";
+import * as WeightedGraph from "../../core/weightedGraph";
+import type {NodeWeight} from "../../core/weights";
 import type {ReferenceDetector, URL} from "../../core/references";
 import type {Initiative, InitiativeRepository} from "./initiative";
 import {addressFromId} from "./initiative";
@@ -33,6 +35,13 @@ function initiativeNode(initiative: Initiative): Node {
     description:
       url == null ? initiative.title : `[${initiative.title}](${url})`,
   };
+}
+
+export function initiativeWeight(initiative: Initiative): ?NodeWeight {
+  if (!initiative.weight) return;
+  return initiative.completed
+    ? initiative.weight.complete
+    : initiative.weight.incomplete;
 }
 
 type EdgeFactoryT = (initiative: Initiative, other: NodeAddressT) => Edge;
@@ -63,15 +72,21 @@ const referenceEdge = edgeFactory(referencesEdgeType.prefix, true);
 const contributionEdge = edgeFactory(contributesToEdgeType.prefix, false);
 const championEdge = edgeFactory(championsEdgeType.prefix, false);
 
-export function createGraph(
+export function createWeightedGraph(
   repo: InitiativeRepository,
   refs: ReferenceDetector
-): Graph {
-  const graph = new Graph();
+): WeightedGraphT {
+  const wg = WeightedGraph.empty();
+  const {graph, weights} = wg;
 
   for (const initiative of repo.initiatives()) {
     // Adds the Initiative node.
-    graph.addNode(initiativeNode(initiative));
+    const node = initiativeNode(initiative);
+    const weight = initiativeWeight(initiative);
+    graph.addNode(node);
+    if (weight) {
+      weights.nodeWeights.set(node.address, weight);
+    }
 
     // Generic approach to adding edges when the reference detector has a hit.
     const edgeHandler = (
@@ -92,5 +107,5 @@ export function createGraph(
     edgeHandler(initiative.champions, championEdge);
   }
 
-  return graph;
+  return wg;
 }

--- a/src/plugins/initiatives/example/initiative-A.json
+++ b/src/plugins/initiatives/example/initiative-A.json
@@ -6,6 +6,10 @@
   {
     "title": "Initiative A",
     "timestampIso": "2020-01-08T22:01:57.711Z",
+    "weight": {
+      "incomplete": 0,
+      "complete": 100
+    },
     "completed": true,
     "champions": ["http://foo.bar/A/champ"],
     "contributions": ["http://foo.bar/A/contrib"],

--- a/src/plugins/initiatives/example/initiative-B.json
+++ b/src/plugins/initiatives/example/initiative-B.json
@@ -6,6 +6,10 @@
   {
     "title": "Initiative B",
     "timestampIso": "2020-01-08T22:01:57.722Z",
+    "weight": {
+      "incomplete": 42,
+      "complete": 69
+    },
     "completed": false,
     "champions": ["http://foo.bar/B/champ"],
     "contributions": ["http://foo.bar/B/contrib"],

--- a/src/plugins/initiatives/initiative.js
+++ b/src/plugins/initiatives/initiative.js
@@ -1,6 +1,7 @@
 // @flow
 
 import {type NodeAddressT, NodeAddress} from "../../core/graph";
+import {type NodeWeight} from "../../core/weights";
 import {initiativeNodeType} from "./declaration";
 
 export type URL = string;
@@ -21,6 +22,12 @@ export function addressFromId(id: InitiativeId): NodeAddressT {
   return NodeAddress.append(initiativeNodeType.prefix, ...id);
 }
 
+// A before completion and after completion weight for Initiatives.
+export type InitiativeWeight = {|
+  +incomplete: NodeWeight,
+  +complete: NodeWeight,
+|};
+
 /**
  * An intermediate representation of an Initiative.
  *
@@ -39,6 +46,7 @@ export type Initiative = {|
   +id: InitiativeId,
   +title: string,
   +timestampMs: number,
+  +weight?: InitiativeWeight,
   +completed: boolean,
   +dependencies: $ReadOnlyArray<URL>,
   +references: $ReadOnlyArray<URL>,

--- a/src/plugins/initiatives/initiativesDirectory.js
+++ b/src/plugins/initiatives/initiativesDirectory.js
@@ -13,6 +13,7 @@ import {
 } from "../../core/references";
 import {
   type Initiative,
+  type InitiativeWeight,
   type InitiativeId,
   type InitiativeRepository,
   type URL,
@@ -82,6 +83,7 @@ export async function loadDirectory(
 export type InitiativeFile = {|
   +title: string,
   +timestampIso: ISOTimestamp,
+  +weight: InitiativeWeight,
   +completed: boolean,
   +dependencies: $ReadOnlyArray<URL>,
   +references: $ReadOnlyArray<URL>,

--- a/src/plugins/initiatives/initiativesDirectory.test.js
+++ b/src/plugins/initiatives/initiativesDirectory.test.js
@@ -26,6 +26,7 @@ import {
 const exampleInitiativeFile = (): InitiativeFile => ({
   title: "Sample initiative",
   timestampIso: ("2020-01-08T22:01:57.766Z": any),
+  weight: {incomplete: 360, complete: 420},
   completed: false,
   champions: ["http://foo.bar/champ"],
   contributions: ["http://foo.bar/contrib"],


### PR DESCRIPTION
Using a required tuple of before and after completion weight is a simple
way to start minting Cred on Initiatives. It sets expectations by having
both states defined in a version controlled file.

Test plan: `yarn test`