### PR TITLE
Initiatives: add declaration for NodeEntry types and edges

### DIFF
--- a/src/plugins/initiatives/declaration.test.js
+++ b/src/plugins/initiatives/declaration.test.js
@@ -1,0 +1,13 @@
+// @flow
+
+import {_formatNodeEntryField} from "./declaration";
+
+describe("plugins/initiatives/declaration", () => {
+  describe("_formatNodeEntryField", () => {
+    it("should work given the various fields", () => {
+      expect(_formatNodeEntryField("CONTRIBUTION")).toEqual("Contribution");
+      expect(_formatNodeEntryField("DEPENDENCY")).toEqual("Dependency");
+      expect(_formatNodeEntryField("REFERENCE")).toEqual("Reference");
+    });
+  });
+});


### PR DESCRIPTION
Depends on #1753 

Adds a new NodeType for each NodeEntryField. Allowing multipliers to be
set per field.

Since the "contributes to" edge is very generic and created a naming
conflict, this includes a slightly awkward "contributes to entry" addition.
Including "entry" to differentiate from the existing edge type.

Test plan:
- `yarn test` for basic errors.
- Manually loading a project with initiatives.
(Need to learn sharness for a full test case)
- `yarn start` to validate the explorer includes the new plugin definition.

The edge weights for this loosely follow the current edge weight rationale. When we've merged enough functionality to do in-browser testing of different weights with an example scenario, I think we should revisit them.