### PR TITLE
cli2: add skeleton

### DIFF
--- a/config/paths.js
+++ b/config/paths.js
@@ -30,6 +30,7 @@ module.exports = {
   // point within the build directory.
   backendEntryPoints: {
     sourcecred: resolveApp("src/cli/main.js"),
+    sc2: resolveApp("src/cli2/main.js"),
     //
     generateGithubGraphqlFlowTypes: resolveApp(
       "src/plugins/github/bin/generateGraphqlFlowTypes.js"

--- a/src/cli2/command.js
+++ b/src/cli2/command.js
@@ -1,0 +1,3 @@
+// @flow
+
+export * from "../cli/command";

--- a/src/cli2/main.js
+++ b/src/cli2/main.js
@@ -1,0 +1,23 @@
+// @flow
+
+import {handlingErrors} from "./command";
+import sourcecred from "./sourcecred";
+
+require("../tools/entry");
+
+export default function main(): Promise<void> {
+  return handlingErrors(sourcecred)(process.argv.slice(2), {
+    out: (x) => console.log(x),
+    err: (x) => console.error(x),
+  }).then((exitCode) => {
+    process.exitCode = exitCode;
+  });
+}
+
+// Only run in the Webpack bundle, not as a Node module (during tests).
+/* istanbul ignore next */
+/*:: declare var __webpack_require__: mixed; */
+// eslint-disable-next-line camelcase
+if (typeof __webpack_require__ !== "undefined") {
+  main();
+}

--- a/src/cli2/sourcecred.js
+++ b/src/cli2/sourcecred.js
@@ -1,5 +1,4 @@
 // @flow
-// Implementation of the root `sourcecred` command.
 
 import type {Command} from "./command";
 

--- a/src/cli2/sourcecred.js
+++ b/src/cli2/sourcecred.js
@@ -1,0 +1,11 @@
+// @flow
+// Implementation of the root `sourcecred` command.
+
+import type {Command} from "./command";
+
+const sourcecred: Command = async (args, std) => {
+  std.err("SourceCred CLI v2 not yet implemented");
+  return 1;
+};
+
+export default sourcecred;


### PR DESCRIPTION
Summary:
This patch creates a new binary, `./bin/sc2`, which will be the home for
a rewrite of the CLI intended to implement an instance system. See:
<https://discourse.sourcecred.io/t/sourcecred-instance-system/244>

Paired with @decentralion.

Test Plan:
Run `yarn backend && node ./bin/sc2.js`, which should nicely fail with a
“not yet implemented” message.

wchargin-branch: cli2-skeleton
