### PR TITLE
Add the CredResult module

### DIFF
--- a/src/analysis/__snapshots__/credResult.test.js.snap
+++ b/src/analysis/__snapshots__/credResult.test.js.snap
@@ -1,0 +1,156 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`analysis/credResult to/fro JSON to/froJSON snapshots as expected 1`] = `
+"[
+  {
+    \\"type\\": \\"sourcecred/credResult\\",
+    \\"version\\": \\"0.1.0\\"
+  },
+  {
+    \\"credData\\": {
+      \\"edgeOverTime\\": [
+      ],
+      \\"edgeSummaries\\": [
+      ],
+      \\"intervalEnds\\": [
+        259200000
+      ],
+      \\"nodeOverTime\\": [
+        {
+          \\"cred\\": [
+            0.5
+          ],
+          \\"seedFlow\\": [
+            0.1
+          ],
+          \\"syntheticLoopFlow\\": [
+            0.4
+          ]
+        },
+        {
+          \\"cred\\": [
+            0.5
+          ],
+          \\"seedFlow\\": [
+            0.1
+          ],
+          \\"syntheticLoopFlow\\": [
+            0.4
+          ]
+        }
+      ],
+      \\"nodeSummaries\\": [
+        {
+          \\"cred\\": 0.5,
+          \\"seedFlow\\": 0.1,
+          \\"syntheticLoopFlow\\": 0.4
+        },
+        {
+          \\"cred\\": 0.5,
+          \\"seedFlow\\": 0.1,
+          \\"syntheticLoopFlow\\": 0.4
+        }
+      ]
+    },
+    \\"params\\": {
+      \\"alpha\\": 0.2,
+      \\"intervalDecay\\": 0.5
+    },
+    \\"plugins\\": [
+      {
+        \\"type\\": \\"sourcecred/pluginDeclarations\\",
+        \\"version\\": \\"0.1.0\\"
+      },
+      [
+        {
+          \\"edgePrefix\\": \\"E\\\\u0000\\",
+          \\"edgeTypes\\": [
+            {
+              \\"backwardName\\": \\"is pointed to\\",
+              \\"defaultWeight\\": {
+                \\"backwards\\": 3,
+                \\"forwards\\": 2
+              },
+              \\"description\\": \\"a type\\",
+              \\"forwardName\\": \\"points\\",
+              \\"prefix\\": \\"E\\\\u0000edge\\\\u0000\\"
+            }
+          ],
+          \\"name\\": \\"empty\\",
+          \\"nodePrefix\\": \\"N\\\\u0000\\",
+          \\"nodeTypes\\": [
+            {
+              \\"defaultWeight\\": 2,
+              \\"description\\": \\"a type\\",
+              \\"name\\": \\"node\\",
+              \\"pluralName\\": \\"nodes\\",
+              \\"prefix\\": \\"N\\\\u0000node\\\\u0000\\"
+            }
+          ],
+          \\"userTypes\\": [
+            {
+              \\"defaultWeight\\": 2,
+              \\"description\\": \\"a type\\",
+              \\"name\\": \\"node\\",
+              \\"pluralName\\": \\"nodes\\",
+              \\"prefix\\": \\"N\\\\u0000node\\\\u0000\\"
+            }
+          ]
+        }
+      ]
+    ],
+    \\"weightedGraph\\": [
+      {
+        \\"type\\": \\"sourcecred/weightedGraph\\",
+        \\"version\\": \\"0.1.0\\"
+      },
+      {
+        \\"graphJSON\\": [
+          {
+            \\"type\\": \\"sourcecred/graph\\",
+            \\"version\\": \\"0.8.0\\"
+          },
+          {
+            \\"edges\\": [
+            ],
+            \\"nodes\\": [
+              {
+                \\"description\\": \\"n1\\",
+                \\"index\\": 0,
+                \\"timestampMs\\": 100000
+              },
+              {
+                \\"description\\": \\"n2\\",
+                \\"index\\": 1,
+                \\"timestampMs\\": 110000
+              }
+            ],
+            \\"sortedNodeAddresses\\": [
+              [
+                \\"node\\",
+                \\"1\\"
+              ],
+              [
+                \\"node\\",
+                \\"2\\"
+              ]
+            ]
+          }
+        ],
+        \\"weightsJSON\\": [
+          {
+            \\"type\\": \\"sourcecred/weights\\",
+            \\"version\\": \\"0.2.0\\"
+          },
+          {
+            \\"edgeWeights\\": {
+            },
+            \\"nodeWeights\\": {
+            }
+          }
+        ]
+      }
+    ]
+  }
+]"
+`;

