### PR TITLE
Integrate Discord into CLI2

### DIFF
--- a/src/api/load.js
+++ b/src/api/load.js
@@ -4,7 +4,7 @@ import {type Project} from "../core/project";
 import {type Weights as WeightsT} from "../core/weights";
 import {type PluginDeclaration} from "../analysis/pluginDeclaration";
 import {type TimelineCredParameters} from "../analysis/timeline/params";
-import {type DiscordToken} from "../plugins/experimental-discord/params";
+import {type DiscordToken} from "../plugins/experimental-discord/config";
 import {type GithubToken} from "../plugins/github/token";
 import {type CacheProvider} from "../backend/cache";
 import {DataDirectory} from "../backend/dataDirectory";

--- a/src/backend/loadContext.js
+++ b/src/backend/loadContext.js
@@ -6,7 +6,7 @@ import {type WeightedGraph as WeightedGraphT} from "../core/weightedGraph";
 import * as WeightedGraph from "../core/weightedGraph";
 import {type TimelineCredParameters} from "../analysis/timeline/params";
 import {type GithubToken} from "../plugins/github/token";
-import {type DiscordToken} from "../plugins/experimental-discord/params";
+import {type DiscordToken} from "../plugins/experimental-discord/config";
 import {type CacheProvider} from "./cache";
 import {TaskReporter} from "../util/taskReporter";
 import {TimelineCred} from "../analysis/timeline/timelineCred";

--- a/src/backend/pluginLoaders.js
+++ b/src/backend/pluginLoaders.js
@@ -7,7 +7,7 @@ import * as WeightedGraph from "../core/weightedGraph";
 import {type PluginDeclaration} from "../analysis/pluginDeclaration";
 import {type CacheProvider} from "./cache";
 import {type GithubToken} from "../plugins/github/token";
-import {type DiscordToken} from "../plugins/experimental-discord/params";
+import {type DiscordToken} from "../plugins/experimental-discord/config";
 import {type Loader as GithubLoader} from "../plugins/github/loader";
 import {type Loader as DiscordLoader} from "../plugins/experimental-discord/loader";
 import {type Loader as DiscourseLoader} from "../plugins/discourse/loader";

--- a/src/cli/common.js
+++ b/src/cli/common.js
@@ -7,7 +7,7 @@ import deepFreeze from "deep-freeze";
 import fs from "fs-extra";
 import {type Weights, fromJSON as weightsFromJSON} from "../core/weights";
 import {validateToken, type GithubToken} from "../plugins/github/token";
-import {type DiscordToken} from "../plugins/experimental-discord/params";
+import {type DiscordToken} from "../plugins/experimental-discord/config";
 
 export type PluginName = "git" | "github";
 

--- a/src/cli2/bundledPlugins.js
+++ b/src/cli2/bundledPlugins.js
@@ -3,6 +3,7 @@
 import type {CliPlugin} from "./cliPlugin";
 import {GithubCliPlugin} from "../plugins/github/cliPlugin";
 import {DiscourseCliPlugin} from "../plugins/discourse/cliPlugin";
