### PR TITLE
Add parser for TimelineCredParams

### DIFF
--- a/src/analysis/timeline/params.js
+++ b/src/analysis/timeline/params.js
@@ -1,5 +1,7 @@
 // @flow
 
+import * as C from "../../util/combo";
+
 /**
  * Parameters for computing TimelineCred
  *
@@ -44,6 +46,16 @@ export function paramsFromJSON(
     intervalDecay: p.intervalDecay,
   };
 }
+
+const partialParser: C.Parser<$Shape<TimelineCredParameters>> = C.shape({
+  alpha: C.number,
+  intervalDecay: C.number,
+});
+
+export const parser: C.Parser<TimelineCredParameters> = C.fmap(
+  partialParser,
+  partialParams
+);
 
 /**
  * Exports the default TimelineCredParameters.

--- a/src/analysis/timeline/params.test.js
+++ b/src/analysis/timeline/params.test.js
@@ -8,6 +8,7 @@ import {
   type TimelineCredParameters,
   DEFAULT_ALPHA,
   DEFAULT_INTERVAL_DECAY,
+  parser,
 } from "./params";
 
 describe("analysis/timeline/params", () => {
@@ -43,6 +44,19 @@ describe("analysis/timeline/params", () => {
       const params = partialParams({intervalDecay: 0.1});
       expect(params.alpha).toEqual(DEFAULT_ALPHA);
       expect(params.intervalDecay).toEqual(0.1);
+    });
+  });
+
+  describe("parser", () => {
+    it("works on a full object", () => {
+      const params: TimelineCredParameters = {alpha: 0.34, intervalDecay: 0.1};
+      expect(parser.parseOrThrow(params)).toEqual(params);
+    });
+    it("works on a partial object", () => {
+      expect(parser.parseOrThrow({})).toEqual(defaultParams());
+    });
+    it("rejects bad params", () => {
+      expect(() => parser.parseOrThrow({alpha: "foo"})).toThrowError("string");
     });
   });
 });


### PR DESCRIPTION
This will allow us to integrate with the `scores` module in a way that
has runtime validation of the config.

Test plan: See included tests.