### PR TITLE
cli2: exit on invalid subcommand invocation

### DIFF
--- a/src/cli2/graph.js
+++ b/src/cli2/graph.js
@@ -22,7 +22,7 @@ function die(std, message) {
 
 const graphCommand: Command = async (args, std) => {
   if (args.length !== 0) {
-    die(std, "usage: sourcecred graph");
+    return die(std, "usage: sourcecred graph");
   }
   const taskReporter = new LoggingTaskReporter();
   taskReporter.start("graph");

--- a/src/cli2/load.js
+++ b/src/cli2/load.js
@@ -11,7 +11,7 @@ function die(std, message) {
 
 const loadCommand: Command = async (args, std) => {
   if (args.length !== 0) {
-    die(std, "usage: sourcecred load");
+    return die(std, "usage: sourcecred load");
   }
   const taskReporter = new LoggingTaskReporter();
   taskReporter.start("load");


### PR DESCRIPTION
Summary:
We’d written `die("usage: ...")`, but forgotten to actually return.

Test Plan:
After patching a test instance’s `sourcecred.json` to be invalid,
running `sc2 load extra-arg` now only prints a usage message rather than
an invalid configuration message.

wchargin-branch: cli2-actually-die