+import {DiscordCliPlugin} from "../plugins/experimental-discord/cliPlugin";
 
 /**
  * Returns an object mapping owner-name pairs to CLI plugin
@@ -12,5 +13,6 @@ export function bundledPlugins(): {[pluginId: string]: CliPlugin} {
   return {
     "sourcecred/github": new GithubCliPlugin(),
     "sourcecred/discourse": new DiscourseCliPlugin(),
+    "sourcecred/discord": new DiscordCliPlugin(),
   };
 }

--- a/src/core/project.js
+++ b/src/core/project.js
@@ -7,7 +7,7 @@ import {type ProjectParameters as Initiatives} from "../plugins/initiatives/para
 import {type Identity} from "../plugins/identity/identity";
 import {type DiscourseServer} from "../plugins/discourse/server";
 import type {TimelineCredParameters} from "../analysis/timeline/params";
-import {type ProjectOptions as Discord} from "../plugins/experimental-discord/params";
+import {type DiscordConfig as Discord} from "../plugins/experimental-discord/config";
 
 export type ProjectId = string;
 

--- a/src/plugins/experimental-discord/cliPlugin.js
+++ b/src/plugins/experimental-discord/cliPlugin.js
@@ -1,0 +1,89 @@
+// @flow
+
+import Database from "better-sqlite3";
+
+import type {CliPlugin, PluginDirectoryContext} from "../../cli2/cliPlugin";
+import type {PluginDeclaration} from "../../analysis/pluginDeclaration";
+import {parseConfig, type DiscordConfig, type DiscordToken} from "./config";
+import {declaration} from "./declaration";
+import {join as pathJoin} from "path";
+import fs from "fs-extra";
+import {type TaskReporter} from "../../util/taskReporter";
+import {Fetcher} from "./fetcher";
+import {Mirror} from "./mirror";
+import type {ReferenceDetector} from "../../core/references/referenceDetector";
+import type {WeightedGraph} from "../../core/weightedGraph";
+import {weightsForDeclaration} from "../../analysis/pluginDeclaration";
+import {createGraph} from "./createGraph";
+import * as Model from "./models";
+import {SqliteMirrorRepository} from "./mirrorRepository";
+
+async function loadConfig(
+  dirContext: PluginDirectoryContext
+): Promise<DiscordConfig> {
+  const dirname = dirContext.configDirectory();
+  const path = pathJoin(dirname, "config.json");
+  const contents = await fs.readFile(path);
+  return Promise.resolve(parseConfig(JSON.parse(contents)));
+}
+
+const TOKEN_ENV_VAR_NAME = "SOURCECRED_DISCORD_TOKEN";
+
+function getTokenFromEnv(): DiscordToken {
+  const rawToken = process.env[TOKEN_ENV_VAR_NAME];
+  if (rawToken == null) {
+    throw new Error(`No Discord token provided: set ${TOKEN_ENV_VAR_NAME}`);
+  }
+  return rawToken;
+}
+
+export class DiscordCliPlugin implements CliPlugin {
+  declaration(): PluginDeclaration {
+    return declaration;
+  }
+
+  async load(
+    ctx: PluginDirectoryContext,
+    reporter: TaskReporter
+  ): Promise<void> {
+    const {guildId} = await loadConfig(ctx);
+    const token = getTokenFromEnv();
+    const fetcher = new Fetcher({token});
+    const repo = await repository(ctx, guildId);
+    const mirror = new Mirror(repo, fetcher, guildId);
+    await mirror.update(reporter);
+  }
+
+  async graph(
+    ctx: PluginDirectoryContext,
+    rd: ReferenceDetector
+  ): Promise<WeightedGraph> {
+    const _ = rd; // TODO(#1808): not yet used
+    const {guildId, reactionWeights} = await loadConfig(ctx);
+    const repo = await repository(ctx, guildId);
+    const declarationWeights = weightsForDeclaration(declaration);
+    return await createGraph(
+      guildId,
+      repo,
+      declarationWeights,
+      reactionWeights
+    );
+  }
+
+  async referenceDetector(
+    _unused_ctx: PluginDirectoryContext
+  ): Promise<ReferenceDetector> {
+    // TODO: Implement Discord reference detection
+    // (low priority bc ppl rarely hardlink to Discord messages)
+    return {addressFromUrl: () => undefined};
+  }
+}
+
+async function repository(
+  ctx: PluginDirectoryContext,
+  guild: Model.Snowflake
+): Promise<SqliteMirrorRepository> {
+  const path = pathJoin(ctx.cacheDirectory(), "discordMirror.db");
+  const db = await new Database(path);
+  return new SqliteMirrorRepository(db, guild);
+}

--- a/src/plugins/experimental-discord/config.js
+++ b/src/plugins/experimental-discord/config.js
@@ -1,11 +1,37 @@
 // @flow
 
+import * as Combo from "../../util/combo";
 import * as Model from "./models";
 import {type EmojiWeightMap} from "./createGraph";
 
 export type {BotToken as DiscordToken} from "./models";
 
 export type DiscordConfig = {|
+  // Id of the Discord server.
+  // To get the ID, go into your Discord settings and under "Appearance",
+  // go to the "Advanced" section and enable "Developer Mode".
+  // Then right click on the server icon and choose "copy ID".
   +guildId: Model.Snowflake,
+  // An object mapping a reaction to a weight, as in:
+  // {
+  //   "🥰": 16,
+  //   "sourcecred:626763367893303303": 32,
+  // }
+  // Note that server custom emojis have a snowflake identifier.
+  //
+  // You can get a custom emoji ID by right clicking the custom emoji and
+  // copying it's URL, with the ID being the image file name.
   +reactionWeights: EmojiWeightMap,
 |};
+
+export function parseConfig(raw: Combo.JsonObject): DiscordConfig {
+  return parser.parseOrThrow(raw);
+}
+
+const parser: Combo.Parser<DiscordConfig> = (() => {
+  const C = Combo;
+  return C.object({
+    guildId: C.string,
+    reactionWeights: C.dict(C.number),
+  });
+})();

--- a/src/plugins/experimental-discord/config.js
+++ b/src/plugins/experimental-discord/config.js
@@ -5,7 +5,7 @@ import {type EmojiWeightMap} from "./createGraph";
 
 export type {BotToken as DiscordToken} from "./models";
 
-export type ProjectOptions = {|
+export type DiscordConfig = {|
   +guildId: Model.Snowflake,
   +reactionWeights: EmojiWeightMap,
 |};

--- a/src/plugins/experimental-discord/config.test.js
+++ b/src/plugins/experimental-discord/config.test.js
@@ -1,0 +1,17 @@
+// @flow
+
+import {type DiscordConfig, parseConfig} from "./config";
+
+describe("plugins/experimental-discord/config", () => {
+  it("can load a basic config", () => {
+    const raw = {
+      guildId: "453243919774253079",
+      reactionWeights: {
+        "🥰": 4,
+        ":sourcecred:626763367893303303": 16,
+      },
+    };
+    const parsed: DiscordConfig = parseConfig(raw);
+    expect(parsed).toEqual(raw);
+  });
+});

--- a/src/plugins/experimental-discord/loader.js
+++ b/src/plugins/experimental-discord/loader.js
@@ -7,7 +7,7 @@ import {type CacheProvider} from "../../backend/cache";
 import {SqliteMirrorRepository} from "./mirrorRepository";
 import {weightsForDeclaration} from "../../analysis/pluginDeclaration";
 import {createGraph as _createGraph} from "./createGraph";
-import {type ProjectOptions} from "./params";
+import {type DiscordConfig} from "./config";
 import {declaration} from "./declaration";
 import * as Model from "./models";
 import {Fetcher} from "./fetcher";
@@ -26,7 +26,7 @@ export default ({
 }: Loader);
 
 export async function updateMirror(
-  {guildId}: ProjectOptions,
+  {guildId}: DiscordConfig,
   token: Model.BotToken,
   cache: CacheProvider,
   reporter: TaskReporter
@@ -38,7 +38,7 @@ export async function updateMirror(
 }
 
 export async function createGraph(
-  {guildId, reactionWeights}: ProjectOptions,
+  {guildId, reactionWeights}: DiscordConfig,
   cache: CacheProvider
 ): Promise<WeightedGraph> {
   const repo = await repository(cache, guildId);


### PR DESCRIPTION
This sequence of three commits integrates the experimental Discord plugin into the new CLI2 system.

Test plan: I've tested this locally on SourceCred's own cred instance. We don't have a testing strategy for the Discord plugin overall (and this is really hard to do because it requires bot-specific tokens that we shouldn't share). For now my manual testing will have to suffice.