### PR TITLE
Add `legacyConverter` module for the grain ledger

### DIFF
--- a/src/grain/legacyConverter.js
+++ b/src/grain/legacyConverter.js
@@ -1,0 +1,145 @@
+// @flow
+
+import {
+  type DistributionV1,
+  type ImmediateV1,
+  type LifetimeV1,
+} from "./distribution";
+import {type TransferV1} from "./ledger";
+import {type Alias, resolveAlias} from "../plugins/identity/alias";
+import type {LedgerEvent} from "./ledger";
+import {type Grain, ONE, ZERO} from "./grain";
+
+type LegacyInterval = {|+startTimeMs: number, +endTimeMs: number|};
+type LegacyPayment = {|+alias: string, +fast: number, +slow: number|};
+type LegacyDistribution = {|
+  +interval: LegacyInterval,
+  +payments: $ReadOnlyArray<LegacyPayment>,
+|};
+type LegacyTransfer = {|
+  +from: Alias,
+  +to: Alias,
+  +amount: number,
+  +timestamp: number,
+  +references: $ReadOnlyArray<string>,
+|};
+
+export function convertLegacyEvents(
+  legacyDistributions: $ReadOnlyArray<LegacyDistribution>,
+  legacyTransfers: $ReadOnlyArray<LegacyTransfer>,
+  discourseUrl: string
+): $ReadOnlyArray<LedgerEvent> {
+  const distributionPairs = legacyDistributions.map((x) =>
+    convertLegacyDistribution(x, discourseUrl)
+  );
+  const distributions = [].concat(...distributionPairs);
+  const transactions = legacyTransfers.map((x) =>
+    convertLegacyTransfer(x, discourseUrl)
+  );
+  return zipperEvents(distributions, transactions);
+}
+
+export function zipperEvents(
+  distributions: $ReadOnlyArray<DistributionV1>,
+  transfers: $ReadOnlyArray<TransferV1>
+): LedgerEvent[] {
+  let dIndex = 0;
+  let tIndex = 0;
+  const result = [];
+  while (dIndex < distributions.length || tIndex < transfers.length) {
+    const pushTx =
+      dIndex === distributions.length ||
+      (tIndex < transfers.length &&
+        // if the transaction and distribution have equal timestamp, then
+        // we conservatively push the distribution first.
+        transfers[tIndex].timestampMs < distributions[dIndex].timestampMs);
+    if (pushTx) {
+      result.push(transfers[tIndex]);
+      tIndex++;
+    } else {
+      result.push(distributions[dIndex]);
+      dIndex++;
+    }
+  }
+  return result;
+}
+
+function convertLegacyGrainRepresentation(x: number): Grain {
+  // The legacy variant tracks grain as integer centi-grain, so we can
+  // multiply it by the full grain representation and then divide by 100.
+  // $ExpectFlowError
+  return (BigInt(x) * ONE) / 100n;
+}
+
+// Convert a legacy distribution event into two new-style distribution
+// events. One weird property of this is that the budget will be the
+// actual amount distributed, not the intended budget, i.e. if due to rounding
+// we distributed 4999 grain off a 5000 budget, we'll retroactively see the
+// budget as having been 4999. I don't think this is a problem.
+export function convertLegacyDistribution(
+  x: LegacyDistribution,
+  discourseUrl: string | null
+): [DistributionV1, DistributionV1] {
+  const timestampMs = x.interval.endTimeMs;
+  const immediateReceipts = [];
+  let immediateBudget = ZERO;
+  const lifetimeReceipts = [];
+  let lifetimeBudget = ZERO;
+  for (const {alias, fast, slow} of x.payments) {
+    const address = resolveAlias(alias, discourseUrl);
+    const immediate = convertLegacyGrainRepresentation(fast);
+    const lifetime = convertLegacyGrainRepresentation(slow);
+    immediateBudget += immediate;
+    lifetimeBudget += lifetime;
+    if (immediate > ZERO) {
+      immediateReceipts.push({address, amount: immediate});
+    }
+    if (lifetime > ZERO) {
+      lifetimeReceipts.push({address, amount: lifetime});
+    }
+  }
+  const immediateStrategy: ImmediateV1 = {
+    type: "IMMEDIATE",
+    version: 1,
+    budget: immediateBudget,
+  };
+  const lifetimeStrategy: LifetimeV1 = {
+    type: "LIFETIME",
+    version: 1,
+    budget: lifetimeBudget,
+  };
+  const immediateDistribution: DistributionV1 = {
+    type: "DISTRIBUTION",
+    timestampMs,
+    version: 1,
+    strategy: immediateStrategy,
+    receipts: immediateReceipts,
+  };
+  const lifetimeDistribution: DistributionV1 = {
+    type: "DISTRIBUTION",
+    timestampMs,
+    version: 1,
+    strategy: lifetimeStrategy,
+    receipts: lifetimeReceipts,
+  };
+  return [immediateDistribution, lifetimeDistribution];
+}
+
+export function convertLegacyTransfer(
+  x: LegacyTransfer,
+  discourseUrl: string | null
+): TransferV1 {
+  const memo = x.references.join(", ");
+  const sender = resolveAlias(x.from, discourseUrl);
+  const recipient = resolveAlias(x.to, discourseUrl);
+  const amount = convertLegacyGrainRepresentation(x.amount);
+  return {
+    type: "TRANSFER",
+    version: 1,
+    sender,
+    recipient,
+    amount,
+    timestampMs: x.timestamp,
+    memo,
+  };
+}

