### PR TITLE
Prevent overriding project fields when auto-upgrading

### DIFF
--- a/src/core/project.js
+++ b/src/core/project.js
@@ -88,8 +88,8 @@ export function encodeProjectId(id: ProjectId): string {
 }
 
 const upgradeFrom051 = (p: ProjectV051): ProjectV052 => ({
-  ...p,
   discord: null,
+  ...p,
 });
 
 export type ProjectV051 = {|
@@ -103,8 +103,8 @@ export type ProjectV051 = {|
 
 const upgradeFrom050 = (p: ProjectV050) =>
   upgradeFrom051({
-    ...p,
     timelineCredParams: {},
+    ...p,
   });
 
 export type ProjectV050 = {|
@@ -117,8 +117,8 @@ export type ProjectV050 = {|
 
 const upgradeFrom040 = (p: ProjectV040) =>
   upgradeFrom050({
-    ...p,
     initiatives: null,
+    ...p,
   });
 
 export type ProjectV040 = {|

--- a/src/core/project.test.js
+++ b/src/core/project.test.js
@@ -15,7 +15,7 @@ import {
 
 import {makeRepoId} from "../plugins/github/repoId";
 import {toCompat} from "../util/compat";
-import type {ProjectV050, ProjectV051} from "./project";
+import type {ProjectV050, ProjectV051, ProjectV052} from "./project";
 
 describe("core/project", () => {
   const foobar = deepFreeze(makeRepoId("foo", "bar"));
@@ -173,7 +173,7 @@ describe("core/project", () => {
   it("should upgrade from 0.5.1 formatting", () => {
     // Given
     const body: ProjectV051 = {
-      id: "example-050",
+      id: "example-051",
       repoIds: [foobar, foozod],
       discourseServer: {serverUrl: "https://example.com"},
       identities: [],
@@ -193,6 +193,33 @@ describe("core/project", () => {
       ({
         ...body,
         discord: null,
+      }: Project)
+    );
+  });
+
+  it("should upgrade from 0.5.0 formatting without overwriting fields", () => {
+    // Given
+    const body: ProjectV052 = {
+      id: "example-051",
+      repoIds: [foobar, foozod],
+      discourseServer: {serverUrl: "https://example.com"},
+      identities: [],
+      initiatives: null,
+      timelineCredParams: {alpha: 0.2, intervalDecay: 0.5},
+      discord: {guildId: "1234", reactionWeights: {}},
+    };
+    const compat = toCompat(
+      {type: "sourcecred/project", version: "0.5.0"},
+      body
+    );
+
+    // When
+    const project = projectFromJSON(compat);
+
+    // Then
+    expect(project).toEqual(
+      ({
+        ...body,
       }: Project)
     );
   });


### PR DESCRIPTION
If a project.json file defines a field that belongs to a newer version but the compat version wasnt updated, the
auto-upgrade code would silently throw away the field, changing it to the default setting of null. This fixes it
by spreading the project object after adding the new field instead of before, that way if that field was defined
in the project file it wont get overwritten while still adding the empty case if it wasnt defined.

Test Plan: Add a field belonging to ProjectV052 in a project file with compat version 0.5.0 and ensure it doesn't get
overwritten.