### PR TITLE
Util: implement sortBy

### DIFF
--- a/src/analysis/pagerankNodeDecomposition.js
+++ b/src/analysis/pagerankNodeDecomposition.js
@@ -1,6 +1,6 @@
 // @flow
 
-import sortBy from "lodash.sortby";
+import sortBy from "../util/sortBy";
 
 import type {NodeAddressT} from "../core/graph";
 import {

--- a/src/analysis/timeline/timelineCred.js
+++ b/src/analysis/timeline/timelineCred.js
@@ -1,7 +1,7 @@
 // @flow
 
 import {sum} from "d3-array";
-import sortBy from "lodash.sortby";
+import sortBy from "../../util/sortBy";
 import * as NullUtil from "../../util/null";
 import * as MapUtil from "../../util/map";
 import {toCompat, fromCompat, type Compatible} from "../../util/compat";
@@ -136,7 +136,9 @@ export class TimelineCred {
       const match = (a) => prefixes.some((p) => NodeAddress.hasPrefix(a, p));
       addresses = addresses.filter(match);
     }
-    const credNodes = addresses.map((a) => this.credNode(a));
+    const credNodes = NullUtil.filterList(
+      addresses.map((a) => this.credNode(a))
+    );
     return sortBy(credNodes, (x: CredNode) => -x.total);
   }
 

--- a/src/analysis/timeline/timelineCred.test.js
+++ b/src/analysis/timeline/timelineCred.test.js
@@ -2,7 +2,7 @@
 
 import deepFreeze from "deep-freeze";
 import {sum} from "d3-array";
-import sortBy from "lodash.sortby";
+import sortBy from "../../util/sortBy";
 import {utcWeek} from "d3-time";
 import {NodeAddress, EdgeAddress} from "../../core/graph";
 import * as WeightedGraph from "../../core/weightedGraph";

--- a/src/core/algorithm/graphToMarkovChain.test.js
+++ b/src/core/algorithm/graphToMarkovChain.test.js
@@ -1,6 +1,6 @@
 // @flow
 
