### PR TITLE
Modify default Discourse weights

### DIFF
--- a/src/plugins/discourse/declaration.js
+++ b/src/plugins/discourse/declaration.js
@@ -12,7 +12,7 @@ export const topicNodeType: NodeType = deepFreeze({
   name: "Topic",
   pluralName: "Topics",
   prefix: NodeAddress.append(nodePrefix, "topic"),
-  defaultWeight: 2,
+  defaultWeight: 0,
   description:
     "A topic (or post-container) in a Discourse instance. Every topic has at least one post.",
 });
@@ -21,7 +21,7 @@ export const postNodeType: NodeType = deepFreeze({
   name: "Post",
   pluralName: "Posts",
   prefix: NodeAddress.append(nodePrefix, "post"),
-  defaultWeight: 1,
+  defaultWeight: 0,
   description: "A post in some topic in a Discourse instance.",
 });
 
@@ -45,7 +45,7 @@ export const topicContainsPostEdgeType: EdgeType = deepFreeze({
   forwardName: "contains post",
   backwardName: "is contained by topic",
   prefix: EdgeAddress.append(edgePrefix, "topicContainsPost"),
-  defaultWeight: {forwards: 1 / 16, backwards: 1 / 4},
+  defaultWeight: {forwards: 0, backwards: 1 / 8},
   description: "Connects a topic to the posts that it contains.",
 });
 
@@ -53,7 +53,7 @@ export const postRepliesEdgeType: EdgeType = deepFreeze({
   forwardName: "post is reply to",
   backwardName: "post replied to by",
   prefix: EdgeAddress.append(edgePrefix, "replyTo"),
-  defaultWeight: {forwards: 1, backwards: 1 / 16},
+  defaultWeight: {forwards: 1 / 2, backwards: 0},
   description: "Connects a post to the post that it is a reply to.",
 });
 
@@ -61,7 +61,7 @@ export const authorsTopicEdgeType: EdgeType = deepFreeze({
   forwardName: "authors topic",
   backwardName: "topic is authored by",
   prefix: EdgeAddress.append(edgePrefix, "authors", "topic"),
-  defaultWeight: {forwards: 1 / 4, backwards: 1},
+  defaultWeight: {forwards: 0, backwards: 1},
   description: "Connects an author to a topic they created.",
 });
 
@@ -69,7 +69,7 @@ export const authorsPostEdgeType: EdgeType = deepFreeze({
   forwardName: "authors post",
   backwardName: "post is authored by",
   prefix: EdgeAddress.append(edgePrefix, "authors", "post"),
-  defaultWeight: {forwards: 1 / 4, backwards: 1},
+  defaultWeight: {forwards: 0, backwards: 1},
   description: "Connects an author to a post they've created.",
 });
 
@@ -77,7 +77,7 @@ export const createsLikeEdgeType: EdgeType = deepFreeze({
   forwardName: "creates like",
   backwardName: "like created by",
   prefix: EdgeAddress.append(edgePrefix, "createsLike"),
-  defaultWeight: {forwards: 1, backwards: 1 / 16},
+  defaultWeight: {forwards: 1, backwards: 0},
   description: "Connects a Discourse user to a like that they created.",
 });
 
@@ -85,7 +85,7 @@ export const likesEdgeType: EdgeType = deepFreeze({
   forwardName: "likes",
   backwardName: "is liked by",
   prefix: EdgeAddress.append(edgePrefix, "likes"),
-  defaultWeight: {forwards: 1, backwards: 1 / 16},
+  defaultWeight: {forwards: 1, backwards: 0},
   description: "Connects a Discourse like to a post that was liked.",
 });
 
@@ -93,7 +93,7 @@ export const referencesPostEdgeType: EdgeType = deepFreeze({
   forwardName: "references post",
   backwardName: "post is referenced by",
   prefix: EdgeAddress.append(edgePrefix, "references", "post"),
-  defaultWeight: {forwards: 1 / 2, backwards: 1 / 16},
+  defaultWeight: {forwards: 1 / 2, backwards: 0},
   description: "Connects a Discourse post to another post it referenced.",
 });
 
@@ -101,7 +101,7 @@ export const referencesTopicEdgeType: EdgeType = deepFreeze({
   forwardName: "references topic",
   backwardName: "topic is referenced by",
   prefix: EdgeAddress.append(edgePrefix, "references", "topic"),
-  defaultWeight: {forwards: 1 / 2, backwards: 1 / 16},
+  defaultWeight: {forwards: 1 / 2, backwards: 0},
   description: "Connects a Discourse post to a topic it referenced.",
 });
 
@@ -109,7 +109,7 @@ export const referencesUserEdgeType: EdgeType = deepFreeze({
   forwardName: "mentions",
   backwardName: "is mentioned by",
   prefix: EdgeAddress.append(edgePrefix, "references", "user"),
-  defaultWeight: {forwards: 1 / 4, backwards: 1 / 16},
+  defaultWeight: {forwards: 1 / 4, backwards: 0},
   description: "Connects a Discourse post to a user it mentions",
 });
 


### PR DESCRIPTION
This commit modifies the default weights in the Discourse plugin. The
overall theme is to make the plugin flow less cred to "raw activity", in
favor of only flowing cred to posts where there is some explicit signal
that they were valuable.

Most significantly, we move over to fully [like-minted cred][1], instead
of minting cred directly to posts and topics. Also, we remove the edges
that tend to flow cred to posts indiscriminately. For example, topics no
longer flow cred to every post within the topic.

Based on local testing on a few forums I'm familiar with, I feel
confident that these cred scores are an improvement over the current
defaults, as we now have a few "real life test cases" of high-noise,
high-activity users, and these weights reduce the amount of cred that
accrues to such "stress testers". With these changes, I feel that we can
start cautiously using the Discourse plugin in [Trust Level 2][2]
communities.

Test plan: `yarn flow` and code inspection are sufficient to verify that
the new weights are technically valid. Because my calibration process
for validating these changes involves subjective judgements about
contributions from real people, I'm declining to publicly post any
specifics; reviewers are welcome to reach out to my offline for further
discussion.

[1]: https://discourse.sourcecred.io/t/minting-discourse-cred-on-likes-not-posts/603
[2]: https://github.com/sourcecred/docs/pull/24