### PR TITLE
Upgrade flow-bin

### DIFF
--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
     "eslint-plugin-jsx-a11y": "^6.2.3",
     "eslint-plugin-react": "7.16.0",
     "file-loader": "^6.0.0",
-    "flow-bin": "^0.120.1",
+    "flow-bin": "^0.124.0",
     "jest": "^26.0.1",
     "jest-fetch-mock": "^3.0.2",
     "prettier": "^2.0.1",

--- a/src/plugins/github/nodes.test.js
+++ b/src/plugins/github/nodes.test.js
@@ -64,8 +64,8 @@ describe("plugins/github/nodes", () => {
 
   // Incorrect types should be caught statically, either due to being
   // totally invalid...
-  // $ExpectFlowError
   const _unused_badRepo: GN.RepoAddress = {
+    // $ExpectFlowError
     type: "REPOSITORY",
     owner: "foo",
     name: "bar",

--- a/src/util/map.test.js
+++ b/src/util/map.test.js
@@ -295,6 +295,7 @@ describe("util/map", () => {
       // $ExpectFlowError
       const _unused_badMap: Map<string, number> = MapUtil.merge([
         numberMap,
+        // $ExpectFlowError
         stringMap,
       ]);
     });

--- a/src/webutil/createRelativeHistory.test.js
+++ b/src/webutil/createRelativeHistory.test.js
@@ -12,7 +12,7 @@ import createRelativeHistory from "./createRelativeHistory";
 require("./testUtil").configureEnzyme();
 
 describe("webutil/createRelativeHistory", () => {
-  function createHistory(basename, path) {
+  function createHistory(basename: string, path: string) {
     const memoryHistory = createMemoryHistory(path);
     const relativeHistory = createRelativeHistory(memoryHistory, basename);
     return {memoryHistory, relativeHistory};
@@ -46,10 +46,13 @@ describe("webutil/createRelativeHistory", () => {
         );
       });
       it("should require a basename", () => {
-        // $ExpectFlowError
-        expect(() => createHistory(undefined, "undefined/")).toThrow(
-          "basename: expected string, got: undefined"
-        );
+        expect(() =>
+          createHistory(
+            // $ExpectFlowError
+            undefined,
+            "undefined/"
+          )
+        ).toThrow("basename: expected string, got: undefined");
       });
       it("should reject a basename that does not start with a slash", () => {
         expect(() =>

--- a/yarn.lock
+++ b/yarn.lock
@@ -4170,10 +4170,10 @@ flatted@^2.0.0:
   resolved "https://registry.yarnpkg.com/flatted/-/flatted-2.0.2.tgz#4575b21e2bcee7434aa9be662f4b7b5f9c2b5138"
   integrity sha512-r5wGx7YeOwNWNlCA0wQ86zKyDLMQr+/RB8xy74M4hTphfmjlijTSSXGuH8rnvKZnfT9i+75zmd8jcKdMR4O6jA==
 
-flow-bin@^0.120.1:
-  version "0.120.1"
-  resolved "https://registry.yarnpkg.com/flow-bin/-/flow-bin-0.120.1.tgz#ab051d6df71829b70a26a2c90bb81f9d43797cae"
-  integrity sha512-KgE+d+rKzdXzhweYVJty1QIOOZTTbtnXZf+4SLnmArLvmdfeLreQOZpeLbtq5h79m7HhDzX/HkUkoyu/fmSC2A==
+flow-bin@^0.124.0:
+  version "0.124.0"
+  resolved "https://registry.yarnpkg.com/flow-bin/-/flow-bin-0.124.0.tgz#24b2e55874e1e2041f9247f42473b3db2ef32758"
+  integrity sha512-KEtDJ7CFUjcuhw6N52FTZshDd1krf1fxpp4APSIrwhVm+IrlcKJ+EMXpeXKM1kKNSZ347dYGh8wEvXQl4pHZEA==
 
 flush-write-stream@^1.0.0:
   version "1.1.1"


### PR DESCRIPTION
~~Continues from #1785~~
Closes #1711

Versions >= v0.121.0 require more specific suppression comments. Which caused the issues in #1711. See https://github.com/facebook/flow/releases/tag/v0.121.0

Test plan: `yarn flow`