### PR TITLE
Add grain payout strategies

### DIFF
--- a/src/grain/grain.js
+++ b/src/grain/grain.js
@@ -108,3 +108,36 @@ export function format(
   }
   return digits.join("") + suffix;
 }
+
+/**
+ * Multiply a grain amount by a floating point number.
+ *
+ * Use this method when you need to multiply a grain balance by a floating
+ * point number, e.g. a ratio.
+ *
+ * Note that this method is imprecise. It is not safe to assume, for example,
+ * that `multiply(g, 1/3) + multiply(g, 2/3) === g` due to loss of precision.
+ * However, the errors will be small in absolute terms (i.e. tiny compared to
+ * one full grain).
+ *
+ * See some messy analysis of the numerical errors here:
+ * https://observablehq.com/@decentralion/grain-arithmetic
+ */
+export function multiplyFloat(grain: Grain, num: number): Grain {
+  return BigInt(Math.floor(Number(grain) * num));
+}
+
+/**
+ * Aproximately create a grain balance from a float.
+ *
+ * This method tries to convert the floating point `amt` into a grain
+ * balance. For example, `grain(1)` approximately equals `ONE`.
+ *
+ * Do not assume this will be precise! For example, `grain(0.1337)` results in
+ * `133700000000000016n`. This method is intended for test code.
+ *
+ * This is a shorthand for `multiplyFloat(ONE, amt)`.
+ */
+export function fromFloat(f: number): Grain {
+  return multiplyFloat(ONE, f);
+}

--- a/src/grain/grain.test.js
+++ b/src/grain/grain.test.js
@@ -1,68 +1,64 @@
 // @flow
 
