### PR TITLE
Discourse: use plaintext cache keys

### DIFF
--- a/src/plugins/discourse/cacheKey.js
+++ b/src/plugins/discourse/cacheKey.js
@@ -1,0 +1,14 @@
+// @flow
+
+import {type ServerUrl} from "./models";
+
+/**
+ * Creates a cache key that's unique and safe for filesystem use.
+ */
+export function cacheKey(serverUrl: ServerUrl): string {
+  const url = new global.URL(serverUrl);
+  // Remove trailing colon from protol.
+  const protocol = url.protocol.replace(/:$/, "");
+  const portSuffix = url.port ? `_${url.port}` : "";
+  return `discourse_${protocol}_${url.hostname}${portSuffix}`.toLowerCase();
+}

--- a/src/plugins/discourse/cacheKey.test.js
+++ b/src/plugins/discourse/cacheKey.test.js
@@ -1,0 +1,45 @@
+// @flow
+
+import {parseServerUrl} from "./models";
+import {cacheKey} from "./cacheKey";
+
+describe("plugins/discourse/cacheKey", () => {
+  describe("cacheKey", () => {
+    it("should work with valid server URLs", () => {
+      const expected = [
+        {serverUrl: "https://foo.bar", cacheKey: "discourse_https_foo.bar"},
+        {
+          serverUrl: "http://example.com/",
+          cacheKey: "discourse_http_example.com",
+        },
+        {
+          serverUrl: "HTTPS://Casing.WTF",
+          cacheKey: "discourse_https_casing.wtf",
+        },
+        {
+          serverUrl: "https://custom.port.wtf:9001",
+          cacheKey: "discourse_https_custom.port.wtf_9001",
+        },
+        {
+          serverUrl: "http://default.port.wtf:80",
+          cacheKey: "discourse_http_default.port.wtf",
+        },
+        {
+          serverUrl: "https://default.port.wtf:443",
+          cacheKey: "discourse_https_default.port.wtf",
+        },
+        {
+          serverUrl: "https://discourse.sourcecred.io/",
+          cacheKey: "discourse_https_discourse.sourcecred.io",
+        },
+      ];
+
+      const actual = expected.map(({serverUrl}) => ({
+        serverUrl,
+        cacheKey: cacheKey(parseServerUrl(serverUrl)),
+      }));
+
+      expect(expected).toEqual(actual);
+    });
+  });
+});

--- a/src/plugins/discourse/loader.js
+++ b/src/plugins/discourse/loader.js
@@ -1,6 +1,5 @@
 // @flow
 
-import base64url from "base64url";
 import {TaskReporter} from "../../util/taskReporter";
 import {type CacheProvider} from "../../backend/cache";
 import {type WeightedGraph} from "../../core/weightedGraph";
@@ -14,6 +13,8 @@ import {DiscourseReferenceDetector} from "./referenceDetector";
 import {createGraph as _createGraph} from "./createGraph";
 import {declaration} from "./declaration";
 import {Fetcher} from "./fetch";
