### PR TITLE
Admin panel server helpers

### DIFF
--- a/src/admin/localService/loadFile.js
+++ b/src/admin/localService/loadFile.js
@@ -1,0 +1,50 @@
+// @flow
+const fs = require("fs");
+const pathJoin = require("path").join;
+
+const readdir = fs.promises.readdir;
+
+/**
+ * load file into server memory
+ */
+async function loadFile(credDir: string, fileName: string): Promise<string> {
+  const filePath = await getFilePath(`${credDir}/`, fileName);
+  if (!filePath)
+    return Promise.reject(
+      new Error(`${fileName} not found. Please enter a full cred repo`)
+    );
+
+  return fs.promises.readFile(pathJoin(filePath, fileName), "utf8");
+}
+
+/**
+ * server utility function used to naively locate ancillary files needed in the frontend:
+ * weightedGraph.json
+ * project.json
+ * pluginDeclarations.json
+ */
+async function getFilePath(dir: string, targetFile: string): Promise<string> {
+  const files: Dirent[] = await ((readdir(dir, {
+    withFileTypes: true,
+  }): any): Promise<Dirent[]>); // Dirent is not currently in the builtin node flow-typed lib
+  if (files.map((f) => f.name).includes(targetFile)) return dir;
+  const search = files
+    .filter((f) => f.isDirectory())
+    .map(async (f) => {
+      return await getFilePath(pathJoin(dir, f.name), targetFile);
+    });
+  if (search.length > 0) {
+    const results: Array<string> = await Promise.all(search);
+    const result = results.find((e) => !!e) || "";
+    return result;
+  }
+  return "";
+}
+
+type Dirent = {|
+  name: string,
+  type: number,
+  isDirectory(): boolean,
+|};
+
+module.exports = {loadFile, getFilePath};

--- a/src/admin/localService/loadFile.js
+++ b/src/admin/localService/loadFile.js
@@ -11,7 +11,9 @@ async function loadFile(credDir: string, fileName: string): Promise<string> {
   const filePath = await getFilePath(`${credDir}/`, fileName);
   if (!filePath)
     return Promise.reject(
-      new Error(`${fileName} not found. Please enter a full cred repo`)
+      new Error(
+        `${fileName} not found. Please enter the root folder for Cred repo that contains the file.`
+      )
     );
 
   return fs.promises.readFile(pathJoin(filePath, fileName), "utf8");
@@ -22,6 +24,9 @@ async function loadFile(credDir: string, fileName: string): Promise<string> {
  * weightedGraph.json
  * project.json
  * pluginDeclarations.json
+ *
+ * Recursively traverses the provided `dir` until it finds the first instance of the `targetFile`
+ * and returns the containing path to the file's directory. Otherwise it return a falsy empty string
  */
 async function getFilePath(dir: string, targetFile: string): Promise<string> {
   const files: Dirent[] = await ((readdir(dir, {
@@ -33,12 +38,10 @@ async function getFilePath(dir: string, targetFile: string): Promise<string> {
     .map(async (f) => {
       return await getFilePath(pathJoin(dir, f.name), targetFile);
     });
-  if (search.length > 0) {
-    const results: Array<string> = await Promise.all(search);
-    const result = results.find((e) => !!e) || "";
-    return result;
-  }
-  return "";
+  if (!search.length) return "";
+
+  const results: Array<string> = await Promise.all(search);
+  return results.find((e) => !!e) || "";
 }
 
 type Dirent = {|

--- a/src/admin/localService/loadFile.test.js
+++ b/src/admin/localService/loadFile.test.js
@@ -2,27 +2,35 @@
 import {loadFile} from "./loadFile";
 import fs from "fs";
 
+const testDirRoot = "./test";
+const testDirPath = `${testDirRoot}/dir`;
+const testFilePath = `${testDirPath}/some-file.txt`;
+
 describe("src/admin/localService/loadFile", () => {
   beforeAll(async () => {
     // Arrange
-    await fs.promises.mkdir("./test/dir", {recursive: true});
-    await fs.promises.writeFile("./test/dir/some-file.txt", "found me!");
+    await fs.promises.mkdir(testDirPath, {recursive: true});
+    await fs.promises.writeFile(testFilePath, "found me!");
   });
   it("finds and reads a file", async () => {
+    // Arrange
+    expect.assertions(1);
     // Act
-    const filePath = await loadFile("test", "some-file.txt");
+    const fileContent = await loadFile("test", "some-file.txt");
     // Assert
-    expect(filePath).toEqual("found me!");
+    expect(fileContent).toEqual("found me!");
   });
   it("throws an error if no file is found in an existing directory", async () => {
+    // Arrange
+    expect.assertions(1);
     // Act
     return expect(loadFile("test", "missing-file.txt")).rejects.toThrow(
       // Assert
-      "missing-file.txt not found. Please enter a full cred repo"
+      "missing-file.txt not found. Please enter the root folder for Cred repo that contains the file."
     );
   });
   it("throws an error if the entered directory doesn't exist", async () => {
-    //arrange
+    // Arrange
     expect.assertions(1);
     // Act
     return expect(
@@ -32,8 +40,8 @@ describe("src/admin/localService/loadFile", () => {
     );
   });
   afterAll(async () => {
-    await fs.promises.unlink("./test/dir/some-file.txt");
-    await fs.promises.rmdir("./test/dir");
-    return await fs.promises.rmdir("./test");
+    await fs.promises.unlink(testFilePath);
+    await fs.promises.rmdir(testDirPath);
+    return await fs.promises.rmdir(testDirRoot); // recursive dir unlinking is still unstable, thus this second step
   });
 });

--- a/src/admin/localService/loadFile.test.js
+++ b/src/admin/localService/loadFile.test.js
@@ -1,0 +1,39 @@
+// @flow
+import {loadFile} from "./loadFile";
+import fs from "fs";
+
+describe("src/admin/localService/loadFile", () => {
+  beforeAll(async () => {
+    // Arrange
+    await fs.promises.mkdir("./test/dir", {recursive: true});
+    await fs.promises.writeFile("./test/dir/some-file.txt", "found me!");
+  });
+  it("finds and reads a file", async () => {
+    // Act
+    const filePath = await loadFile("test", "some-file.txt");
+    // Assert
+    expect(filePath).toEqual("found me!");
+  });
+  it("throws an error if no file is found in an existing directory", async () => {
+    // Act
+    return expect(loadFile("test", "missing-file.txt")).rejects.toThrow(
+      // Assert
+      "missing-file.txt not found. Please enter a full cred repo"
+    );
+  });
+  it("throws an error if the entered directory doesn't exist", async () => {
+    //arrange
+    expect.assertions(1);
+    // Act
+    return expect(
+      loadFile("missing-directory", "missing-file.txt")
+    ).rejects.toThrow(
+      "ENOENT: no such file or directory, scandir 'missing-directory/'"
+    );
+  });
+  afterAll(async () => {
+    await fs.promises.unlink("./test/dir/some-file.txt");
+    await fs.promises.rmdir("./test/dir");
+    return await fs.promises.rmdir("./test");
+  });
+});


### PR DESCRIPTION
These functions are used by the admin panel node service to local files
and load them into memory.

`getFilePath` conducts a breadth-first-search in the supplied directory
for the file and returns the path to the directory containing the file.
This is used to set up static services.

`loadFile` utilizes getFilePath and actually loads the file into memory.
This will be used by the conversion mondule to read distinct initiative
files and convert them before loading them into db.json

test plan
both functions are tested simultaneously in unit testing in order to
ensure they return a file matching the name, and error properly when
either the supplied directory or the supplied file name does not exist.