### PR TITLE
cli2: Use TaskReporters

### DIFF
--- a/src/cli2/cliPlugin.js
+++ b/src/cli2/cliPlugin.js
@@ -3,12 +3,20 @@
 import type {PluginDeclaration} from "../analysis/pluginDeclaration";
 import type {WeightedGraph} from "../core/weightedGraph";
 import type {ReferenceDetector} from "../core/references/referenceDetector";
+import type {TaskReporter} from "../util/taskReporter";
 
 export interface CliPlugin {
   declaration(): PluginDeclaration;
-  load(PluginDirectoryContext): Promise<void>;
-  graph(PluginDirectoryContext, ReferenceDetector): Promise<WeightedGraph>;
-  referenceDetector(PluginDirectoryContext): Promise<ReferenceDetector>;
+  load(PluginDirectoryContext, TaskReporter): Promise<void>;
+  graph(
+    PluginDirectoryContext,
+    ReferenceDetector,
+    TaskReporter
+  ): Promise<WeightedGraph>;
+  referenceDetector(
+    PluginDirectoryContext,
+    TaskReporter
+  ): Promise<ReferenceDetector>;
 }
 
 export interface PluginDirectoryContext {

--- a/src/cli2/graph.js
+++ b/src/cli2/graph.js
@@ -5,6 +5,7 @@ import sortBy from "lodash.sortby";
 import stringify from "json-stable-stringify";
 import {join as pathJoin} from "path";
 
+import {LoggingTaskReporter} from "../util/taskReporter";
 import {CascadingReferenceDetector} from "../core/references/cascadingReferenceDetector";
 import type {Command} from "./command";
 import {
@@ -23,32 +24,43 @@ const graphCommand: Command = async (args, std) => {
   if (args.length !== 0) {
     die(std, "usage: sourcecred graph");
   }
+  const taskReporter = new LoggingTaskReporter();
+  taskReporter.start("graph");
   const baseDir = process.cwd();
   const config = await loadInstanceConfig(baseDir);
   const graphOutputPrefix = ["output", "graphs"];
 
-  const rd = await buildReferenceDetector(baseDir, config);
+  const rd = await buildReferenceDetector(baseDir, config, taskReporter);
   for (const [name, plugin] of config.bundledPlugins) {
+    const task = `${name}: generating graph`;
+    taskReporter.start(task);
     const dirContext = pluginDirectoryContext(baseDir, name);
-    const graph = await plugin.graph(dirContext, rd);
+    const graph = await plugin.graph(dirContext, rd, taskReporter);
     const serializedGraph = stringify(weightedGraphToJSON(graph));
     const outputDir = makePluginDir(baseDir, graphOutputPrefix, name);
     const outputPath = pathJoin(outputDir, "graph.json");
     await fs.writeFile(outputPath, serializedGraph);
+    taskReporter.finish(task);
   }
+  taskReporter.finish("graph");
   return 0;
 };
 
-async function buildReferenceDetector(baseDir, config) {
+async function buildReferenceDetector(baseDir, config, taskReporter) {
+  taskReporter.start("reference detector");
   const rds = [];
   for (const [name, plugin] of sortBy(
     [...config.bundledPlugins],
     ([k, _]) => k
   )) {
     const dirContext = pluginDirectoryContext(baseDir, name);
-    const rd = await plugin.referenceDetector(dirContext);
+    const task = `reference detector for ${name}`;
+    taskReporter.start(task);
+    const rd = await plugin.referenceDetector(dirContext, taskReporter);
     rds.push(rd);
+    taskReporter.finish(task);
   }
+  taskReporter.finish("reference detector");
   return new CascadingReferenceDetector(rds);
 }
 

--- a/src/cli2/load.js
+++ b/src/cli2/load.js
@@ -2,6 +2,7 @@
 
 import type {Command} from "./command";
 import {loadInstanceConfig, pluginDirectoryContext} from "./common";
+import {LoggingTaskReporter} from "../util/taskReporter";
 
 function die(std, message) {
   std.err("fatal: " + message);
@@ -12,12 +13,22 @@ const loadCommand: Command = async (args, std) => {
   if (args.length !== 0) {
     die(std, "usage: sourcecred load");
   }
+  const taskReporter = new LoggingTaskReporter();
+  taskReporter.start("load");
   const baseDir = process.cwd();
   const config = await loadInstanceConfig(baseDir);
+  const loadPromises = [];
   for (const [name, plugin] of config.bundledPlugins) {
+    const task = `loading ${name}`;
+    taskReporter.start(task);
     const dirContext = pluginDirectoryContext(baseDir, name);
-    plugin.load(dirContext);
+    const promise = plugin
+      .load(dirContext, taskReporter)
+      .then(() => taskReporter.finish(task));
+    loadPromises.push(promise);
   }
+  await Promise.all(loadPromises);
+  taskReporter.finish("load");
   return 0;
 };
 

--- a/src/plugins/github/cliPlugin.js
+++ b/src/plugins/github/cliPlugin.js
@@ -18,6 +18,8 @@ import {fromRelationalViews as referenceDetectorFromRelationalViews} from "./ref
 import {parse as parseConfig, type GithubConfig} from "./config";
 import {validateToken, type GithubToken} from "./token";
 import {weightsForDeclaration} from "../../analysis/pluginDeclaration";
+import {type TaskReporter} from "../../util/taskReporter";
+import {repoIdToString} from "./repoId";
 
 const TOKEN_ENV_VAR_NAME = "SOURCECRED_GITHUB_TOKEN";
 
@@ -56,12 +58,19 @@ export class GithubCliPlugin implements CliPlugin {
     return declaration;
   }
 
-  async load(ctx: PluginDirectoryContext): Promise<void> {
+  async load(
+    ctx: PluginDirectoryContext,
+    reporter: TaskReporter
+  ): Promise<void> {
     const cache = new CacheProviderImpl(ctx);
     const token = getTokenFromEnv();
     const config = await loadConfig(ctx);
     for (const repoId of config.repoIds) {
+      const repoString = repoIdToString(repoId);
+      const task = `github: loading ${repoString}`;
+      reporter.start(task);
       await fetchGithubRepo(repoId, {token, cache});
+      reporter.finish(task);
     }
   }
 


### PR DESCRIPTION
This commit modifies the cli2 interfaces so that plugins may use task
reporters when loading, generating a reference detector, or creating a
graph. Also, the scaffold now automatically reports on task/plugin-level
progress as appropriate.

Test plan: Generate an example instance as described in previous
commits, then run `load` and `graph` and get timing info:

```
~/tmp/instance❯ node $sc/bin/sc2.js load
  GO   load
  GO   loading sourcecred/github
 DONE  loading sourcecred/github: 1ms
 DONE  load: 7ms
~/tmp/instance❯ node $sc/bin/sc2.js graph
  GO   graph
  GO   reference detector
  GO   reference detector for sourcecred/github
 DONE  reference detector for sourcecred/github: 296ms
 DONE  reference detector: 297ms
  GO   sourcecred/github: generating graph
 DONE  sourcecred/github: generating graph: 242ms
 DONE  graph: 544ms
 ```