### PR TITLE
MapUtil: permit read-only input to `fromObject`

### DIFF
--- a/src/util/map.js
+++ b/src/util/map.js
@@ -21,7 +21,7 @@ export function toObject<K: string, V, InK: K, InV: V>(
  * iteration order, as returned by `Object.keys`.
  */
 export function fromObject<K, V, InK: K & string, InV: V>(object: {
-  [InK]: InV,
+  +[InK]: InV,
 }): Map<K, V> {
   const result = new Map();
   const keys = (((Object.keys(object): string[]): any): InK[]);

--- a/src/util/map.test.js
+++ b/src/util/map.test.js
@@ -71,6 +71,10 @@ describe("util/map", () => {
       const o: {|[string]: number|} = ({a: 1}: any);
       const _: Map<string, number> = MapUtil.fromObject(o);
     });
+    it("can accept a read-only object", () => {
+      const o: {+[string]: number} = {a: 1};
+      const _: Map<string, number> = MapUtil.fromObject(o);
+    });
     it("statically rejects a map with keys not a subtype of string", () => {
       const input: {[number]: string} = {};
       input[12] = "not okay";


### PR DESCRIPTION
Summary:
Because `fromObject` does not mutate its input, it’s safe to accept
read-only inputs. This is needed for parts of the CredRank Markov
process graph implementation.

Test Plan:
Typing test added.

wchargin-branch: maputil-readonly-input