### PR TITLE
Discourse: handle incorrect URIs for reference detection

### DIFF
--- a/src/plugins/discourse/references.js
+++ b/src/plugins/discourse/references.js
@@ -80,7 +80,13 @@ export function linksToReferences(
   const references: DiscourseReference[] = [];
   for (const link of links) {
     let match = null;
-    const decoded = decodeURI(link);
+    let decoded;
+    try {
+      decoded = decodeURI(link);
+    } catch (e) {
+      console.error(`${e}\nFor URL: ${link}`);
+      continue;
+    }
     if ((match = decoded.match(postRegex))) {
       references.push({
         type: "POST",


### PR DESCRIPTION
Found this incorrectly encoded `%93` in an actual forum post.
This change will make it so we will print the error and ignore the URL
for reference detection, rather than crash.

Test plan: `yarn test`