### PR TITLE
mirror: remove unnecessary query parameter

### DIFF
--- a/src/graphql/mirror.js
+++ b/src/graphql/mirror.js
@@ -593,7 +593,7 @@ export class Mirror {
           `
         )
         .pluck()
-        .all({timeEpochMillisThreshold: +since});
+        .all();
       const objects: $PropertyType<QueryPlan, "objects"> = db
         .prepare(
           dedent`\


### PR DESCRIPTION
Summary:
In `_findOutdated`, we bound a query parameter that was not used by the
query. This is entirely harmless, but should still be fixed.

Test Plan:
That unit tests continue to pass suffices.

wchargin-branch: mirror-findoutdated-superfluous-param