### PR TITLE
add initial Grain events and ledger

### DIFF
--- a/src/grain/distribution.js
+++ b/src/grain/distribution.js
@@ -1,0 +1,226 @@
+// @flow
+
+/**
+ * In SourceCred, projects regularly distribute Grain to contributors based on
+ * their Cred scores. This is called a "Distribution".
+ *
+ * This module contains the logic for calculating distribution amounts for
+ * contributors. A distribution contains "receipts" showing how much Grain each
+ * contributor will receive, the timestamp of the distribution in question, and the
+ * "strategy" used to distribute grain.
+ *
+ * Currently we support two strategies:
+ * - IMMEDIATE, which distributes a fixed budget of grain based on the cred scores
+ * in the most recent completed time interval
+ * - LIFETIME, which distributes a fixed budget of grain based on cred scores
+ * across
+ * all time, prioritizing paying people who were under-paid historically (i.e.
+ * their lifetime earnings are lower than we would expect given their current
+ * cred score)
+ *
+ * In all cases, the timestamp for the distribution is used to determine which cred
+ * scores are in scope. For example, if you create a immediate distribution with a
+ * timestamp in the past, it will reward people with cred in the past time
+ * period, not the current one.
+ */
+import {sum} from "d3-array";
+import {mapToArray} from "../util/map";
+import {type NodeAddressT} from "../core/graph";
+import {type Grain, multiplyFloat, ZERO} from "./grain";
+
+export const DISTRIBUTION_VERSION_1 = 1;
+
+export type DistributionStrategy = ImmediateV1 | LifetimeV1;
+
+export type ImmediateV1 = {|
+  +type: "IMMEDIATE",
+  +version: number,
+  +budget: Grain,
+|};
+
+export type LifetimeV1 = {|
+  +type: "LIFETIME",
+  +version: number,
+  +budget: Grain,
+|};
+
+export type GrainReceipt = {|
+  +address: NodeAddressT,
+  +amount: Grain,
+|};
+
+export type DistributionV1 = {|
+  +type: "DISTRIBUTION",
+  +timestampMs: number,
+  +version: number,
+  +strategy: DistributionStrategy,
+  +receipts: $ReadOnlyArray<GrainReceipt>,
+|};
+
+export type CredTimeSlice = {|
+  +intervalEndMs: number,
+  +cred: Map<NodeAddressT, number>,
+|};
+
+export type CredHistory = $ReadOnlyArray<CredTimeSlice>;
+
+/**
+ * Compute a full Distribution given:
+ * - the strategy we're using
+ * - the full cred history for all users
+ * - the lifetime earnings of all users
+ * - the timestamp for the distribution
+ */
+export function distribution(
+  strategy: DistributionStrategy,
+  credHistory: CredHistory,
+  earnings: Map<NodeAddressT, Grain>,
+  timestampMs: number
+): DistributionV1 {
+  const filteredSlices = credHistory.filter(
+    (s) => s.intervalEndMs <= timestampMs
+  );
+  if (!filteredSlices.length) {
+    return {
+      type: "DISTRIBUTION",
+      timestampMs,
+      version: DISTRIBUTION_VERSION_1,
+      strategy,
+      receipts: [],
+    };
+  }
+
+  const receipts: $ReadOnlyArray<GrainReceipt> = (function () {
+    switch (strategy.type) {
+      case "IMMEDIATE":
+        if (strategy.version !== 1) {
+          throw new Error(
+            `Unsupported IMMEDIATE strategy: ${strategy.version}`
+          );
+        }
+        const lastSlice = filteredSlices[filteredSlices.length - 1];
+        return computeImmediateReceipts(strategy.budget, lastSlice.cred);
+      case "LIFETIME":
+        if (strategy.version !== 1) {
+          throw new Error(`Unsupported LIFETIME strategy: ${strategy.version}`);
+        }
+        const totalCred = new Map();
+        for (const {cred} of filteredSlices) {
+          for (const [address, ownCred] of cred.entries()) {
+            const existingCred = totalCred.get(address) || 0;
+            totalCred.set(address, existingCred + ownCred);
+          }
+        }
+        return computeLifetimeReceipts(strategy.budget, totalCred, earnings);
+      default:
+        throw new Error(`Unexpected type ${(strategy.type: empty)}`);
+    }
+  })();
+
+  return {
+    type: "DISTRIBUTION",
+    version: DISTRIBUTION_VERSION_1,
+    strategy,
+    receipts,
+    timestampMs,
+  };
+}
+
+/**
+ * Split a grain budget in proportion to the provided scores
+ */
+function computeImmediateReceipts(
+  budget: Grain,
+  cred: Map<NodeAddressT, number>
+): $ReadOnlyArray<GrainReceipt> {
+  if (budget < ZERO) {
+    throw new Error(`invalid budget: ${String(budget)}`);
+  }
+
+  const totalCred = sum(cred.values());
+  if (totalCred === 0) {
+    return [];
+  }
+
+  return mapToArray(cred, ([address, cred]) => ({
+    address,
+    amount: multiplyFloat(budget, cred / totalCred),
+  }));
+}
+
+/**
+ * Distribute a fixed budget of Grain to the users who were "most underpaid".
+ *
+ * We consider a user underpaid if they have recieved a smaller proportion of
+ * past earnings than their share of score. They are lifetimely paid if their
+ * proportion of earnings is equal to their score share, and they are overpaid
+ * if their proportion of earnings is higher than their share of the score.
+ *
+ * We start by imagining a hypothetical world, where the entire grain supply of
+ * the project (including this distribution) were distributed according to the
+ * current scores. Based on this, we can calculate the "lifetime" lifetime earnings
+ * for each participant. Usually, some will be "underpaid" (they recieved less
+ * than this amount) and others are "overpaid".
+ *
+ * We can sum across all users who were underpaid to find the "total
+ * underpayment".
+ *
+ * Now that we've calculated each actor's underpayment, and the total
+ * underpayment, we divide the distribution's grain budget across users in
+ * proportion to their underpayment.
+ *
+ * You should use this distribution when you want to divide a fixed budget of grain
+ * across participants in a way that aligns long-term payment with total cred
+ * scores.
+ */
+function computeLifetimeReceipts(
+  budget: Grain,
+  credMap: Map<NodeAddressT, number>,
+  earnings: Map<NodeAddressT, Grain>
+): $ReadOnlyArray<GrainReceipt> {
+  if (budget < ZERO) {
+    throw new Error(`invalid budget: ${String(budget)}`);
+  }
+
+  let totalEarnings = ZERO;
+  for (const e of earnings.values()) {
+    totalEarnings += e;
+  }
+  let totalCred = 0;
+  for (const s of credMap.values()) {
+    totalCred += s;
+  }
+  if (totalCred === 0) {
+    return [];
+  }
+
+  const targetGrainPerCred = multiplyFloat(
+    totalEarnings + budget,
+    1 / totalCred
+  );
+
+  let totalUnderpayment = ZERO;
+  const userUnderpayment: Map<NodeAddressT, Grain> = new Map();
+  const addresses = new Set([...credMap.keys(), ...earnings.keys()]);
+
+  for (const addr of addresses) {
+    const earned = earnings.get(addr) || ZERO;
+    const cred = credMap.get(addr) || 0;
+
+    const target = multiplyFloat(targetGrainPerCred, cred);
+    if (target > earned) {
+      const underpayment = target - earned;
+      userUnderpayment.set(addr, underpayment);
+      totalUnderpayment += underpayment;
+    }
+  }
+
+  return mapToArray(userUnderpayment, ([address, underpayment]) => {
+    const underpaymentProportion =
+      Number(underpayment) / Number(totalUnderpayment);
+    return {
+      address,
+      amount: multiplyFloat(budget, underpaymentProportion),
+    };
+  });
+}

