### PR TITLE
Enable address to alias conversion

### DIFF
--- a/src/plugins/identity/alias.test.js
+++ b/src/plugins/identity/alias.test.js
@@ -1,9 +1,10 @@
 // @flow
 
-import {resolveAlias} from "./alias";
+import {resolveAlias, toAlias} from "./alias";
 import {loginAddress as githubAddress} from "../github/nodes";
 import {userAddress as discourseAddress} from "../discourse/address";
 import {identityAddress} from "./identity";
+import {NodeAddress} from "../../core/graph";
 
 describe("src/plugins/identity/alias", () => {
   describe("resolveAlias", () => {
@@ -88,6 +89,25 @@ describe("src/plugins/identity/alias", () => {
         const b = resolveAlias("sourcecred/@example", null);
         expect(a).toEqual(b);
       });
+    });
+  });
+  describe("toAlias", () => {
+    function checkRoundTrip(alias) {
+      const addr = resolveAlias(alias, "https://example.com");
+      expect(toAlias(addr)).toEqual(alias);
+    }
+    it("works for a GitHub node address", () => {
+      checkRoundTrip("github/example");
+    });
+    it("works for a Discourse node address", () => {
+      checkRoundTrip("discourse/example");
+    });
+    it("works for a identity node address", () => {
+      checkRoundTrip("sourcecred/example");
+    });
+    it("returns null for an address without an aliasing scheme", () => {
+      const address = NodeAddress.fromParts(["sourcecred", "plugin", "foo"]);
+      expect(toAlias(address)).toEqual(null);
     });
   });
 });


### PR DESCRIPTION
This commit updates the alias module so that we may convert node
addresses into aliases. Naturally, the node address needs to be some
kind of user node address that is known to the aliasing scheme.

It's a big in-elegant that this creates a "hidden" integration point for
plugins, where plugins creating new user node types should add hardcoded
logic into the identity plugin's alias system. However, it is a
convenience and we currently use this system, so I'm just going to add
this functionality for now, and think about how the alias system should
work long term (or whether we should phase it out) for another
discussion.

This is needed for #1773.

I have `toAlias` return `null` when the address doesn't correspond to a
known aliasing scheme, rather than erroring. I think erroring would be
too harsh, given that it's quite possible that the user has loaded
third-party plugins that haven't registered aliasing schemes upstream
with us. In that case, the application should make a best effort attempt
to proceed without an alias (e.g. fallback to the full address), for
robustness.

Test plan: Unit tests included; `yarn test` passes.