### PR TITLE
deps: upgrade Prettier to 2.0.1

### DIFF
--- a/config/test.js
+++ b/config/test.js
@@ -180,7 +180,7 @@ function makeTasks(
       deps: ["backend"],
     },
   ];
-  const tasks = (function() {
+  const tasks = (function () {
     switch (mode) {
       case "BASIC":
         return basicTasks;

--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
     "flow-bin": "^0.120.1",
     "jest": "^25.1.0",
     "jest-fetch-mock": "^3.0.2",
-    "prettier": "^1.19.1",
+    "prettier": "^2.0.1",
     "raf": "^3.4.1",
     "react-dev-utils": "^5.0.3",
     "static-site-generator-webpack-plugin": "^3.4.2",
@@ -90,7 +90,7 @@
   },
   "scripts": {
     "prettify": "prettier --write '**/*.js'",
-    "check-pretty": "prettier --list-different '**/*.js'",
+    "check-pretty": "prettier --list-different '**/*.js' || echo 'Failures OK during Prettier upgrade'",
     "start": "NODE_ENV=development webpack-dev-server --config config/webpack.config.web.js",
     "build": "NODE_ENV=production webpack --config config/webpack.config.web.js",
     "backend": "NODE_ENV=development webpack --config config/webpack.config.backend.js",

--- a/package.json
+++ b/package.json
@@ -90,7 +90,7 @@
   },
   "scripts": {
     "prettify": "prettier --write '**/*.js'",
-    "check-pretty": "prettier --list-different '**/*.js' || echo 'Failures OK during Prettier upgrade'",
+    "check-pretty": "prettier --list-different '**/*.js'",
     "start": "NODE_ENV=development webpack-dev-server --config config/webpack.config.web.js",
     "build": "NODE_ENV=production webpack --config config/webpack.config.web.js",
     "backend": "NODE_ENV=development webpack --config config/webpack.config.backend.js",

--- a/src/core/algorithm/nodeDistribution.test.js
+++ b/src/core/algorithm/nodeDistribution.test.js
@@ -49,11 +49,7 @@ describe("core/algorithm/nodeDistribution", () => {
       );
     });
     it("can create a uniform distribution if all weights are equal", () => {
-      const map = new Map()
-        .set(a, 1)
-        .set(b, 1)
-        .set(c, 1)
-        .set(d, 1);
+      const map = new Map().set(a, 1).set(b, 1).set(c, 1).set(d, 1);
       expect(weightedDistribution(order(), map)).toEqual(
         new Float64Array([0.25, 0.25, 0.25, 0.25])
       );

--- a/src/core/algorithm/timelinePagerank.test.js
+++ b/src/core/algorithm/timelinePagerank.test.js
@@ -57,11 +57,7 @@ describe("src/core/algorithm/timelinePagerank", () => {
       const b = node("b");
       const e1 = edge("e1", a, b);
       const e2 = edge("e2", a, a);
-      const graph = new Graph()
-        .addNode(a)
-        .addNode(b)
-        .addEdge(e1)
-        .addEdge(e2);
+      const graph = new Graph().addNode(a).addNode(b).addEdge(e1).addEdge(e2);
 
       function weightsToChain(
         w: Map<EdgeAddressT, EdgeWeight>

--- a/src/core/graph.test.js
+++ b/src/core/graph.test.js
@@ -36,10 +36,7 @@ describe("core/graph", () => {
   const loopEdge = edge("loop", src, src);
 
   const simpleGraph = () =>
-    new Graph()
-      .addNode(src)
-      .addNode(dst)
-      .addEdge(simpleEdge);
+    new Graph().addNode(src).addNode(dst).addEdge(simpleEdge);
 
   function sortNodes(nodes: Node[]): Node[] {
     return sortBy(nodes, (x) => x.address);
@@ -410,11 +407,7 @@ describe("core/graph", () => {
         const n3 = partsNode(["foo", "bar"]);
         const n4 = partsNode(["zod", "bar"]);
         const prefixGraph = () =>
-          new Graph()
-            .addNode(n1)
-            .addNode(n2)
-            .addNode(n3)
-            .addNode(n4);
+          new Graph().addNode(n1).addNode(n2).addNode(n3).addNode(n4);
         function expectEqualNodes(
           options: {|+prefix: NodeAddressT|} | void,
           expected: Node[]
@@ -490,10 +483,7 @@ describe("core/graph", () => {
           it("throws on conflicting edge", () => {
             const e1 = edge("1", src, dst);
             const e2 = edge("1", src, src);
-            const graph = new Graph()
-              .addNode(src)
-              .addNode(dst)
-              .addEdge(e1);
+            const graph = new Graph().addNode(src).addNode(dst).addEdge(e1);
             expect(() => graph.addEdge(e2)).toThrow(
               "conflict between new edge"
             );
@@ -513,10 +503,7 @@ describe("core/graph", () => {
               dst: dst.address,
               timestampMs: 1,
             };
-            const graph = new Graph()
-              .addNode(src)
-              .addNode(dst)
-              .addEdge(e1);
+            const graph = new Graph().addNode(src).addNode(dst).addEdge(e1);
             expect(() => graph.addEdge(e2)).toThrow(
               "conflict between new edge"
             );
@@ -779,11 +766,7 @@ describe("core/graph", () => {
         describe("with multiple loop edges", () => {
           const e1 = edge("e1", src, src);
           const e2 = edge("e2", src, src);
-          const quiver = () =>
-            new Graph()
-              .addNode(src)
-              .addEdge(e1)
-              .addEdge(e2);
+          const quiver = () => new Graph().addNode(src).addEdge(e1).addEdge(e2);
           it("adding multiple loop edges throws no error", () => {
             quiver();
           });
@@ -827,10 +810,7 @@ describe("core/graph", () => {
             expect(g.isDanglingEdge(simpleEdge.address)).toBe(true);
           });
           it("in the case where an edge ceased being dangling after being added", () => {
-            const g = new Graph()
-              .addEdge(simpleEdge)
-              .addNode(src)
-              .addNode(dst);
+            const g = new Graph().addEdge(simpleEdge).addNode(src).addNode(dst);
             expect(g.hasEdge(simpleEdge.address)).toBe(true);
             expect(Array.from(g.edges({showDangling: true}))).toEqual([
               simpleEdge,
@@ -1160,10 +1140,7 @@ describe("core/graph", () => {
       });
       it("adding an edge changes equality", () => {
         const g1 = new Graph().addNode(src).addNode(dst);
-        const g2 = new Graph()
-          .addNode(src)
-          .addNode(dst)
-          .addEdge(simpleEdge);
+        const g2 = new Graph().addNode(src).addNode(dst).addEdge(simpleEdge);
         expectEquality(g1, g2, false);
       });
       it("adding nodes in different order doesn't change equality", () => {
@@ -1172,10 +1149,7 @@ describe("core/graph", () => {
         expectEquality(g1, g2, true);
       });
       it("graphs with conflicting edges are not equal", () => {
-        const g1 = new Graph()
-          .addNode(src)
-          .addNode(dst)
-          .addEdge(simpleEdge);
+        const g1 = new Graph().addNode(src).addNode(dst).addEdge(simpleEdge);
         const g2 = new Graph()
           .addNode(src)
           .addNode(dst)
@@ -1247,10 +1221,7 @@ describe("core/graph", () => {
         expectCopyEqual(g);
       });
       it("graph with an edge", () => {
-        const g = new Graph()
-          .addNode(src)
-          .addNode(dst)
-          .addEdge(simpleEdge);
+        const g = new Graph().addNode(src).addNode(dst).addEdge(simpleEdge);
         expectCopyEqual(g);
       });
       it("graph with edge added and removed", () => {
@@ -1283,17 +1254,11 @@ describe("core/graph", () => {
       expect(g1.equals(g2)).toBe(false);
     });
     it("is identity on a singleton input", () => {
-      const graph = new Graph()
-        .addNode(foo)
-        .addNode(bar)
-        .addEdge(foobar);
+      const graph = new Graph().addNode(foo).addNode(bar).addEdge(foobar);
       expect(graph.equals(Graph.merge([graph]))).toBe(true);
     });
     it("merges two graphs with no intersection", () => {
-      const g1 = new Graph()
-        .addNode(foo)
-        .addNode(bar)
-        .addEdge(foobar);
+      const g1 = new Graph().addNode(foo).addNode(bar).addEdge(foobar);
       const g2 = new Graph().addNode(zod);
       const g3Actual = Graph.merge([g1, g2]);
       const g3Expected = new Graph()
@@ -1352,10 +1317,7 @@ describe("core/graph", () => {
       expect(merged.equals(expected)).toBe(true);
     });
     it("rejects graphs with conflicting edges", () => {
-      const g1 = new Graph()
-        .addNode(foo)
-        .addNode(zod)
-        .addEdge(zodfoo);
+      const g1 = new Graph().addNode(foo).addNode(zod).addEdge(zodfoo);
       const g2 = new Graph()
         .addNode(foo)
         .addNode(zod)
@@ -1562,10 +1524,7 @@ describe("core/graph", () => {
         expectCompose(g);
       });
       it("for a graph with nodes added and removed", () => {
-        const g = new Graph()
-          .addNode(src)
-          .addNode(dst)
-          .removeNode(src.address);
+        const g = new Graph().addNode(src).addNode(dst).removeNode(src.address);
         expectCompose(g);
       });
       it("a graph with a dangling edge added and removed", () => {
@@ -1615,10 +1574,7 @@ describe("core/graph", () => {
           .addEdge(simpleEdge)
           .removeEdge(simpleEdge.address)
           .addEdge(loopEdge);
-        const g2 = new Graph()
-          .addNode(src)
-          .addNode(dst)
-          .addEdge(loopEdge);
+        const g2 = new Graph().addNode(src).addNode(dst).addEdge(loopEdge);
         expectCanonicity(g1, g2);
       });
       it("for the advanced graph", () => {

--- a/src/core/trie.test.js
+++ b/src/core/trie.test.js
@@ -74,19 +74,13 @@ describe("core/trie", () => {
   });
 
   it("get isn't fazed by intermediary parts missing values", () => {
-    const x = new NodeTrie()
-      .add(fooBar, 2)
-      .add(fooBarZod, 3)
-      .add(empty, 0);
+    const x = new NodeTrie().add(fooBar, 2).add(fooBarZod, 3).add(empty, 0);
     // note there is no "foo" node
     expect(x.get(fooBarZod)).toEqual([0, 2, 3]);
   });
 
   it("getLast gets the last available value", () => {
-    const x = new NodeTrie()
-      .add(foo, 2)
-      .add(fooBar, 3)
-      .add(empty, 0);
+    const x = new NodeTrie().add(foo, 2).add(fooBar, 3).add(empty, 0);
     expect(x.getLast(fooBarZod)).toEqual(3);
   });
 
@@ -96,10 +90,7 @@ describe("core/trie", () => {
 
   it("overwriting a value is illegal", () => {
     expect(() =>
-      new NodeTrie()
-        .add(foo, 3)
-        .add(empty, 1)
-        .add(foo, 4)
+      new NodeTrie().add(foo, 3).add(empty, 1).add(foo, 4)
     ).toThrowError("overwrite");
   });
 

--- a/src/explorer/legacy/App.test.js
+++ b/src/explorer/legacy/App.test.js
@@ -110,12 +110,9 @@ describe("explorer/legacy/App", () => {
 
   it("should have a feedback link with a valid URL", () => {
     const {el} = example();
-    const link = el.find("Link").filterWhere((x) =>
-      x
-        .children()
-        .text()
-        .includes("feedback")
-    );
+    const link = el
+      .find("Link")
+      .filterWhere((x) => x.children().text().includes("feedback"));
     expect(link).toHaveLength(1);
     expect(link.prop("href")).toMatch(/https?:\/\//);
   });

--- a/src/explorer/legacy/pagerankTable/Connection.test.js
+++ b/src/explorer/legacy/pagerankTable/Connection.test.js
@@ -209,12 +209,7 @@ describe("explorer/legacy/pagerankTable/Connection", () => {
       const {cvForConnection, syntheticConnection} = await setup();
       const view = cvForConnection(syntheticConnection);
       expect(view.find("span")).toHaveLength(0);
-      expect(
-        view
-          .find("Badge")
-          .children()
-          .text()
-      ).toEqual("synthetic loop");
+      expect(view.find("Badge").children().text()).toEqual("synthetic loop");
     });
   });
 });

--- a/src/explorer/legacy/pagerankTable/Table.test.js
+++ b/src/explorer/legacy/pagerankTable/Table.test.js
@@ -94,10 +94,7 @@ describe("explorer/legacy/pagerankTable/Table", () => {
       it("with expected label text", async () => {
         const {element} = await setup();
         const label = element.find("label");
-        const filterText = label
-          .find("span")
-          .first()
-          .text();
+        const filterText = label.find("span").first().text();
         expect(filterText).toMatchSnapshot();
       });
       it("with expected option groups", async () => {

--- a/src/explorer/legacy/pagerankTable/TableRow.test.js
+++ b/src/explorer/legacy/pagerankTable/TableRow.test.js
@@ -98,9 +98,7 @@ describe("explorer/legacy/pagerankTable/TableRow", () => {
   it("can display literal text in the multiuseColumn", () => {
     const index = COLUMNS().indexOf("");
     expect(index).not.toEqual(-1);
-    const td = example()
-      .find("td")
-      .at(index);
+    const td = example().find("td").at(index);
     expect(td.text()).toEqual("50.00%");
   });
   it("displays general react nodes in the multiuseColumn", () => {
@@ -115,17 +113,13 @@ describe("explorer/legacy/pagerankTable/TableRow", () => {
   it("displays formatted cred in the correct column", () => {
     const index = COLUMNS().indexOf("Cred");
     expect(index).not.toEqual(-1);
-    const td = example()
-      .find("td")
-      .at(index);
+    const td = example().find("td").at(index);
     expect(td.text()).toEqual("133.70");
   });
   it("displays the description in the correct column", () => {
     const index = COLUMNS().indexOf("Description");
     expect(index).not.toEqual(-1);
-    const td = example()
-      .find("td")
-      .at(index);
+    const td = example().find("td").at(index);
     expect(td.find({"data-test-description": true})).toHaveLength(1);
   });
   it("doesn't create extra padding rows if showPadding=false", () => {

--- a/src/explorer/weights/WeightSlider.test.js
+++ b/src/explorer/weights/WeightSlider.test.js
@@ -42,22 +42,12 @@ describe("explorer/weights/WeightSlider", () => {
     it("prints the provided weight", () => {
       for (const w of exampleWeights) {
         const {element} = example(w);
-        expect(
-          element
-            .find("span")
-            .at(1)
-            .text()
-        ).toBe(formatWeight(w));
+        expect(element.find("span").at(1).text()).toBe(formatWeight(w));
       }
     });
     it("displays the provided name", () => {
       const {element} = example(0);
-      expect(
-        element
-          .find("span")
-          .at(0)
-          .text()
-      ).toBe("foo");
+      expect(element.find("span").at(0).text()).toBe("foo");
     });
     it("changes to the slider trigger the onChange with the corresponding weight", () => {
       const sliderVals = [MIN_SLIDER, 0, MAX_SLIDER];
@@ -71,12 +61,9 @@ describe("explorer/weights/WeightSlider", () => {
     });
     it("has a description tooltip", () => {
       const {element} = example(0);
-      expect(
-        element
-          .find("label")
-          .at(0)
-          .prop("title")
-      ).toBe("A test description");
+      expect(element.find("label").at(0).prop("title")).toBe(
+        "A test description"
+      );
     });
     it("the weight and slider position may be inconsistent", () => {
       // If the weight does not correspond to an integer slider value, then

--- a/src/graphql/generateFlowTypes.js
+++ b/src/graphql/generateFlowTypes.js
@@ -129,9 +129,7 @@ export default function generateFlowTypes(
         const rhs =
           Object.keys(type.clauses).length === 0
             ? "empty"
-            : Object.keys(type.clauses)
-                .sort()
-                .join(" | ");
+            : Object.keys(type.clauses).sort().join(" | ");
         definitions.push(`export type ${typename} = ${rhs};`);
         break;
       }

--- a/src/graphql/mirror.test.js
+++ b/src/graphql/mirror.test.js
@@ -234,10 +234,7 @@ describe("graphql/mirror", () => {
         expect(rowId).toEqual(1);
         expect(+date).toBe(12345); // please don't mutate the date...
         expect(
-          db
-            .prepare("SELECT time_epoch_millis FROM updates")
-            .pluck()
-            .all()
+          db.prepare("SELECT time_epoch_millis FROM updates").pluck().all()
         ).toEqual([12345]);
       });
       it("returns distinct results regardless of timestamps", () => {
@@ -252,10 +249,7 @@ describe("graphql/mirror", () => {
         expect(uid2).not.toEqual(uid3);
         expect(uid3).not.toEqual(uid1);
         expect(
-          db
-            .prepare("SELECT COUNT(1) FROM updates")
-            .pluck()
-            .get()
+          db.prepare("SELECT COUNT(1) FROM updates").pluck().get()
         ).toEqual(3);
       });
     });

--- a/src/graphql/queries.js
+++ b/src/graphql/queries.js
@@ -197,9 +197,7 @@ export function multilineLayout(tab: string): LayoutStrategy {
   function strategy(indentLevel: number) {
     return {
       atom: (line: string) => {
-        const indentation = Array(indentLevel)
-          .fill(tab)
-          .join("");
+        const indentation = Array(indentLevel).fill(tab).join("");
         return indentation + line;
       },
       join: (xs: string[]) => xs.join("\n"),

--- a/src/homepage/App.js
+++ b/src/homepage/App.js
@@ -17,7 +17,7 @@ export default class App extends React.Component<{|
       <Router
         history={history}
         routes={createRoutes(routeData)}
-        onUpdate={function() {
+        onUpdate={function () {
           const router = this;
           const path: string = router.state.location.pathname;
           document.title = resolveTitleFromPath(routeData, path);

--- a/src/plugins/discourse/mirrorRepository.js
+++ b/src/plugins/discourse/mirrorRepository.js
@@ -377,10 +377,7 @@ export class SqliteMirrorRepository
   }
 
   users(): $ReadOnlyArray<string> {
-    return this._db
-      .prepare("SELECT username FROM users")
-      .pluck()
-      .all();
+    return this._db.prepare("SELECT username FROM users").pluck().all();
   }
 
   findUsername(username: string): ?string {

--- a/src/plugins/github/relationalView.js
+++ b/src/plugins/github/relationalView.js
@@ -473,7 +473,7 @@ export class RelationalView {
     parent: IssueAddress | PullAddress | ReviewAddress,
     json: T.IssueComment | T.PullRequestReviewComment
   ): CommentAddress {
-    const id = (function() {
+    const id = (function () {
       switch (parent.type) {
         case N.ISSUE_TYPE:
           return issueCommentUrlToId(json.url);

--- a/src/util/compat.test.js
+++ b/src/util/compat.test.js
@@ -116,7 +116,7 @@ describe("util/compat", () => {
       }
       fromJSON(json: any): OuterV1 {
         return fromCompat({type: "outer", version: v1}, json, {
-          [v1]: function(x) {
+          [v1]: function (x) {
             return new OuterV1(InnerV2.fromJSON(x.platypus));
           },
         });
@@ -137,10 +137,10 @@ describe("util/compat", () => {
       }
       static fromJSON(json: any): OuterV2 {
         return fromCompat({type: "outer", version: v2}, json, {
-          [v1]: function(x) {
+          [v1]: function (x) {
             return new OuterV2(InnerV2.fromJSON(x.platypus));
           },
-          [v2]: function(x) {
+          [v2]: function (x) {
             return new OuterV2(InnerV2.fromJSON(x.inner));
           },
         });

--- a/src/util/map.test.js
+++ b/src/util/map.test.js
@@ -119,16 +119,10 @@ describe("util/map", () => {
       input.set(3, "three");
       output.set(4, "four");
       expect(input).toEqual(
-        new Map()
-          .set(1, "one")
-          .set(2, "two")
-          .set(3, "three")
+        new Map().set(1, "one").set(2, "two").set(3, "three")
       );
       expect(output).toEqual(
-        new Map()
-          .set(1, "one")
-          .set(2, "two")
-          .set(4, "four")
+        new Map().set(1, "one").set(2, "two").set(4, "four")
       );
     });
     it("allows upcasting the key and value types of the result map", () => {
@@ -273,10 +267,7 @@ describe("util/map", () => {
       const b = new Map().set("b", 2);
       const c = new Map().set("c", 3);
       expect(MapUtil.merge([a, b, c])).toEqual(
-        new Map()
-          .set("a", 1)
-          .set("b", 2)
-          .set("c", 3)
+        new Map().set("a", 1).set("b", 2).set("c", 3)
       );
     });
     it("treats empty map as an identity", () => {

--- a/src/util/taskReporter.js
+++ b/src/util/taskReporter.js
@@ -34,7 +34,7 @@ export class LoggingTaskReporter implements TaskReporter {
     this._consoleLog = consoleLog || console.log;
     this._getTime =
       getTime ||
-      function() {
+      function () {
         return +new Date();
       };
     this.activeTasks = new Map();

--- a/src/util/taskReporter.test.js
+++ b/src/util/taskReporter.test.js
@@ -73,10 +73,7 @@ describe("util/taskReporter", () => {
     });
     it("errors when finishing a task twice", () => {
       const fail = () =>
-        new TestCase()
-          .start("foo")
-          .finish("foo")
-          .finish("foo");
+        new TestCase().start("foo").finish("foo").finish("foo");
       expect(fail).toThrowError("task foo not registered");
     });
 
@@ -120,10 +117,7 @@ describe("util/taskReporter", () => {
     });
     it("errors when finishing a task twice", () => {
       const fail = () =>
-        new TestTaskReporter()
-          .start("foo")
-          .finish("foo")
-          .finish("foo");
+        new TestTaskReporter().start("foo").finish("foo").finish("foo");
       expect(fail).toThrow("task foo not active");
     });
     it("errors when finishing an unstarted test", () => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -7114,10 +7114,10 @@ prelude-ls@~1.1.2:
   resolved "https://registry.yarnpkg.com/prelude-ls/-/prelude-ls-1.1.2.tgz#21932a549f5e52ffd9a827f570e04be62a97da54"
   integrity sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ=
 
-prettier@^1.19.1:
-  version "1.19.1"
-  resolved "https://registry.yarnpkg.com/prettier/-/prettier-1.19.1.tgz#f7d7f5ff8a9cd872a7be4ca142095956a60797cb"
-  integrity sha512-s7PoyDv/II1ObgQunCbB9PdLmUcBZcnWOcxDh7O0N/UwDEsHyqkW+Qh28jW+mVuCdx7gLB0BotYI1Y6uI9iyew==
+prettier@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.0.1.tgz#3f00ac71263be34684b2b2c8d7e7f63737592dac"
+  integrity sha512-piXGBcY1zoFOG0MvHpNE5reAGseLmaCRifQ/fmfF49BcYkInEs/naD/unxGNAeOKFA5+JxVrPyMvMlpzcd20UA==
 
 pretty-format@^25.1.0:
   version "25.1.0"


### PR DESCRIPTION
This is done as three commits so that we can tell Git to ignore the
middle commit (a pure reformat) when showing blame. (A follow-up PR will
create the appropriate `.git-blame-ignore-revs` file; we need to know
the commit hash to do that, which will only be known after this PR is
rebased and merged.)

Closes #1716.
