### PR TITLE
Add math helper methods to the `grain` module

### DIFF
--- a/src/grain/grain.js
+++ b/src/grain/grain.js
@@ -108,3 +108,36 @@ export function format(
   }
   return digits.join("") + suffix;
 }
+
+/**
+ * Multiply a grain amount by a floating point number.
+ *
+ * Use this method when you need to multiply a grain balance by a floating
+ * point number, e.g. a ratio.
+ *
+ * Note that this method is imprecise. It is not safe to assume, for example,
+ * that `multiply(g, 1/3) + multiply(g, 2/3) === g` due to loss of precision.
+ * However, the errors will be small in absolute terms (i.e. tiny compared to
+ * one full grain).
+ *
+ * See some messy analysis of the numerical errors here:
+ * https://observablehq.com/@decentralion/grain-arithmetic
+ */
+export function multiplyFloat(grain: Grain, num: number): Grain {
+  return BigInt(Math.floor(Number(grain) * num));
+}
+
+/**
+ * Aproximately create a grain balance from a float.
+ *
+ * This method tries to convert the floating point `amt` into a grain
+ * balance. For example, `grain(1)` approximately equals `ONE`.
+ *
+ * Do not assume this will be precise! For example, `grain(0.1337)` results in
+ * `133700000000000016n`. This method is intended for test code.
+ *
+ * This is a shorthand for `multiplyFloat(ONE, amt)`.
+ */
+export function fromFloat(f: number): Grain {
+  return multiplyFloat(ONE, f);
+}

--- a/src/grain/grain.test.js
+++ b/src/grain/grain.test.js
@@ -1,68 +1,64 @@
 // @flow
 
