### PR TITLE
build: fix references to `yarn backend`

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -100,8 +100,8 @@ to run them all. This will run:
     disable spurious lint errors on a per-line basis by inserting a
     preceding line with `// eslint-disable-next-line LINT_RULE_NAME`.
 
-  - **Backend applications build** (`yarn backend`). This makes sure
-    that the CLI still builds.
+  - **Backend applications build** (`yarn build:backend`). This makes
+    sure that the CLI still builds.
 
   - **Check for `@flow` pragmas** (`./scripts/ensure-flow.sh`). This
     makes sure that every file includes a `// @flow` directive or an

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,6 +16,6 @@ ENV SOURCECRED_DIRECTORY ${SOURCECRED_DEFAULT_DIRECTORY}
 
 # Install the remainder of our code.
 COPY . /code
-RUN yarn backend
+RUN yarn build:backend
 
 ENTRYPOINT ["/bin/bash", "/code/scripts/docker-entrypoint.sh"]

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ You'll still need to create a GitHub token to use as an environment variable (sh
 git clone https://github.com/sourcecred/sourcecred.git
 cd sourcecred
 yarn install
-yarn backend
+yarn build
 export SOURCECRED_GITHUB_TOKEN=YOUR_GITHUB_TOKEN
 ```
 

--- a/src/plugins/git/example/synchronizeToGithub.sh
+++ b/src/plugins/git/example/synchronizeToGithub.sh
@@ -7,7 +7,7 @@ main() {
         DRY_RUN=1
     fi
     cd "$(git rev-parse --show-toplevel)"
-    yarn backend
+    yarn build:backend
     printf '\n'
     printf 'Synchronizing: example-git\n'
     synchronize \

--- a/src/plugins/github/fetchGithubOrgTest.sh
+++ b/src/plugins/github/fetchGithubOrgTest.sh
@@ -12,7 +12,7 @@ usage() {
   printf '  -u|--updateSnapshot\n'
   printf '      Update the stored file instead of checking its contents\n'
   printf ' --[no-]build\n'
-  printf '      Whether to run "yarn backend" before the test.\n'
+  printf '      Whether to run "yarn build:backend" before the test.\n'
   printf '      Default is --build.\n'
   printf '  --help\n'
   printf '      Show this message\n'
@@ -20,7 +20,8 @@ usage() {
   printf 'Environment variables:'
   printf '  SOURCECRED_BIN\n'
   printf '      When using --no-build, directory containing the SourceCred\n'
-  printf '      executables (output of "yarn backend"). Default is ./bin.\n'
+  printf '      executables (output of "yarn build:backend").\n'
+  printf '      Default is ./bin.\n'
 }
 
 fetch() {
@@ -80,7 +81,7 @@ main() {
   done
   if [ -n "${BUILD}" ]; then
     unset BIN
-    yarn backend
+    yarn build:backend
   else
     export NODE_PATH="./node_modules${NODE_PATH:+:${NODE_PATH}}"
   fi

--- a/src/plugins/github/fetchGithubRepoTest.sh
+++ b/src/plugins/github/fetchGithubRepoTest.sh
@@ -12,7 +12,7 @@ usage() {
   printf '  -u|--updateSnapshot\n'
   printf '      Update the stored file instead of checking its contents\n'
   printf ' --[no-]build\n'
-  printf '      Whether to run "yarn backend" before the test.\n'
+  printf '      Whether to run "yarn build:backend" before the test.\n'
   printf '      Default is --build.\n'
   printf '  --help\n'
   printf '      Show this message\n'
@@ -20,7 +20,8 @@ usage() {
   printf 'Environment variables:'
   printf '  SOURCECRED_BIN\n'
   printf '      When using --no-build, directory containing the SourceCred\n'
-  printf '      executables (output of "yarn backend"). Default is ./bin.\n'
+  printf '      executables (output of "yarn build:backend").\n'
+  printf '      Default is ./bin.\n'
 }
 
 fetch() {
@@ -69,7 +70,7 @@ main() {
   done
   if [ -n "${BUILD}" ]; then
     unset SOURCECRED_BIN
-    yarn backend
+    yarn build:backend
   else
     export NODE_PATH="./node_modules${NODE_PATH:+:${NODE_PATH}}"
   fi

--- a/src/plugins/github/graphqlTypes.test.js
+++ b/src/plugins/github/graphqlTypes.test.js
@@ -10,7 +10,7 @@ describe("plugins/github/graphqlTypes", () => {
     const typesFilename = path.join(__dirname, "graphqlTypes.js");
     const actual = (await fs.readFile(typesFilename)).toString();
     const expected = generateGithubGraphqlFlowTypes();
-    // If this fails, run `yarn backend` and then invoke
+    // If this fails, run `yarn build:backend` and then invoke
     //      node ./bin/generateGithubGraphqlFlowTypes.js
     // saving the output to the types file listed above.
     expect(actual).toEqual(expected);


### PR DESCRIPTION
Summary:
Follow-up to #1903. In particular, this should fix the Docker build.

Test Plan:
Running `git grep 'yarn backend'` no longer turns up examples.

wchargin-branch: build-update-yarn-backend-refs
