### PR TITLE
distributionToCred propagates cred flow data

### DIFF
--- a/src/core/algorithm/distributionToCred.test.js
+++ b/src/core/algorithm/distributionToCred.test.js
@@ -23,7 +23,7 @@ describe("src/core/algorithm/distributionToCred", () => {
           distribution: new Float64Array([0.9, 0.1]),
           backwardFlow: new Float64Array([]),
           forwardFlow: new Float64Array([]),
-          seedFlow: new Float64Array([0.5, 0.5]),
+          seedFlow: new Float64Array([0.9, 0.1]),
           syntheticLoopFlow: new Float64Array([0, 0]),
         },
       ];
@@ -33,10 +33,18 @@ describe("src/core/algorithm/distributionToCred", () => {
         {
           interval: {startTimeMs: 0, endTimeMs: 10},
           cred: new Float64Array([1, 1]),
+          backwardFlow: new Float64Array([]),
+          forwardFlow: new Float64Array([]),
+          seedFlow: new Float64Array([1, 1]),
+          syntheticLoopFlow: new Float64Array([0, 0]),
         },
         {
           interval: {startTimeMs: 10, endTimeMs: 20},
           cred: new Float64Array([9, 1]),
+          backwardFlow: new Float64Array([]),
+          forwardFlow: new Float64Array([]),
+          seedFlow: new Float64Array([9, 1]),
+          syntheticLoopFlow: new Float64Array([0, 0]),
         },
       ];
       expect(expected).toEqual(actual);
@@ -58,7 +66,7 @@ describe("src/core/algorithm/distributionToCred", () => {
           distribution: new Float64Array([0.9, 0.1]),
           backwardFlow: new Float64Array([]),
           forwardFlow: new Float64Array([]),
-          seedFlow: new Float64Array([0.5, 0.5]),
+          seedFlow: new Float64Array([0.9, 0.1]),
           syntheticLoopFlow: new Float64Array([0, 0]),
         },
       ];
@@ -68,10 +76,18 @@ describe("src/core/algorithm/distributionToCred", () => {
         {
           interval: {startTimeMs: 0, endTimeMs: 10},
           cred: new Float64Array([1, 1]),
+          backwardFlow: new Float64Array([]),
+          forwardFlow: new Float64Array([]),
+          seedFlow: new Float64Array([1, 1]),
+          syntheticLoopFlow: new Float64Array([0, 0]),
         },
         {
           interval: {startTimeMs: 10, endTimeMs: 20},
           cred: new Float64Array([9, 1]),
+          backwardFlow: new Float64Array([]),
+          forwardFlow: new Float64Array([]),
+          seedFlow: new Float64Array([9, 1]),
+          syntheticLoopFlow: new Float64Array([0, 0]),
         },
       ];
       expect(expected).toEqual(actual);
@@ -103,10 +119,18 @@ describe("src/core/algorithm/distributionToCred", () => {
         {
           interval: {startTimeMs: 0, endTimeMs: 10},
           cred: new Float64Array([2, 2]),
+          backwardFlow: new Float64Array([]),
+          forwardFlow: new Float64Array([]),
+          seedFlow: new Float64Array([2, 2]),
+          syntheticLoopFlow: new Float64Array([0, 0]),
         },
         {
           interval: {startTimeMs: 10, endTimeMs: 20},
           cred: new Float64Array([90, 10]),
+          backwardFlow: new Float64Array([]),
+          forwardFlow: new Float64Array([]),
+          seedFlow: new Float64Array([90, 10]),
+          syntheticLoopFlow: new Float64Array([0, 0]),
         },
       ];
       expect(expected).toEqual(actual);
@@ -119,7 +143,7 @@ describe("src/core/algorithm/distributionToCred", () => {
           distribution: new Float64Array([0.5, 0.5]),
           backwardFlow: new Float64Array([]),
           forwardFlow: new Float64Array([]),
-          seedFlow: new Float64Array([0.5, 0.5]),
+          seedFlow: new Float64Array([2, 2]),
           syntheticLoopFlow: new Float64Array([0, 0]),
         },
       ];
@@ -129,6 +153,10 @@ describe("src/core/algorithm/distributionToCred", () => {
         {
           interval: {startTimeMs: 0, endTimeMs: 10},
           cred: new Float64Array([0, 0]),
+          backwardFlow: new Float64Array([]),
+          forwardFlow: new Float64Array([]),
+          seedFlow: new Float64Array([0, 0]),
+          syntheticLoopFlow: new Float64Array([0, 0]),
         },
       ];
       expect(actual).toEqual(expected);
@@ -152,9 +180,57 @@ describe("src/core/algorithm/distributionToCred", () => {
         {
           interval: {startTimeMs: 0, endTimeMs: 10},
           cred: new Float64Array([0, 0]),
+          backwardFlow: new Float64Array([]),
+          forwardFlow: new Float64Array([]),
+          seedFlow: new Float64Array([0, 0]),
+          syntheticLoopFlow: new Float64Array([0, 0]),
         },
       ];
       expect(actual).toEqual(expected);
+    });
+
+    it("re-normalizes all of the flows consistently", () => {
+      const ds = [
+        {
+          interval: {startTimeMs: 0, endTimeMs: 10},
+          intervalWeight: 2,
+          distribution: new Float64Array([0.5, 0.5]),
+          backwardFlow: new Float64Array([0.1, 0.2, 0.3]),
+          forwardFlow: new Float64Array([0.3, 0.2, 0.1]),
+          seedFlow: new Float64Array([0.5, 0.5]),
+          syntheticLoopFlow: new Float64Array([0.1, 0.2]),
+        },
+        {
+          interval: {startTimeMs: 10, endTimeMs: 20},
+          intervalWeight: 10,
+          distribution: new Float64Array([0.9, 0.1]),
+          backwardFlow: new Float64Array([0.5, 0.2, 0.1]),
+          forwardFlow: new Float64Array([0, 0.2, 0.1]),
+          seedFlow: new Float64Array([0.9, 0.1]),
+          syntheticLoopFlow: new Float64Array([0.01, 0.05]),
+        },
+      ];
+      const nodeOrder = [na("foo"), na("bar")];
+      const actual = distributionToCred(ds, nodeOrder, [NodeAddress.empty]);
+      const expected = [
+        {
+          interval: {startTimeMs: 0, endTimeMs: 10},
+          cred: new Float64Array([1, 1]),
+          backwardFlow: new Float64Array([0.2, 0.4, 0.6]),
+          forwardFlow: new Float64Array([0.6, 0.4, 0.2]),
+          seedFlow: new Float64Array([1, 1]),
+          syntheticLoopFlow: new Float64Array([0.2, 0.4]),
+        },
+        {
+          interval: {startTimeMs: 10, endTimeMs: 20},
+          cred: new Float64Array([9, 1]),
+          backwardFlow: new Float64Array([5, 2, 1]),
+          forwardFlow: new Float64Array([0, 2, 1]),
+          seedFlow: new Float64Array([9, 1]),
+          syntheticLoopFlow: new Float64Array([0.1, 0.5]),
+        },
+      ];
+      expect(expected).toEqual(actual);
     });
 
     it("returns empty CredScores if no intervals are present", () => {
@@ -200,24 +276,44 @@ describe("src/core/algorithm/distributionToCred", () => {
           },
           Array [
             Object {
+              "backwardFlow": Array [],
               "cred": Array [
                 2,
                 2,
               ],
+              "forwardFlow": Array [],
               "interval": Object {
                 "endTimeMs": 10,
                 "startTimeMs": 0,
               },
+              "seedFlow": Array [
+                2,
+                2,
+              ],
+              "syntheticLoopFlow": Array [
+                0,
+                0,
+              ],
             },
             Object {
+              "backwardFlow": Array [],
               "cred": Array [
                 90,
                 10,
               ],
+              "forwardFlow": Array [],
               "interval": Object {
                 "endTimeMs": 20,
                 "startTimeMs": 10,
               },
+              "seedFlow": Array [
+                90,
+                10,
+              ],
+              "syntheticLoopFlow": Array [
+                0,
+                0,
+              ],
             },
           ],
         ]


### PR DESCRIPTION
This commit modifies the distributionToCred module so that in addition
to normalizing the scores into cred, it also normalizes the score flows
(from #1802) into cred flows. This is another big part of #1773, so that
we can support the `OutputEdge` format and give meaningful info on cred
flows for each edge.

The change is quite simple, as we already compute a normalization
constant, we just need to apply it to a few more arrays.

Test plan: I added a new unit test that has values in all of the
different flows, so we can validate that they are normalized
consistently.