-import sortBy from "lodash.sortby";
+import sortBy from "../../util/sortBy";
 
 import {Graph, EdgeAddress} from "../graph";
 import {

--- a/src/core/graph.test.js
+++ b/src/core/graph.test.js
@@ -1,6 +1,6 @@
 // @flow
 
-import sortBy from "lodash.sortby";
+import sortBy from "../util/sortBy";
 
 import {
   type Node,

--- a/src/core/interval.js
+++ b/src/core/interval.js
@@ -1,7 +1,7 @@
 // @flow
 
 import {max, min} from "d3-array";
-import sortBy from "lodash.sortby";
+import sortBy from "../util/sortBy";
 import {utcWeek} from "d3-time";
 import * as NullUtil from "../util/null";
 import type {Node, Edge, Graph} from "./graph";
@@ -30,6 +30,8 @@ export type GraphInterval = {|
 
 export type GraphIntervalPartition = $ReadOnlyArray<GraphInterval>;
 
+type TimefulNode = {|...Node, timestampMs: number|};
+
 /**
  * Partition a graph based on time intervals.
  *
@@ -40,7 +42,9 @@ export type GraphIntervalPartition = $ReadOnlyArray<GraphInterval>;
  */
 export function partitionGraph(graph: Graph): GraphIntervalPartition {
   const nodes = Array.from(graph.nodes());
-  const timefulNodes = nodes.filter((x) => x.timestampMs != null);
+  const timefulNodes: $ReadOnlyArray<TimefulNode> = (nodes.filter(
+    (x) => x.timestampMs != null
+  ): any);
   const sortedNodes = sortBy(timefulNodes, (x) => x.timestampMs);
   const edges = Array.from(graph.edges({showDangling: false}));
   const sortedEdges = sortBy(edges, (x) => x.timestampMs);

--- a/src/explorer/legacy/pagerankTable/Node.js
+++ b/src/explorer/legacy/pagerankTable/Node.js
@@ -1,7 +1,7 @@
 // @flow
 
 import React from "react";
-import sortBy from "lodash.sortby";
+import sortBy from "../../../util/sortBy";
 import * as NullUtil from "../../../util/null";
 
 import {type NodeAddressT} from "../../../core/graph";

--- a/src/explorer/legacy/pagerankTable/Node.test.js
+++ b/src/explorer/legacy/pagerankTable/Node.test.js
@@ -2,7 +2,7 @@
 
 import React from "react";
 import {shallow} from "enzyme";
-import sortBy from "lodash.sortby";
+import sortBy from "../../../util/sortBy";
 import * as NullUtil from "../../../util/null";
 import {TableRow} from "./TableRow";
 import {AggregationRowList} from "./Aggregation";

--- a/src/explorer/legacy/pagerankTable/Table.js
+++ b/src/explorer/legacy/pagerankTable/Table.js
@@ -1,7 +1,7 @@
 // @flow
 
 import React from "react";
-import sortBy from "lodash.sortby";
+import sortBy from "../../../util/sortBy";
 
 import {WeightConfig} from "../../weights/WeightConfig";
 import {WeightsFileManager} from "../../weights/WeightsFileManager";

--- a/src/explorer/legacy/pagerankTable/aggregate.js
+++ b/src/explorer/legacy/pagerankTable/aggregate.js
@@ -1,7 +1,7 @@
 // @flow
 
 import deepFreeze from "deep-freeze";
-import sortBy from "lodash.sortby";
+import sortBy from "../../../util/sortBy";
 import stringify from "json-stable-stringify";
 import * as MapUtil from "../../../util/map";
 import * as NullUtil from "../../../util/null";

--- a/src/plugins/discourse/createGraph.test.js
+++ b/src/plugins/discourse/createGraph.test.js
@@ -1,6 +1,6 @@
 // @flow
 
-import sortBy from "lodash.sortby";
+import sortBy from "../../util/sortBy";
 import * as NullUtil from "../../util/null";
 import type {ReadRepository} from "./mirrorRepository";
 import type {Topic, Post, PostId, TopicId, LikeAction} from "./fetch";

--- a/src/plugins/discourse/mirror.test.js
+++ b/src/plugins/discourse/mirror.test.js
@@ -1,7 +1,7 @@
 // @flow
 
 import {max} from "d3-array";
-import sortBy from "lodash.sortby";
+import sortBy from "../../util/sortBy";
 import Database from "better-sqlite3";
 import {Mirror, type MirrorOptions} from "./mirror";
 import {SqliteMirrorRepository} from "./mirrorRepository";

--- a/src/util/sortBy.js
+++ b/src/util/sortBy.js
@@ -1,0 +1,30 @@
+//@flow
+
+type PluckFn<T> = (T) => any;
+
+const identity = (x) => x;
+
+/**
+ * Sorting utility. Accepts an array and optionally any number of "pluck"
+ * functions to get the value to sort by. Will create a shallow copy, and sort in ascending order.
+ * - `arr`: The input array to sort
+ * - `pluckArgs`: (0...n) Functions to get the value to sort by. Defaults to identity.
+ */
+export default function sortBy<T>(
+  arr: $ReadOnlyArray<T>,
+  ...pluckArgs: PluckFn<T>[]
+): T[] {
+  const plucks: PluckFn<T>[] = pluckArgs.length === 0 ? [identity] : pluckArgs;
+
+  function sortByCompare(a: T, b: T) {
+    for (const pluck of plucks) {
+      const valA = pluck(a);
+      const valB = pluck(b);
+      if (valA > valB) return 1;
+      if (valA < valB) return -1;
+    }
+    return 0;
+  }
+
+  return [...arr].sort(sortByCompare);
+}

--- a/src/util/sortBy.test.js
+++ b/src/util/sortBy.test.js
@@ -1,0 +1,139 @@
+// @flow
+
+import deepFreeze from "deep-freeze";
+import sortBy from "./sortBy";
+
+describe("util/sortBy", () => {
+  const numericSample = deepFreeze([4, 2, 1, 8, 16]);
+  const objectsSample = deepFreeze([
+    {
+      group: 1,
+      key: "bbb",
+      value: 8,
+    },
+    {
+      group: 1,
+      key: "ccc",
+      value: 32,
+    },
+    {
+      group: 2,
+      key: "aaa",
+      value: 16,
+    },
+    {
+      group: 2,
+      key: "ddd",
+      value: 4,
+    },
+  ]);
+
+  describe("sortBy", () => {
+    it("should sort in ascending order", () => {
+      const input = numericSample;
+      const output = sortBy(input);
+      expect(output).toEqual([1, 2, 4, 8, 16]);
+    });
+
+    it("should support plucking to a number", () => {
+      const input = objectsSample;
+      const output = sortBy(input, (x) => x.value);
+      expect(output).toEqual([
+        {
+          group: 2,
+          key: "ddd",
+          value: 4,
+        },
+        {
+          group: 1,
+          key: "bbb",
+          value: 8,
+        },
+        {
+          group: 2,
+          key: "aaa",
+          value: 16,
+        },
+        {
+          group: 1,
+          key: "ccc",
+          value: 32,
+        },
+      ]);
+    });
+
+    it("should support plucking to a string", () => {
+      const input = objectsSample;
+      const output = sortBy(input, (x) => x.key);
+      expect(output).toEqual([
+        {
+          group: 2,
+          key: "aaa",
+          value: 16,
+        },
+        {
+          group: 1,
+          key: "bbb",
+          value: 8,
+        },
+        {
+          group: 1,
+          key: "ccc",
+          value: 32,
+        },
+        {
+          group: 2,
+          key: "ddd",
+          value: 4,
+        },
+      ]);
+    });
+
+    it("should support plucking multiple levels", () => {
+      const input = objectsSample;
+      const output = sortBy(
+        input,
+        (x) => x.group,
+        (x) => x.key
+      );
+      expect(output).toEqual([
+        {
+          group: 1,
+          key: "bbb",
+          value: 8,
+        },
+        {
+          group: 1,
+          key: "ccc",
+          value: 32,
+        },
+        {
+          group: 2,
+          key: "aaa",
+          value: 16,
+        },
+        {
+          group: 2,
+          key: "ddd",
+          value: 4,
+        },
+      ]);
+    });
+
+    it("should create a shallow copy", () => {
+      const mutationTarget = {
+        key: "ddd",
+        value: 4,
+      };
+
+      const input = [mutationTarget, ...objectsSample];
+      const output = sortBy(input, (x) => x.value);
+      mutationTarget.key = "mutated";
+
+      expect(output).not.toBe(input);
+      expect(input[0]).toBe(mutationTarget);
+      expect(output[0]).toBe(mutationTarget);
+      expect(output[0].key).toBe("mutated");
+    });
+  });
+});


### PR DESCRIPTION
This replaces the complex `lodash.sortby` dependency.
Doing what we need it for in just a few lines.

Fixes #1488

Note: one major difference here is we're now more aware of the types being used for comparison.
I'll make some inline comments to point out cases where I needed to filter out nulls for example.

Test plan: `yarn test --full`

Suggested entry point for review: `src/util/sortBy.js`