### PR TITLE
Refactor TimelineCredScores data type

### DIFF
--- a/src/analysis/timeline/timelineCred.js
+++ b/src/analysis/timeline/timelineCred.js
@@ -209,12 +209,12 @@ export class TimelineCred {
     const addressToCred = new Map();
     for (let i = 0; i < nodeOrder.length; i++) {
       const addr = nodeOrder[i];
-      const addrCred = credScores.intervalCredScores.map((cred) => cred[i]);
+      const addrCred = credScores.map(({cred}) => cred[i]);
       addressToCred.set(addr, addrCred);
     }
     return new TimelineCred(
       weightedGraph,
-      credScores.intervals,
+      credScores.map((x) => x.interval),
       addressToCred,
       fullParams,
       plugins

--- a/src/core/algorithm/distributionToCred.test.js
+++ b/src/core/algorithm/distributionToCred.test.js
@@ -21,16 +21,16 @@ describe("src/core/algorithm/distributionToCred", () => {
       ];
       const nodeOrder = [na("foo"), na("bar")];
       const actual = distributionToCred(ds, nodeOrder, [NodeAddress.empty]);
-      const expected = {
-        intervals: [
-          {startTimeMs: 0, endTimeMs: 10},
-          {startTimeMs: 10, endTimeMs: 20},
-        ],
-        intervalCredScores: [
-          new Float64Array([1, 1]),
-          new Float64Array([9, 1]),
-        ],
-      };
+      const expected = [
+        {
+          interval: {startTimeMs: 0, endTimeMs: 10},
+          cred: new Float64Array([1, 1]),
+        },
+        {
+          interval: {startTimeMs: 10, endTimeMs: 20},
+          cred: new Float64Array([9, 1]),
+        },
+      ];
       expect(expected).toEqual(actual);
     });
     it("correctly handles multiple scoring prefixes", () => {
@@ -48,16 +48,16 @@ describe("src/core/algorithm/distributionToCred", () => {
       ];
       const nodeOrder = [na("foo"), na("bar")];
       const actual = distributionToCred(ds, nodeOrder, [na("foo"), na("bar")]);
-      const expected = {
-        intervals: [
-          {startTimeMs: 0, endTimeMs: 10},
-          {startTimeMs: 10, endTimeMs: 20},
-        ],
-        intervalCredScores: [
-          new Float64Array([1, 1]),
-          new Float64Array([9, 1]),
-        ],
-      };
+      const expected = [
+        {
+          interval: {startTimeMs: 0, endTimeMs: 10},
+          cred: new Float64Array([1, 1]),
+        },
+        {
+          interval: {startTimeMs: 10, endTimeMs: 20},
+          cred: new Float64Array([9, 1]),
+        },
+      ];
       expect(expected).toEqual(actual);
     });
     it("works in a case where some nodes are scoring", () => {
@@ -75,16 +75,16 @@ describe("src/core/algorithm/distributionToCred", () => {
       ];
       const nodeOrder = [na("foo"), na("bar")];
       const actual = distributionToCred(ds, nodeOrder, [na("bar")]);
-      const expected = {
-        intervals: [
-          {startTimeMs: 0, endTimeMs: 10},
-          {startTimeMs: 10, endTimeMs: 20},
-        ],
-        intervalCredScores: [
-          new Float64Array([2, 2]),
-          new Float64Array([90, 10]),
-        ],
-      };
+      const expected = [
+        {
+          interval: {startTimeMs: 0, endTimeMs: 10},
+          cred: new Float64Array([2, 2]),
+        },
+        {
+          interval: {startTimeMs: 10, endTimeMs: 20},
+          cred: new Float64Array([90, 10]),
+        },
+      ];
       expect(expected).toEqual(actual);
     });
     it("handles the case where no nodes are scoring", () => {
@@ -97,10 +97,12 @@ describe("src/core/algorithm/distributionToCred", () => {
       ];
       const nodeOrder = [na("foo"), na("bar")];
       const actual = distributionToCred(ds, nodeOrder, []);
-      const expected = {
-        intervals: [{startTimeMs: 0, endTimeMs: 10}],
-        intervalCredScores: [new Float64Array([0, 0])],
-      };
+      const expected = [
+        {
+          interval: {startTimeMs: 0, endTimeMs: 10},
+          cred: new Float64Array([0, 0]),
+        },
+      ];
       expect(actual).toEqual(expected);
     });
 
@@ -114,18 +116,17 @@ describe("src/core/algorithm/distributionToCred", () => {
       ];
       const nodeOrder = [na("foo"), na("bar")];
       const actual = distributionToCred(ds, nodeOrder, [na("bar")]);
-      const expected = {
-        intervals: [{startTimeMs: 0, endTimeMs: 10}],
-        intervalCredScores: [new Float64Array([0, 0])],
-      };
+      const expected = [
+        {
+          interval: {startTimeMs: 0, endTimeMs: 10},
+          cred: new Float64Array([0, 0]),
+        },
+      ];
       expect(actual).toEqual(expected);
     });
 
     it("returns empty CredScores if no intervals are present", () => {
-      expect(distributionToCred([], [], [])).toEqual({
-        intervals: [],
-        intervalCredScores: [],
-      });
+      expect(distributionToCred([], [], [])).toEqual([]);
     });
   });
   describe("to/from JSON", () => {
@@ -155,30 +156,30 @@ describe("src/core/algorithm/distributionToCred", () => {
         Array [
           Object {
             "type": "sourcecred/timelineCredScores",
-            "version": "0.1.0",
+            "version": "0.2.0",
           },
-          Object {
-            "intervalCredScores": Array [
-              Array [
+          Array [
+            Object {
+              "cred": Array [
                 2,
                 2,
               ],
-              Array [
-                90,
-                10,
-              ],
-            ],
-            "intervals": Array [
-              Object {
+              "interval": Object {
                 "endTimeMs": 10,
                 "startTimeMs": 0,
               },
-              Object {
+            },
+            Object {
+              "cred": Array [
+                90,
+                10,
+              ],
+              "interval": Object {
                 "endTimeMs": 20,
                 "startTimeMs": 10,
               },
-            ],
-          },
+            },
+          ],
         ]
       `);
     });


### PR DESCRIPTION
This commit refactors the TimelineCredScores data type so it is an
array-of-objects rather than an object-of-arrays. I want to add several
more fields (for forward cred flow, backwards cred flow, seed flow,
synthetic loop flow), and feel it will be a lot cleaner with an
array-of-objects.

This is a refactor of a local data type, and there's test coverage.
Likelihood of regression is very low.

Test plan: Updated tests; `yarn test` passes.