### PR TITLE
Eslint, warn on prefer-const rule

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -21,6 +21,7 @@ module.exports = {
     "plugin:flowtype/recommended",
   ],
   rules: {
+    "prefer-const": ["warn"],
     camelcase: ["error", {properties: "never", allow: ["^_unused_.*"]}],
     eqeqeq: ["error", "always", {null: "ignore"}],
     "no-unused-vars": [

--- a/src/core/algorithm/markovChain.js
+++ b/src/core/algorithm/markovChain.js
@@ -203,7 +203,7 @@ export function findStationaryDistribution(
   params: PagerankParams,
   options: PagerankOptions
 ): Promise<StationaryDistributionResult> {
-  let gen = findStationaryDistributionGenerator(params, {
+  const gen = findStationaryDistributionGenerator(params, {
     verbose: options.verbose,
     convergenceThreshold: options.convergenceThreshold,
     maxIterations: options.maxIterations,

--- a/src/explorer/legacy/pagerankTable/Table.test.js
+++ b/src/explorer/legacy/pagerankTable/Table.test.js
@@ -84,7 +84,7 @@ describe("explorer/legacy/pagerankTable/Table", () => {
         const {element} = await setup();
         findButton(element).simulate("click");
         findButton(element).simulate("click");
-        let button = findButton(element);
+        const button = findButton(element);
         expect(button.text()).toEqual("Show weight configuration");
         expect(element.find({"data-test-weight-config": true})).toHaveLength(0);
       });

--- a/src/plugins/git/edges.js
+++ b/src/plugins/git/edges.js
@@ -75,7 +75,7 @@ function lengthDecode(
 }
 function multiLengthDecode(x: $ReadOnlyArray<string>, fail: () => Error) {
   let remaining = x;
-  let partses = [];
+  const partses = [];
   while (remaining.length > 0) {
     const {parts, rest} = lengthDecode(remaining, fail);
     partses.push(parts);

--- a/src/plugins/github/edges.js
+++ b/src/plugins/github/edges.js
@@ -177,7 +177,7 @@ function lengthDecode(
 }
 function multiLengthDecode(x: $ReadOnlyArray<string>, fail: () => Error) {
   let remaining = x;
-  let partses = [];
+  const partses = [];
   while (remaining.length > 0) {
     const {parts, rest} = lengthDecode(remaining, fail);
     partses.push(parts);

--- a/src/plugins/github/relationalView.test.js
+++ b/src/plugins/github/relationalView.test.js
@@ -299,7 +299,7 @@ describe("plugins/github/relationalView", () => {
       }
       function commitChain(n: number): T.Commit[] {
         let head = wrapCommit(0, []);
-        let results = [head];
+        const results = [head];
         for (let i = 1; i < n; i++) {
           head = wrapCommit(i, [head]);
           results.push(head);
@@ -307,7 +307,7 @@ describe("plugins/github/relationalView", () => {
         return results;
       }
       const commits = commitChain(COMMIT_CHAIN_LENGTH);
-      let pullRequests: T.PullRequest[] = [];
+      const pullRequests: T.PullRequest[] = [];
       function pullRequest(
         prNumber: number,
         mergeCommit: T.Commit


### PR DESCRIPTION
Based on an idea from https://github.com/sourcecred/sourcecred/pull/1697#discussion_r397734818

"This rule is aimed at flagging variables that are declared using let
keyword, but never reassigned after the initial assignment."
https://eslint.org/docs/rules/prefer-const

This is a rule that helps you spot mistakes while writing code with a
let statement. When thinking that you will need to reassign it, eslint
will point out you're not actually doing so.

This could be because you've forgotten something, assigned the wrong
variable, or no longer need to reassign.