### PR TITLE
Initiatives: use core/references' URL type

### DIFF
--- a/src/plugins/initiatives/initiative.js
+++ b/src/plugins/initiatives/initiative.js
@@ -1,10 +1,9 @@
 // @flow
 
+import {type URL} from "../../core/references";
 import {type NodeAddressT, NodeAddress} from "../../core/graph";
 import {type NodeWeight} from "../../core/weights";
 import {initiativeNodeType} from "./declaration";
-
-export type URL = string;
 
 // Composite ID, used as input for NodeAddressT.
 export opaque type InitiativeId = string[];

--- a/src/plugins/initiatives/initiativesDirectory.js
+++ b/src/plugins/initiatives/initiativesDirectory.js
@@ -3,6 +3,7 @@
 import path from "path";
 import fs from "fs-extra";
 import globby from "globby";
+import {type URL} from "../../core/references";
 import {type NodeAddressT, NodeAddress} from "../../core/graph";
 import {type Compatible, fromCompat, toCompat} from "../../util/compat";
 import {compatReader} from "../../backend/compatIO";
@@ -16,7 +17,6 @@ import {
   type InitiativeWeight,
   type InitiativeId,
   type InitiativeRepository,
-  type URL,
   createId,
   addressFromId,
 } from "./initiative";


### PR DESCRIPTION
Depends on #1744, as the Discourse features imported this.

The URL type used by Initiatives was added before reference detection was
fully fleshed out. Since we'll use this reference detection, we'll use
it's URL type as well.

Test plan: `yarn test` still works