--- a/src/grain/distribution.test.js
+++ b/src/grain/distribution.test.js
@@ -1,0 +1,384 @@
+// @flow
+
+import {NodeAddress} from "../core/graph";
+import {ONE, ZERO, fromApproximateFloat, format} from "./grain";
+import {DISTRIBUTION_VERSION_1, distribution} from "./distribution";
+import deepFreeze from "deep-freeze";
+import type {
+  CredHistory,
+  LifetimeV1,
+  ImmediateV1,
+  GrainReceipt,
+  DistributionStrategy,
+  DistributionV1,
+} from "./distribution";
+import type {Grain} from "./grain";
+
+describe("src/grain/distribution", () => {
+  const foo = NodeAddress.fromParts(["foo"]);
+  const bar = NodeAddress.fromParts(["bar"]);
+
+  const timestampMs = 1000;
+
+  const credHistory: CredHistory = deepFreeze([
+    {
+      intervalEndMs: 10,
+      cred: new Map([
+        [foo, 9],
+        [bar, 1],
+      ]),
+    },
+    {
+      intervalEndMs: 20,
+      cred: new Map([
+        [foo, 1],
+        [bar, 1],
+      ]),
+    },
+    {intervalEndMs: 30, cred: new Map([[bar, 2]])},
+  ]);
+
+  // there's no JSON serialization for BigInts, so we need to convert
+  // the BigInts before passing them into expect comparisons. Otherwise,
+  // when the tests fail, they'll fail with an unhelpful JSON serialization
+  // issue.
+  function fmt(g: Grain) {
+    return format(g, 3);
+  }
+  function safeReceipts(receipts: $ReadOnlyArray<GrainReceipt>) {
+    return receipts.map(({address, amount}) => ({
+      address,
+      amount: fmt(amount),
+    }));
+  }
+  function safeStrategy(strat: DistributionStrategy) {
+    return {...strat, budget: fmt(strat.budget)};
+  }
+  function safeDistribution(distribution: DistributionV1) {
+    return {
+      ...distribution,
+      strategy: safeStrategy(distribution.strategy),
+      receipts: safeReceipts(distribution.receipts),
+    };
+  }
+  function expectDistributionsEqual(h1, h2) {
+    expect(safeDistribution(h1)).toEqual(safeDistribution(h2));
+  }
+
+  describe("immediateDistribution", () => {
+    const strategy: ImmediateV1 = deepFreeze({
+      type: "IMMEDIATE",
+      budget: ONE,
+      version: 1,
+    });
+
+    describe("it should return an empty distribution when", () => {
+      const emptyDistribution = deepFreeze({
+        type: "DISTRIBUTION",
+        version: DISTRIBUTION_VERSION_1,
+        receipts: [],
+        strategy,
+        timestampMs,
+      });
+
+      it("there are no cred scores at all", () => {
+        const actual = distribution(strategy, [], new Map(), timestampMs);
+        expectDistributionsEqual(actual, emptyDistribution);
+      });
+
+      it("all cred scores are from the future", () => {
+        const actual = distribution(strategy, credHistory, new Map(), 0);
+        expectDistributionsEqual(actual, {
+          ...emptyDistribution,
+          timestampMs: 0,
+        });
+      });
+
+      it("all the cred sums to 0", () => {
+        const actual = distribution(
+          strategy,
+          [
+            {
+              intervalEndMs: timestampMs - 500,
+              cred: new Map([
+                [foo, 0],
+                [bar, 0],
+              ]),
+            },
+          ],
+          new Map(),
+          timestampMs
+        );
+
+        expectDistributionsEqual(actual, emptyDistribution);
+      });
+    });
+
+    const createImmediateDistribution = (
+      timestampMs: number,
+      receipts: $ReadOnlyArray<GrainReceipt>
+    ) => {
+      return {
+        type: "DISTRIBUTION",
+        version: DISTRIBUTION_VERSION_1,
+        receipts,
+        strategy,
+        timestampMs,
+      };
+    };
+
+    it("throws an error if given an unsupported strategy", () => {
+      const unsupportedStrategy = {
+        ...strategy,
+        version: 2,
+      };
+      expect(() =>
+        distribution(unsupportedStrategy, credHistory, new Map(), timestampMs)
+      ).toThrowError(`Unsupported IMMEDIATE strategy: 2`);
+    });
+    it("handles an interval in the middle", () => {
+      const result = distribution(strategy, credHistory, new Map(), 20);
+      // $ExpectFlowError
+      const HALF = ONE / 2n;
+      const expectedReceipts = [
+        {address: foo, amount: HALF},
+        {address: bar, amount: HALF},
+      ];
+      const expectedDistribution = createImmediateDistribution(
+        20,
+        expectedReceipts
+      );
+      expectDistributionsEqual(result, expectedDistribution);
+    });
+    it("handles an interval with un-even cred distribution", () => {
+      const result = distribution(strategy, credHistory, new Map(), 12);
+      // $ExpectFlowError
+      const ONE_TENTH = ONE / 10n;
+      const NINE_TENTHS = ONE - ONE_TENTH;
+      const expectedReceipts = [
+        {address: foo, amount: NINE_TENTHS},
+        {address: bar, amount: ONE_TENTH},
+      ];
+      const expectedDistribution = createImmediateDistribution(
+        12,
+        expectedReceipts
+      );
+      expectDistributionsEqual(result, expectedDistribution);
+    });
+    it("handles an interval at the end", () => {
+      const result = distribution(strategy, credHistory, new Map(), 1000);
+      const expectedReceipts = [{address: bar, amount: ONE}];
+      const expectedDistribution = createImmediateDistribution(
+        1000,
+        expectedReceipts
+      );
+      expectDistributionsEqual(result, expectedDistribution);
+    });
+  });
+
+  describe("lifetimeDistribution", () => {
+    const strategy = deepFreeze({
+      type: "LIFETIME",
+      budget: fromApproximateFloat(14),
+      version: 1,
+    });
+
+    const createLifetimeDistribution = (
+      timestampMs: number,
+      receipts: $ReadOnlyArray<GrainReceipt>,
+      strategy: LifetimeV1
+    ) => {
+      return {
+        type: "DISTRIBUTION",
+        version: DISTRIBUTION_VERSION_1,
+        receipts,
+        strategy,
+        timestampMs,
+      };
+    };
+
+    describe("it should return an empty distribution when", () => {
+      const emptyDistribution = deepFreeze({
+        type: "DISTRIBUTION",
+        version: DISTRIBUTION_VERSION_1,
+        receipts: [],
+        strategy,
+        timestampMs,
+      });
+
+      it("there are no cred scores at all", () => {
+        const actual = distribution(strategy, [], new Map(), timestampMs);
+
+        expectDistributionsEqual(actual, emptyDistribution);
+      });
+
+      it("all cred scores are from the future", () => {
+        const actual = distribution(strategy, credHistory, new Map(), 0);
+        expectDistributionsEqual(actual, {
+          ...emptyDistribution,
+          timestampMs: 0,
+        });
+      });
+
+      it("all the cred sums to 0", () => {
+        const actual = distribution(
+          strategy,
+          [
+            {
+              intervalEndMs: timestampMs - 500,
+              cred: new Map([
+                [foo, 0],
+                [bar, 0],
+              ]),
+            },
+          ],
+          new Map(),
+          timestampMs
+        );
+
+        expectDistributionsEqual(actual, emptyDistribution);
+      });
+    });
+
+    it("throws an error if given an unsupported strategy", () => {
+      const unsupportedStrategy = {
+        ...strategy,
+        version: 2,
+      };
+      expect(() =>
+        distribution(unsupportedStrategy, credHistory, new Map(), timestampMs)
+      ).toThrowError(`Unsupported LIFETIME strategy: 2`);
+    });
+
+    it("should only pay Foo if Foo is sufficiently underpaid", () => {
+      const earnings = new Map([
+        [foo, ZERO],
+        [bar, fromApproximateFloat(99)],
+      ]);
+      const expectedReceipts = [
+        {address: foo, amount: fromApproximateFloat(14)},
+      ];
+      const expectedDistribution = createLifetimeDistribution(
+        timestampMs,
+        expectedReceipts,
+        strategy
+      );
+      const actual = distribution(strategy, credHistory, earnings, timestampMs);
+      expectDistributionsEqual(expectedDistribution, actual);
+    });
+    it("should divide according to cred if everyone is already lifetimely paid", () => {
+      const earnings = new Map([
+        [foo, fromApproximateFloat(5)],
+        [bar, fromApproximateFloat(2)],
+      ]);
+
+      const expectedReceipts = [
+        {address: foo, amount: fromApproximateFloat(10)},
+        {address: bar, amount: fromApproximateFloat(4)},
+      ];
+
+      const expectedDistribution = createLifetimeDistribution(
+        timestampMs,
+        expectedReceipts,
+        strategy
+      );
+
+      const actual = distribution(strategy, credHistory, earnings, timestampMs);
+      expectDistributionsEqual(expectedDistribution, actual);
+    });
+    it("'top off' users who were slightly underpaid'", () => {
+      // Foo is exactly 1 grain behind where they "should" be
+      const earnings = new Map([
+        [foo, fromApproximateFloat(4)],
+        [bar, fromApproximateFloat(2)],
+      ]);
+
+      const strategy15 = {...strategy, budget: fromApproximateFloat(15)};
+
+      const expectedReceipts = [
+        {address: foo, amount: fromApproximateFloat(11)},
+        {address: bar, amount: fromApproximateFloat(4)},
+      ];
+
+      const expectedDistribution = createLifetimeDistribution(
+        timestampMs,
+        expectedReceipts,
+        strategy15
+      );
+
+      const actual = distribution(
+        strategy15,
+        credHistory,
+        earnings,
+        timestampMs
+      );
+      expectDistributionsEqual(expectedDistribution, actual);
+    });
+    it("should ignore cred scores from the future", () => {
+      const middleTimes = 29;
+
+      const strategy12 = {...strategy, budget: fromApproximateFloat(12)};
+
+      // In the last time slice, foo gets 0 cred and bar gets 2
+      const expectedReceipts = [
+        {address: foo, amount: fromApproximateFloat(10)},
+        {address: bar, amount: fromApproximateFloat(2)},
+      ];
+
+      const expectedDistribution = createLifetimeDistribution(
+        middleTimes,
+        expectedReceipts,
+        strategy12
+      );
+
+      const actual = distribution(
+        strategy12,
+        credHistory,
+        new Map(),
+        middleTimes
+      );
+      expectDistributionsEqual(expectedDistribution, actual);
+    });
+    it("should handle the case where one user has no historical earnings", () => {
+      const earnings = new Map([[foo, fromApproximateFloat(5)]]);
+
+      const expectedReceipts = [
+        {address: bar, amount: fromApproximateFloat(2)},
+      ];
+      const strategy2 = {...strategy, budget: fromApproximateFloat(2)};
+
+      const expectedDistribution = createLifetimeDistribution(
+        timestampMs,
+        expectedReceipts,
+        strategy2
+      );
+
+      const actual = distribution(
+        strategy2,
+        credHistory,
+        earnings,
+        timestampMs
+      );
+      expectDistributionsEqual(expectedDistribution, actual);
+    });
+    it("should not break if a user has earnings but no cred", () => {
+      const earnings = new Map([
+        [NodeAddress.fromParts(["zoink"]), fromApproximateFloat(10)],
+      ]);
+
+      const expectedReceipts = [
+        {address: foo, amount: fromApproximateFloat(10)},
+        {address: bar, amount: fromApproximateFloat(4)},
+      ];
+
+      const expectedDistribution = createLifetimeDistribution(
+        timestampMs,
+        expectedReceipts,
+        strategy
+      );
+
+      const actual = distribution(strategy, credHistory, earnings, timestampMs);
+      expectDistributionsEqual(expectedDistribution, actual);
+    });
+  });
+});