-import {format, ONE, DECIMAL_PRECISION, ZERO} from "./grain";
+import {
+  format,
+  ONE,
+  DECIMAL_PRECISION,
+  ZERO,
+  fromFloat,
+  multiplyFloat,
+} from "./grain";
 
 describe("src/grain/grain", () => {
   describe("format", () => {
     // $ExpectFlowError
-    const pointOne = ONE / 10n;
-    // $ExpectFlowError
-    const onePointFive = pointOne * 15n;
-    // $ExpectFlowError
     const almostOne = ONE - 1n;
-    // $ExpectFlowError
-    const fortyTwo = ONE * 42n;
-    // $ExpectFlowError
-    const negative = -1n;
-    // $ExpectFlowError
-    const leet = ONE * 1337n;
-    // $ExpectFlowError
-    const leetAndSpecial = leet * 1000n + fortyTwo + fortyTwo / 100n;
 
     it("correctly rounds to smallest integer when decimals==0", () => {
       expect(format(ZERO)).toEqual("0g");
-      expect(format(pointOne)).toEqual("0g");
+      expect(format(fromFloat(0.1))).toEqual("0g");
       expect(format(almostOne)).toEqual("0g");
       expect(format(ONE)).toEqual("1g");
-      expect(format(onePointFive)).toEqual("1g");
-      expect(format(fortyTwo)).toEqual("42g");
+      expect(format(fromFloat(1.5))).toEqual("1g");
+      expect(format(fromFloat(42))).toEqual("42g");
     });
     it("correctly adds comma formatting for large numbers", () => {
-      expect(format(leet)).toEqual("1,337g");
-      expect(format(leet, 1)).toEqual("1,337.0g");
-      expect(format(leet + pointOne)).toEqual("1,337g");
-      expect(format(leet + pointOne, 1)).toEqual("1,337.1g");
-      expect(format(leetAndSpecial, 0)).toEqual("1,337,042g");
-      expect(format(leetAndSpecial, 2)).toEqual("1,337,042.42g");
+      expect(format(fromFloat(1337))).toEqual("1,337g");
+      expect(format(fromFloat(1337), 1)).toEqual("1,337.0g");
+      expect(format(fromFloat(1337.11))).toEqual("1,337g");
+      expect(format(fromFloat(1337.11), 1)).toEqual("1,337.1g");
+      expect(format(fromFloat(1337042.42), 0)).toEqual("1,337,042g");
+      expect(format(fromFloat(1337042.42), 2)).toEqual("1,337,042.42g");
     });
     it("correctly handles negative numbers", () => {
-      expect(format(negative * pointOne)).toEqual("-0g");
-      expect(format(negative * onePointFive)).toEqual("-1g");
-      expect(format(negative * fortyTwo)).toEqual("-42g");
-      expect(format(negative * onePointFive, 1)).toEqual("-1.5g");
-      expect(format(negative * onePointFive, 1)).toEqual("-1.5g");
-      expect(format(negative * leetAndSpecial, 0)).toEqual("-1,337,042g");
-      expect(format(negative * leetAndSpecial, 2)).toEqual("-1,337,042.42g");
+      expect(format(fromFloat(-0.1))).toEqual("-0g");
+      expect(format(fromFloat(-1.5))).toEqual("-1g");
+      expect(format(fromFloat(-42))).toEqual("-42g");
+      expect(format(fromFloat(-1.5), 1)).toEqual("-1.5g");
+      expect(format(fromFloat(-1.5), 1)).toEqual("-1.5g");
+      expect(format(fromFloat(-1337042.42), 0)).toEqual("-1,337,042g");
+      expect(format(fromFloat(-1337042.42), 2)).toEqual("-1,337,042.42g");
     });
     it("handles full precision", () => {
       expect(format(ZERO, DECIMAL_PRECISION)).toEqual("0.000000000000000000g");
       expect(format(ONE, DECIMAL_PRECISION)).toEqual("1.000000000000000000g");
-      expect(format(pointOne, DECIMAL_PRECISION)).toEqual(
+      expect(format(fromFloat(0.1), DECIMAL_PRECISION)).toEqual(
         "0.100000000000000000g"
       );
       // $ExpectFlowError
       expect(format(-12345n, DECIMAL_PRECISION)).toEqual(
         "-0.000000000000012345g"
       );
-      expect(format(leetAndSpecial, DECIMAL_PRECISION)).toEqual(
+      // $ExpectFlowError
+      expect(format((ONE / 100n) * 133704242n, DECIMAL_PRECISION)).toEqual(
         "1,337,042.420000000000000000g"
       );
     });
     it("supports alternative suffixes", () => {
-      expect(format(onePointFive, 0, "SEEDS")).toEqual("1SEEDS");
-      expect(format(fortyTwo, 0, "SEEDS")).toEqual("42SEEDS");
-      expect(format(negative * onePointFive, 1, "SEEDS")).toEqual("-1.5SEEDS");
-      expect(format(negative * leetAndSpecial, 0, "SEEDS")).toEqual(
+      expect(format(fromFloat(1.5), 0, "SEEDS")).toEqual("1SEEDS");
+      expect(format(fromFloat(42), 0, "SEEDS")).toEqual("42SEEDS");
+      expect(format(fromFloat(-1.5), 1, "SEEDS")).toEqual("-1.5SEEDS");
+      expect(format(fromFloat(-1337042.42), 0, "SEEDS")).toEqual(
         "-1,337,042SEEDS"
       );
     });
@@ -79,6 +75,38 @@ describe("src/grain/grain", () => {
       for (const bad of badValues) {
         expect(() => format(ONE, bad)).toThrowError("must be integer in range");
       }
+    });
+  });
+
+  describe("multiplyFloat", () => {
+    it("behaves reasonably for tiny grain values", () => {
+      // $ExpectFlowError
+      expect(multiplyFloat(1n, 5)).toEqual(5n);
+    });
+    it("behaves reasonably for larger grain values", () => {
+      // $ExpectFlowError
+      expect(multiplyFloat(ONE, 2)).toEqual(2n * ONE);
+    });
+    it("has small error on large grain values", () => {
+      // To compare with arbitrary precision results, see:
+      // https://observablehq.com/@decentralion/grain-arithmetic
+
+      // Within 1 attoGrain of "true" value
+      // $ExpectFlowError
+      expect(multiplyFloat(ONE, 1 / 1337)).toEqual(747943156320119n);
+
+      // Within 300 attoGrain of "true" value
+      // $ExpectFlowError
+      expect(multiplyFloat(ONE, Math.PI)).toEqual(3141592653589793280n);
+    });
+  });
+  describe("fromFloat", () => {
+    it("fromFloat(1) === ONE", () => {
+      expect(fromFloat(1)).toEqual(ONE);
+    });
+    it("fromFloat(0.1) === ONE / 10", () => {
+      // $ExpectFlowError
+      expect(fromFloat(0.1)).toEqual(ONE / 10n);
     });
   });
 });

--- a/src/grain/payouts.js
+++ b/src/grain/payouts.js
@@ -1,0 +1,169 @@
+// @flow
+/* global BigInt */
+
+/**
+ * This module contains "payout strategies" for distributing Grain based on scores.
+ *
+ * We currently have three payout strategies:
+ * - fixedAmount: Given a fixed amount of Grain to distribute, split it proportional
+ *   to cred scores.
+ *
+ * - fixedRatio: Given a target level of grainPerCred, mint Grain so that every
+ *   contributors' lifetime earnings is at least grainPerCred * theirCred. Takes past
+ *   earnings into account.
+ *
+ * - underpayment: Given a fixed amount of Grain, distribute it according to cred scores,
+ *   prioritizing paying users who were "underpaid" in the past (i.e. they have a smaller
+ *   proportion of lifetime earnings than is suggested by their cred score).
+ */
+import {sum} from "d3-array";
+import * as MapUtil from "../util/map";
+import {type NodeAddressT} from "../core/graph";
+import {type Grain, ZERO, ONE, multiplyFloat} from "./grain";
+
+/**
+ * Distribute an amount of Grain, strictly in proportion to the scores.
+ *
+ * This might be a good fit for distributing a fixed grain per week directly
+ * in proportion to the weekly cred score.
+ */
+export function fixedAmount(
+  harvestAmount: Grain,
+  scores: Map<NodeAddressT, number>
+): Map<NodeAddressT, Grain> {
+  if (harvestAmount < ZERO) {
+    throw new Error(`invalid harvestAmount: ${String(harvestAmount)}`);
+  }
+  if (scores.size === 0) {
+    return new Map();
+  }
+  const totalScore = sum(Array.from(scores.values()));
+  if (totalScore === 0) {
+    const perCapita = multiplyFloat(harvestAmount, 1 / scores.size);
+    return MapUtil.mapValues(scores, () => perCapita);
+  }
+  const computeShare = (_, score) =>
+    multiplyFloat(harvestAmount, score / totalScore);
+  return MapUtil.mapValues(scores, computeShare);
+}
+
+/**
+ * Distribute Grain so that each contributor's lifetime earnings
+ * are at least a fixed multiple of their score.
+ *
+ * Parameters:
+ *
+ * grainPerScore: Target amount of grain for each unit of score. This is
+ *   recorded as a number, and ignores grain precision (e.g. if
+ *   grainPerScore===2, then we are aiming to distribute two "full" grain per
+ *   unit of score, which might be tracked as 2n * 10n**18n).
+ *
+ * scores: The map from users' addresses to their scores. This could be
+ *   lifetime cred scores, it could be this week's scores, etc.
+ *
+ * earnings: The map from users' addresses to their lifetime distributed payout.
+ *   This information is used to determine which users have been "underpaid"
+ *   relative to the payout target, and by how much.
+ *
+ * Since this strategy provides a consistent reward per unit cred, it means that
+ * as the activity level (and thus, cred generation) in a project increases, the
+ * rewards also increase. This avoids the problem with fixed-reward strategies,
+ * where more participants mean less reward per person.
+ *
+ * If some users have been historically over-paid (e.g. because the
+ * target grainPerScore was higher in the past, or a weight change decreased
+ * their score), they might go for a long time without any payouts.
+ *
+ * Also, if users find a way to game/inflate cred scores, using this payout
+ * strategy will cause grain to inflate as well.
+ */
+export function fixedRatio(
+  grainPerScore: number,
+  scores: Map<NodeAddressT, number>,
+  earnings: Map<NodeAddressT, Grain>
+): Map<NodeAddressT, Grain> {
+  if (!isFinite(grainPerScore) || grainPerScore < 0) {
+    throw new Error(`invalid grainPerScore: ${grainPerScore}`);
+  }
+  return MapUtil.mapValues(scores, (addr, score) => {
+    const earned = earnings.get(addr) || ZERO;
+    const target = multiplyFloat(ONE, grainPerScore * score);
+    return target > earned ? target - earned : ZERO;
+  });
+}
+
+/**
+ * Distribute a fixed amount of Grain to the users who were "most underpaid".
+ *
+ * We consider a user underpaid if they have recieved a smaller proportion of
+ * past earnings than their share of score. They are fairly paid if their
+ * proportion of earnings is equal to their score share, and they are overpaid
+ * if their proportion of earnings is higher than their share of the score.
+ *
+ * We start by imagining a hypothetical world, where the entire grain supply of
+ * the project (including this harvest) were distributed according to the
+ * current scores. Based on this, we can calculate the "fair" lifetime earnings
+ * for each participant. Usually, some will be "underpaid" (they recieved less
+ * than this amount) and others are "overpaid".
+ *
+ * We can sum across all users who were underpaid to find the "total
+ * underpayment". As an invariant, `totalUnderpayment = harvestAmount +
+ * totalOverpayment`, since no-one has yet been paid the harvestAmount, and
+ * beyond that every grain of overpayment to one actor is underpayment for a
+ * different actor.
+ *
+ * Now that we've calculated each actor's underpayment, and the total
+ * underpayment, we divide the harvest's grain amount across users in
+ * proportion to their underpayment.
+ *
+ * You should use this harvest when you want to divide a fixed amount of grain
+ * across participants in a way that aligns long-term payment with total cred
+ * scores.
+ */
+export function underpayment(
+  harvestAmount: Grain,
+  scores: Map<NodeAddressT, number>,
+  earnings: Map<NodeAddressT, Grain>
+): Map<NodeAddressT, Grain> {
+  let totalEarnings = ZERO;
+  for (const e of earnings.values()) {
+    totalEarnings += e;
+  }
+  let totalScore = 0;
+  for (const s of scores.values()) {
+    totalScore += s;
+  }
+  if (totalScore === 0) {
+    return fixedAmount(harvestAmount, scores);
+  }
+  const targetGrainPerScore =
+    Number(totalEarnings + harvestAmount) / totalScore;
+  let totalUnderpayment = ZERO;
+  let totalOverpayment = ZERO;
+  let userUnderpayment: Map<NodeAddressT, Grain> = new Map();
+  const addresses = new Set([...scores.keys(), ...earnings.keys()]);
+  for (const addr of addresses) {
+    const earned = earnings.get(addr) || ZERO;
+    const score = scores.get(addr) || 0;
+    // $ExpectFlowError
+    const target = BigInt(Math.floor(targetGrainPerScore * score));
+    if (target > earned) {
+      totalUnderpayment += target - earned;
+      userUnderpayment.set(addr, target - earned);
+    } else {
+      totalOverpayment += earned - target;
+    }
+  }
+  // invariant check
+  //
+  if (totalOverpayment + harvestAmount !== totalUnderpayment) {
+    console.error(totalOverpayment, harvestAmount, totalUnderpayment);
+  }
+  const results = new Map();
+  for (const [addr, underpayment] of userUnderpayment) {
+    const underpaymentProportion =
+      Number(underpayment) / Number(totalUnderpayment);
+    results.set(addr, multiplyFloat(harvestAmount, underpaymentProportion));
+  }
+  return results;
+}

--- a/src/grain/payouts.test.js
+++ b/src/grain/payouts.test.js
@@ -1,0 +1,224 @@
+// @flow
+
+import {NodeAddress} from "../core/graph";
+import {ONE, ZERO, fromFloat} from "./grain";
+import {fixedAmount, fixedRatio, underpayment} from "./payouts";
+
+describe("src/grain/payouts", () => {
+  const foo = NodeAddress.fromParts(["foo"]);
+  const bar = NodeAddress.fromParts(["bar"]);
+
+  describe("fixedAmount", () => {
+    it("handles the empty case", () => {
+      expect(fixedAmount(ZERO, new Map())).toEqual(new Map());
+      expect(fixedAmount(ONE, new Map())).toEqual(new Map());
+    });
+    it("handles a case where no users have score", () => {
+      expect(
+        fixedAmount(
+          fromFloat(2),
+          new Map([
+            [foo, 0],
+            [bar, 0],
+          ])
+        )
+      ).toEqual(
+        new Map([
+          [foo, ONE],
+          [bar, ONE],
+        ])
+      );
+    });
+    it("pays full amount to one contributor", () => {
+      expect(fixedAmount(ONE, new Map([[foo, 1]]))).toEqual(
+        new Map([[foo, ONE]])
+      );
+    });
+    it("splits in proportion to score", () => {
+      expect(
+        fixedAmount(
+          fromFloat(10),
+          new Map([
+            [foo, 9],
+            [bar, 1],
+          ])
+        )
+      ).toEqual(
+        new Map([
+          [foo, fromFloat(9)],
+          [bar, fromFloat(1)],
+        ])
+      );
+    });
+    it("errors on invalid total", () => {
+      // $ExpectFlowError
+      const neg = -1n;
+      expect(() => fixedAmount(neg, new Map())).toThrowError(
+        "invalid harvestAmount"
+      );
+    });
+  });
+
+  describe("fixedRatio", () => {
+    it("works on an empty case", () => {
+      expect(fixedRatio(0, new Map(), new Map())).toEqual(new Map());
+    });
+    it("works on a case where no-one has ever been paid", () => {
+      const scores = new Map([
+        [foo, 1],
+        [bar, 2],
+      ]);
+      expect(fixedRatio(1, scores, new Map())).toEqual(
+        new Map([
+          [foo, fromFloat(1)],
+          [bar, fromFloat(2)],
+        ])
+      );
+    });
+    it("works in a case where everyone is already paid", () => {
+      const scores = new Map([
+        [foo, 2],
+        [bar, 1],
+      ]);
+      const earnings = new Map([
+        [foo, fromFloat(4)],
+        [bar, fromFloat(3)],
+      ]);
+      expect(fixedRatio(2, scores, earnings)).toEqual(
+        new Map([
+          [foo, ZERO],
+          [bar, ZERO],
+        ])
+      );
+    });
+    it("works in a case where some are underpaid", () => {
+      const scores = new Map([
+        [foo, 1],
+        [bar, 3],
+      ]);
+      const earnings = new Map([
+        [foo, fromFloat(3)],
+        [bar, fromFloat(1)],
+      ]);
+      expect(fixedRatio(2, scores, earnings)).toEqual(
+        new Map([
+          [foo, fromFloat(0)],
+          [bar, fromFloat(5)],
+        ])
+      );
+    });
+    it("errors on invalid inputs", () => {
+      const bad = [-1, Infinity, NaN, -Infinity];
+      for (const b of bad) {
+        expect(() => fixedRatio(b, new Map(), new Map())).toThrowError(
+          "invalid grainPerScore"
+        );
+      }
+    });
+  });
+
+  describe("underpayment", () => {
+    it("handles the empty case", () => {
+      expect(underpayment(ZERO, new Map(), new Map())).toEqual(new Map());
+    });
+    it("distributes proportional to score, if there are no earnings", () => {
+      const scores = new Map([
+        [foo, 1],
+        [bar, 2],
+      ]);
+      const earnings = new Map();
+      const payouts = underpayment(fromFloat(3), scores, earnings);
+      expect(payouts).toEqual(
+        new Map([
+          [foo, fromFloat(1)],
+          [bar, fromFloat(2)],
+        ])
+      );
+    });
+    it("distributes proportional to score, if everyone was fairly paid", () => {
+      const scores = new Map([
+        [foo, 1],
+        [bar, 2],
+      ]);
+      const earnings = new Map([
+        [foo, fromFloat(2)],
+        [bar, fromFloat(4)],
+      ]);
+      const payouts = underpayment(fromFloat(3), scores, earnings);
+      expect(payouts).toEqual(
+        new Map([
+          [foo, fromFloat(1)],
+          [bar, fromFloat(2)],
+        ])
+      );
+    });
+    it("will skip over-paid accounts", () => {
+      const scores = new Map([
+        [foo, 1],
+        [bar, 2],
+      ]);
+      const earnings = new Map([
+        [foo, fromFloat(2)],
+        [bar, fromFloat(2)],
+      ]);
+      const payouts = underpayment(fromFloat(2), scores, earnings);
+      // After this payment, 6 grain will have been distributed.
+      // At that point, foo should have 2 grain, which they already have.
+      // So they don't get a distribution, and it all goes to bar.
+      const expected = new Map([[bar, fromFloat(2)]]);
+      expect(payouts).toEqual(expected);
+    });
+    it("will 'fill up' slightly overpaid accounts", () => {
+      const scores = new Map([
+        [foo, 1],
+        [bar, 1],
+      ]);
+      const earnings = new Map([
+        [foo, fromFloat(1)],
+        [bar, fromFloat(2)],
+      ]);
+      const payouts = underpayment(fromFloat(7), scores, earnings);
+      // After the payout, 10 grain will have been distributed.
+      // Since foo and bar have equal scores, they should each have 5.
+      const expected = new Map([
+        [foo, fromFloat(4)],
+        [bar, fromFloat(3)],
+      ]);
+      expect(payouts).toEqual(expected);
+    });
+    it("handles a case where some users have no reported earnings", () => {
+      const scores = new Map([
+        [foo, 1],
+        [bar, 1],
+      ]);
+      const earnings = new Map([[foo, fromFloat(1)]]);
+      const payouts = underpayment(fromFloat(1), scores, earnings);
+      const expected = new Map([[bar, fromFloat(1)]]);
+      expect(payouts).toEqual(expected);
+    });
+    it("handles a case where some users have earnings but no reported score", () => {
+      const scores = new Map([[bar, 1]]);
+      const earnings = new Map([[foo, fromFloat(1)]]);
+      const payouts = underpayment(fromFloat(1), scores, earnings);
+      const expected = new Map([[bar, fromFloat(1)]]);
+      expect(payouts).toEqual(expected);
+    });
+    it("splits rewards evenly if no users have any score", () => {
+      const scores = new Map([
+        [foo, 0],
+        [bar, 0],
+      ]);
+      const earnings = new Map([[foo, fromFloat(1)]]);
+      const payouts = underpayment(fromFloat(2), scores, earnings);
+      // In principle, it should probably give more to bar since bar was never paid.
+      // But this is an extreme edge case, we're just checking that we have some
+      // documented and consistent behavior.
+      expect(payouts).toEqual(
+        new Map([
+          [foo, fromFloat(1)],
+          [bar, fromFloat(1)],
+        ])
+      );
+    });
+  });
+});


### PR DESCRIPTION
This module adds "payout strategies" for computing how to divide grain
between participants based on their scores and their lifetime earnings.

We have three payout strategies:

- fixedAmount: Given a fixed amount of Grain to distribute, split it
  proportional to cred scores.

- fixedRatio: Given a target level of grainPerCred, mint Grain so that
  every contributors' lifetime earnings is at least grainPerCred *
  theirCred. Takes past earnings into account.

- underpayment: Given a fixed amount of Grain, distribute it according
  to cred scores, prioritizing paying users who were "underpaid" in the
  past (i.e. they have a smaller proportion of lifetime earnings than is
  suggested by their cred score).

Test plan: Included somewhat thorough unit tests. I'd like to have
reviewers carefully review the algorithms.
