### PR TITLE
deps: upgrade `better-sqlite3@^7.0.0`

### DIFF
--- a/flow-typed/npm/better-sqlite3_vx.x.x.js
+++ b/flow-typed/npm/better-sqlite3_vx.x.x.js
@@ -1,5 +1,5 @@
-// flow-typed signature: 946429b216273f6ed9345df0294cfd25
-// flow-typed version: <<STUB>>/better-sqlite3_v4.1.4/flow_v0.77.0
+// flow-typed signature: eb0227169323c50fa1a5b34a9f938e98
+// flow-typed version: <<STUB>>/better-sqlite3_v7.0.0/flow_v0.120.1
 
 declare class bettersqlite3$Database {
   +memory: boolean;
@@ -49,9 +49,11 @@ declare type bettersqlite3$Database$RegisterOptions = {
 // values. In the case that a user provides multiple binding
 // dictionaries, better-sqlite3 will fail fast with a TypeError.
 //
-// Also note that better-sqlite3 permits binding `Integer.IntLike` from
-// npm/integer, not just `number`, but we don't have those typedefs. For
-// now, `number` is a good approximation.
+// Also note that better-sqlite3 permits binding and returning `BigInt`s
+// rather than `number`s, but Flow doesn't support `BigInt`s. As long as
+// `defaultSafeIntegers` is not set and the user code never itself
+// provides `BigInt`s, using `number` alone is a good enough
+// approximation.
 declare type bettersqlite3$BoundValue = number | string | Buffer | null;
 declare type bettersqlite3$BindingDictionary = {
   +[string]: bettersqlite3$BoundValue

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "dependencies": {
     "aphrodite": "^2.4.0",
     "base64url": "^3.0.1",
-    "better-sqlite3": "^6.0.1",
+    "better-sqlite3": "^7.0.0",
     "bottleneck": "^2.19.5",
     "chalk": "^3.0.0",
     "commonmark": "^0.29.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1813,13 +1813,12 @@ bcrypt-pbkdf@^1.0.0:
   dependencies:
     tweetnacl "^0.14.3"
 
-better-sqlite3@^6.0.1:
-  version "6.0.1"
-  resolved "https://registry.yarnpkg.com/better-sqlite3/-/better-sqlite3-6.0.1.tgz#391f827c119fbc4e92b1d4969c558f07c17c5c15"
-  integrity sha512-4aV1zEknM9g1a6B0mVBx1oIlmYioEJ8gSS3J6EpN1b1bKYEE+N5lmpmXHKNKTi0qjHziSd7XrXwHl1kpqvEcHQ==
+better-sqlite3@^7.0.0:
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/better-sqlite3/-/better-sqlite3-7.0.0.tgz#13e0840e7ed9f66f3f2205b072d63dab932ece15"
+  integrity sha512-3i3r8djWlZyjF5IEhc0oJhJP726Vh1zK3w6BBvMgWNDolA6Qbq/gHx5/Eu3JlHbLYsa5UpIKBsT4PzxaZZpC9A==
   dependencies:
     bindings "^1.5.0"
-    integer "^3.0.1"
     prebuild-install "^5.3.3"
     tar "4.4.10"
 
@@ -4786,14 +4785,6 @@ inquirer@^7.0.0:
     string-width "^4.1.0"
     strip-ansi "^6.0.0"
     through "^2.3.6"
-
-integer@^3.0.1:
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/integer/-/integer-3.0.1.tgz#49b17f2543e7fd3f606f5bcc968be7a9c4690f73"
-  integrity sha512-OqtER6W2GIJTIcnT5o2B/pWGgvurnVOYs4OZCgay40QEIbMTnNq4R0KSaIw1TZyFtPWjm5aNM+pBBMTfc3exmw==
-  dependencies:
-    bindings "^1.5.0"
-    prebuild-install "^5.3.3"
 
 internal-ip@^4.3.0:
   version "4.3.0"
@@ -8062,7 +8053,7 @@ schema-utils@^1.0.0:
     ajv-errors "^1.0.0"
     ajv-keywords "^3.1.0"
 
-schema-utils@^2.5.0, schema-utils@^2.6.0:
+schema-utils@^2.6.0:
   version "2.6.4"
   resolved "https://registry.yarnpkg.com/schema-utils/-/schema-utils-2.6.4.tgz#a27efbf6e4e78689d91872ee3ccfa57d7bdd0f53"
   integrity sha512-VNjcaUxVnEeun6B2fiiUDjXXBtD4ZSH7pdbfIu1pOFwgptDPLMo/z9jr4sUfsjFVPqDCEin/F7IYlq7/E6yDbQ==


### PR DESCRIPTION
Summary:
Notably, this includes a Jest compatibility improvement:
<https://github.com/JoshuaWise/better-sqlite3/issues/162#issuecomment-619401380>

Test Plan:
Existing unit tests pass.

wchargin-branch: better-sqlite3-v7.0.0