### PR TITLE
github: fix stack overflow in `RelationalView`

### DIFF
--- a/src/plugins/github/relationalView.js
+++ b/src/plugins/github/relationalView.js
@@ -352,15 +352,16 @@ export class RelationalView {
 
   _addCommit(json: T.Commit): CommitAddress {
     const commitStack = [json]; // reified recursion to avoid stack overflow
-    let originalAddress;
+    let originalAddress = null;
     while (true) {
       const json = commitStack.pop();
       if (json == null) {
+        // End of stack.
         break;
       }
       const address = {type: N.COMMIT_TYPE, id: json.id};
       const rawAddress = N.toRaw(address);
-      if (originalAddress === undefined) {
+      if (originalAddress == null) {
         originalAddress = address;
       }
       // This fast-return is critical, because a single commit may appear
@@ -410,7 +411,8 @@ export class RelationalView {
         }
       }
     }
-    return originalAddress;
+    // must have gone through at least one loop iteration
+    return NullUtil.get(originalAddress);
   }
 
   _addPull(repo: RepoAddress, json: T.PullRequest): PullAddress {

--- a/src/plugins/github/relationalView.js
+++ b/src/plugins/github/relationalView.js
@@ -351,55 +351,66 @@ export class RelationalView {
   }
 
   _addCommit(json: T.Commit): CommitAddress {
-    const address = {type: N.COMMIT_TYPE, id: json.id};
-    const rawAddress = N.toRaw(address);
-    // This fast-return is critical, because a single commit may appear
-    // many times in the repository.
-    //
-    // For example, a repository with 1000 commits, each of which was
-    // created by merging a pull request, will include 1001 structural
-    // references to the root commit (one via the HEAD ref, and one
-    // along a parent-chain from each pull request), so the number of
-    // occurrences of commits can easily be quadratic in the number of
-    // actual commits.
-    //
-    // Furthermore, it can be exponential: consider merge commits like
-    //
-    //     HEAD
-    //     / \
-    //    1A 1B
-    //    | X |
-    //    2A 2B
-    //    | X |
-    //    3A 3B
-    //     \ /
-    //     root
-    //
-    // where each merge commit has two parents. The root commit is
-    // reachable along about 2^(n/2) paths.
-    //
-    // This check ensures that we process each commit edge only once.
-    if (this._commits.has(rawAddress)) {
-      return address;
-    }
+    const commitStack = [json]; // reified recursion to avoid stack overflow
+    let originalAddress;
+    while (true) {
+      const json = commitStack.pop();
+      if (json == null) {
+        break;
+      }
+      const address = {type: N.COMMIT_TYPE, id: json.id};
+      const rawAddress = N.toRaw(address);
+      if (originalAddress === undefined) {
+        originalAddress = address;
+      }
+      // This fast-return is critical, because a single commit may appear
+      // many times in the repository.
+      //
+      // For example, a repository with 1000 commits, each of which was
+      // created by merging a pull request, will include 1001 structural
+      // references to the root commit (one via the HEAD ref, and one
+      // along a parent-chain from each pull request), so the number of
+      // occurrences of commits can easily be quadratic in the number of
+      // actual commits.
+      //
+      // Furthermore, it can be exponential: consider merge commits like
+      //
+      //     HEAD
+      //     / \
+      //    1A 1B
+      //    | X |
+      //    2A 2B
+      //    | X |
+      //    3A 3B
+      //     \ /
+      //     root
+      //
+      // where each merge commit has two parents. The root commit is
+      // reachable along about 2^(n/2) paths.
+      //
+      // This check ensures that we process each commit edge only once.
+      if (this._commits.has(rawAddress)) {
+        continue;
+      }
 
-    const authors =
-      json.author == null ? [] : this._addNullableAuthor(json.author.user);
-    const entry: CommitEntry = {
-      address,
-      url: json.url,
-      authors,
-      message: json.message,
-      hash: json.oid,
-      timestampMs: +new Date(json.authoredDate),
-    };
-    this._commits.set(N.toRaw(address), entry);
-    for (const parent of json.parents) {
-      if (parent != null) {
-        this._addCommit(parent);
+      const authors =
+        json.author == null ? [] : this._addNullableAuthor(json.author.user);
+      const entry: CommitEntry = {
+        address,
+        url: json.url,
+        authors,
+        message: json.message,
+        hash: json.oid,
+        timestampMs: +new Date(json.authoredDate),
+      };
+      this._commits.set(N.toRaw(address), entry);
+      for (const parent of json.parents) {
+        if (parent != null) {
+          commitStack.push(parent);
+        }
       }
     }
-    return address;
+    return originalAddress;
   }
 
   _addPull(repo: RepoAddress, json: T.PullRequest): PullAddress {

--- a/src/plugins/github/relationalView.test.js
+++ b/src/plugins/github/relationalView.test.js
@@ -3,6 +3,7 @@
 import {NodeAddress} from "../../core/graph";
 import * as R from "./relationalView";
 import * as N from "./nodes";
+import * as T from "./graphqlTypes";
 import {exampleRepository, exampleRelationalView} from "./example/example";
 import * as MapUtil from "../../util/map";
 

--- a/src/plugins/github/relationalView.test.js
+++ b/src/plugins/github/relationalView.test.js
@@ -316,6 +316,7 @@ describe("plugins/github/relationalView", () => {
           __typename: "PullRequest",
           additions: 0,
           author: userNode,
+          baseRefName: "master",
           body: "",
           comments: [],
           createdAt: dateString,

--- a/src/plugins/github/relationalView.test.js
+++ b/src/plugins/github/relationalView.test.js
@@ -259,6 +259,121 @@ describe("plugins/github/relationalView", () => {
     hasCorrectParent("review", review);
   });
 
+  describe("handles long sequences of commits", () => {
+    // Chain length needs to be significantly higher than what one might
+    // expect would be sufficient to trigger a stack overflow (~5000)
+    // due to V8 hotspot-based optimizations. See:
+    // https://github.com/sourcecred/sourcecred/issues/1354#issuecomment-593062805
+    const COMMIT_CHAIN_LENGTH = 8192;
+    const PULL_REQUEST_SPACING = 10;
+    function exampleResponse(options: {|
+      +includePullRequests: boolean,
+    |}): T.Repository {
+      const dateString: string = "2001-02-03T04:05:06Z";
+      const userNode: T.User = {
+        __typename: "User",
+        id: "user:admin",
+        login: "admin",
+        url: "https://example.com/admin",
+      };
+      function wrapCommit(
+        index: number,
+        parents: $ReadOnlyArray<T.Commit>
+      ): T.Commit {
+        const hex = index.toString(16);
+        const oid = "0".repeat(40 - hex.length) + hex;
+        return {
+          __typename: "Commit",
+          author: {
+            date: dateString,
+            user: userNode,
+          },
+          authoredDate: dateString,
+          id: `commit:${oid}`,
+          message: "",
+          oid,
+          parents,
+          url: `https://example.com/admin/repo/commit/${oid}`,
+        };
+      }
+      function commitChain(n: number): T.Commit[] {
+        let head = wrapCommit(0, []);
+        let results = [head];
+        for (let i = 1; i < n; i++) {
+          head = wrapCommit(i, [head]);
+          results.push(head);
+        }
+        return results;
+      }
+      const commits = commitChain(COMMIT_CHAIN_LENGTH);
+      let pullRequests: T.PullRequest[] = [];
+      function pullRequest(
+        prNumber: number,
+        mergeCommit: T.Commit
+      ): T.PullRequest {
+        return {
+          __typename: "PullRequest",
+          additions: 0,
+          author: userNode,
+          body: "",
+          comments: [],
+          createdAt: dateString,
+          deletions: 0,
+          id: `pr:admin/repo#${prNumber}`,
+          mergeCommit,
+          number: prNumber,
+          reactions: [],
+          reviews: [],
+          title: "",
+          url: `https://example.com/admin/repo/pull/${prNumber}`,
+        };
+      }
+      {
+        let nextPrNumber = 1;
+        if (options.includePullRequests) {
+          for (let i = 0; i < commits.length - 1; i += PULL_REQUEST_SPACING) {
+            pullRequests.push(pullRequest(nextPrNumber++, commits[i]));
+          }
+        }
+        pullRequests.push(
+          pullRequest(nextPrNumber++, commits[commits.length - 1])
+        );
+      }
+      return {
+        __typename: "Repository",
+        createdAt: dateString,
+        defaultBranchRef: {
+          __typename: "Ref",
+          id: "ref:master",
+          target: commits[commits.length - 1],
+        },
+        id: "repo:admin/repo",
+        issues: [],
+        name: "repo",
+        owner: userNode,
+        pullRequests,
+        url: "https://example.com/admin/repo",
+      };
+    }
+
+    it("without regularly spaced pull requests", () => {
+      const rv = new R.RelationalView();
+      // Next line expected to stack overflow on a naive implementation.
+      rv.addRepository(exampleResponse({includePullRequests: false}));
+      expect(Array.from(rv.commits())).toHaveLength(COMMIT_CHAIN_LENGTH);
+      expect(Array.from(rv.pulls())).toHaveLength(1);
+    });
+
+    it("with regularly spaced pull requests", () => {
+      const rv = new R.RelationalView();
+      rv.addRepository(exampleResponse({includePullRequests: true}));
+      expect(Array.from(rv.commits())).toHaveLength(COMMIT_CHAIN_LENGTH);
+      expect(Array.from(rv.pulls())).toHaveLength(
+        Math.ceil((COMMIT_CHAIN_LENGTH - 1) / PULL_REQUEST_SPACING) + 1
+      );
+    });
+  });
+
   it("paired with edges", () => {
     const issue10 = Array.from(view.issues()).find((x) => x.number() === "10");
     if (issue10 == null) {


### PR DESCRIPTION
Summary:
The `_addCommit` helper recurs against the list of parents of a commit.
We add pull requests to the repository in ascending numeric order, so in
many cases the depth of this recursion is bounded, because each PR’s
merge commit is only a few levels down from the previous one’s. But this
is not the case for repositories that have long sequences of commits
none of which was merged by a pull request. In such cases, we’ll simply
blow the stack.

To complicate matters, the conditions in which we observe this are hard
to predict, because V8 optimizes `_addCommit` when it determines that
it’s a hotspot. This means that the tests are a bit brittle, with
carefully chosen constants that balance test execution time against
regression-catching power. See [comment on #1354 with my analysis][c].

[c]: https://github.com/sourcecred/sourcecred/issues/1354#issuecomment-593062805

Fixes #1354.

Test Plan:
Tests pass as written, and fail if `commitStack.push(parent)` is
replaced with `this._addCommit(parent)`, even if the two `it`-blocks
under the new `describe` spec are commuted. An end-to-end test shows
that we can now compute cred for `passbolt/passbolt_api` (which takes
about an hour to load and compute).

wchargin-branch: rv-fix-addcommit-overflow
