### PR TITLE
Modify the GitHub plugin to get pulls' base refs

### DIFF
--- a/src/plugins/github/example/example-github.json
+++ b/src/plugins/github/example/example-github.json
@@ -753,6 +753,7 @@
                 "login": "decentralion",
                 "url": "https://github.com/decentralion"
             },
+            "baseRefName": "master",
             "body": "Oh look, it's a pull request.",
             "comments": [
                 {
@@ -867,6 +868,7 @@
                 "login": "decentralion",
                 "url": "https://github.com/decentralion"
             },
+            "baseRefName": "master",
             "body": "@wchargin could you please do the following:\r\n- add a commit comment\r\n- add a review comment requesting some trivial change\r\n- i'll change it\r\n- then approve the pr",
             "comments": [
                 {
@@ -1215,6 +1217,7 @@
                 "login": "decentralion",
                 "url": "https://github.com/decentralion"
             },
+            "baseRefName": "master",
             "body": "Nominally paired with @wchargin",
             "comments": [
             ],

--- a/src/plugins/github/graphqlTypes.js
+++ b/src/plugins/github/graphqlTypes.js
@@ -77,6 +77,7 @@ export type PullRequest = {|
   +__typename: "PullRequest",
   +additions: Int,
   +author: null | Actor,
+  +baseRefName: String,
   +body: String,
   +comments: $ReadOnlyArray<null | IssueComment>,
   +createdAt: DateTime,

--- a/src/plugins/github/schema.js
+++ b/src/plugins/github/schema.js
@@ -63,6 +63,7 @@ export default function schema(): Schema.Schema {
       reviews: s.connection("PullRequestReview"),
       reactions: s.connection("Reaction"),
       createdAt: s.primitive(s.nonNull("DateTime")),
+      baseRefName: s.primitive(s.nonNull("String")),
     }),
     IssueComment: s.object({
       id: s.id(),


### PR DESCRIPTION
This will enable us to mint cred on merges to master; see #1682.

Test plan: Inspect snapshot changes, `yarn test --full` passes.