### PR TITLE
Make cli2 report the version and provide help

### DIFF
--- a/src/cli/sourcecred.js
+++ b/src/cli/sourcecred.js
@@ -1,17 +1,25 @@
 // @flow
 
 import type {Command} from "./command";
+import {VERSION_SHORT} from "../core/version";
 
 import load from "./load";
 import graph from "./graph";
 import score from "./score";
+import help from "./help";
 
 const sourcecred: Command = async (args, std) => {
   if (args.length === 0) {
-    std.err("fatal: specify a command");
+    help([], {out: std.err, err: std.err});
     return 1;
   }
   switch (args[0]) {
+    case "--version":
+      std.out("sourcecred " + VERSION_SHORT);
+      return 0;
+    case "--help":
+    case "help":
+      return help(args.slice(1), std);
     case "load":
       return load(args.slice(1), std);
     case "graph":
@@ -20,6 +28,7 @@ const sourcecred: Command = async (args, std) => {
       return score(args.slice(1), std);
     default:
       std.err("fatal: unknown command: " + JSON.stringify(args[0]));
+      std.err("fatal: run 'sourcecred help' for commands and usage");
       return 1;
   }
 };

--- a/src/cli/sourcecred.test.js
+++ b/src/cli/sourcecred.test.js
@@ -1,0 +1,62 @@
+// @flow
+
+import {run} from "./testUtil";
+import sourcecred from "./sourcecred";
+
+function mockCommand(name) {
+  return jest.fn().mockImplementation(async (args, std) => {
+    std.out(`out(${name}): ${JSON.stringify(args)}`);
+    std.err(`err(${name})`);
+    return args.length;
+  });
+}
+
+jest.mock("./help", () => mockCommand("help"));
+jest.mock("./load", () => mockCommand("load"));
+jest.mock("./graph", () => mockCommand("graph"));
+jest.mock("./score", () => mockCommand("score"));
+
+describe("cli/sourcecred", () => {
+  it("fails with usage when invoked with no arguments", async () => {
+    expect(await run(sourcecred, [])).toEqual({
+      exitCode: 1,
+      stdout: [],
+      stderr: ["out(help): []", "err(help)"],
+    });
+  });
+
+  it("responds to '--version'", async () => {
+    expect(await run(sourcecred, ["--version"])).toEqual({
+      exitCode: 0,
+      stdout: [expect.stringMatching(/^sourcecred v\d+\.\d+\.\d+$/)],
+      stderr: [],
+    });
+  });
+
+  it("responds to '--help'", async () => {
+    expect(await run(sourcecred, ["--help"])).toEqual({
+      exitCode: 0,
+      stdout: ["out(help): []"],
+      stderr: ["err(help)"],
+    });
+  });
+
+  it("responds to 'help'", async () => {
+    expect(await run(sourcecred, ["help"])).toEqual({
+      exitCode: 0,
+      stdout: ["out(help): []"],
+      stderr: ["err(help)"],
+    });
+  });
+
+  it("fails given an unknown command", async () => {
+    expect(await run(sourcecred, ["wat"])).toEqual({
+      exitCode: 1,
+      stdout: [],
+      stderr: [
+        'fatal: unknown command: "wat"',
+        "fatal: run 'sourcecred help' for commands and usage",
+      ],
+    });
+  });
+});


### PR DESCRIPTION
We need the `--version` flag, both for general goodness, and because our
Docker publish pipeline depends on it. While I was at it, I
re-integrated the `help` command as well, along with some unit testing.

Test plan: `yarn test` passes; run `yarn backend` and then run the
command both without args (to see a dummy help message), or with the
`--help` or `help` args, or with `--version` args. Unit tests cover all
thsi behavior.