### PR TITLE
Add a mock middleware module for the grain ui

### DIFF
--- a/.babelrc.js
+++ b/.babelrc.js
@@ -17,6 +17,9 @@ const presets = [
   "@babel/preset-flow",
 ];
 
-const plugins = ["@babel/plugin-proposal-class-properties"];
+const plugins = [
+  "@babel/plugin-proposal-class-properties",
+  "@babel/plugin-syntax-bigint",
+];
 
 module.exports = {presets, plugins};

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
   "devDependencies": {
     "@babel/core": "^7.8.7",
     "@babel/plugin-proposal-class-properties": "^7.8.3",
+    "@babel/plugin-syntax-bigint": "^7.8.3",
     "@babel/preset-env": "^7.8.7",
     "@babel/preset-flow": "^7.8.3",
     "@babel/preset-react": "^7.8.3",

--- a/src/grain-explorer/middleware.js
+++ b/src/grain-explorer/middleware.js
@@ -1,0 +1,72 @@
+// @flow
+
+import {type NodeAddressT} from "../core/graph";
+import {type Grain} from "../grain/grain";
+import {type LedgerEvent} from "../grain/ledger";
+
+export type Contributor = {|
+  +address: NodeAddressT,
+  // Markdown name (may contain hyperlinks)
+  +name: string,
+  +balance: Grain,
+  +lastPeriodIssuance: Grain,
+|};
+
+export type MatchOptions = {|
+  +exact: boolean,
+|};
+
+/**
+ * The GrainMiddleware class provides data that's been preprocessed and
+ * organized to closely match the needs of the grain frontend.
+ */
+export class GrainMiddleware {
+  /*
+   * Lists every contributor in the project, along with summary information
+   * like their grain balance. In the future, we may add pagination.
+   */
+  contributors(): $ReadOnlyArray<Contributor> {
+    throw new Error("Not yet implemented");
+  }
+
+  /**
+   * Given the address of a contributor, return the summary information.
+   */
+  contributor(address: NodeAddressT): ?Contributor {
+    throw new Error("Not yet implemented" + address);
+  }
+
+  /**
+   * Returns all of the LedgerEvents corresponding to a particular contributor.
+   * In the future, we will add options (e.g. on how the events should be sorted);
+   * for now it will provide them in descending timestamp order.
+   * In the future, we may change this to a paginated or asynchronous API.
+   */
+  events(address: NodeAddressT): $ReadOnlyArray<LedgerEvent> {
+    throw new Error("Not yet implemented" + address);
+  }
+
+  /**
+   * Fuzzily searches over the contributors to find ones that match the
+   * search string. Assigns a score to each match based on its closeness.
+   *
+   * In the future, we may add options (e.g. for exactness).
+   */
+  autocomplete(
+    search: string
+  ): $ReadOnlyArray<{|+score: number, +contributor: Contributor|}> {
+    throw new Error("Not yet implemented" + search);
+  }
+
+  /**
+   * Returns timeseries data of how much total supply of Grain there's been at
+   * every "issuance period". For now, we'll consider any timestamp which has
+   * at least one Grain distribution to be an issuance period.
+   */
+  supplyTimeseries(): $ReadOnlyArray<{|
+    +timestampMs: number,
+    +supply: Grain,
+  |}> {
+    throw new Error("Not yet implemented");
+  }
+}

--- a/src/grain-explorer/middleware.test.js
+++ b/src/grain-explorer/middleware.test.js
@@ -1,0 +1,7 @@
+// @flow
+
+describe("grain-explorer/middleware", () => {
+  it("needs to be implemented", () => {
+    return;
+  });
+});

--- a/src/grain/grain.js
+++ b/src/grain/grain.js
@@ -1,0 +1,68 @@
+// @flow
+
+/**
+ * This module contains the types for tracking Grain, which is the native
+ * project-specific, cred-linked token created in SourceCred instances. In
+ * practice, projects can call these tokens anything they want, but we will
+ * refer to the tokens as "Grain" throughout the codebase. The conserved
+ * properties of all Grains are that they are minted/distributed based on cred
+ * scores, and that they can be used to Boost contributions in a cred graph.
+ *
+ * Grain is represented by [BigInt]s so that we can avoid precision issues.
+ * Following the convention for ERC20 tokens, we will track and format Grain
+ * with 18 decimals of precision.
+ *
+ * Unfortunately Flow does not support BigInts yet. For now, we will hack
+ * around this by lying to Flow and claiming that the BigInts are actually
+ * numbers. Whenever we actually construct a BigInt, we will
+ * suppress the flow error at that declaration. Mixing BigInts with other types
+ * (e.g. 5n + 3) produces a runtime error, so even though Flow will not save
+ * us from these, they will be easy to detect. See [facebook/flow#6639][flow]
+ *
+ * [BigInt]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/BigInt
+ * [flow]: https://github.com/facebook/flow/issues/6639
+ */
+export type Grain = number;
+
+// $ExpectFlowError
+export const zero = 0n;
+
+// One "full" grain (with 18 decimals precision)
+// $ExpectFlowError
+export const one = 10n ** 18n;
+
+/**
+ * Format a grain balance as a human-readable number, removing 18 digits of
+ * precision. By default, it will present the largest whole value (i.e.
+ * 3500000000000000000 will be formatted as 3). Optionally, the client may
+ * specify additional digits of precision. At present it always rounds down,
+ * although we might change this in the future.
+ */
+export function format(g: Grain, decimals: number = 0): string {
+  if (
+    Math.floor(decimals) !== decimals ||
+    decimals < 0 ||
+    !isFinite(decimals) ||
+    decimals > 18
+  ) {
+    throw new Error(
+      `decimals must be integer in range [0..18], got ${decimals}`
+    );
+  }
+
+  // $ExpectFlowError
+  let div = 10n ** 18n;
+  let result = String(g / div);
+  g %= div;
+  if (decimals > 0) {
+    result += ".";
+    while (decimals > 0) {
+      // $ExpectFlowError
+      div /= 10n;
+      result += String(g / div);
+      g = g % div;
+      decimals--;
+    }
+  }
+  return result;
+}

--- a/src/grain/grain.test.js
+++ b/src/grain/grain.test.js
@@ -1,0 +1,52 @@
+// @flow
+
+import {format} from "./grain";
+
+describe("src/grain/grain", () => {
+  describe("format", () => {
+    // $ExpectFlowError
+    const pointOne = 10n ** 17n;
+    // $ExpectFlowError
+    const one = pointOne * 10n;
+    // $ExpectFlowError
+    const onePointFive = pointOne * 15n;
+    // $ExpectFlowError
+    const almostOne = one - 1n;
+    // $ExpectFlowError
+    const fortyTwo = one * 42n;
+    it("works at 0 decimals precision (and rounds down)", () => {
+      expect(format(pointOne)).toEqual("0");
+      expect(format(almostOne)).toEqual("0");
+      expect(format(one)).toEqual("1");
+      expect(format(onePointFive)).toEqual("1");
+      expect(format(fortyTwo)).toEqual("42");
+    });
+    it("works at 1 decimals precision (and rounds down)", () => {
+      expect(format(pointOne, 1)).toEqual("0.1");
+      expect(format(almostOne, 1)).toEqual("0.9");
+      expect(format(one, 1)).toEqual("1.0");
+      expect(format(onePointFive, 1)).toEqual("1.5");
+      expect(format(fortyTwo, 1)).toEqual("42.0");
+    });
+    it("works at 2 decimals precision (and rounds down)", () => {
+      expect(format(pointOne, 2)).toEqual("0.10");
+      expect(format(almostOne, 2)).toEqual("0.99");
+      expect(format(one, 2)).toEqual("1.00");
+      expect(format(onePointFive, 2)).toEqual("1.50");
+      expect(format(fortyTwo, 2)).toEqual("42.00");
+    });
+    it("works at 18 decimals precision", () => {
+      expect(format(pointOne, 18)).toEqual("0.100000000000000000");
+      expect(format(almostOne, 18)).toEqual("0.999999999999999999");
+      expect(format(one, 18)).toEqual("1.000000000000000000");
+      expect(format(onePointFive, 18)).toEqual("1.500000000000000000");
+      expect(format(fortyTwo, 18)).toEqual("42.000000000000000000");
+    });
+    it("throws an error if decimals is not an integer in range [0..18]", () => {
+      const badValues = [-1, -0.5, 0.33, 19, Infinity, -Infinity, NaN];
+      for (const bad of badValues) {
+        expect(() => format(one, bad)).toThrowError("must be integer in range");
+      }
+    });
+  });
+});

--- a/src/grain/ledger.js
+++ b/src/grain/ledger.js
@@ -1,0 +1,161 @@
+// @flow
+
+import deepFreeze from "deep-freeze";
+import {type NodeAddressT, NodeAddress} from "../core/graph";
+import stringify from "json-stable-stringify";
+import * as NullUtil from "../util/null";
+import {type Grain, format as formatGrain} from "./grain";
+
+export type LedgerEvent = Distribution | Transfer;
+
+export opaque type OrderT = symbol;
+export const Order: {|
+  +ASCENDING: OrderT,
+  +DESCENDING: OrderT,
+|} = deepFreeze({
+  ASCENDING: Symbol("ASCENDING"),
+  DESCENDING: Symbol("DESCENDING"),
+});
+
+export type EventsOptions = {|
+  +address: ?NodeAddressT,
+  +order: ?OrderT,
+|};
+
+export type Transfer = {|
+  +type: "TRANSFER",
+  +sender: NodeAddressT,
+  +recipient: NodeAddressT,
+  +amount: Grain,
+  +timestampMs: number,
+|};
+
+export type Distribution = {|
+  +type: "DISTRIBUTION",
+  +recipient: NodeAddressT,
+  +amount: Grain,
+  +timestampMs: number,
+|};
+
+export type AliasSpec = {|
+  +canonical: NodeAddressT,
+  +alias: NodeAddressT,
+|};
+
+export type LedgerHistory = {|
+  +events: $ReadOnlyArray<LedgerEvent>,
+  +aliases: Map<NodeAddressT, NodeAddressT>,
+|};
+
+export interface Ledger {
+  balances(): Map<NodeAddressT, Grain>;
+  earnings(): Map<NodeAddressT, Grain>;
+  events(EventsOptions): $ReadOnlyArray<LedgerEvent>;
+  history(): LedgerHistory;
+}
+
+// $ExpectFlowError
+const zero: Grain = 0n;
+
+export class InMemoryLedger implements Ledger {
+  _balances: Map<NodeAddressT, Grain>;
+  _earnings: Map<NodeAddressT, Grain>;
+  _history: LedgerHistory;
+
+  constructor(history: LedgerHistory) {
+    this._history = history;
+    this._balances = new Map();
+    this._earnings = new Map();
+    let lastTimestamp = -Infinity;
+    for (const e of history.events) {
+      if (e.timestampMs < lastTimestamp) {
+        throw new Error(
+          `event timestamps out of order: encountered ${e.timestampMs} after ${lastTimestamp}`
+        );
+      }
+      switch (e.type) {
+        case "DISTRIBUTION":
+          this._processDistribution((e: Distribution));
+          break;
+        case "TRANSFER":
+          this._processTransfer((e: Transfer));
+          break;
+        default:
+          throw new Error((e.type: empty));
+      }
+    }
+  }
+
+  events(opts: EventsOptions): $ReadOnlyArray<LedgerEvent> {
+    let filter = (_) => true;
+    if (opts.address) {
+      filter = (x: LedgerEvent) => {
+        switch (x.type) {
+          case "DISTRIBUTION":
+            return x.recipient === opts.address;
+          case "TRANSFER":
+            return x.recipient === opts.address || x.sender === opts.address;
+          default:
+            throw new Error((x.type: empty));
+        }
+      };
+    }
+    const events = this._history.events.filter(filter);
+    if (opts.order === Order.DESCENDING) {
+      events.reverse();
+    }
+    return events;
+  }
+
+  history() {
+    return this._history;
+  }
+
+  balances(): Map<NodeAddressT, Grain> {
+    return new Map(this._balances);
+  }
+
+  _balance(a: NodeAddressT): Grain {
+    return NullUtil.orElse(this._balances.get(a), zero);
+  }
+
+  _earning(a: NodeAddressT): Grain {
+    return NullUtil.orElse(this._earnings.get(a), zero);
+  }
+
+  earnings(): Map<NodeAddressT, Grain> {
+    return new Map(this._earnings);
+  }
+
+  canonicalAddress(a: NodeAddressT): NodeAddressT {
+    return NullUtil.orElse(this._history.aliases.get(a), a);
+  }
+
+  _processDistribution(d: Distribution) {
+    const recipient = this.canonicalAddress(d.recipient);
+    const balance = this._balance(recipient) + d.amount;
+    this._balances.set(recipient, balance);
+    const earned = NullUtil.orElse(this._earnings.get(recipient), zero);
+    this._earnings.set(recipient, earned + d.amount);
+  }
+
+  _processTransfer(t: Transfer) {
+    const recipient = this.canonicalAddress(t.recipient);
+    const sender = this.canonicalAddress(t.sender);
+    const recipientBalance = this._balance(recipient);
+    const senderBalance = this._balance(sender);
+    if (senderBalance < t.amount) {
+      const forDisplay = {
+        amount: formatGrain(t.amount, 18),
+        recipient: NodeAddress.toString(t.recipient),
+        sender: NodeAddress.toString(t.sender),
+        timestampMs: t.timestampMs,
+      };
+      throw new Error(
+        `Invalid transfer (sender can't afford): ${stringify(forDisplay)}`
+      );
+    }
+    this._balances.set(recipient, recipientBalance + t.amount);
+    this._balances.set(sender, senderBalance - t.amount);
+  }
+}

--- a/src/grain/ledger.test.js
+++ b/src/grain/ledger.test.js
@@ -1,0 +1,169 @@
+// @flow
+
+import {NodeAddress} from "../core/graph";
+import {InMemoryLedger} from "./ledger";
+
+describe("src/grain/ledger", () => {
+  describe("InMemoryLedger", () => {
+    const foo = NodeAddress.fromParts(["foo"]);
+    const bar = NodeAddress.fromParts(["bar"]);
+    const zod = NodeAddress.fromParts(["zod"]);
+
+    it("works properly for an empty history", () => {
+      const history = {events: [], aliases: new Map()};
+      const ledger = new InMemoryLedger(history);
+      expect(ledger.balances()).toEqual(new Map());
+      expect(ledger.earnings()).toEqual(new Map());
+      expect(ledger.canonicalAddress(foo)).toEqual(foo);
+      expect(ledger.history()).toEqual(history);
+    });
+    it("correctly models some simple distributions", () => {
+      const history = {
+        aliases: new Map(),
+        events: [
+          // $ExpectFlowError
+          {type: "DISTRIBUTION", recipient: foo, amount: 10n, timestampMs: 0},
+          // $ExpectFlowError
+          {type: "DISTRIBUTION", recipient: bar, amount: 99n, timestampMs: 1},
+        ],
+      };
+      const ledger = new InMemoryLedger(history);
+      const expected = new Map([
+        // $ExpectFlowError
+        [foo, 10n],
+        // $ExpectFlowError
+        [bar, 99n],
+      ]);
+      expect(ledger.balances()).toEqual(expected);
+      expect(ledger.earnings()).toEqual(expected);
+      expect(ledger.history()).toEqual(history);
+    });
+    it("correctly models a simple transfer", () => {
+      const history = {
+        aliases: new Map(),
+        events: [
+          // $ExpectFlowError
+          {type: "DISTRIBUTION", recipient: foo, amount: 10n, timestampMs: 0},
+          // $ExpectFlowError
+          {type: "DISTRIBUTION", recipient: bar, amount: 99n, timestampMs: 1},
+          {
+            type: "TRANSFER",
+            recipient: foo,
+            sender: bar,
+            // $ExpectFlowError
+            amount: 50n,
+            timestampMs: 2,
+          },
+        ],
+      };
+      const ledger = new InMemoryLedger(history);
+      const expectedEarnings = new Map([
+        // $ExpectFlowError
+        [foo, 10n],
+        // $ExpectFlowError
+        [bar, 99n],
+      ]);
+      const expectedBalances = new Map([
+        // $ExpectFlowError
+        [foo, 60n],
+        // $ExpectFlowError
+        [bar, 49n],
+      ]);
+      expect(ledger.balances()).toEqual(expectedBalances);
+      expect(ledger.earnings()).toEqual(expectedEarnings);
+      expect(ledger.history()).toEqual(history);
+    });
+    it("throws an error if there are invalid transfers", () => {
+      const history = {
+        events: [
+          // $ExpectFlowError
+          {type: "DISTRIBUTION", recipient: foo, amount: 10n, timestampMs: 0},
+          {
+            type: "TRANSFER",
+            recipient: foo,
+            sender: bar,
+            // $ExpectFlowError
+            amount: 50n,
+            timestampMs: 2,
+          },
+        ],
+        aliases: new Map(),
+      };
+      const fail = () => new InMemoryLedger(history);
+      expect(fail).toThrowError("Invalid transfer (sender can't afford)");
+    });
+    it("aggregates balances and distributions across aliases", () => {
+      const history = {
+        aliases: new Map([[foo, zod]]),
+        events: [
+          // $ExpectFlowError
+          {type: "DISTRIBUTION", recipient: foo, amount: 10n, timestampMs: 0},
+          // $ExpectFlowError
+          {type: "DISTRIBUTION", recipient: zod, amount: 10n, timestampMs: 0},
+          // $ExpectFlowError
+          {type: "DISTRIBUTION", recipient: bar, amount: 99n, timestampMs: 1},
+          {
+            type: "TRANSFER",
+            recipient: foo,
+            sender: bar,
+            // $ExpectFlowError
+            amount: 50n,
+            timestampMs: 2,
+          },
+        ],
+      };
+      const ledger = new InMemoryLedger(history);
+      const expectedEarnings = new Map([
+        // $ExpectFlowError
+        [zod, 20n],
+        // $ExpectFlowError
+        [bar, 99n],
+      ]);
+      const expectedBalances = new Map([
+        // $ExpectFlowError
+        [zod, 70n],
+        // $ExpectFlowError
+        [bar, 49n],
+      ]);
+      expect(ledger.balances()).toEqual(expectedBalances);
+      expect(ledger.earnings()).toEqual(expectedEarnings);
+      expect(ledger.history()).toEqual(history);
+      expect(ledger.canonicalAddress(foo)).toEqual(zod);
+      expect(ledger.canonicalAddress(bar)).toEqual(bar);
+      expect(ledger.canonicalAddress(zod)).toEqual(zod);
+    });
+    it("it can 'mix and match' transfers across aliases", () => {
+      const history = {
+        events: [
+          // $ExpectFlowError
+          {type: "DISTRIBUTION", recipient: foo, amount: 10n, timestampMs: 0},
+          // Transfer is sent by zod, but grain was recieved as foo
+          {
+            type: "TRANSFER",
+            sender: zod,
+            recipient: bar,
+            // $ExpectFlowError
+            amount: 10n,
+            timestampMs: 2,
+          },
+        ],
+        aliases: new Map([[foo, zod]]),
+      };
+      const ledger = new InMemoryLedger(history);
+      const expectedBalances = new Map([
+        // $ExpectFlowError
+        [zod, 0n],
+        // $ExpectFlowError
+        [bar, 10n],
+      ]);
+      expect(ledger.balances()).toEqual(expectedBalances);
+      // $ExpectFlowError
+      const expectedEarnings = new Map([[zod, 10n]]);
+      expect(ledger.earnings()).toEqual(expectedEarnings);
+      expect(ledger.history()).toEqual(history);
+      expect(ledger.canonicalAddress(foo)).toEqual(zod);
+      expect(ledger.canonicalAddress(bar)).toEqual(bar);
+      expect(ledger.canonicalAddress(zod)).toEqual(zod);
+    });
+  });
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -348,7 +348,7 @@
   dependencies:
     "@babel/helper-plugin-utils" "^7.8.0"
 
-"@babel/plugin-syntax-bigint@^7.0.0":
+"@babel/plugin-syntax-bigint@^7.0.0", "@babel/plugin-syntax-bigint@^7.8.3":
   version "7.8.3"
   resolved "https://registry.yarnpkg.com/@babel/plugin-syntax-bigint/-/plugin-syntax-bigint-7.8.3.tgz#4c9a6f669f5d0cdf1b90a1671e9a146be5300cea"
   integrity sha512-wnTnFlG+YxQm3vDxpGE57Pj0srRU4sHE/mDkt1qv2YJJSeUAec2ma4WLUnUPeKjyrfntVwe/N6dCXpU+zL3Npg==


### PR DESCRIPTION
This contains a skeleton class (interface really) for the data provider
for the upcoming grain user interface. By agreeing on the interface, we
allow work on the backend and frontend to proceed in parallel.

Paired with @ianjdarrow

Test plan: Only mock tests were added, so really `yarn flow` and `yarn
lint` are doing all the work. They pass. :)