### PR TITLE
Adopt a less restrictive TimestampMs type

### DIFF
--- a/src/core/graph.js
+++ b/src/core/graph.js
@@ -6,6 +6,7 @@ import deepFreeze from "deep-freeze";
 import {makeAddressModule, type AddressModule} from "./address";
 import {toCompat, fromCompat, type Compatible} from "../util/compat";
 import * as NullUtil from "../util/null";
+import {type TimestampMs} from "../util/timestamp";
 
 /**
  * This module contains the Graph, which is one of the most fundamental pieces
@@ -130,7 +131,7 @@ export type Node = {|
   // Should be null for a "timeless" node, where we don't
   // want to model that node as having been created at any particular
   // point in time. User nodes are a good example of this.
-  +timestampMs: number | null,
+  +timestampMs: TimestampMs | null,
 |};
 
 /**
@@ -140,7 +141,7 @@ export type Edge = {|
   +address: EdgeAddressT,
   +src: NodeAddressT,
   +dst: NodeAddressT,
-  +timestampMs: number,
+  +timestampMs: TimestampMs,
 |};
 
 const COMPAT_INFO = {type: "sourcecred/graph", version: "0.8.0"};
@@ -182,13 +183,13 @@ type Integer = number;
 type IndexedNodeJSON = {|
   +index: Integer,
   +description: string,
-  +timestampMs: number | null,
+  +timestampMs: TimestampMs | null,
 |};
 type IndexedEdgeJSON = {|
   +address: AddressJSON,
   +srcIndex: Integer,
   +dstIndex: Integer,
-  +timestampMs: number,
+  +timestampMs: TimestampMs,
 |};
 
 export type GraphJSON = Compatible<{|
@@ -1187,7 +1188,7 @@ export function edgeToStrings(
   +address: string,
   +src: string,
   +dst: string,
-  +timestampMs: number,
+  +timestampMs: TimestampMs,
 |} {
   return {
     address: EdgeAddress.toString(edge.address),
@@ -1203,7 +1204,7 @@ export function edgeToParts(
   +addressParts: string[],
   +srcParts: string[],
   +dstParts: string[],
-  +timestampMs: number,
+  +timestampMs: TimestampMs,
 |} {
   const addressParts = EdgeAddress.toParts(edge.address);
   const srcParts = NodeAddress.toParts(edge.src);

--- a/src/core/interval.js
+++ b/src/core/interval.js
@@ -4,6 +4,7 @@ import {max, min} from "d3-array";
 import sortBy from "../util/sortBy";
 import {utcWeek} from "d3-time";
 import * as NullUtil from "../util/null";
+import type {TimestampMs} from "../util/timestamp";
 import type {Node, Edge, Graph} from "./graph";
 
 /**
@@ -13,8 +14,8 @@ import type {Node, Edge, Graph} from "./graph";
  * start of the older interval.
  */
 export type Interval = {|
-  +startTimeMs: number,
-  +endTimeMs: number,
+  +startTimeMs: TimestampMs,
+  +endTimeMs: TimestampMs,
 |};
 
 /**
@@ -30,7 +31,7 @@ export type GraphInterval = {|
 
 export type GraphIntervalPartition = $ReadOnlyArray<GraphInterval>;
 
-type TimefulNode = {|...Node, timestampMs: number|};
+type TimefulNode = {|...Node, timestampMs: TimestampMs|};
 
 /**
  * Partition a graph based on time intervals.

--- a/src/plugins/discord/models.js
+++ b/src/plugins/discord/models.js
@@ -1,5 +1,6 @@
 // @flow
 
+import {type TimestampMs} from "../../util/timestamp";
 // https://discordapp.com/developers/docs/reference#snowflakes
 export type Snowflake = string;
 export const ZeroSnowflake: Snowflake = "0";
@@ -124,7 +125,7 @@ export type Message = {|
   +authorId: Snowflake,
   // Could be a message from a webhook, meaning the authorId isn't a user.
   +nonUserAuthor: boolean,
-  +timestampMs: number,
+  +timestampMs: TimestampMs,
   +content: string,
   // Normally includes reaction counters, but we don't care about counters.
   // We could filter based on which types of emoji have been added though.

--- a/src/plugins/discourse/fetch.js
+++ b/src/plugins/discourse/fetch.js
@@ -13,6 +13,7 @@
 import fetch from "isomorphic-fetch";
 import Bottleneck from "bottleneck";
 import * as NullUtil from "../../util/null";
+import {type TimestampMs} from "../../util/timestamp";
 
 export type UserId = number;
 export type PostId = number;
@@ -30,7 +31,7 @@ export type TopicView = {|
   +id: TopicId,
   +categoryId: CategoryId,
   +title: string,
-  +timestampMs: number,
+  +timestampMs: TimestampMs,
   +authorUsername: string,
 |};
 
@@ -45,7 +46,7 @@ export type TopicLatest = {|
   +id: TopicId,
   +categoryId: CategoryId,
   +title: string,
-  +timestampMs: number,
+  +timestampMs: TimestampMs,
   +bumpedMs: number,
 |};
 
@@ -66,7 +67,7 @@ export type Post = {|
   // reply to. Will be `null` if this post was the first post, or if it was a
   // reply to the first post.
   +replyToPostIndex: number | null,
-  +timestampMs: number,
+  +timestampMs: TimestampMs,
   +authorUsername: string,
   // The post HTML for rendering.
   +cooked: string,
@@ -83,7 +84,7 @@ export type LikeAction = {|
   +username: string,
   // The post being liked
   +postId: PostId,
-  +timestampMs: number,
+  +timestampMs: TimestampMs,
 |};
 
 /**

--- a/src/plugins/discourse/mirrorRepository.js
+++ b/src/plugins/discourse/mirrorRepository.js
@@ -11,6 +11,7 @@ import type {
   Post,
   LikeAction,
 } from "./fetch";
+import {type TimestampMs} from "../../util/timestamp";
 
 // The version should be bumped any time the database schema is changed,
 // so that the cache will be properly invalidated.
@@ -129,7 +130,7 @@ export interface MirrorRepository extends ReadRepository {
   /**
    * Bumps the definitionCheckMs (from SyncHeads) to the provided timestamp.
    */
