### PR TITLE
Add BigInt to eslint globals

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -45,4 +45,7 @@ module.exports = {
       version: "detect",
     },
   },
+  globals: {
+    BigInt: "readonly",
+  },
 };

--- a/src/grain/grain.js
+++ b/src/grain/grain.js
@@ -1,7 +1,5 @@
 // @flow
 
-/* global BigInt */
-
 /**
  * This module contains the types for tracking Grain, which is the native
  * project-specific, cred-linked token created in SourceCred instances. In


### PR DESCRIPTION
Test Plan: grep for global BigInt and make sure there's no longer
instances in code files now that we added it to central ESLint Config

Paired with @decentralion