+import {parseServerUrl} from "./models";
+import {cacheKey} from "./cacheKey";
 
 export interface Loader {
   declaration(): PluginDeclaration;
@@ -73,7 +74,7 @@ async function repository(
   cache: CacheProvider,
   serverUrl: string
 ): Promise<SqliteMirrorRepository> {
-  // TODO: should replace base64url with hex, to be case insensitive.
-  const db = await cache.database(base64url.encode(serverUrl));
+  const normalizedUrl = parseServerUrl(serverUrl);
+  const db = await cache.database(cacheKey(normalizedUrl));
   return new SqliteMirrorRepository(db, serverUrl);
 }

--- a/src/plugins/discourse/models.js
+++ b/src/plugins/discourse/models.js
@@ -1,0 +1,43 @@
+// @flow
+
+/**
+ * Represents a normalized Discourse ServerUrl.
+ *
+ * - Protocols http / https are allowed.
+ * - Hostnames are allowed.
+ * - Ports are allowed.
+ * - Other components are not allowed.
+ * - Explicit default ports are removed.
+ * - Trailing slashes are removed.
+ * - URL is lowercased.
+ */
+export opaque type ServerUrl: string = string;
+
+/**
+ * Does a strict validation of serverUrl inputs and returns an opaque type
+ * indicating it's normalized to match our ServerUrl assumptions.
+ */
+export function parseServerUrl(serverUrl: string): ServerUrl {
+  try {
+    const url = new global.URL(serverUrl);
+
+    if (!new RegExp(/^https?/i).test(url.protocol)) {
+      throw "URL should have a http/https protocol";
+    }
+
+    const rebuiltUrl = new global.URL(
+      `${url.protocol}//${url.hostname}:${url.port}`
+    );
+
+    if (url.toString() !== rebuiltUrl.toString()) {
+      throw "Only a hostname and port are allowed";
+    }
+
+    // Remove trailing slashes
+    return rebuiltUrl.toString().replace(/\/+$/, "");
+  } catch (e) {
+    throw new Error(
+      `Provided Discourse Server URL was invalid: ${serverUrl}\n${e}`
+    );
+  }
+}

--- a/src/plugins/discourse/models.test.js
+++ b/src/plugins/discourse/models.test.js
@@ -1,0 +1,68 @@
+// @flow
+
+import {parseServerUrl} from "./models";
+
+describe("plugins/discourse/models", () => {
+  describe("parseServerUrl", () => {
+    it("should work with valid server URLs", () => {
+      const expected = [
+        {serverUrl: "https://foo.bar", normalizedUrl: "https://foo.bar"},
+        {
+          serverUrl: "http://example.com/",
+          normalizedUrl: "http://example.com",
+        },
+        {
+          serverUrl: "HTTPS://Casing.WTF",
+          normalizedUrl: "https://casing.wtf",
+        },
+        {
+          serverUrl: "https://custom.port.wtf:9001",
+          normalizedUrl: "https://custom.port.wtf:9001",
+        },
+        {
+          serverUrl: "http://default.port.wtf:80",
+          normalizedUrl: "http://default.port.wtf",
+        },
+        {
+          serverUrl: "https://default.port.wtf:443",
+          normalizedUrl: "https://default.port.wtf",
+        },
+        {
+          serverUrl: "https://discourse.sourcecred.io/",
+          normalizedUrl: "https://discourse.sourcecred.io",
+        },
+      ];
+
+      const actual = expected.map(({serverUrl}) => ({
+        serverUrl,
+        normalizedUrl: parseServerUrl(serverUrl),
+      }));
+
+      expect(expected).toEqual(actual);
+    });
+
+    it("should fail on invalid server urls", () => {
+      const expected = {
+        "file:///dev/null": (url) =>
+          `Provided Discourse Server URL was invalid: ${url}\n` +
+          `URL should have a http/https protocol`,
+        "http://user:pass@foo.bar": (url) =>
+          `Provided Discourse Server URL was invalid: ${url}\n` +
+          `Only a hostname and port are allowed`,
+        "http://foo.bar/path": (url) =>
+          `Provided Discourse Server URL was invalid: ${url}\n` +
+          `Only a hostname and port are allowed`,
+        "http://foo.bar/?search": (url) =>
+          `Provided Discourse Server URL was invalid: ${url}\n` +
+          `Only a hostname and port are allowed`,
+        "http://foo.bar/#hash": (url) =>
+          `Provided Discourse Server URL was invalid: ${url}\n` +
+          `Only a hostname and port are allowed`,
+      };
+
+      for (const url in expected) {
+        expect(() => parseServerUrl(url)).toThrow(expected[url](url));
+      }
+    });
+  });
+});


### PR DESCRIPTION
In a similar vain to #1685, make the cache keys human readable.

Previously we had base64 and no prefix, which is case-sensitive.
So we were not scoping to our plugin, nor supporting case-insensitive
filesystems.

The fields preserved from a URL are the protocol, hostname and optional
custom port. Using `_` as the separator for those.

Test plan: `yarn test`