### PR TITLE
Fix: added missing await keywords in storeProject

### DIFF
--- a/src/backend/dataDirectory.js
+++ b/src/backend/dataDirectory.js
@@ -45,18 +45,18 @@ export class DataDirectory implements CacheProvider, ProjectStorageProvider {
       const fileName = path.join(projectDirectory, name);
       await fs.writeFile(fileName, data);
     };
-    writeFile("project.json", stringify(projectToJSON(project)));
+    await writeFile("project.json", stringify(projectToJSON(project)));
     if (weightedGraph) {
-      writeFile(
+      await writeFile(
         "weightedGraph.json",
         stringify(WeightedGraph.toJSON(weightedGraph))
       );
     }
     if (cred) {
-      writeFile("cred.json", stringify(cred.toJSON()));
+      await writeFile("cred.json", stringify(cred.toJSON()));
     }
     if (pluginDeclarations) {
-      writeFile(
+      await writeFile(
         "pluginDeclarations.json",
         stringify(pluginsToJSON(pluginDeclarations))
       );


### PR DESCRIPTION
Though we don't return any value, we should wait till we've completed
the file I/O. This likely caused the flake from #1655. As we didn't
await the write, it caused a race condition where we tried to read first.

Fixes: #1655

Test plan: existing tests + manual review.

There's not a good way to reliably reproduce this race condition, without introducing artificial delays to the `storeProject` function. Writing larger test data could reproduce this issue, but is not a guarantee.