--- a/src/grain/legacyConverter.test.js
+++ b/src/grain/legacyConverter.test.js
@@ -1,0 +1,136 @@
+// @flow
+
+import deepFreeze from "deep-freeze";
+import {fromApproximateFloat, ONE, ZERO} from "./grain";
+import {loginAddress as githubAddress} from "../plugins/github/nodes";
+import {identityAddress} from "../plugins/identity/identity";
+import {userAddress as discourseAddress} from "../plugins/discourse/address";
+import {
+  convertLegacyDistribution,
+  convertLegacyTransfer,
+  zipperEvents,
+  convertLegacyEvents,
+} from "./legacyConverter";
+
+describe("src/grain/legacyConverter", () => {
+  const exampleUrl = "https://example.com";
+  const githubFoo = githubAddress("foo");
+  const sourcecredBar = identityAddress("bar");
+  const discourseZod = discourseAddress(exampleUrl, "zod");
+
+  const legacyDistribution = deepFreeze({
+    interval: {startTimeMs: 123, endTimeMs: 456},
+    payments: [
+      {alias: "github/foo", fast: 100, slow: 200},
+      {alias: "sourcecred/bar", fast: 500, slow: 0},
+    ],
+  });
+  const expectedImmediate = deepFreeze({
+    type: "DISTRIBUTION",
+    strategy: {
+      type: "IMMEDIATE",
+      budget: fromApproximateFloat(6),
+      version: 1,
+    },
+    version: 1,
+    timestampMs: 456,
+    receipts: [
+      {address: githubFoo, amount: fromApproximateFloat(1)},
+      {address: sourcecredBar, amount: fromApproximateFloat(5)},
+    ],
+  });
+  const expectedLifetime = deepFreeze({
+    type: "DISTRIBUTION",
+    strategy: {
+      type: "LIFETIME",
+      budget: fromApproximateFloat(2),
+      version: 1,
+    },
+    version: 1,
+    timestampMs: 456,
+    receipts: [{address: githubFoo, amount: fromApproximateFloat(2)}],
+  });
+  const legacyTransfer = deepFreeze({
+    from: "sourcecred/bar",
+    to: "discourse/zod",
+    amount: 100,
+    timestamp: 555,
+    references: ["hello there", "my friend"],
+  });
+  const expectedTransfer = deepFreeze({
+    sender: sourcecredBar,
+    recipient: discourseZod,
+    amount: ONE,
+    timestampMs: 555,
+    memo: "hello there, my friend",
+    type: "TRANSFER",
+    version: 1,
+  });
+  describe("convertLegacyDistribution", function () {
+    it("should work on a representative case", function () {
+      expect(
+        convertLegacyDistribution(legacyDistribution, exampleUrl)
+      ).toEqual([expectedImmediate, expectedLifetime]);
+    });
+  });
+  describe("convertLegacyTransfer", function () {
+    it("should work on a representative case", () => {
+      expect(convertLegacyTransfer(legacyTransfer, exampleUrl)).toEqual(
+        expectedTransfer
+      );
+    });
+  });
+  describe("zipperEvents", () => {
+    function dx(timestampMs: number) {
+      return deepFreeze({
+        type: "DISTRIBUTION",
+        version: 1,
+        receipts: [],
+        strategy: {type: "IMMEDIATE", budget: ZERO, version: 1},
+        timestampMs,
+      });
+    }
+    function tx(timestampMs: number) {
+      return deepFreeze({
+        type: "TRANSFER",
+        version: 1,
+        recipient: sourcecredBar,
+        sender: sourcecredBar,
+        amount: ZERO,
+        timestampMs,
+        memo: "",
+      });
+    }
+    const d1 = dx(1);
+    const d2 = dx(2);
+    const d3 = dx(3);
+    const t2 = tx(2);
+    const t3 = tx(3);
+
+    it("should work on empty events", function () {
+      expect(zipperEvents([], [])).toEqual([]);
+    });
+    it("should work when there are only distributions", function () {
+      expect(zipperEvents([d1], [])).toEqual([d1]);
+    });
+    it("should work when there are only transfers", function () {
+      expect(zipperEvents([], [t2])).toEqual([t2]);
+    });
+    it("should merge in timestamp order, with distributions first", function () {
+      expect(zipperEvents([d1, d2, d3], [t2, t3])).toEqual([
+        d1,
+        d2,
+        t2,
+        d3,
+        t3,
+      ]);
+    });
+  });
+  describe("convertLegacyEvents", () => {
+    it("works on a representative case", () => {
+      expect(
+        convertLegacyEvents([legacyDistribution], [legacyTransfer], exampleUrl)
+      ).toEqual([expectedImmediate, expectedLifetime, expectedTransfer]);
+    });
+  });
+});


### PR DESCRIPTION
As part of the CredSperiment, we currently track grain distributions and
transfers in a very ad-hoc format in [sourcecred/cred][1]. This commit
adds a formal specification of that ad-hoc type, and tested logic for
converting from that type to our new event format. Once we complete this
conversion, we can throw this code away.

Test plan: `yarn test`, since I added nice unit tests.