### PR TITLE
blame: ignore reformattings due to Prettier 2.0.1

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -10,10 +10,11 @@
 # replacing `COMMIT_HASH` with the appropriate hash, or pass similar
 # formatting to `git log`, etc.
 #
-# To teach your Git client to read this file, run
+# To use this file, ensure that you have Git 2.23 or later installed,
+# then configure your repository to teach it about this file:
 #
 #     git config blame.ignoreRevsFile .git-blame-ignore-revs
 #
-# (with Git 2.23+). See `git help blame` `git help config` for details.
+# See `git help blame` or `git help config` for details.
 
 421aded196eb40c1dd3ec103bedc48d13111fa98  # prettier: reformat code for 2.0.1

--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,19 @@
+# List of commits that `git blame` should ignore.
+#
+# Include ONLY commits that are known to be no-ops, like automated
+# reformattings.
+#
+# To properly format an entry, run
+#
+#     git show --no-patch --format='%H  # %s' COMMIT_HASH
+#
+# replacing `COMMIT_HASH` with the appropriate hash, or pass similar
+# formatting to `git log`, etc.
+#
+# To teach your Git client to read this file, run
+#
+#     git config blame.ignoreRevsFile .git-blame-ignore-revs
+#
+# (with Git 2.23+). See `git help blame` `git help config` for details.
+
+421aded196eb40c1dd3ec103bedc48d13111fa98  # prettier: reformat code for 2.0.1


### PR DESCRIPTION
Summary:
This commit introduces an `ignoreRevsFile` for use with Git blame. See
the header of the new file for details.

Test Plan:
Run `git blame -L183,183 config/test.js`. Before this change, note that
it blames to the reformatting commit. After this change, and after
configuring `git config blame.ignoreRevsFile .git-blame-ignore-revs`,
note that it blames to the last real change.

wchargin-branch: prettier-2.0.1-unblame