--- a/src/analysis/credResult.js
+++ b/src/analysis/credResult.js
@@ -1,0 +1,87 @@
+// @flow
+
+import {
+  type WeightedGraph,
+  type WeightedGraphJSON,
+  toJSON as wgToJSON,
+  fromJSON as wgFromJSON,
+} from "../core/weightedGraph";
+import {type Compatible, toCompat, fromCompat} from "../util/compat";
+import {
+  type TimelineCredParameters,
+  type TimelineCredParametersJSON,
+  paramsToJSON,
+  paramsFromJSON,
+} from "./timeline/params";
+import {
+  type PluginDeclarations,
+  type PluginDeclarationsJSON,
+  toJSON as pluginsToJSON,
+  fromJSON as pluginsFromJSON,
+} from "./pluginDeclaration";
+import {timelinePagerank} from "../core/algorithm/timelinePagerank";
+import {type CredData, computeCredData} from "./credData";
+import {distributionToCred} from "../core/algorithm/distributionToCred";
+
+/**
+ * Comprehensive cred output data, including the graph, the scores, the params, and the plugins.
+ */
+export type CredResult = {|
+  // The Graph on which this cred data was computed.
+  +weightedGraph: WeightedGraph,
+  // Cred level information, always stored in graph address order.
+  +credData: CredData,
+  // Parameters used to compute this cred data
+  +params: TimelineCredParameters,
+  // Plugin declarations used to compute this cred data
+  +plugins: PluginDeclarations,
+|};
+
+export async function compute(
+  wg: WeightedGraph,
+  params: TimelineCredParameters,
+  plugins: PluginDeclarations
+): Promise<CredResult> {
+  const {graph} = wg;
+  const nodeOrder = Array.from(graph.nodes()).map((x) => x.address);
+  const userTypes = [].concat(...plugins.map((x) => x.userTypes));
+  const scorePrefixes = userTypes.map((x) => x.prefix);
+  const distribution = await timelinePagerank(
+    wg,
+    params.intervalDecay,
+    params.alpha
+  );
+  const credScores = distributionToCred(distribution, nodeOrder, scorePrefixes);
+  const credData = computeCredData(credScores);
+  return {weightedGraph: wg, credData, params, plugins};
+}
+
+const COMPAT_INFO = {type: "sourcecred/credResult", version: "0.1.0"};
+
+export type CredResultJSON = Compatible<{|
+  +weightedGraph: WeightedGraphJSON,
+  +credData: CredData,
+  +params: TimelineCredParametersJSON,
+  +plugins: PluginDeclarationsJSON,
+|}>;
+
+export function toJSON(x: CredResult): CredResultJSON {
+  const {weightedGraph, credData, params, plugins} = x;
+  return toCompat(COMPAT_INFO, {
+    weightedGraph: wgToJSON(weightedGraph),
+    credData,
+    params: paramsToJSON(params),
+    plugins: pluginsToJSON(plugins),
+  });
+}
+
+export function fromJSON(j: CredResultJSON): CredResult {
+  const x = fromCompat(COMPAT_INFO, j);
+  const {weightedGraph, credData, params, plugins} = x;
+  return {
+    weightedGraph: wgFromJSON(weightedGraph),
+    credData,
+    params: paramsFromJSON(params),
+    plugins: pluginsFromJSON(plugins),
+  };
+}

--- a/src/analysis/credResult.test.js
+++ b/src/analysis/credResult.test.js
@@ -1,0 +1,76 @@
+// @flow
+
+import stringify from "json-stable-stringify";
+import {Graph, NodeAddress, EdgeAddress} from "../core/graph";
+import * as Weights from "../core/weights";
+import type {NodeType, EdgeType} from "./types";
+import type {PluginDeclaration} from "./pluginDeclaration";
+import {defaultParams} from "./timeline/params";
+import {compute, toJSON, fromJSON} from "./credResult";
+
+describe("analysis/credResult", () => {
+  describe("to/fro JSON", () => {
+    async function example() {
+      const nodeType: NodeType = {
+        name: "node",
+        pluralName: "nodes",
+        prefix: NodeAddress.fromParts(["node"]),
+        defaultWeight: 2,
+        description: "a type",
+      };
+      const edgeType: EdgeType = {
+        forwardName: "points",
+        backwardName: "is pointed to",
+        prefix: EdgeAddress.fromParts(["edge"]),
+        defaultWeight: {forwards: 2, backwards: 3},
+        description: "a type",
+      };
+      const declaration: PluginDeclaration = {
+        name: "empty",
+        nodePrefix: NodeAddress.empty,
+        edgePrefix: EdgeAddress.empty,
+        nodeTypes: [nodeType],
+        edgeTypes: [edgeType],
+        userTypes: [nodeType],
+      };
+
+      const graph = new Graph()
+        .addNode({
+          address: NodeAddress.fromParts(["node", "1"]),
+          description: "n1",
+          timestampMs: 100000,
+        })
+        .addNode({
+          address: NodeAddress.fromParts(["node", "2"]),
+          description: "n2",
+          timestampMs: 110000,
+        });
+      const weights = Weights.empty();
+      const wg = {graph, weights};
+      const params = defaultParams();
+      const result = await compute(wg, params, [declaration]);
+      return result;
+    }
+
+    describe("to/froJSON", () => {
+      it("round-trips appropriately", async () => {
+        const r = await example();
+        const j = toJSON(r);
+        const r_ = fromJSON(j);
+        const j_ = toJSON(r_);
+
+        expect(r.weightedGraph.graph.equals(r_.weightedGraph.graph)).toBe(true);
+        expect(r.weightedGraph.weights).toEqual(r_.weightedGraph.weights);
+        expect(r.credData).toEqual(r_.credData);
+        expect(r.params).toEqual(r_.params);
+        expect(r.plugins).toEqual(r_.plugins);
+        expect(j).toEqual(j_);
+      });
+      it("snapshots as expected", async () => {
+        const r = await example();
+        const j = toJSON(r);
+        expect(stringify(j, {space: 2})).toMatchSnapshot();
+      });
+    });
+  });
+});


### PR DESCRIPTION
This module has a concise and clean type for storing all the output data
from running SourceCred, including:
- The graph
- The weights
- The cred scores and flows
- The interval timing info
- The plugins used
- The parameters used

We also have a method `compute` which computes one of these given the
weighted graph, parameters, and plugins. It's all quite clean and
simple. I feel good about thsi API.

Test plan:
The main `compute` function is only sanity checked via flow and unit
testing, which is appropriate since it's a pure-piping function with
little than can go wrong. I've also added JSON serialization; this is
tested with round trip testing.