### PR TITLE
Discord: remove roles from GuildMember type

### DIFF
--- a/src/plugins/discord/fetcher.js
+++ b/src/plugins/discord/fetcher.js
@@ -83,7 +83,6 @@ export class Fetcher {
         bot: x.user.bot || x.user.system || false,
       },
       nick: x.nick || null,
-      roles: x.roles,
     }));
     const hasNextPage = results.length === membersLimit;
     const endCursor =

--- a/src/plugins/discord/fetcher.test.js
+++ b/src/plugins/discord/fetcher.test.js
@@ -80,7 +80,6 @@ describe("plugins/discord/fetcher", () => {
         bot: true,
       },
       nick: "nickname",
-      roles: ["test role"],
     });
 
     const options = () => ({

--- a/src/plugins/discord/models.js
+++ b/src/plugins/discord/models.js
@@ -74,7 +74,6 @@ export type User = {|
 export type GuildMember = {|
   +user: User,
   +nick: string | null,
-  +roles: $ReadOnlyArray<Snowflake>,
 |};
 
 // From the Discord docs: "emoji takes the form of name:id for


### PR DESCRIPTION
Removes `roles` as a property of `GuildMember` because the use
case is not clear at this point in time.

Test Plan: Yarn Test passes. `git grep -i "roles"` also returns an
empty result.