### PR TITLE
Add Address.fromRaw

### DIFF
--- a/src/core/address.test.js
+++ b/src/core/address.test.js
@@ -164,6 +164,33 @@ describe("core/address", () => {
       });
     });
 
+    describe("fromRaw", () => {
+      const {FooAddress, BarAddress} = makeModules();
+      function thunk(x: string) {
+        return () => FooAddress.fromRaw(x);
+      }
+      it("throws on an empty string", () => {
+        expect(thunk("")).toThrow("address does not end with separator");
+      });
+      it("throws on a string that doesn't start with the right separator", () => {
+        expect(thunk("\0")).toThrow("expected FooAddress, got");
+      });
+      it("throws on a string from a different address module", () => {
+        expect(thunk(BarAddress.empty)).toThrow(
+          "expected FooAddress, got BarAddress"
+        );
+      });
+      function roundTrip(x) {
+        expect(FooAddress.fromRaw(x)).toEqual(x);
+      }
+      it("works on an empty address", () => {
+        roundTrip(FooAddress.empty);
+      });
+      it("works on a non-empty address", () => {
+        roundTrip(FooAddress.fromParts(["foo", "bar"]));
+      });
+    });
+
     describe("fromParts", () => {
       const {FooAddress, BarAddress} = makeModules();
 

--- a/src/core/trie.js
+++ b/src/core/trie.js
@@ -13,7 +13,7 @@ const EMPTY_ENTRY_SYMBOL = Symbol("EMPTY");
 
 type Entry<V> = {|+map: RecursiveMap<V>, value: V | typeof EMPTY_ENTRY_SYMBOL|};
 type RecursiveMap<V> = Map<string, Entry<V>>;
-class BaseTrie<K, V> {
+class BaseTrie<K: string, V> {
   addressModule: AddressModule<K>;
   entry: Entry<V>;
 


### PR DESCRIPTION
This adds a fromRaw method to the Address module so that we may properly
parse serialized addresses. It has a type signature of `string =>
Address`, and throws an error if the string is not a valid address.

I basically copied the implementation out of the `assertValid` method. I
considered deduplicating them (i.e. having `assertValid` simply call
`fromRaw`), but `assertValid` had some extra logic around accepting a
prefix for the error message, and it felt simpler to simply copy+paste
rather than trying to wrap it.

Test plan:
I added unit tests; `yarn test` passes.