### PR TITLE
Add parser for core.Weights

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -22,7 +22,10 @@ module.exports = {
   ],
   rules: {
     "prefer-const": ["warn"],
-    camelcase: ["error", {properties: "never", allow: ["^_unused_.*"]}],
+    camelcase: [
+      "error",
+      {properties: "never", allow: ["^_unused_.*", "(_\\d+)+"]},
+    ],
     eqeqeq: ["error", "always", {null: "ignore"}],
     "no-unused-vars": [
       "warn",

--- a/src/core/weights.test.js
+++ b/src/core/weights.test.js
@@ -4,6 +4,7 @@ import stringify from "json-stable-stringify";
 import {NodeAddress, EdgeAddress} from "../core/graph";
 import {type Weights as WeightsT} from "./weights";
 import * as Weights from "./weights";
+import {toCompat} from "../util/compat";
 
 describe("core/weights", () => {
   it("copy makes a copy", () => {
@@ -70,6 +71,21 @@ describe("core/weights", () => {
       expect(weights).toEqual(Weights.fromJSON(json));
     });
   });
+
+  describe("parser", () => {
+    it("works for the 0_2_0 format", () => {
+      const json: Weights.WeightsJSON_0_2_0 = toCompat(
+        {type: "sourcecred/weights", version: "0.2.0"},
+        {
+          nodeWeights: {},
+          edgeWeights: {},
+        }
+      );
+      // Any cast due to #1875
+      expect(Weights.parser.parseOrThrow((json: any))).toEqual(Weights.empty());
+    });
+  });
+
   describe("merge", () => {
     function simpleWeights(
       nodeWeights: [string, number][],


### PR DESCRIPTION
This adds a proper parse for core.Weights, and modifies the `fromJSON`
method to use that parser.

This means we now have runtime validation that all Weights files are
actually valid.

Note: I made a tweak to the eslint config so as to allow `_`s in names
when followed by a sequence of numbers, so that types like `Data_0_1_0`
(for including version strings) do not trigger lint failures.

Test plan: All existing tests pass, and I added a new test to validate
that we keep supporting the 0.2.0 format going forward.