### PR TITLE
create admin panel service helper functions

### DIFF
--- a/src/admin/localService/loadFile.js
+++ b/src/admin/localService/loadFile.js
@@ -1,0 +1,50 @@
+// @flow
+const fs = require("fs");
+const pathJoin = require("path").join;
+
+const readdir = fs.promises.readdir;
+
+/**
+ * load file into server memory
+ */
+async function loadFile(credDir: string, fileName: string): Promise<string> {
+  const filePath = await getFilePath(`${credDir}/`, fileName);
+  if (!filePath)
+    return Promise.reject(
+      new Error(`${fileName} not found. Please enter a full cred repo`)
+    );
+
+  return fs.promises.readFile(pathJoin(filePath, fileName), "utf8");
+}
+
+/**
+ * server utility function used to naively locate ancillary files needed in the frontend:
+ * weightedGraph.json
+ * project.json
+ * pluginDeclarations.json
+ */
+async function getFilePath(dir: string, targetFile: string): Promise<string> {
+  const files: Dirent[] = await ((readdir(dir, {
+    withFileTypes: true,
+  }): any): Promise<Dirent[]>); // Dirent is not currently in the builtin node flow-typed lib
+  if (files.map((f) => f.name).includes(targetFile)) return dir;
+  const search = files
+    .filter((f) => f.isDirectory())
+    .map(async (f) => {
+      return await getFilePath(pathJoin(dir, f.name), targetFile);
+    });
+  if (search.length > 0) {
+    const results: Array<string> = await Promise.all(search);
+    const result = results.find((e) => !!e) || "";
+    return result;
+  }
+  return "";
+}
+
+type Dirent = {|
+  name: string,
+  type: number,
+  isDirectory(): boolean,
+|};
+
+module.exports = {loadFile, getFilePath};

--- a/src/admin/localService/loadFile.test.js
+++ b/src/admin/localService/loadFile.test.js
@@ -1,0 +1,39 @@
+// @flow
+import {loadFile} from "./loadFile";
+import fs from "fs";
+
+describe("src/admin/localService/loadFile", () => {
+  beforeAll(async () => {
+    // Arrange
+    await fs.promises.mkdir("./test/dir", {recursive: true});
+    await fs.promises.writeFile("./test/dir/some-file.txt", "found me!");
+  });
+  it("finds and reads a file", async () => {
+    // Act
+    const filePath = await loadFile("test", "some-file.txt");
+    // Assert
+    expect(filePath).toEqual("found me!");
+  });
+  it("throws an error if no file is found in an existing directory", async () => {
+    // Act
+    return expect(loadFile("test", "missing-file.txt")).rejects.toThrow(
+      // Assert
+      "missing-file.txt not found. Please enter a full cred repo"
+    );
+  });
+  it("throws an error if the entered directory doesn't exist", async () => {
+    //arrange
+    expect.assertions(1);
+    // Act
+    return expect(
+      loadFile("missing-directory", "missing-file.txt")
+    ).rejects.toThrow(
+      "ENOENT: no such file or directory, scandir 'missing-directory/'"
+    );
+  });
+  afterAll(async () => {
+    await fs.promises.unlink("./test/dir/some-file.txt");
+    await fs.promises.rmdir("./test/dir");
+    return await fs.promises.rmdir("./test");
+  });
+});


### PR DESCRIPTION
These functions are used by the admin panel node service to local files
and load them into memory.

`getFilePath` conducts a breadth-first-search in the supplied directory
for the file and returns the path to the directory containing the file.
This is used to set up static paths.

`loadFile` utilizes getFilePath and actually loads the file into memory.
This will be used by the conversion mondule to read distinct initiative
files and convert them before loading them into db.json

test plan
both functions are tested simultaneously in unit testing in order to
ensure they return a file matching the name, and error properly when
either the supplied directory or the supplied file name does not exist.