### PR TITLE
`yarn start` uses test-instance by default

### DIFF
--- a/config/webpack.config.web.js
+++ b/config/webpack.config.web.js
@@ -48,9 +48,7 @@ async function makeConfig(
           developmentInstancePath = argv[argv.length - 1];
         }
         if (developmentInstancePath == null) {
-          throw new Error(
-            "Please provide a SourceCred cli instance, via $SOURCECRED_DEV_INSTANCE, or --instance PATH"
-          );
+          developmentInstancePath = "sharness/__snapshots__/test-instance";
         }
         const configPath = path.join(
           developmentInstancePath,


### PR DESCRIPTION
Prior to this commit, `yarn start` would fail if a development instance
path is not provided. However, now that we package a test instance
inside of our snapshots, we can use that as the default dev instance
instead.

Test plan: `yarn start` with no arguments or environment variables now
loads the test instance, both when run from repository root, and when
cd'd into a subdirectory.