### PR TITLE
Discourse: add index to database for `findPostInTopic` performance

### DIFF
--- a/src/plugins/discourse/mirrorRepository.test.js
+++ b/src/plugins/discourse/mirrorRepository.test.js
@@ -45,12 +45,29 @@ describe("plugins/discourse/mirrorRepository", () => {
     );
   });
 
+  it("should upgrade from v6", () => {
+    const db = new Database(":memory:");
+    const serverUrl = "http://example.com";
+    const version = "discourse_mirror_v6";
+
+    // Manually create an older database
+    for (const sql of createVersion[version]()) {
+      db.prepare(sql).run();
+    }
+    db.prepare("REPLACE INTO meta (zero, config) VALUES (0, ?)").run(
+      stringifyConfig({version, serverUrl})
+    );
+
+    // Silently upgrade.
+    expect(() => new SqliteMirrorRepository(db, serverUrl)).not.toThrow();
+  });
+
   it("should upgrade from v5", () => {
     const db = new Database(":memory:");
     const serverUrl = "http://example.com";
     const version = "discourse_mirror_v5";
 
-    // Manually create a v5 database
+    // Manually create an older database
     for (const sql of createVersion[version]()) {
       db.prepare(sql).run();
     }


### PR DESCRIPTION
Depends on #1699

By stress testing the Discourse plugin, it turns out `findPostInTopic`
is a major bottleneck when creating the graph. It's used in two cases.
When a post has a `replyToPostIndex` and for URLs that reference posts.

The test case I used was https://users.rust-lang.org.
Which had about 110k posts, this query was done about 94.5k times.
Without this index that took in the 10s of minutes. Now less than 10s.