### PR TITLE
Initiatives: implement loader

### DIFF
--- a/src/backend/loadContext.js
+++ b/src/backend/loadContext.js
@@ -16,6 +16,7 @@ import * as PluginLoaders from "./pluginLoaders";
 import {default as githubLoader} from "../plugins/github/loader";
 import {default as identityLoader} from "../plugins/identity/loader";
 import {default as discourseLoader} from "../plugins/discourse/loader";
+import {default as initiativesLoader} from "../plugins/initiatives/loader";
 import {type PluginDeclarations} from "../analysis/pluginDeclaration";
 
 export type LoadResult = {|
@@ -85,6 +86,7 @@ export class LoadContext {
     github: githubLoader,
     discourse: discourseLoader,
     identity: identityLoader,
+    initiatives: initiativesLoader,
   };
 
   /**

--- a/src/plugins/initiatives/loader.js
+++ b/src/plugins/initiatives/loader.js
@@ -1,0 +1,48 @@
+// @flow
+
+import {TaskReporter} from "../../util/taskReporter";
+import {type WeightedGraph} from "../../core/weightedGraph";
+import * as Weights from "../../core/weights";
+import {type ReferenceDetector} from "../../core/references";
+import {type PluginDeclaration} from "../../analysis/pluginDeclaration";
+import {type InitiativeRepository} from "./initiative";
+import {weightsForDeclaration} from "../../analysis/pluginDeclaration";
+import {createWeightedGraph} from "./createGraph";
+import {
+  type InitiativesDirectory,
+  type LoadedInitiativesDirectory,
+  loadDirectory as _loadDirectory,
+} from "./initiativesDirectory";
+import {declaration} from "./declaration";
+
+export interface Loader {
+  declaration(): PluginDeclaration;
+  loadDirectory: typeof loadDirectory;
+  createGraph: typeof createGraph;
+}
+
+export default ({
+  declaration: () => declaration,
+  loadDirectory,
+  createGraph,
+}: Loader);
+
+export async function loadDirectory(
+  dir: InitiativesDirectory,
+  reporter: TaskReporter
+): Promise<LoadedInitiativesDirectory> {
+  reporter.start("initiatives");
+  const loadedDir = await _loadDirectory(dir);
+  reporter.finish("initiatives");
+  return loadedDir;
+}
+
+export async function createGraph(
+  repo: InitiativeRepository,
+  refs: ReferenceDetector
+): Promise<WeightedGraph> {
+  const {graph, weights} = createWeightedGraph(repo, refs);
+  const declarationWeights = weightsForDeclaration(declaration);
+  const combinedWeights = Weights.merge([weights, declarationWeights]);
+  return {graph, weights: combinedWeights};
+}

--- a/src/plugins/initiatives/loader.test.js
+++ b/src/plugins/initiatives/loader.test.js
@@ -1,0 +1,50 @@
+// @flow
+
+import path from "path";
+import {TestTaskReporter} from "../../util/taskReporter";
+import {MappedReferenceDetector} from "../../core/references";
+import {weightsForDeclaration} from "../../analysis/pluginDeclaration";
+import {type InitiativesDirectory} from "./initiativesDirectory";
+import {loadDirectory, createGraph} from "./loader";
+import {declaration} from "./declaration";
+
+describe("plugins/initiatives/loader", () => {
+  describe("loadDirectory", () => {
+    it("should report correct tasks", async () => {
+      // Given
+      const reporter = new TestTaskReporter();
+      const dir: InitiativesDirectory = {
+        localPath: path.join(__dirname, "example"),
+        remoteUrl: "http://example.com/initiatives",
+      };
+
+      // When
+      const result = await loadDirectory(dir, reporter);
+
+      // Then
+      expect(result).toEqual({
+        initiatives: {initiatives: expect.any(Function)},
+        referenceDetector: expect.any(MappedReferenceDetector),
+      });
+      expect(reporter.activeTasks()).toEqual([]);
+      expect(reporter.entries()).toEqual([
+        {type: "START", taskId: "initiatives"},
+        {type: "FINISH", taskId: "initiatives"},
+      ]);
+    });
+  });
+
+  describe("createGraph", () => {
+    it("should add the default weights", async () => {
+      // Given
+      const mockRepository = {initiatives: () => []};
+      const mockReferences = {addressFromUrl: () => null};
+
+      // When
+      const wg = await createGraph(mockRepository, mockReferences);
+
+      // Then
+      expect(wg.weights).toEqual(weightsForDeclaration(declaration));
+    });
+  });
+});


### PR DESCRIPTION
Depends on: #1671, #1672, #1673, #1674

Test plan:

Has partial unit test coverage, `yarn test`.
Can be manually tested:
`SOURCECRED_INITIATIVES_DIRECTORY=<path> sourcecred load --project <file>`

Below files with default weights should result in:
> #initiative connected to test nodes | 92 Cred

<details><summary>Example project.json</summary>

```json
[
  {
    "type": "sourcecred/project",
    "version": "0.5.0"
  },
  {
    "initiatives": {
      "remoteUrl": "https://github.com/sourcecred/cred/tree/master/initiatives"
    },
    "id": "@sourcecred-test",
    "identities": [],
    "discourseServer": {
      "serverUrl": "https://sourcecred-test.discourse.group"
    },
    "repoIds": [
      {
        "name": "example-github",
        "owner": "sourcecred-test"
      }
    ]
  }
]
```

</details>

<details><summary>Example initiative.json</summary>

```json
[
  {
    "type": "sourcecred/initiativeFile",
    "version": "0.1.0"
  },
  {
    "title": "#initiative connected to test nodes",
    "timestampIso": "2019-08-08T22:01:57.722Z",
    "weight": [42, 69],
    "completed": true,
    "dependencies": [
      "https://sourcecred-test.discourse.group/t/this-post-will-be-a-wiki/19",
      "https://github.com/sourcecred-test/example-github/pull/9"
    ],
    "references": [
      "https://sourcecred-test.discourse.group/t/my-first-test-post/11",
      "https://github.com/sourcecred-test/example-github/issues/13"
    ],
    "contributions": [],
    "champions": [
      "https://github.com/decentralion",
      "https://sourcecred-test.discourse.group/u/dl-proto"
    ]
  }
]
```

</details>