### PR TITLE
Discourse: enable mirror schema upgrading

### DIFF
--- a/src/plugins/discourse/mirrorSchema.js
+++ b/src/plugins/discourse/mirrorSchema.js
@@ -1,0 +1,91 @@
+// @flow
+
+import stringify from "json-stable-stringify";
+import dedent from "../../util/dedent";
+
+// The version should be bumped any time the database schema is changed,
+// so that the cache will be properly invalidated.
+export const SCHEMA_VERSION = "discourse_mirror_v6";
+
+type Upgrade = {|
+  +target: string,
+  +changes: $ReadOnlyArray<string>,
+|};
+
+type VersionConfig = {|
+  +version: string,
+  +serverUrl: string,
+|};
+
+export const stringifyConfig = (c: VersionConfig): string => stringify(c);
+export const parseConfig = (json: string): VersionConfig => JSON.parse(json);
+
+// Queries to upgrade from a previous version to the target version.
+export const upgrades: {[current: string]: Upgrade} = {
+  discourse_mirror_v5: {
+    target: "discourse_mirror_v6",
+    changes: [
+      dedent`\
+        CREATE TABLE sync_heads (
+          key TEXT PRIMARY KEY,
+          timestamp_ms INTEGER NOT NULL
+        )`,
+    ],
+  },
+};
+
+// Queries to build a "greenfield" instance of that version.
+export const createVersion: {[target: string]: () => $ReadOnlyArray<string>} = {
+  discourse_mirror_v6() {
+    return [
+      ...this.discourse_mirror_v5(),
+      ...upgrades.discourse_mirror_v5.changes,
+    ];
+  },
+  discourse_mirror_v5() {
+    return [
+      ...this.meta(),
+      "CREATE TABLE users (username TEXT PRIMARY KEY)",
+      dedent`\
+        CREATE TABLE topics (
+          id INTEGER PRIMARY KEY,
+          category_id INTEGER NOT NULL,
+          title TEXT NOT NULL,
+          timestamp_ms INTEGER NOT NULL,
+          bumped_ms INTEGER NOT NULL,
+          author_username TEXT NOT NULL,
+          FOREIGN KEY(author_username) REFERENCES users(username)
+        )`,
+      dedent`\
+        CREATE TABLE posts (
+          id INTEGER PRIMARY KEY,
+          timestamp_ms INTEGER NOT NULL,
+          author_username TEXT NOT NULL,
+          topic_id INTEGER NOT NULL,
+          index_within_topic INTEGER NOT NULL,
+          reply_to_post_index INTEGER,
+          cooked TEXT NOT NULL,
+          FOREIGN KEY(topic_id) REFERENCES topics(id),
+          FOREIGN KEY(author_username) REFERENCES users(username)
+        )`,
+      dedent`\
+        CREATE TABLE likes (
+          post_id INTEGER NOT NULL,
+          username TEXT NOT NULL,
+          timestamp_ms INTEGER NOT NULL,
+          CONSTRAINT username_post PRIMARY KEY (post_id, username),
+          FOREIGN KEY(post_id) REFERENCES posts(id),
+          FOREIGN KEY(username) REFERENCES users(username)
+        )`,
+    ];
+  },
+  meta() {
+    return [
+      dedent`\
+        CREATE TABLE IF NOT EXISTS meta (
+          zero INTEGER PRIMARY KEY,
+          config TEXT NOT NULL
+        )`,
+    ];
+  },
+};

--- a/src/plugins/discourse/mirrorSchema.js
+++ b/src/plugins/discourse/mirrorSchema.js
@@ -12,6 +12,9 @@ type Upgrade = {|
   +changes: $ReadOnlyArray<string>,
 |};
 