-  bumpDefinitionTopicCheck(timestampMs: number): void;
+  bumpDefinitionTopicCheck(timestampMs: TimestampMs): void;
 }
 
 function toAddResult({
@@ -417,7 +418,7 @@ export class SqliteMirrorRepository
       .get({topic_id: topicId, index_within_topic: indexWithinTopic});
   }
 
-  bumpDefinitionTopicCheck(timestampMs: number): void {
+  bumpDefinitionTopicCheck(timestampMs: TimestampMs): void {
     this._db
       .prepare(
         dedent`\

--- a/src/plugins/git/edges.js
+++ b/src/plugins/git/edges.js
@@ -8,6 +8,7 @@ import {
   NodeAddress,
 } from "../../core/graph";
 import * as GitNode from "./nodes";
+import {type TimestampMs} from "../../util/timestamp";
 
 export opaque type RawAddress: EdgeAddressT = EdgeAddressT;
 
@@ -39,7 +40,7 @@ export const createEdge = deepFreeze({
   hasParent: (
     child: GitNode.CommitAddress,
     parent: GitNode.CommitAddress,
-    timestampMs: number
+    timestampMs: TimestampMs
   ): Edge => ({
     address: toRaw({type: HAS_PARENT_TYPE, child, parent}),
     src: GitNode.toRaw(child),

--- a/src/plugins/github/edges.js
+++ b/src/plugins/github/edges.js
@@ -13,6 +13,7 @@ import {
   type ReactionContent,
   ReactionContent$Values as Reactions,
 } from "./graphqlTypes";
+import {type TimestampMs} from "../../util/timestamp";
 
 export opaque type RawAddress: EdgeAddressT = EdgeAddressT;
 
@@ -87,7 +88,7 @@ export const createEdge = deepFreeze({
   authors: (
     author: GithubNode.UserlikeAddress,
     content: GithubNode.AuthorableAddress,
-    timestampMs: number
+    timestampMs: TimestampMs
   ): Edge => ({
     address: toRaw({type: AUTHORS_TYPE, author, content}),
     src: GithubNode.toRaw(author),
@@ -97,7 +98,7 @@ export const createEdge = deepFreeze({
   mergedAs: (
     pull: GithubNode.PullAddress,
     commit: GithubNode.CommitAddress,
-    timestampMs: number
+    timestampMs: TimestampMs
   ): Edge => ({
     address: toRaw({type: MERGED_AS_TYPE, pull}),
     src: GithubNode.toRaw(pull),
@@ -107,7 +108,7 @@ export const createEdge = deepFreeze({
   correspondsToCommit: (
     githubCommit: GithubNode.CommitAddress,
     gitCommit: GitNode.CommitAddress,
-    timestampMs: number
+    timestampMs: TimestampMs
   ): Edge => ({
     address: toRaw({type: CORRESPONDS_TO_COMMIT_TYPE, githubCommit}),
     src: GithubNode.toRaw(githubCommit),
@@ -117,7 +118,7 @@ export const createEdge = deepFreeze({
   hasParent: (
     child: GithubNode.ChildAddress,
     parent: GithubNode.ParentAddress,
-    timestampMs: number
+    timestampMs: TimestampMs
   ): Edge => ({
     address: toRaw({type: HAS_PARENT_TYPE, child}),
     src: GithubNode.toRaw(child),
@@ -127,7 +128,7 @@ export const createEdge = deepFreeze({
   references: (
     referrer: GithubNode.TextContentAddress,
     referent: GithubNode.ReferentAddress,
-    timestampMs: number
+    timestampMs: TimestampMs
   ): Edge => ({
     address: toRaw({type: REFERENCES_TYPE, referrer, referent}),
     src: GithubNode.toRaw(referrer),
@@ -138,7 +139,7 @@ export const createEdge = deepFreeze({
     reactionType: ReactionContent,
     user: GithubNode.UserlikeAddress,
     reactable: GithubNode.ReactableAddress,
-    timestampMs: number
+    timestampMs: TimestampMs
   ): Edge => ({
     address: toRaw({
       type: REACTS_TYPE,

--- a/src/plugins/github/relationalView.js
+++ b/src/plugins/github/relationalView.js
@@ -7,6 +7,7 @@ import stringify from "json-stable-stringify";
 import {parseReferences} from "./parseReferences";
 import * as N from "./nodes";
 import dedent from "../../util/dedent";
+import {type TimestampMs} from "../../util/timestamp";
 
 // Workaround for https://github.com/facebook/flow/issues/6538
 import type {
@@ -734,7 +735,7 @@ export class RelationalView {
 type ReactionRecord = {|
   +content: T.ReactionContent,
   +user: UserlikeAddress,
-  +timestampMs: number,
+  +timestampMs: TimestampMs,
 |};
 
 type Entry =
@@ -775,7 +776,7 @@ type RepoEntry = {|
   +url: string,
   +issues: IssueAddress[],
   +pulls: PullAddress[],
-  +timestampMs: number,
+  +timestampMs: TimestampMs,
 |};
 
 export class Repo extends _Entity<RepoEntry> {
@@ -819,7 +820,7 @@ type IssueEntry = {|
   +comments: CommentAddress[],
   +authors: UserlikeAddress[],
   +reactions: ReactionRecord[],
-  +timestampMs: number,
+  +timestampMs: TimestampMs,
 |};
 
 export class Issue extends _Entity<IssueEntry> {
@@ -878,7 +879,7 @@ type PullEntry = {|
   +deletions: number,
   +authors: UserlikeAddress[],
   +reactions: ReactionRecord[],
-  +timestampMs: number,
+  +timestampMs: TimestampMs,
 |};
 
 export class Pull extends _Entity<PullEntry> {
@@ -947,7 +948,7 @@ type ReviewEntry = {|
   +comments: CommentAddress[],
   +state: T.PullRequestReviewState,
   +authors: UserlikeAddress[],
-  +timestampMs: number,
+  +timestampMs: TimestampMs,
 |};
 
 export class Review extends _Entity<ReviewEntry> {
@@ -994,7 +995,7 @@ type CommentEntry = {|
   +url: string,
   +authors: UserlikeAddress[],
   +reactions: ReactionRecord[],
-  +timestampMs: number,
+  +timestampMs: TimestampMs,
 |};
 
 export class Comment extends _Entity<CommentEntry> {
@@ -1048,7 +1049,7 @@ type CommitEntry = {|
   +hash: string,
   +authors: UserlikeAddress[],
   +message: string,
-  +timestampMs: number,
+  +timestampMs: TimestampMs,
 |};
 
 export class Commit extends _Entity<CommitEntry> {

--- a/src/util/timestamp.js
+++ b/src/util/timestamp.js
@@ -9,7 +9,7 @@
  */
 
 // A timestamp representation in ms since epoch.
-export opaque type TimestampMs: number = number;
+export type TimestampMs = number;
 
 // A timestamp representation in ISO 8601 format.
 export opaque type TimestampISO: string = string;


### PR DESCRIPTION
This commit modifies the TimestampMs type so that it is no longer
opaque, which means that use of the `toNumber` function is no longer
enforced. This is because `toNumber` adds very little safety (I don't
believe it would have ever triggered, or caught any bugs, across the
history of the codebase), and needing to call a function every time we
make an example in test code is very tedious.

Thanks to this change, it becomes easy to roll out the TimestampMs type
across the codebase, which improve the legibility of our types. I found
replacement candidates by grepping for `timestampMs: number`, and
replaced all such usages.

Test plan: `yarn test` and `git grep "timestampMs: number"`. The only
hit is within the timestamp module itself.