### PR TITLE
credrank: add Markov process graph and basic CLI

### DIFF
--- a/src/cli/credrank.js
+++ b/src/cli/credrank.js
@@ -1,0 +1,72 @@
+// @flow
+
+import fs from "fs-extra";
+import stringify from "json-stable-stringify";
+import {join as pathJoin} from "path";
+
+import {credrank} from "../core/algorithm/credrank";
+import {LoggingTaskReporter} from "../util/taskReporter";
+import {MarkovProcessGraph} from "../core/markovProcessGraph";
+import type {Command} from "./command";
+import {loadInstanceConfig} from "./common";
+import {fromJSON as weightedGraphFromJSON} from "../core/weightedGraph";
+
+const DEFAULT_ALPHA = 0.2;
+const DEFAULT_BETA = 0.5;
+const DEFAULT_GAMMA_FORWARD = 0.15;
+const DEFAULT_GAMMA_BACKWARD = 0.15;
+
+function die(std, message) {
+  std.err("fatal: " + message);
+  return 1;
+}
+
+const credrankCommand: Command = async (args, std) => {
+  if (args.length !== 0) {
+    return die(std, "usage: sourcecred credrank");
+  }
+  const taskReporter = new LoggingTaskReporter();
+  taskReporter.start("credrank");
+
+  const baseDir = process.cwd();
+  const config = await loadInstanceConfig(baseDir);
+
+  const plugins = Array.from(config.bundledPlugins.values());
+  const declarations = plugins.map((x) => x.declaration());
+
+  taskReporter.start("read weighted graph");
+  const wgPath = pathJoin(baseDir, "output", "graph.json");
+  const wgJson = JSON.parse(await fs.readFile(wgPath));
+  const wg = weightedGraphFromJSON(wgJson);
+  taskReporter.finish("read weighted graph");
+
+  taskReporter.start("create Markov process graph");
+  // TODO: Support loading transition probability params from config.
+  const fibrationOptions = {
+    what: [].concat(
+      ...declarations.map((d) => d.userTypes.map((t) => t.prefix))
+    ),
+    beta: DEFAULT_BETA,
+    gammaForward: DEFAULT_GAMMA_FORWARD,
+    gammaBackward: DEFAULT_GAMMA_BACKWARD,
+  };
+  const seedOptions = {
+    alpha: DEFAULT_ALPHA,
+  };
+  const mpg = MarkovProcessGraph.new(wg, fibrationOptions, seedOptions);
+  taskReporter.finish("create Markov process graph");
+
+  taskReporter.start("run CredRank");
+  const credGraph = await credrank(mpg);
+  taskReporter.finish("run CredRank");
+
+  taskReporter.start("write cred graph");
+  const cgJson = stringify(credGraph.toJSON());
+  const outputPath = pathJoin(baseDir, "output", "credGraph.json");
+  await fs.writeFile(outputPath, cgJson);
+  taskReporter.finish("write cred graph");
+
+  return 0;
+};
+
+export default credrankCommand;

--- a/src/cli/credrank.js
+++ b/src/cli/credrank.js
@@ -15,10 +15,10 @@ import {
   fromJSON as weightedGraphFromJSON,
 } from "../core/weightedGraph";
 