+export type Upgrades = {[current: string]: Upgrade};
+export type Creates = {[target: string]: () => $ReadOnlyArray<string>};
+
 type VersionConfig = {|
   +version: string,
   +serverUrl: string,
@@ -21,7 +24,7 @@ export const stringifyConfig = (c: VersionConfig): string => stringify(c);
 export const parseConfig = (json: string): VersionConfig => JSON.parse(json);
 
 // Queries to upgrade from a previous version to the target version.
-export const upgrades: {[current: string]: Upgrade} = {
+export const upgrades: Upgrades = {
   discourse_mirror_v5: {
     target: "discourse_mirror_v6",
     changes: [
@@ -35,7 +38,7 @@ export const upgrades: {[current: string]: Upgrade} = {
 };
 
 // Queries to build a "greenfield" instance of that version.
-export const createVersion: {[target: string]: () => $ReadOnlyArray<string>} = {
+export const createVersion: Creates = {
   discourse_mirror_v6() {
     return [
       ...this.discourse_mirror_v5(),

--- a/src/plugins/discourse/mirrorSchema.test.js
+++ b/src/plugins/discourse/mirrorSchema.test.js
@@ -1,0 +1,196 @@
+// @flow
+
+import type {Creates, Upgrades} from "./mirrorSchema";
+import {SCHEMA_VERSION, createVersion, upgrades} from "./mirrorSchema";
+
+// Assumes a v1 style suffix.
+const versionRE = new RegExp(/v(\d+)$/i);
+function extractVersionNumber(version: string): number {
+  const match = versionRE.exec(version);
+  if (!match) {
+    throw new Error(`Version didn't match expected pattern: ${version}`);
+  }
+  return Number(match[1]);
+}
+
+function expectHigherTargetVersions(upgrades: Upgrades) {
+  for (const currentKey in upgrades) {
+    const {target: targetKey} = upgrades[currentKey];
+    const current = extractVersionNumber(currentKey);
+    const target = extractVersionNumber(targetKey);
+    if (current >= target) {
+      throw new Error(
+        `Upgrade from ${currentKey} does not upgrade to a newer version (${targetKey})`
+      );
+    }
+  }
+}
+
+function expectUpgradePathToLatest(latest: string, upgrades: Upgrades) {
+  // Tracks the versions with upgrade paths so far. Starting with just latest.
+  const resolved = new Set([latest]);
+  const pending = new Set(Object.keys(upgrades));
+
+  while (pending.size) {
+    // Find all upgrade sources which can be resolved in 1 step.
+    const resolvable = Array.from(pending).filter((source) =>
+      resolved.has(upgrades[source].target)
+    );
+
+    // If there's isn't any path forward in this pass, we're violating the invariant.
+    if (resolvable.length === 0) {
+      throw new Error(
+        `Can't find a path for upgrades [${Array.from(pending).join(", ")}]`
+      );
+    }
+
+    // Grow the set of resolved targets with the ones in this pass.
+    for (const k of resolvable) {
+      resolved.add(k);
+      pending.delete(k);
+    }
+  }
+}
+
+function expectUpgradePathToLatestFromCreate(
+  latest: string,
+  creates: Creates,
+  upgrades: Upgrades
+) {
+  // Knowing that each upgrade resolves to latest, we can add these to the resolved keys.
+  expectUpgradePathToLatest(latest, upgrades);
+
+  // All upgrade sources and latest will resolve to latest.
+  const resolved = new Set([latest, ...Object.keys(upgrades)]);
+
+  // We already resolved the upgrades, so all creates must resolve in 1 step.
+  // "meta" is an exception to this.
+  const unresolved = Object.keys(creates)
+    .filter((k) => k !== "meta")
+    .filter((k) => !resolved.has(k));
+
+  // If there's isn't any path forward in this pass, we're violating the invariant.
+  if (unresolved.length > 0) {
+    throw new Error(
+      `Can't find a path for creates [${Array.from(unresolved).join(", ")}]`
+    );
+  }
+}
+
+describe("plugins/discourse/mirrorSchema", () => {
+  describe("createVersion", () => {
+    it("invariant: should always have a 'meta' version", () => {
+      if (!createVersion.meta) {
+        throw new Error("createVersion is missing a meta key");
+      }
+    });
+
+    it("invariant: should always have a path to the latest version", () => {
+      expectUpgradePathToLatestFromCreate(
+        SCHEMA_VERSION,
+        createVersion,
+        upgrades
+      );
+    });
+  });
+
+  describe("upgrades", () => {
+    it("invariant: should always upgrade to a higher version", () => {
+      expectHigherTargetVersions(upgrades);
+    });
+    it("invariant: should always have a path to the latest version", () => {
+      expectUpgradePathToLatest(SCHEMA_VERSION, upgrades);
+    });
+  });
+
+  describe("test helper functions", () => {
+    const blankCreate = () => [];
+
+    describe("expectUpgradePathToLatestFromCreate", () => {
+      it("should pass for a good example", () => {
+        expectUpgradePathToLatestFromCreate(
+          "v2",
+          {
+            v1: blankCreate,
+            v2: blankCreate,
+          },
+          {
+            v1: {target: "v2", changes: []},
+          }
+        );
+      });
+    });
+
+    describe("expectUpgradePathToLatest", () => {
+      it("should pass for a good example", () => {
+        expectUpgradePathToLatest("v5", {
+          v1: {target: "v2", changes: []},
+          v2: {target: "v4", changes: []}, // Skips v3
+          v3: {target: "v4", changes: []},
+          v4: {target: "v5", changes: []},
+        });
+      });
+
+      it("should throw when upgrades don't go up to the current version", () => {
+        expect(() =>
+          expectUpgradePathToLatest("v3", {
+            v1: {target: "v2", changes: []},
+          })
+        ).toThrow("Can't find a path for upgrades [v1]");
+      });
+
+      it("should throw when there's a dangling upgrade", () => {
+        expect(() =>
+          expectUpgradePathToLatest("v4", {
+            v1: {target: "v2", changes: []},
+            // Missing v2 upgrade path.
+            v3: {target: "v4", changes: []},
+          })
+        ).toThrow("Can't find a path for upgrades [v1]");
+      });
+
+      it("should throw when there are multiple upgrades not resolvable", () => {
+        expect(() =>
+          expectUpgradePathToLatest("v6", {
+            v1: {target: "v2", changes: []},
+            v2: {target: "v3", changes: []},
+            v5: {target: "v6", changes: []},
+          })
+        ).toThrow("Can't find a path for upgrades [v1, v2]");
+      });
+
+      it("should throw when upgrading beyond the current version", () => {
+        expect(() =>
+          expectUpgradePathToLatest("v3", {
+            v2: {target: "v4", changes: []},
+          })
+        ).toThrow("Can't find a path for upgrades [v2]");
+      });
+    });
+
+    describe("expectHigherTargetVersions", () => {
+      it("should pass for a good example", () => {
+        expectHigherTargetVersions({
+          v1: {target: "v2", changes: []},
+          v9: {target: "v10", changes: []},
+        });
+      });
+
+      it("should throw when downgrading", () => {
+        expect(() =>
+          expectHigherTargetVersions({
+            v10: {target: "v2", changes: []},
+          })
+        ).toThrow("Upgrade from v10 does not upgrade to a newer version (v2)");
+      });
+
+      it("should throw when staying on the same version", () => {
+        expect(() =>
+          expectHigherTargetVersions({
+            v10: {target: "v10", changes: []},
+          })
+        ).toThrow("Upgrade from v10 does not upgrade to a newer version (v10)");
+      });
+    });
+  });
+});


### PR DESCRIPTION
There's a small change I have in mind to upgrade to a v7 database.
However it doesn't warrant throwing out your existing cache, so I've
created a way to upgrade versions.

For this PR I've dug up the v5 (previous) schema and added an upgrade
to the current v6 as an example. This so the upgrading PR can be reviewed
separately from the v7 schema I'll suggest in a follow-up.

Test plan: `yarn test`