--- a/src/grain/grain.js
+++ b/src/grain/grain.js
@@ -139,3 +139,15 @@ export function multiplyFloat(grain: Grain, num: number): Grain {
 export function fromApproximateFloat(f: number): Grain {
   return multiplyFloat(ONE, f);
 }
+
+/**
+ * Approximates the division of two grain values
+ *
+ * This naive implementation of grain division converts the given values
+ * to floats and performs simple floating point division.
+ *
+ * Do not assume this will be precise!
+ */
+export function toFloatRatio(numerator: Grain, denominator: Grain): number {
+  return Number(numerator) / Number(denominator);
+}

--- a/src/grain/grain.test.js
+++ b/src/grain/grain.test.js
@@ -7,6 +7,7 @@ import {
   ZERO,
   fromApproximateFloat,
   multiplyFloat,
+  toFloatRatio,
 } from "./grain";
 
 describe("src/grain/grain", () => {
@@ -115,6 +116,34 @@ describe("src/grain/grain", () => {
     it("fromApproximateFloat(0.1) === ONE / 10", () => {
       // $ExpectFlowError
       expect(fromApproximateFloat(0.1)).toEqual(ONE / 10n);
+    });
+  });
+
+  describe("toFloatRatio", () => {
+    it("handles a one-to-one ratio", () => {
+      expect(toFloatRatio(ONE, ONE)).toEqual(1);
+    });
+    it("handles a larger numerator", () => {
+      // $ExpectFlowError
+      expect(toFloatRatio(ONE * 2n, ONE)).toEqual(2);
+    });
+    it("handles fractional numbers", () => {
+      // $ExpectFlowError
+      expect(toFloatRatio(ONE * 5n, ONE * 2n)).toEqual(2.5);
+    });
+    it("calculates repeating decimal ratios", () => {
+      // $ExpectFlowError
+      expect(toFloatRatio(ONE * 5n, ONE * 3n)).toEqual(5 / 3);
+    });
+    it("approximates correctly when Grain values are not exactly equal", () => {
+      // $ExpectFlowError
+      const almostOne = ONE - 1n;
+      expect(toFloatRatio(ONE, almostOne)).toEqual(1);
+    });
+    it("handles irrational numbers", () => {
+      const bigPi = multiplyFloat(ONE, Math.PI);
+      // $ExpectFlowError
+      expect(toFloatRatio(bigPi, ONE * 2n)).toEqual(Math.PI / 2);
     });
   });
 });

--- a/src/grain/ledger.js
+++ b/src/grain/ledger.js
@@ -22,6 +22,7 @@ export type TransferV1 = {|
   +recipient: NodeAddressT,
   +amount: Grain,
   +timestampMs: number,
+  +memo: string,
 |};
 
 export type LedgerEvent = DistributionV1 | TransferV1;

--- a/src/grain/ledger.js
+++ b/src/grain/ledger.js
@@ -50,7 +50,11 @@ export interface Ledger {
   events(): $ReadOnlyArray<LedgerEvent>;
 }
 
-export class InMemoryLedger implements Ledger {
+export function inMemoryLedger(events: $ReadOnlyArray<LedgerEvent>): Ledger {
+  return new _InMemoryLedger(events);
+}
+
+class _InMemoryLedger implements Ledger {
   _balances: Map<NodeAddressT, Grain>;
   _earnings: Map<NodeAddressT, Grain>;
   _events: $ReadOnlyArray<LedgerEvent>;

--- a/src/grain/ledger.js
+++ b/src/grain/ledger.js
@@ -1,0 +1,146 @@
+// @flow
+
+import {type NodeAddressT, NodeAddress} from "../core/graph";
+import stringify from "json-stable-stringify";
+import * as NullUtil from "../util/null";
+import {
+  type Grain,
+  format as formatGrain,
+  ZERO,
+  DECIMAL_PRECISION,
+} from "./grain";
+import {type DistributionV1} from "./distribution";
+
+/**
+ * Models a transfer of grain from a sender to recipient.
+ * A grainholder may transfer grain to themself (which is a no-op).
+ */
+export type TransferV1 = {|
+  +type: "TRANSFER",
+  +version: number,
+  +sender: NodeAddressT,
+  +recipient: NodeAddressT,
+  +amount: Grain,
+  +timestampMs: number,
+|};
+
+export type LedgerEvent = DistributionV1 | TransferV1;
+
+/**
+ * A ledger tracks balances, earnings, and the event history of participants.
+ *
+ * We may refactor the `events` to be an async generator in the future,
+ * when we stop storing all the events in memory.
+ */
+export interface Ledger {
+  /**
+   * Stores the current grain balance of each address.
+   */
+  balances(): Map<NodeAddressT, Grain>;
+  /**
+   * Stores the lifetime earnings of each address.
+   *
+   * Necessary for computing which participants have been underpaid.
+   */
+  earnings(): Map<NodeAddressT, Grain>;
+  /**
+   * Retrieve the events.
+   */
+  events(): $ReadOnlyArray<LedgerEvent>;
+}
+
+export class InMemoryLedger implements Ledger {
+  _balances: Map<NodeAddressT, Grain>;
+  _earnings: Map<NodeAddressT, Grain>;
+  _events: $ReadOnlyArray<LedgerEvent>;
+
+  /**
+   * Construct a Ledger from an array of in-memory events.
+   *
+   * The events must be in timestamp sorted order.
+   */
+  constructor(events: $ReadOnlyArray<LedgerEvent>) {
+    this._balances = new Map();
+    this._earnings = new Map();
+    this._events = events;
+    let lastTimestamp = -Infinity;
+    for (const e of events) {
+      if (e.timestampMs < lastTimestamp) {
+        throw new Error(
+          `event timestamps out of order: encountered ${e.timestampMs} after ${lastTimestamp}`
+        );
+      }
+      lastTimestamp = e.timestampMs;
+      switch (e.type) {
+        case "DISTRIBUTION":
+          this._processDistribution((e: DistributionV1));
+          break;
+        case "TRANSFER":
+          this._processTransfer((e: TransferV1));
+          break;
+        default:
+          throw new Error(`Unsupported event type: ${(e.type: empty)}`);
+      }
+    }
+  }
+
+  events(): $ReadOnlyArray<LedgerEvent> {
+    return [...this._events];
+  }
+
+  balances(): Map<NodeAddressT, Grain> {
+    return new Map(this._balances);
+  }
+
+  _balance(a: NodeAddressT): Grain {
+    return NullUtil.orElse(this._balances.get(a), ZERO);
+  }
+
+  _earning(a: NodeAddressT): Grain {
+    return NullUtil.orElse(this._earnings.get(a), ZERO);
+  }
+
+  earnings(): Map<NodeAddressT, Grain> {
+    return new Map(this._earnings);
+  }
+
+  _processDistribution(d: DistributionV1) {
+    const {version, receipts} = d;
+    if (version !== 1) {
+      throw new Error(`Unsupported distribution version: ${version}`);
+    }
+    for (const {amount, address} of receipts) {
+      const balance = this._balance(address) + amount;
+      this._balances.set(address, balance);
+      const earned = this._earning(address) + amount;
+      this._earnings.set(address, earned);
+    }
+  }
+
+  _processTransfer(t: TransferV1) {
+    const {recipient, sender, amount, version, timestampMs} = t;
+    if (version !== 1) {
+      throw new Error(`Unsupported transfer version: ${t.version}`);
+    }
+    const recipientBalance = this._balance(recipient);
+    const senderBalance = this._balance(sender);
+    if (senderBalance < amount) {
+      const forDisplay = {
+        amount: formatGrain(amount, DECIMAL_PRECISION),
+        recipient: NodeAddress.toString(recipient),
+        sender: NodeAddress.toString(sender),
+        timestampMs: timestampMs,
+      };
+      throw new Error(
+        `Invalid transfer (sender can't afford): ${stringify(forDisplay)}`
+      );
+    }
+    if (sender === recipient) {
+      // No need to do any update if the sender and recipient are the same.
+      // (And using the logic below would cause grain to "vanish")
+      return;
+    }
+    this._balances.set(recipient, recipientBalance + amount);
+    this._balances.set(sender, senderBalance - amount);
+  }
+}

--- a/src/grain/ledger.test.js
+++ b/src/grain/ledger.test.js
@@ -39,6 +39,7 @@ describe("src/grain/ledger", () => {
       sender: from,
       amount: fromApproximateFloat(amount),
       timestampMs,
+      memo: "",
     };
   }
 
@@ -157,6 +158,7 @@ describe("src/grain/ledger", () => {
             sender: foo,
             amount: ZERO,
             timestampMs: 2,
+            memo: "bad",
           },
         ];
         const fail = () => new InMemoryLedger(events);

--- a/src/grain/ledger.test.js
+++ b/src/grain/ledger.test.js
@@ -1,0 +1,184 @@
+// @flow
+
+import {NodeAddress, type NodeAddressT} from "../core/graph";
+import {InMemoryLedger} from "./ledger";
+import {fromApproximateFloat, ZERO, type Grain} from "./grain";
+import {type DistributionV1, type DistributionStrategy} from "./distribution";
+
+describe("src/grain/ledger", () => {
+  function mockDistribution(
+    timestampMs: number,
+    recipients: [NodeAddressT, number][]
+  ): DistributionV1 {
+    const receipts = recipients.map(([address, amount]) => ({
+      address,
+      amount: fromApproximateFloat(amount),
+    }));
+    let amt = ZERO;
+    for (const {amount} of receipts) {
+      amt += amount;
+    }
+    const strategy: DistributionStrategy = {
+      type: "IMMEDIATE",
+      version: 1,
+      amount: amt,
+    };
+    return {type: "DISTRIBUTION", version: 1, receipts, strategy, timestampMs};
+  }
+
+  function mockTransfer(
+    timestampMs: number,
+    from: NodeAddressT,
+    to: NodeAddressT,
+    amount: number
+  ) {
+    return {
+      type: "TRANSFER",
+      version: 1,
+      recipient: to,
+      sender: from,
+      amount: fromApproximateFloat(amount),
+      timestampMs,
+    };
+  }
+
+  function grainMap(
+    recipients: [NodeAddressT, number][]
+  ): Map<NodeAddressT, Grain> {
+    return new Map(
+      recipients.map(([address, amount]) => [
+        address,
+        fromApproximateFloat(amount),
+      ])
+    );
+  }
+  describe("InMemoryLedger", () => {
+    const foo = NodeAddress.fromParts(["foo"]);
+    const bar = NodeAddress.fromParts(["bar"]);
+
+    it("works properly for an empty history", () => {
+      const ledger = new InMemoryLedger([]);
+      expect(ledger.balances()).toEqual(new Map());
+      expect(ledger.earnings()).toEqual(new Map());
+      expect(ledger.events()).toEqual([]);
+    });
+    it("correctly models some simple distributions", () => {
+      const events = [
+        mockDistribution(0, [
+          [foo, 10],
+          [bar, 99],
+        ]),
+      ];
+      const ledger = new InMemoryLedger(events);
+      const expected = grainMap([
+        [foo, 10],
+        [bar, 99],
+      ]);
+      expect(ledger.balances()).toEqual(expected);
+      expect(ledger.earnings()).toEqual(expected);
+      expect(ledger.events()).toEqual(events);
+    });
+    it("correctly models a simple transfer", () => {
+      const events = [
+        mockDistribution(0, [
+          [foo, 10],
+          [bar, 99],
+        ]),
+        mockTransfer(2, bar, foo, 50),
+      ];
+      const ledger = new InMemoryLedger(events);
+      const expectedEarnings = grainMap([
+        [foo, 10],
+        [bar, 99],
+      ]);
+      const expectedBalances = grainMap([
+        [foo, 60],
+        [bar, 49],
+      ]);
+      expect(ledger.balances()).toEqual(expectedBalances);
+      expect(ledger.earnings()).toEqual(expectedEarnings);
+      expect(ledger.events()).toEqual(events);
+    });
+    it("supports a self-transfer", () => {
+      const events = [
+        mockDistribution(0, [[foo, 10]]),
+        mockTransfer(1, foo, foo, 5),
+      ];
+      const ledger = new InMemoryLedger(events);
+      const expectedEarnings = grainMap([[foo, 10]]);
+      const expectedBalances = grainMap([[foo, 10]]);
+      expect(ledger.balances()).toEqual(expectedBalances);
+      expect(ledger.earnings()).toEqual(expectedEarnings);
+      expect(ledger.events()).toEqual(events);
+    });
+    it("events returns an independent copy", () => {
+      const ledger = new InMemoryLedger([]);
+      // $ExpectFlowError
+      ledger.events().push(33);
+      expect(ledger.events()).toHaveLength(0);
+    });
+
+    describe("errors on", () => {
+      it("unaffordable transfers", () => {
+        const events = [
+          mockDistribution(0, [[foo, 10]]),
+          mockTransfer(1, bar, foo, 5),
+        ];
+        const fail = () => new InMemoryLedger(events);
+        expect(fail).toThrowError("Invalid transfer (sender can't afford)");
+      });
+      it("unaffordable self-transfers", () => {
+        const events = [
+          mockDistribution(0, [[foo, 10]]),
+          mockTransfer(1, foo, foo, 11),
+        ];
+        const fail = () => new InMemoryLedger(events);
+        expect(fail).toThrowError("Invalid transfer (sender can't afford)");
+      });
+      it("distributions with unsupported versions", () => {
+        const events = [
+          {
+            type: "DISTRIBUTION",
+            version: 999,
+            timestampMs: 0,
+          },
+        ];
+        // $ExpectFlowError
+        const fail = () => new InMemoryLedger(events);
+        expect(fail).toThrowError("Unsupported distribution version: 99");
+      });
+      it("transfers with unsupported version", () => {
+        const events = [
+          mockDistribution(0, [[foo, 99]]),
+          {
+            type: "TRANSFER",
+            version: 999,
+            recipient: foo,
+            sender: foo,
+            amount: ZERO,
+            timestampMs: 2,
+          },
+        ];
+        const fail = () => new InMemoryLedger(events);
+        expect(fail).toThrowError("Unsupported transfer version: 999");
+      });
+      it("unsupported event types", () => {
+        const events = [
+          {
+            type: "FOO",
+            version: 999,
+            timestampMs: 0,
+          },
+        ];
+        // $ExpectFlowError
+        const fail = () => new InMemoryLedger(events);
+        expect(fail).toThrowError("Unsupported event type: FOO");
+      });
+      it("out-of-order events", () => {
+        const events = [mockDistribution(5, []), mockDistribution(4, [])];
+        const fail = () => new InMemoryLedger(events);
+        expect(fail).toThrowError("event timestamps out of order");
+      });
+    });
+  });
+});


### PR DESCRIPTION
This commit adds a GrainEvent type, which represents any valid event in
the Grain ledger. Currently, distributions (minting grain) and transfers
are supported. We expect to add more events later (like
boosts/sponsorship).

Given a sequence of GrainEvents, we can construct a Ledger, which keeps
track of the balances and earnings for each actor, and allows querying
over the events. Currently, we just have an InMemoryLedger, but we may
expect more implementations in the future.

For now, I've kept the interface simple and synchronous, since in the
near-term we will be loading all events in memory. In the future, we may
refactor to an async/generator approach.

We track all grainholders by their node address.

Test plan: Inspect unit tests; `yarn test` passes.