### PR TITLE
Configure frontend2 to load from instances

### DIFF
--- a/src/homepage2/HomePage.js
+++ b/src/homepage2/HomePage.js
@@ -5,7 +5,23 @@ import React from "react";
 import type {Assets} from "../webutil/assets";
 import {StyleSheet, css} from "aphrodite/no-important";
 
+async function loadAndReport(assets, path) {
+  const url = assets.resolve(path);
+  const response = await fetch(url);
+  if (!response.ok) {
+    console.error(path, response);
+  }
+  const json = await response.json();
+  console.log(path, json);
+}
+
 export default class HomePage extends React.Component<{|+assets: Assets|}> {
+  async componentDidMount() {
+    loadAndReport(this.props.assets, "sourcecred.json");
+    loadAndReport(this.props.assets, "output/credResult.json");
+    loadAndReport(this.props.assets, "config/sourcecred/discourse/config.json");
+  }
+
   render() {
     return (
       <div className={css(styles.container)}>


### PR DESCRIPTION
This modifies the frontend2 so that we can load real data from cli2
instances, including:
- the root `sourcecred.json` config
- files inside the `config/` directory
- files inside the `output/` directory

This works both for the dev server and the compiled output.

In the case of the dev server, it's now necessary to provide the path to
the cli2 instance you're developing against. You can pass this via the
`--instance` argument, as in `yarn start2 --instance=/path/`, or via
the `$SOURCECRED_DEV_INSTANCE` environment variable (recommended). If
neither is provided, or if that path doesn't look like a valid instance,
an error is thrown.

In the case of the built output, given a valid sc2 instance, you can set
it up via the following:

```
cp -r build2/favicon.png build2/index.html build2/static $INSTANCE
```

Then spin up a simple http server in the $INSTANCE.

You can look at console messages in the frontend to verify that the
instance is working (note it expects to see a discourse config file, not
a GitHub config file as was used in some previous examples).

Test plan:
Setup an example Discourse instance, and then turn on the server via
`yarn start2 --instance=PATH`,
`SOURCECRED_DEV_INSTANCE=path yarn start2`,
and by manually copying in the built outputs using the instructions
above.

In each case, you can load the homepage and check the console to see
that assets loaded successfully.