### PR TITLE
Change lowercase const names to all caps in grain.js

### DIFF
--- a/src/grain/grain.js
+++ b/src/grain/grain.js
@@ -27,14 +27,14 @@
 export type Grain = number;
 
 // $ExpectFlowError
-export const zero = 0n;
+export const ZERO = 0n;
 
 // How many digits of precision there are in "one" grain
-export const decimalPrecision = 18;
+export const DECIMAL_PRECISION = 18;
 
 // One "full" grain
 // $ExpectFlowError
-export const one = 10n ** BigInt(decimalPrecision);
+export const ONE = 10n ** BigInt(DECIMAL_PRECISION);
 
 export const DEFAULT_SUFFIX = "g";
 
@@ -65,10 +65,10 @@ export function format(
   if (
     !Number.isInteger(decimals) ||
     decimals < 0 ||
-    decimals > decimalPrecision
+    decimals > DECIMAL_PRECISION
   ) {
     throw new Error(
-      `decimals must be integer in range [0..${decimalPrecision}]`
+      `decimals must be integer in range [0..${DECIMAL_PRECISION}]`
     );
   }
   const isNegative = grain < 0;
@@ -79,15 +79,15 @@ export function format(
   }
 
   // If the number is less than one, we need to pad it with zeros at the front
-  if (digits.length < decimalPrecision + 1) {
+  if (digits.length < DECIMAL_PRECISION + 1) {
     digits = [
-      ...new Array(decimalPrecision + 1 - digits.length).fill("0"),
+      ...new Array(DECIMAL_PRECISION + 1 - digits.length).fill("0"),
       ...digits,
     ];
   }
   // If we have more than 1000 grain, then we will insert commas for
   // readability
-  const integerDigits = digits.length - decimalPrecision;
+  const integerDigits = digits.length - DECIMAL_PRECISION;
   const numCommasToInsert = Math.floor(integerDigits / 3);
   for (let i = 0; i < numCommasToInsert; i++) {
     // Count digits backwards from the last integer.
@@ -98,10 +98,10 @@ export function format(
   }
   if (decimals > 0) {
     // Insert a decimal point at the right spot
-    digits.splice(digits.length - decimalPrecision, 0, ".");
+    digits.splice(digits.length - DECIMAL_PRECISION, 0, ".");
   }
   // Slice away all the unwanted precision
-  digits = digits.slice(0, digits.length - decimalPrecision + decimals);
+  digits = digits.slice(0, digits.length - DECIMAL_PRECISION + decimals);
   if (isNegative) {
     // re-insert the negative sign, if appropriate
     digits.splice(0, 0, "-");

--- a/src/grain/grain.test.js
+++ b/src/grain/grain.test.js
@@ -1,29 +1,29 @@
 // @flow
 
-import {format, one, decimalPrecision, zero} from "./grain";
+import {format, ONE, DECIMAL_PRECISION, ZERO} from "./grain";
 
 describe("src/grain/grain", () => {
   describe("format", () => {
     // $ExpectFlowError
-    const pointOne = one / 10n;
+    const pointOne = ONE / 10n;
     // $ExpectFlowError
     const onePointFive = pointOne * 15n;
     // $ExpectFlowError
-    const almostOne = one - 1n;
+    const almostOne = ONE - 1n;
     // $ExpectFlowError
-    const fortyTwo = one * 42n;
+    const fortyTwo = ONE * 42n;
     // $ExpectFlowError
     const negative = -1n;
     // $ExpectFlowError
-    const leet = one * 1337n;
+    const leet = ONE * 1337n;
     // $ExpectFlowError
     const leetAndSpecial = leet * 1000n + fortyTwo + fortyTwo / 100n;
 
     it("correctly rounds to smallest integer when decimals==0", () => {
-      expect(format(zero)).toEqual("0g");
+      expect(format(ZERO)).toEqual("0g");
       expect(format(pointOne)).toEqual("0g");
       expect(format(almostOne)).toEqual("0g");
-      expect(format(one)).toEqual("1g");
+      expect(format(ONE)).toEqual("1g");
       expect(format(onePointFive)).toEqual("1g");
       expect(format(fortyTwo)).toEqual("42g");
     });
@@ -45,16 +45,16 @@ describe("src/grain/grain", () => {
       expect(format(negative * leetAndSpecial, 2)).toEqual("-1,337,042.42g");
     });
     it("handles full precision", () => {
-      expect(format(zero, decimalPrecision)).toEqual("0.000000000000000000g");
-      expect(format(one, decimalPrecision)).toEqual("1.000000000000000000g");
-      expect(format(pointOne, decimalPrecision)).toEqual(
+      expect(format(ZERO, DECIMAL_PRECISION)).toEqual("0.000000000000000000g");
+      expect(format(ONE, DECIMAL_PRECISION)).toEqual("1.000000000000000000g");
+      expect(format(pointOne, DECIMAL_PRECISION)).toEqual(
         "0.100000000000000000g"
       );
       // $ExpectFlowError
-      expect(format(-12345n, decimalPrecision)).toEqual(
+      expect(format(-12345n, DECIMAL_PRECISION)).toEqual(
         "-0.000000000000012345g"
       );
-      expect(format(leetAndSpecial, decimalPrecision)).toEqual(
+      expect(format(leetAndSpecial, DECIMAL_PRECISION)).toEqual(
         "1,337,042.420000000000000000g"
       );
     });
@@ -71,13 +71,13 @@ describe("src/grain/grain", () => {
         -1,
         -0.5,
         0.33,
-        decimalPrecision + 1,
+        DECIMAL_PRECISION + 1,
         Infinity,
         -Infinity,
         NaN,
       ];
       for (const bad of badValues) {
-        expect(() => format(one, bad)).toThrowError("must be integer in range");
+        expect(() => format(ONE, bad)).toThrowError("must be integer in range");
       }
     });
   });


### PR DESCRIPTION
Improves readability of the code and makes it easy to understand that these are constants instead of parameters/variables

Test plan: This is a rename; verify that CI passes.