### PR TITLE
Release: bump version to 0.5.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sourcecred",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "private": false,
   "dependencies": {
     "aphrodite": "^2.4.0",

--- a/src/core/version.js
+++ b/src/core/version.js
@@ -60,7 +60,7 @@ const environment = parseEnvironment(process.env.NODE_ENV);
 
 export const VERSION_INFO: VersionInfo = deepFreeze({
   major: 0,
-  minor: 4,
+  minor: 5,
   patch: 0,
   gitState,
   environment,


### PR DESCRIPTION
Depends on #1785, #1786 

**Please consider this PR a release review / sign off to publish v0.5.0.**

See tracking issue #1679 for release notes.
Links to documentation: https://github.com/sourcecred/sourcecred/issues/1679#issuecomment-625335274.

When merged, the resulting commit should be tagged, published and released as `v0.5.0`.

Test plan:
Manually check `1. Preparation` steps in #1679 have been completed.

```sh
yarn backend
node bin/sourcecred.js --version
```
Produces `sourcecred v0.5.0`