-import {format, ONE, DECIMAL_PRECISION, ZERO} from "./grain";
+import {
+  format,
+  ONE,
+  DECIMAL_PRECISION,
+  ZERO,
+  fromFloat,
+  multiplyFloat,
+} from "./grain";
 
 describe("src/grain/grain", () => {
   describe("format", () => {
     // $ExpectFlowError
-    const pointOne = ONE / 10n;
-    // $ExpectFlowError
-    const onePointFive = pointOne * 15n;
-    // $ExpectFlowError
     const almostOne = ONE - 1n;
-    // $ExpectFlowError
-    const fortyTwo = ONE * 42n;
-    // $ExpectFlowError
-    const negative = -1n;
-    // $ExpectFlowError
-    const leet = ONE * 1337n;
-    // $ExpectFlowError
-    const leetAndSpecial = leet * 1000n + fortyTwo + fortyTwo / 100n;
 
     it("correctly rounds to smallest integer when decimals==0", () => {
       expect(format(ZERO)).toEqual("0g");
-      expect(format(pointOne)).toEqual("0g");
+      expect(format(fromFloat(0.1))).toEqual("0g");
       expect(format(almostOne)).toEqual("0g");
       expect(format(ONE)).toEqual("1g");
-      expect(format(onePointFive)).toEqual("1g");
-      expect(format(fortyTwo)).toEqual("42g");
+      expect(format(fromFloat(1.5))).toEqual("1g");
+      expect(format(fromFloat(42))).toEqual("42g");
     });
     it("correctly adds comma formatting for large numbers", () => {
-      expect(format(leet)).toEqual("1,337g");
-      expect(format(leet, 1)).toEqual("1,337.0g");
-      expect(format(leet + pointOne)).toEqual("1,337g");
-      expect(format(leet + pointOne, 1)).toEqual("1,337.1g");
-      expect(format(leetAndSpecial, 0)).toEqual("1,337,042g");
-      expect(format(leetAndSpecial, 2)).toEqual("1,337,042.42g");
+      expect(format(fromFloat(1337))).toEqual("1,337g");
+      expect(format(fromFloat(1337), 1)).toEqual("1,337.0g");
+      expect(format(fromFloat(1337.11))).toEqual("1,337g");
+      expect(format(fromFloat(1337.11), 1)).toEqual("1,337.1g");
+      expect(format(fromFloat(1337042.42), 0)).toEqual("1,337,042g");
+      expect(format(fromFloat(1337042.42), 2)).toEqual("1,337,042.42g");
     });
     it("correctly handles negative numbers", () => {
-      expect(format(negative * pointOne)).toEqual("-0g");
-      expect(format(negative * onePointFive)).toEqual("-1g");
-      expect(format(negative * fortyTwo)).toEqual("-42g");
-      expect(format(negative * onePointFive, 1)).toEqual("-1.5g");
-      expect(format(negative * onePointFive, 1)).toEqual("-1.5g");
-      expect(format(negative * leetAndSpecial, 0)).toEqual("-1,337,042g");
-      expect(format(negative * leetAndSpecial, 2)).toEqual("-1,337,042.42g");
+      expect(format(fromFloat(-0.1))).toEqual("-0g");
+      expect(format(fromFloat(-1.5))).toEqual("-1g");
+      expect(format(fromFloat(-42))).toEqual("-42g");
+      expect(format(fromFloat(-1.5), 1)).toEqual("-1.5g");
+      expect(format(fromFloat(-1.5), 1)).toEqual("-1.5g");
+      expect(format(fromFloat(-1337042.42), 0)).toEqual("-1,337,042g");
+      expect(format(fromFloat(-1337042.42), 2)).toEqual("-1,337,042.42g");
     });
     it("handles full precision", () => {
       expect(format(ZERO, DECIMAL_PRECISION)).toEqual("0.000000000000000000g");
       expect(format(ONE, DECIMAL_PRECISION)).toEqual("1.000000000000000000g");
-      expect(format(pointOne, DECIMAL_PRECISION)).toEqual(
+      expect(format(fromFloat(0.1), DECIMAL_PRECISION)).toEqual(
         "0.100000000000000000g"
       );
       // $ExpectFlowError
       expect(format(-12345n, DECIMAL_PRECISION)).toEqual(
         "-0.000000000000012345g"
       );
-      expect(format(leetAndSpecial, DECIMAL_PRECISION)).toEqual(
+      // $ExpectFlowError
+      expect(format((ONE / 100n) * 133704242n, DECIMAL_PRECISION)).toEqual(
         "1,337,042.420000000000000000g"
       );
     });
     it("supports alternative suffixes", () => {
-      expect(format(onePointFive, 0, "SEEDS")).toEqual("1SEEDS");
-      expect(format(fortyTwo, 0, "SEEDS")).toEqual("42SEEDS");
-      expect(format(negative * onePointFive, 1, "SEEDS")).toEqual("-1.5SEEDS");
-      expect(format(negative * leetAndSpecial, 0, "SEEDS")).toEqual(
+      expect(format(fromFloat(1.5), 0, "SEEDS")).toEqual("1SEEDS");
+      expect(format(fromFloat(42), 0, "SEEDS")).toEqual("42SEEDS");
+      expect(format(fromFloat(-1.5), 1, "SEEDS")).toEqual("-1.5SEEDS");
+      expect(format(fromFloat(-1337042.42), 0, "SEEDS")).toEqual(
         "-1,337,042SEEDS"
       );
     });
@@ -79,6 +75,38 @@ describe("src/grain/grain", () => {
       for (const bad of badValues) {
         expect(() => format(ONE, bad)).toThrowError("must be integer in range");
       }
+    });
+  });
+
+  describe("multiplyFloat", () => {
+    it("behaves reasonably for tiny grain values", () => {
+      // $ExpectFlowError
+      expect(multiplyFloat(1n, 5)).toEqual(5n);
+    });
+    it("behaves reasonably for larger grain values", () => {
+      // $ExpectFlowError
+      expect(multiplyFloat(ONE, 2)).toEqual(2n * ONE);
+    });
+    it("has small error on large grain values", () => {
+      // To compare with arbitrary precision results, see:
+      // https://observablehq.com/@decentralion/grain-arithmetic
+
+      // Within 1 attoGrain of "true" value
+      // $ExpectFlowError
+      expect(multiplyFloat(ONE, 1 / 1337)).toEqual(747943156320119n);
+
+      // Within 300 attoGrain of "true" value
+      // $ExpectFlowError
+      expect(multiplyFloat(ONE, Math.PI)).toEqual(3141592653589793280n);
+    });
+  });
+  describe("fromFloat", () => {
+    it("fromFloat(1) === ONE", () => {
+      expect(fromFloat(1)).toEqual(ONE);
+    });
+    it("fromFloat(0.1) === ONE / 10", () => {
+      // $ExpectFlowError
+      expect(fromFloat(0.1)).toEqual(ONE / 10n);
     });
   });
 });


### PR DESCRIPTION
This commit adds two math helpers to the `grain` module:

`multiplyFloat` has a canonical way to multiply a grain amount by a
floating point number, which is useful e.g. if we need to multiply grain
amounts by cred ratios. For now, we have a naive approach which coerces
the grain into a float, does float multiplication, and then converts
back to grain.

This is imprecise, but in testing (see [notebook]) the absolute error
amounts are very small, i.e. in the atto-grain to femto-grain range.
Because we will be using this in conjunction with payout strategies that
implement explicit payment-error-correction over time (i.e. we calculate
who has been historically under-paid and give them more reward), these
insignificant errors will tend to disappear rather than accumulate over
time.

`fromFloat` is a helper method for creating a grain balance directly
from a float. It's basically an alias for `multiply(ONE, float)` and
is useful for test code.

Test plan: Unit tests included (and re-factored to use the new helpers).
See attached notebook for some exploration of error values.

[notebook]: https://observablehq.com/@decentralion/grain-arithmetic

Inspired by [this pull request review](https://github.com/sourcecred/sourcecred/pull/1709#pullrequestreview-376583943) by @hammadj.

Thanks to @wchargin for discussing grain multiplication with me at depth.