-const DEFAULT_ALPHA = 0.2;
-const DEFAULT_BETA = 0.5;
-const DEFAULT_GAMMA_FORWARD = 0.15;
-const DEFAULT_GAMMA_BACKWARD = 0.15;
+const DEFAULT_ALPHA = 0.1;
+const DEFAULT_BETA = 0.4;
+const DEFAULT_GAMMA_FORWARD = 0.1;
+const DEFAULT_GAMMA_BACKWARD = 0.1;
 
 function die(std, message) {
   std.err("fatal: " + message);

--- a/src/cli/sourcecred.js
+++ b/src/cli/sourcecred.js
@@ -10,6 +10,7 @@ import site from "./site";
 import go from "./go";
 import serve from "./serve";
 import grain from "./grain";
+import credrank from "./credrank";
 import help from "./help";
 
 const sourcecred: Command = async (args, std) => {
@@ -38,6 +39,8 @@ const sourcecred: Command = async (args, std) => {
       return serve(args.slice(1), std);
     case "grain":
       return grain(args.slice(1), std);
+    case "credrank":
+      return credrank(args.slice(1), std);
     default:
       std.err("fatal: unknown command: " + JSON.stringify(args[0]));
       std.err("fatal: run 'sourcecred help' for commands and usage");

--- a/src/core/algorithm/credrank.js
+++ b/src/core/algorithm/credrank.js
@@ -1,0 +1,62 @@
+// @flow
+
+import {sum} from "d3-array";
+import * as NullUtil from "../../util/null";
+import {
+  findStationaryDistribution,
+  type PagerankParams,
+  type PagerankOptions,
+} from "./markovChain";
+
+import {type NodeAddressT} from "../graph";
+import {distributionToNodeDistribution} from "./graphToMarkovChain";
+
+import {uniformDistribution} from "./distribution";
+import type {MarkovProcessGraph} from "../markovProcessGraph";
+import {CredGraph} from "../credGraph";
+
+export const DEFAULT_MAX_ITERATIONS = 255;
+export const DEFAULT_CONVERGENCE_THRESHOLD = 1e-7;
+export const DEFAULT_YIELD_AFTER_MS = 30;
+export const DEFAULT_VERBOSE = false;
+
+export async function credrank(
+  mpg: MarkovProcessGraph,
+  options?: $Shape<PagerankOptions> = {}
+): Promise<CredGraph> {
+  const defaultOptions: PagerankOptions = {
+    maxIterations: DEFAULT_MAX_ITERATIONS,
+    convergenceThreshold: DEFAULT_CONVERGENCE_THRESHOLD,
+    yieldAfterMs: DEFAULT_YIELD_AFTER_MS,
+    verbose: DEFAULT_VERBOSE,
+  };
+  options = {...defaultOptions, ...options};
+  const osmc = mpg.toMarkovChain();
+  const params: PagerankParams = {
+    chain: osmc.chain,
+    pi0: uniformDistribution(osmc.nodeOrder.length),
+    seed: uniformDistribution(osmc.nodeOrder.length),
+    alpha: 0,
+  };
+  const distributionResult = await findStationaryDistribution(params, options);
+  const pi = distributionToNodeDistribution(
+    osmc.nodeOrder,
+    distributionResult.pi
+  );
+
+  const matchingScore = sum(
+    Array.from(mpg.scoringAddresses()).map((a) => NullUtil.get(pi.get(a)))
+  );
+  const cred: Map<NodeAddressT, number> = new Map();
+  let totalNodeWeight = 0;
+  for (const {weight} of mpg.nodes()) {
+    totalNodeWeight += weight;
+  }
+  osmc.nodeOrder.forEach((node, index) => {
+    cred.set(
+      node,
+      (distributionResult.pi[index] / matchingScore) * totalNodeWeight
+    );
+  });
+  return new CredGraph(mpg, cred);
+}

--- a/src/core/algorithm/credrank.js
+++ b/src/core/algorithm/credrank.js
@@ -49,7 +49,7 @@ export async function credrank(
   );
   const cred: Map<NodeAddressT, number> = new Map();
   let totalNodeWeight = 0;
-  for (const {weight} of mpg.nodes()) {
+  for (const {mint: weight} of mpg.nodes()) {
     totalNodeWeight += weight;
   }
   osmc.nodeOrder.forEach((node, index) => {

--- a/src/core/credGraph.js
+++ b/src/core/credGraph.js
@@ -1,0 +1,99 @@
+// @flow
+
+import * as NullUtil from "../util/null";
+import * as MapUtil from "../util/map";
+import {type NodeAddressT, type EdgeAddressT} from "./graph";
+import {type NodeWeight} from "./weights";
+import {
+  MarkovProcessGraph,
+  type MarkovProcessGraphJSON,
+  type MarkovEdge,
+  type TransitionProbability,
+} from "./markovProcessGraph";
+
+export type Node = {|
+  +address: NodeAddressT,
+  +description: string,
+  +cred: number,
+  +weight: NodeWeight,
+|};
+
+export type Edge = {|
+  +address: EdgeAddressT,
+  +reversed: boolean,
+  +src: NodeAddressT,
+  +dst: NodeAddressT,
+  +transitionProbability: TransitionProbability,
+  +credFlow: number,
+|};
+
+export type CredGraphJSON = {|
+  +mpg: MarkovProcessGraphJSON,
+  +scores: {|+[NodeAddressT]: number|},
+|};
+
+export class CredGraph {
+  _mpg: MarkovProcessGraph;
+  _scores: Map<NodeAddressT, number>;
+
+  constructor(
+    markovProcessGraph: MarkovProcessGraph,
+    scores: Map<NodeAddressT, number>
+  ) {
+    this._mpg = markovProcessGraph;
+    this._scores = scores;
+  }
+
+  _cred(addr: NodeAddressT): number {
+    return NullUtil.get(this._scores.get(addr));
+  }
+
+  _credFlow(edge: MarkovEdge): number {
+    const srcCred = this._cred(edge.src);
+    return srcCred * edge.transitionProbability;
+  }
+
+  node(addr: NodeAddressT): ?Node {
+    const node = this._mpg._nodes.get(addr);
+    if (node == null) return undefined;
+    return {...node, cred: this._cred(addr)};
+  }
+
+  *nodes(): Iterator<Node> {
+    for (const node of this._mpg.nodes()) {
+      yield {...node, cred: this._cred(node.address)};
+    }
+  }
+
+  *edges(): Iterator<Edge> {
+    for (const edge of this._mpg.edges()) {
+      yield {...edge, credFlow: this._credFlow(edge)};
+    }
+  }
+
+  *scoringNodes(): Iterator<Node> {
+    for (const addr of this._mpg.scoringAddresses()) {
+      yield NullUtil.get(this.node(addr));
+    }
+  }
+
+  *inNeighbors(addr: NodeAddressT): Iterator<Edge> {
+    for (const edge of this._mpg.inNeighbors(addr)) {
+      yield {...edge, credFlow: this._credFlow(edge)};
+    }
+  }
+
+  toJSON(): CredGraphJSON {
+    return {
+      mpg: this._mpg.toJSON(),
+      scores: MapUtil.toObject(this._scores),
+    };
+  }
+
+  static fromJSON(j: CredGraphJSON): CredGraph {
+    return new CredGraph(
+      MarkovProcessGraph.fromJSON(j.mpg),
+      MapUtil.fromObject(j.scores)
+    );
+  }
+}

--- a/src/core/credGraph.js
+++ b/src/core/credGraph.js
@@ -3,7 +3,6 @@
 import * as NullUtil from "../util/null";
 import * as MapUtil from "../util/map";
 import {type NodeAddressT, type EdgeAddressT} from "./graph";
-import {type NodeWeight} from "./weights";
 import {
   MarkovProcessGraph,
   type MarkovProcessGraphJSON,

--- a/src/core/credGraph.js
+++ b/src/core/credGraph.js
@@ -15,7 +15,7 @@ export type Node = {|
   +address: NodeAddressT,
   +description: string,
   +cred: number,
-  +weight: NodeWeight,
+  +mint: number,
 |};
 
 export type Edge = {|

--- a/src/core/credGraph.js
+++ b/src/core/credGraph.js
@@ -48,7 +48,7 @@ export class CredGraph {
   }
 
   _credFlow(edge: MarkovEdge): number {
-    const srcCred = this._cred(edge.src);
+    const srcCred /* heh */ = this._cred(edge.src);
     return srcCred * edge.transitionProbability;
   }
 

--- a/src/core/credGraph.js
+++ b/src/core/credGraph.js
@@ -2,7 +2,7 @@
 
 import * as NullUtil from "../util/null";
 import * as MapUtil from "../util/map";
-import {type NodeAddressT, type EdgeAddressT} from "./graph";
+import type {NodeAddressT, EdgeAddressT} from "./graph";
 import {
   MarkovProcessGraph,
   type MarkovProcessGraphJSON,

--- a/src/core/markovProcessGraph.js
+++ b/src/core/markovProcessGraph.js
@@ -1,0 +1,579 @@
+// @flow
+
+/**
+ * Data structure representing a particular kind of Markov process, as
+ * kind of a middle ground between the semantic SourceCred graph (in the
+ * `core/graph` module) and a literal transition matrix. Unlike the core
+ * graph, edges in a Markov process graph are unidirectional, edge
+ * weights are raw transition probabilities (which must sum to 1) rather
+ * than unnormalized weights, and there are no dangling edges. Unlike a
+ * fully general transition matrix, parallel edges are still reified,
+ * not collapsed; nodes have weights, representing sources of flow, and
+ * a few SourceCred-specific concepts are made first-class:
+ * specifically, cred minting and time period fibration. The
+ * "teleportation vector" from PageRank is also made explicit via the
+ * "adjoined seed node" graph transformation strategy, so this data
+ * structure can form well-defined Markov processes even from graphs
+ * with nodes with no out-weight. Because the graph reifies the
+ * teleportation and temporal fibration, the associated parameters are
+ * "baked in" to weights of the Markov process graph.
+ *
+ * We use the term "fibration" to refer to a graph transformation where
+ * each scoring node is split into one node per epoch, and incident
+ * edges are rewritten to point to the appropriate epoch nodes. The term
+ * is vaguely inspired from the notion of a fiber bundle, though the
+ * analogy is not precise.
+ *
+ * The Markov process graphs in this module have three kinds of nodes:
+ *
+ *   - *contribution nodes*, which are in 1-to-1 correspondence with the
+ *     nodes in the underlying core graph (including users);
+ *   - *epoch nodes*, which are created for each time period for each
+ *     scoring node; and
+ *   - the *seed node*, which reifies the teleportation vector and
+ *     forces well-definedness and ergodicity of the Markov process (for
+ *     nonzero alpha, and assuming that there is at least one edge in
+ *     the underlying graph).
+ *
+ * The edges include:
+ *
+ *   - *contribution edges* between nodes in the underlying graph, which
+ *     are lifted to their corresponding contribution nodes or to epoch
+ *     nodes if either endpoint has been fibrated;
+ *   - *seed-in* / "redistribution" / "radiation" edges from nodes to
+ *     the seed node;
+ *   - *seed-out* / "minting" edges from the seed node to cred-minting
+ *     nodes;
+ *   - *webbing edges* between temporally adjacent epoch nodes; and
+ *   - *payout edges* from an epoch node to its owner (a scoring node).
+ *
+ * A Markov process graph can be converted to a pure Markov chain for
+ * spectral analysis via the `toMarkovChain` method.
+ */
+
+import {max, min} from "d3-array";
+import {weekIntervals} from "./interval";
+import sortedIndex from "lodash.sortedindex";
+import {makeAddressModule, type AddressModule} from "./address";
+import {
+  type NodeAddressT,
+  NodeAddress,
+  type EdgeAddressT,
+  EdgeAddress,
+  type Graph,
+} from "./graph";
+import {type WeightedGraph as WeightedGraphT} from "./weightedGraph";
+import {type NodeWeight} from "./weights";
+import {
+  nodeWeightEvaluator,
+  edgeWeightEvaluator,
+} from "./algorithm/weightEvaluator";
+import {toCompat, fromCompat, type Compatible} from "../util/compat";
+import * as NullUtil from "../util/null";
+import * as MapUtil from "../util/map";
+import {type SparseMarkovChain} from "./algorithm/markovChain";
+
+export type TimestampMs = number;
+export type TransitionProbability = number;
+
+export type MarkovNode = {|
+  // Node address, unique within a Markov process graph. This is either
+  // the address of a contribution node or an address under the
+  // `sourcecred/core` namespace.
+  +address: NodeAddressT,
+  // Markdown source description, as in `Node` from `core/graph`.
+  +description: string,
+  // Amount of cred to mint at this node.
+  +weight: NodeWeight,
+|};
+export type MarkovEdge = {|
+  // Address of the underlying edge. Note that this attribute alone does
+  // not uniquely identify an edge in the Markov process graph; the
+  // primary key is `(address, reversed)`, not just `address`. For edges
+  // not in the underlying graph (e.g., fibration edges), this will be
+  // an address under the `sourcecred/core` namespace.
+  +address: EdgeAddressT,
+  // If this came from an underlying graph edge or an epoch webbing
+  // edge, have its `src` and `dst` been swapped in the process of
+  // handling the reverse component of a bidirectional edge?
+  +reversed: boolean,
+  // Source node at the Markov chain level.
+  +src: NodeAddressT,
+  // Destination node at the Markov chain level.
+  +dst: NodeAddressT,
+  // Transition probability: $Pr[X_{n+1} = dst | X_{n} = src]$. Must sum
+  // to unity for a given `src`.
+  +transitionProbability: TransitionProbability,
+|};
+export opaque type MarkovEdgeAddressT: string = string;
+export const MarkovEdgeAddress: AddressModule<MarkovEdgeAddressT> = (makeAddressModule(
+  {
+    name: "MarkovEdgeAddress",
+    nonce: "ME",
+    otherNonces: new Map().set("N", "NodeAddress").set("E", "EdgeAddress"),
+  }
+): AddressModule<string>);
+
+function rawEdgeAddress(edge: MarkovEdge): MarkovEdgeAddressT {
+  return MarkovEdgeAddress.fromParts([
+    edge.reversed ? "B" /* Backward */ : "F" /* Forward */,
+    ...EdgeAddress.toParts(edge.address),
+  ]);
+}
+
+export type OrderedSparseMarkovChain = {|
+  +nodeOrder: $ReadOnlyArray<NodeAddressT>,
+  +chain: SparseMarkovChain,
+|};
+
+// Address of a seed node. All graph nodes tithe $\alpha$ to this node,
+// and this node flows out to nodes in proportion to their weight. This
+// is also a node prefix for the "seed node" type, which contains only
+// one node.
+const SEED_ADDRESS = NodeAddress.fromParts(["sourcecred", "core", "SEED"]);
+const SEED_DESCRIPTION = "\u{1f331}"; // SEEDLING
+
+// Node address prefix for epoch nodes.
+const EPOCH_PREFIX = NodeAddress.fromParts(["sourcecred", "core", "EPOCH"]);
+
+export type EpochNodeAddress = {|
+  +type: "EPOCH_NODE",
+  +owner: NodeAddressT,
+  +epochStart: TimestampMs,
+|};
+
+export function epochNodeAddressToRaw(addr: EpochNodeAddress): NodeAddressT {
+  return NodeAddress.append(
+    EPOCH_PREFIX,
+    String(addr.epochStart),
+    ...NodeAddress.toParts(addr.owner)
+  );
+}
+
+export function epochNodeAddressFromRaw(addr: NodeAddressT): EpochNodeAddress {
+  if (!NodeAddress.hasPrefix(addr, EPOCH_PREFIX)) {
+    throw new Error("Not an epoch node address: " + NodeAddress.toString(addr));
+  }
+  const epochPrefixLength = NodeAddress.toParts(EPOCH_PREFIX).length;
+  const parts = NodeAddress.toParts(addr);
+  const epochStart = +parts[epochPrefixLength];
+  const owner = NodeAddress.fromParts(parts.slice(epochPrefixLength + 1));
+  return {
+    type: "EPOCH_NODE",
+    owner,
+    epochStart,
+  };
+}
+
+// Prefixes for fibration edges.
+const FIBRATION_EDGE = EdgeAddress.fromParts([
+  "sourcecred",
+  "core",
+  "fibration",
+]);
+const EPOCH_PAYOUT = EdgeAddress.append(FIBRATION_EDGE, "EPOCH_PAYOUT");
+const EPOCH_WEBBING = EdgeAddress.append(FIBRATION_EDGE, "EPOCH_WEBBING");
+// Prefixes for seed edges.
+const SEED_IN = EdgeAddress.fromParts(["sourcecred", "core", "SEED_IN"]);
+const SEED_OUT = EdgeAddress.fromParts(["sourcecred", "core", "SEED_OUT"]);
+
+export type FibrationOptions = {|
+  // List of node prefixes for temporal fibration. A node with address
+  // `a` will be fibrated if `NodeAddress.hasPrefix(node, prefix)` for
+  // some element `prefix` of `what`.
+  +what: $ReadOnlyArray<NodeAddressT>,
+  // Transition probability for payout edges from epoch nodes to their
+  // owners.
+  +beta: TransitionProbability,
+  // Transition probability for webbing edges from an epoch node to the
+  // next epoch node for the same owner.
+  +gammaForward: TransitionProbability,
+  +gammaBackward: TransitionProbability,
+|};
+export type SeedOptions = {|
+  +alpha: TransitionProbability,
+|};
+
+const COMPAT_INFO = {type: "sourcecred/markovProcessGraph", version: "0.1.0"};
+
+export type MarkovProcessGraphJSON = Compatible<{|
+  +nodes: {|+[NodeAddressT]: MarkovNode|},
+  +edges: {|+[MarkovEdgeAddressT]: MarkovEdge|},
+  +scoringAddresses: $ReadOnlyArray<NodeAddressT>,
+|}>;
+
+export class MarkovProcessGraph {
+  _nodes: Map<NodeAddressT, MarkovNode>;
+  _edges: Map<MarkovEdgeAddressT, MarkovEdge>;
+  _scoringAddresses: Set<NodeAddressT>;
+
+  constructor(
+    nodes: Map<NodeAddressT, MarkovNode>,
+    edges: Map<MarkovEdgeAddressT, MarkovEdge>,
+    scoringAddresses: Set<NodeAddressT>
+  ) {
+    this._nodes = nodes;
+    this._edges = edges;
+    this._scoringAddresses = scoringAddresses;
+  }
+
+  static new(
+    wg: WeightedGraphT,
+    fibration: FibrationOptions,
+    seed: SeedOptions
+  ) {
+    const _nodes = new Map();
+    const _edges = new Map();
+    const _scoringAddresses = _findScoringAddresses(wg.graph, fibration.what);
+
+    const epochTransitionRemainder = (() => {
+      const {beta, gammaForward, gammaBackward} = fibration;
+      if (beta < 0 || gammaForward < 0 || gammaBackward < 0) {
+        throw new Error(
+          "Negative transition probability: " +
+            [beta, gammaForward, gammaBackward].join(" or ")
+        );
+      }
+      const result = 1 - (beta + gammaForward + gammaBackward);
+      if (result < 0) {
+        throw new Error("Overlarge transition probability: " + (1 - result));
+      }
+      return result;
+    })();
+
+    const timeBoundaries = (() => {
+      const edgeTimestamps = Array.from(
+        wg.graph.edges({showDangling: false})
+      ).map((x) => x.timestampMs);
+      const start = min(edgeTimestamps);
+      const end = max(edgeTimestamps);
+      const boundaries = weekIntervals(start, end).map((x) => x.startTimeMs);
+      return [-Infinity, ...boundaries, Infinity];
+    })();
+
+    const addNode = (node: MarkovNode) => {
+      if (_nodes.has(node.address)) {
+        throw new Error("Node conflict: " + node.address);
+      }
+      _nodes.set(node.address, node);
+    };
+    const addEdge = (edge: MarkovEdge) => {
+      const mae = rawEdgeAddress(edge);
+      if (_edges.has(mae)) {
+        throw new Error("Edge conflict: " + mae);
+      }
+      _edges.set(mae, edge);
+    };
+
+    // Add seed node
+    addNode({
+      address: SEED_ADDRESS,
+      description: SEED_DESCRIPTION,
+      weight: 0,
+    });
+
+    // Add graph nodes
+    const nwe = nodeWeightEvaluator(wg.weights);
+    for (const node of wg.graph.nodes()) {
+      const weight = nwe(node.address);
+      if (weight < 0) {
+        const name = NodeAddress.toString(node.address);
+        throw new Error(`Negative node weight for ${name}: ${weight}`);
+      }
+      addNode({
+        address: node.address,
+        description: node.description,
+        weight,
+      });
+    }
+
+    // Add epoch nodes, payout edges, and epoch webbing
+    for (const scoringAddress of _scoringAddresses) {
+      let lastBoundary = null;
+      for (const boundary of timeBoundaries) {
+        const thisEpoch = epochNodeAddressToRaw({
+          type: "EPOCH_NODE",
+          owner: scoringAddress,
+          epochStart: boundary,
+        });
+        addNode({
+          address: thisEpoch,
+          description: `Epoch starting ${boundary} ms past epoch`,
+          weight: 0,
+        });
+        addEdge({
+          address: EdgeAddress.append(
+            EPOCH_PAYOUT,
+            String(boundary),
+            ...NodeAddress.toParts(scoringAddress)
+          ),
+          reversed: false,
+          src: thisEpoch,
+          dst: scoringAddress,
+          transitionProbability: fibration.beta,
+        });
+        if (lastBoundary != null) {
+          const lastEpoch = epochNodeAddressToRaw({
+            type: "EPOCH_NODE",
+            owner: scoringAddress,
+            epochStart: lastBoundary,
+          });
+          const webAddress = EdgeAddress.append(
+            EPOCH_WEBBING,
+            String(boundary),
+            ...NodeAddress.toParts(scoringAddress)
+          );
+          addEdge({
+            address: webAddress,
+            reversed: false,
+            src: lastEpoch,
+            dst: thisEpoch,
+            transitionProbability: fibration.gammaForward,
+          });
+          addEdge({
+            address: webAddress,
+            reversed: true,
+            src: thisEpoch,
+            dst: lastEpoch,
+            transitionProbability: fibration.gammaBackward,
+          });
+        }
+        lastBoundary = boundary;
+      }
+    }
+
+    // Add radiation (seed-in) edges
+    for (const node of wg.graph.nodes()) {
+      addEdge({
+        address: EdgeAddress.append(
+          SEED_IN,
+          ...NodeAddress.toParts(node.address)
+        ),
+        reversed: false,
+        src: node.address,
+        dst: SEED_ADDRESS,
+        transitionProbability: seed.alpha,
+      });
+    }
+
+    // Add minting (seed-out) edges
+    {
+      let totalNodeWeight = 0.0;
+      const positiveNodeWeights: Map<NodeAddressT, number> = new Map();
+      for (const {address, weight} of _nodes.values()) {
+        if (weight > 0) {
+          totalNodeWeight += weight;
+          positiveNodeWeights.set(address, weight);
+        }
+      }
+      if (!(totalNodeWeight > 0)) {
+        throw new Error("No outflow from seed; add cred-minting nodes");
+      }
+      for (const [address, weight] of positiveNodeWeights) {
+        addEdge({
+          address: EdgeAddress.append(
+            SEED_OUT,
+            ...NodeAddress.toParts(address)
+          ),
+          reversed: false,
+          src: SEED_ADDRESS,
+          dst: address,
+          transitionProbability: weight / totalNodeWeight,
+        });
+      }
+    }
+
+    /**
+     * Find an epoch node, or just the original node if it's not a
+     * scoring address.
+     */
+    const rewriteEpochNode = (
+      address: NodeAddressT,
+      edgeTimestampMs: number
+    ): NodeAddressT => {
+      if (!_scoringAddresses.has(address)) {
+        return address;
+      }
+      const epochEndIndex = sortedIndex(timeBoundaries, edgeTimestampMs);
+      const epochStartIndex = epochEndIndex - 1;
+      const epochTimestampMs = timeBoundaries[epochStartIndex];
+      return epochNodeAddressToRaw({
+        type: "EPOCH_NODE",
+        owner: address,
+        epochStart: epochTimestampMs,
+      });
+    };
+
+    // Add graph edges. First, split by direction.
+    type _UnidirectionalGraphEdge = {|
+      +address: EdgeAddressT,
+      +reversed: boolean,
+      +src: NodeAddressT,
+      +dst: NodeAddressT,
+      +timestamp: TimestampMs,
+      +weight: number,
+    |};
+    const unidirectionalGraphEdges = function* (): Iterator<_UnidirectionalGraphEdge> {
+      const ewe = edgeWeightEvaluator(wg.weights);
+      for (const edge of (function* () {
+        for (const edge of wg.graph.edges({showDangling: false})) {
+          const weight = ewe(edge.address);
+          yield {
+            address: edge.address,
+            reversed: false,
+            src: edge.src,
+            dst: edge.dst,
+            timestamp: edge.timestampMs,
+            weight: weight.forwards,
+          };
+          yield {
+            address: edge.address,
+            reversed: true,
+            src: edge.dst,
+            dst: edge.src,
+            timestamp: edge.timestampMs,
+            weight: weight.backwards,
+          };
+        }
+      })()) {
+        if (edge.weight > 0) {
+          yield edge;
+        }
+      }
+    };
+
+    const srcNodes: Map<
+      NodeAddressT /* domain: (nodes with out-edges) U (epoch nodes) */,
+      {totalOutWeight: number, outEdges: _UnidirectionalGraphEdge[]}
+    > = new Map();
+    for (const graphEdge of unidirectionalGraphEdges()) {
+      const src = rewriteEpochNode(graphEdge.src, graphEdge.timestamp);
+      let datum = srcNodes.get(src);
+      if (datum == null) {
+        datum = {totalOutWeight: 0, outEdges: []};
+        srcNodes.set(src, datum);
+      }
+      datum.totalOutWeight += graphEdge.weight;
+      datum.outEdges.push(graphEdge);
+    }
+    for (const [src, {totalOutWeight, outEdges}] of srcNodes) {
+      const totalOutPr = NodeAddress.hasPrefix(src, EPOCH_PREFIX)
+        ? epochTransitionRemainder
+        : 1 - seed.alpha;
+      for (const outEdge of outEdges) {
+        const pr = (outEdge.weight / totalOutWeight) * totalOutPr;
+        addEdge({
+          address: outEdge.address,
+          reversed: outEdge.reversed,
+          src: rewriteEpochNode(outEdge.src, outEdge.timestamp),
+          dst: rewriteEpochNode(outEdge.dst, outEdge.timestamp),
+          transitionProbability: pr,
+        });
+      }
+    }
+
+    return new MarkovProcessGraph(_nodes, _edges, _scoringAddresses);
+  }
+
+  scoringAddresses(): Set<NodeAddressT> {
+    return new Set(this._scoringAddresses);
+  }
+
+  node(address: NodeAddressT): MarkovNode | null {
+    NodeAddress.assertValid(address);
+    return this._nodes.get(address) || null;
+  }
+
+  *nodes(options?: {|+prefix: NodeAddressT|}): Iterator<MarkovNode> {
+    const prefix = options ? options.prefix : NodeAddress.empty;
+    for (const node of this._nodes.values()) {
+      if (NodeAddress.hasPrefix(node.address, prefix)) {
+        yield node;
+      }
+    }
+  }
+
+  *edges(): Iterator<MarkovEdge> {
+    for (const edge of this._edges.values()) {
+      yield edge;
+    }
+  }
+
+  *inNeighbors(nodeAddress: NodeAddressT): Iterator<MarkovEdge> {
+    for (const edge of this._edges.values()) {
+      if (edge.dst !== nodeAddress) {
+        continue;
+      }
+      yield edge;
+    }
+  }
+
+  toMarkovChain(): OrderedSparseMarkovChain {
+    const nodeOrder = Array.from(this._nodes.keys()).sort();
+    const nodeIndex: Map<
+      NodeAddressT,
+      number /* index into nodeOrder */
+    > = new Map();
+    nodeOrder.forEach((n, i) => {
+      nodeIndex.set(n, i);
+    });
+
+    const inNeighbors: Map<NodeAddressT, MarkovEdge[]> = new Map();
+    for (const edge of this._edges.values()) {
+      MapUtil.pushValue(inNeighbors, edge.dst, edge);
+    }
+
+    const chain = nodeOrder.map((addr) => {
+      const inEdges = NullUtil.orElse(inNeighbors.get(addr), []);
+      const inDegree = inEdges.length;
+      const neighbor = new Uint32Array(inDegree);
+      const weight = new Float64Array(inDegree);
+      inEdges.forEach((e, i) => {
+        // Note: We don't group-by src, so there may be multiple `j`
+        // such that `neighbor[j] === k` for a given `k` when there are
+        // parallel edges in the source graph. This should just work
+        // down the stack.
+        const result = nodeIndex.get(e.src);
+        if (result == null) {
+          throw new Error(e.src);
+        }
+        neighbor[i] = result;
+        weight[i] = e.transitionProbability;
+      });
+      return {neighbor, weight};
+    });
+
+    return {nodeOrder, chain};
+  }
+
+  toJSON(): MarkovProcessGraphJSON {
+    return toCompat(COMPAT_INFO, {
+      nodes: MapUtil.toObject(this._nodes),
+      edges: MapUtil.toObject(this._edges),
+      scoringAddresses: Array.from(this._scoringAddresses),
+    });
+  }
+
+  static fromJSON(j: MarkovProcessGraphJSON): MarkovProcessGraph {
+    const data = fromCompat(COMPAT_INFO, j);
+    return new MarkovProcessGraph(
+      MapUtil.fromObject(data.nodes),
+      MapUtil.fromObject(data.edges),
+      new Set(data.scoringAddresses)
+    );
+  }
+}
+
+/** Find addresses of all nodes matching any of the scoring prefixes. */
+function _findScoringAddresses(
+  graph: Graph,
+  scoringPrefixes: $ReadOnlyArray<NodeAddressT>
+): Set<NodeAddressT> {
+  const result = new Set();
+  for (const {address} of graph.nodes()) {
+    if (scoringPrefixes.some((p) => NodeAddress.hasPrefix(address, p))) {
+      result.add(address);
+    }
+  }
+  return result;
+}

--- a/src/core/markovProcessGraph.js
+++ b/src/core/markovProcessGraph.js
@@ -69,9 +69,9 @@ import {
 import {toCompat, fromCompat, type Compatible} from "../util/compat";
 import * as NullUtil from "../util/null";
 import * as MapUtil from "../util/map";
+import type {TimestampMs} from "../util/timestamp";
 import {type SparseMarkovChain} from "./algorithm/markovChain";
 
-export type TimestampMs = number;
 export type TransitionProbability = number;
 
 export type MarkovNode = {|
@@ -391,7 +391,7 @@ export class MarkovProcessGraph {
      */
     const rewriteEpochNode = (
       address: NodeAddressT,
-      edgeTimestampMs: number
+      edgeTimestampMs: TimestampMs
     ): NodeAddressT => {
       if (!_scoringAddresses.has(address)) {
         return address;

--- a/src/core/markovProcessGraph.js
+++ b/src/core/markovProcessGraph.js
@@ -296,6 +296,12 @@ export class MarkovProcessGraph {
         const name = NodeAddress.toString(node.address);
         throw new Error(`Negative node weight for ${name}: ${weight}`);
       }
+      if (NodeAddress.hasPrefix(node.address, CORE_NODE_PREFIX)) {
+        throw new Error(
+          "Unexpected core node in underlying graph: " +
+            NodeAddress.toString(node.address)
+        );
+      }
       addNode({
         address: node.address,
         description: node.description,

--- a/src/core/markovProcessGraph.js
+++ b/src/core/markovProcessGraph.js
@@ -294,9 +294,9 @@ export class MarkovProcessGraph {
     const nwe = nodeWeightEvaluator(wg.weights);
     for (const node of wg.graph.nodes()) {
       const weight = nwe(node.address);
-      if (weight < 0) {
+      if (weight < 0 || !Number.isFinite(weight)) {
         const name = NodeAddress.toString(node.address);
-        throw new Error(`Negative node weight for ${name}: ${weight}`);
+        throw new Error(`Bad node weight for ${name}: ${weight}`);
       }
       if (NodeAddress.hasPrefix(node.address, CORE_NODE_PREFIX)) {
         throw new Error(

--- a/src/core/markovProcessGraph.js
+++ b/src/core/markovProcessGraph.js
@@ -61,7 +61,6 @@ import {
   type Graph,
 } from "./graph";
 import {type WeightedGraph as WeightedGraphT} from "./weightedGraph";
-import {type NodeWeight} from "./weights";
 import {
   nodeWeightEvaluator,
   edgeWeightEvaluator,

--- a/src/core/markovProcessGraph.js
+++ b/src/core/markovProcessGraph.js
@@ -180,8 +180,8 @@ const SEED_MINT = EdgeAddress.fromParts(["sourcecred", "core", "SEED_MINT"]);
 
 export type FibrationOptions = {|
   // List of node prefixes for temporal fibration. A node with address
-  // `a` will be fibrated if `NodeAddress.hasPrefix(node, prefix)` for
-  // some element `prefix` of `what`.
+  // `a` will be fibrated if `NodeAddress.hasPrefix(a, prefix)` for some
+  // element `prefix` of `what`.
   +what: $ReadOnlyArray<NodeAddressT>,
   // Transition probability for payout edges from epoch nodes to their
   // owners.

--- a/src/core/markovProcessGraph.js
+++ b/src/core/markovProcessGraph.js
@@ -125,10 +125,10 @@ export type OrderedSparseMarkovChain = {|
 
 const CORE_NODE_PREFIX = NodeAddress.fromParts(["sourcecred", "core"]);
 
-// Address of a seed node. All graph nodes tithe $\alpha$ to this node,
-// and this node flows out to nodes in proportion to their weight. This
-// is also a node prefix for the "seed node" type, which contains only
-// one node.
+// Address of the seed node. All graph nodes radiate $\alpha$ to this
+// node, and this node flows out to nodes in proportion to their weight
+// (mint). This is also a node prefix for the "seed node" type, which
+// contains only one node.
 const SEED_ADDRESS = NodeAddress.append(CORE_NODE_PREFIX, "SEED");
 const SEED_DESCRIPTION = "\u{1f331}"; // U+1F331 SEEDLING
 
@@ -235,7 +235,9 @@ export class MarkovProcessGraph {
     // Used for computing remainder-to-seed edges.
     const _nodeOutMasses = new Map();
 
-    const epochTransitionRemainder = (() => {
+    // Amount of mass allocated to contribution edges flowing from epoch
+    // nodes.
+    const epochTransitionRemainder: number = (() => {
       const {alpha} = seed;
       const {beta, gammaForward, gammaBackward} = fibration;
       if (beta < 0 || gammaForward < 0 || gammaBackward < 0) {

--- a/src/core/markovProcessGraph.js
+++ b/src/core/markovProcessGraph.js
@@ -82,7 +82,7 @@ export type MarkovNode = {|
   // Markdown source description, as in `Node` from `core/graph`.
   +description: string,
   // Amount of cred to mint at this node.
-  +weight: NodeWeight,
+  +mint: number,
 |};
 export type MarkovEdge = {|
   // Address of the underlying edge. Note that this attribute alone does
@@ -271,7 +271,7 @@ export class MarkovProcessGraph {
     addNode({
       address: SEED_ADDRESS,
       description: SEED_DESCRIPTION,
-      weight: 0,
+      mint: 0,
     });
 
     // Add graph nodes
@@ -285,7 +285,7 @@ export class MarkovProcessGraph {
       addNode({
         address: node.address,
         description: node.description,
-        weight,
+        mint: weight,
       });
     }
 
@@ -301,7 +301,7 @@ export class MarkovProcessGraph {
         addNode({
           address: thisEpoch,
           description: `Epoch starting ${boundary} ms past epoch`,
-          weight: 0,
+          mint: 0,
         });
         addEdge({
           address: EdgeAddress.append(
@@ -362,10 +362,10 @@ export class MarkovProcessGraph {
     {
       let totalNodeWeight = 0.0;
       const positiveNodeWeights: Map<NodeAddressT, number> = new Map();
-      for (const {address, weight} of _nodes.values()) {
-        if (weight > 0) {
-          totalNodeWeight += weight;
-          positiveNodeWeights.set(address, weight);
+      for (const {address, mint} of _nodes.values()) {
+        if (mint > 0) {
+          totalNodeWeight += mint;
+          positiveNodeWeights.set(address, mint);
         }
       }
       if (!(totalNodeWeight > 0)) {

--- a/src/core/markovProcessGraph.js
+++ b/src/core/markovProcessGraph.js
@@ -8,7 +8,7 @@
  * weights are raw transition probabilities (which must sum to 1) rather
  * than unnormalized weights, and there are no dangling edges. Unlike a
  * fully general transition matrix, parallel edges are still reified,
- * not collapsed; nodes have weights, representing sources of flow, and
+ * not collapsed; nodes have weights, representing sources of flow; and
  * a few SourceCred-specific concepts are made first-class:
  * specifically, cred minting and time period fibration. The
  * "teleportation vector" from PageRank is also made explicit via the


### PR DESCRIPTION
Summary:
We introduce the *Markov process graph* data type: a weighted graph with
unidirectional edges whose out-weights sum to 1 for each node, and whose
mixing process semantics are given directly by the transition matrix.
Higher-order transformations like seed teleportation and epoch fibration
are compiled into the graph as new nodes and edges, which behave just
the same way as underlying graph nodes. For more background, see the
CredRank initiative:
<https://discourse.sourcecred.io/t/credrank-scalable-interpretable-flexible-attribution/654>

The main purpose of this patch is to start getting pieces of this work
into master to unblock downstream development. We include a basic CLI
entry point for manual testing, but no automated tests yet, and the
interfaces should be considered merely “not obviously wrong”.

Based on original work in collaboration with @decentralion.

Test Plan:
On a test instance with the GitHub plugin pointing at the SourceCred
core repository, running the `load`, `graph`, `credrank` sequence yields
an `output/credGraph.json`, and a spot-check of the top-scoring users—

```
jq '
    .scores as $scores
    | [
        $scores | keys | .[]
        | {raw: ., parts: split("\u0000")}
        | select(.parts[2:5] == ["github", "USERLIKE", "USER"])
        | {who: .parts | join("/"), score: $scores[.raw]}
    ]
    | sort_by(-.score)[:10]
    | map({(.who): .score})
    | add
'
```

—is roughly consistent with what we’d expect. The `credrank` step takes
about 1–2 seconds to build the Markov process graph and 500 ms to run
CredRank (on my laptop), compared to about 50 seconds to run timeline
cred analysis, so we’re looking at a speedup of multiple orders of
magnitude.

wchargin-branch: credrank-mpg-cli
