### PR TITLE
Ledger tracks user identities

### DIFF
--- a/src/ledger/ledger.js
+++ b/src/ledger/ledger.js
@@ -1,0 +1,344 @@
+// @flow
+
+/**
+ * This module contains the ledger, for accumulating state updates related to
+ * user identities and Grain distribution.
+ *
+ * A key requirement for the ledger is that we need to store an ordered log of
+ * every action that's happened in the ledger, so that we can audit the ledger
+ * state to ensure its integrity.
+ */
+import deepEqual from "lodash.isequal";
+import {type UserId, type User, type Username, userAddress} from "./user";
+import {type NodeAddressT, NodeAddress} from "../core/graph";
+
+/**
+ * The ledger for storing identity changes and (eventually) Grain distributions.
+ *
+ * The following API methods change the ledger state:
+ * - `addUser`
+ * - `renameUser`
+ * - `removeUser`
+ * - `addAlias`
+ * - `removeAlias`
+ *
+ * Every time the ledger state is changed, a corresponding Action is added to
+ * the ledger's action log. The ledger state may be serialized by saving the
+ * action log, and then reconstructed by replaying the action log. The
+ * corresponding methods are `actionLog` and `Ledger.fromActionLog`.
+ *
+ * It's important that any API method that fails (e.g. trying to add a
+ * conflicting user) fails without mutating the ledger state; this way we avoid
+ * ever getting the ledger in a corrupted state. To make this easier to test,
+ * the test code uses deep equality testing on the ledger before/after
+ * attempting illegal actions. To ensure that this testing works, we should
+ * avoid adding any ledger state that can't be verified by deep equality
+ * checking (e.g. don't store state in functions or closures that aren't
+ * attached to the Ledger object).
+ *
+ * Currently, the Ledger only supports user management; logic for tracking
+ * Grain distributions will be added in a future commit.
+ */
+export class Ledger {
+  _actionLog: Action[];
+  _users: Map<UserId, User>;
+  _usernameToId: Map<Username, UserId>;
+  _aliases: Set<NodeAddressT>;
+
+  constructor() {
+    this._actionLog = [];
+    this._users = new Map();
+    this._usernameToId = new Map();
+    this._aliases = new Set();
+  }
+
+  /**
+   * Return all of the Users in the Ledger.
+   */
+  users(): $ReadOnlyArray<User> {
+    return Array.from(this._users.values());
+  }
+
+  /**
+   * Return the User matching given id, or undefined if no user
+   * matches the id.
+   */
+  userById(id: UserId): ?User {
+    return this._users.get(id);
+  }
+
+  /**
+   * Return the User matching given username, or undefined
+   * if no user matches the username.
+   */
+  userByUsername(name: Username): ?User {
+    const id = this._usernameToId.get(name);
+    if (id != null) {
+      return this._users.get(id);
+    }
+  }
+
+  /**
+   * Add a User to the Ledger.
+   *
+   * This will reserve the user's username, and its innate address.
+   *
+   * Will no-op is the user is already in the ledger.
+   *
+   * Will fail if a conflicting user is present, or if the user's username is
+   * already taken, or if the user's innate address is already taken, or if any
+   * of the user's aliases are already taken.
+   */
+  addUser(user: User): Ledger {
+    return this._act({type: "ADD_USER", user: user});
+  }
+  _addUser(user: User) {
+    const existingUser = this._users.get(user.id);
+    if (existingUser != null) {
+      if (deepEqual(existingUser, user)) {
+        // No-op; This user already exists in the ledger.
+        return;
+      } else {
+        throw new Error(`addUser: conflicting user with id ${user.id}`);
+      }
+    }
+    if (this._usernameToId.has(user.name)) {
+      throw new Error(`addUser: username already claimed ${user.name}`);
+    }
+    for (const alias of user.aliases) {
+      if (this._aliases.has(alias)) {
+        throw new Error(
+          `addUser: alias already claimed: ${NodeAddress.toString(alias)}`
+        );
+      }
+    }
+    if (this._aliases.has(userAddress(user.id))) {
+      throw new Error(`addUser: innate address already claimed ${user.id}`);
+    }
+
+    // Now that we've done all our validation, we update state.
+    // This way, in case we fail, we don't get the ledger into a corrupted state.
+    for (const alias of user.aliases) {
+      this._aliases.add(alias);
+    }
+    this._usernameToId.set(user.name, user.id);
+    this._users.set(user.id, user);
+    // Reserve this user's own address
+    this._aliases.add(userAddress(user.id));
+  }
+
+  /**
+   * Change a user's username.
+   *
+   * Will fail if no user matches the userId, or if the user's new
+   * name is already claimed.
+   */
+  renameUser(userId: UserId, newName: Username): Ledger {
+    return this._act({type: "RENAME_USER", userId, newName});
+  }
+  _renameUser(userId: UserId, newName: Username) {
+    const existingUser = this._users.get(userId);
+    if (existingUser == null) {
+      throw new Error(`renameUser: no user matches id ${userId}`);
+    }
+    if (existingUser.name === newName) {
+      // No-op; user already has this name.
+      return;
+    }
+    if (this._usernameToId.has(newName)) {
+      // We already checked that the name is not owned by this user,
+      // so it is a conflict. Fail.
+      throw new Error(`renameUser: conflict on username ${newName}`);
+    }
+    const updatedUser = {
+      id: userId,
+      name: newName,
+      aliases: existingUser.aliases,
+    };
+    this._usernameToId.delete(existingUser.name);
+    this._usernameToId.set(newName, userId);
+    this._users.set(userId, updatedUser);
+  }
+
+  /**
+   * Remove a user from the ledger.
+   *
+   * This also free's the user's username,
+   * the user's innate address, and all the user's aliases.
+   *
+   * Will no-op if the user doesn't exist.
+   */
+  removeUser(userId: UserId): Ledger {
+    return this._act({type: "REMOVE_USER", userId});
+  }
+  _removeUser(userId: UserId) {
+    const existingUser = this._users.get(userId);
+    if (existingUser == null) {
+      // User already removed; no-op.
+      return;
+    }
+    this._usernameToId.delete(existingUser.name);
+    this._users.delete(userId);
+    this._aliases.delete(userAddress(userId));
+    for (const a of existingUser.aliases) {
+      this._aliases.delete(a);
+    }
+  }
+
+  /**
+   * Add an alias for a user.
+   *
+   * Will no-op if the user already has that alias.
+   *
+   * Will faill if the user does not exist.
+   *
+   * Will fail if the alias is already claimed, or if it is
+   * another user's innate address.
+   */
+  addAlias(userId: UserId, alias: NodeAddressT): Ledger {
+    return this._act({type: "ADD_ALIAS", userId, alias});
+  }
+  _addAlias(userId: UserId, alias: NodeAddressT) {
+    const existingUser = this._users.get(userId);
+    if (existingUser == null) {
+      throw new Error(`addAlias: no matching userId ${userId}`);
+    }
+    const existingAliases = existingUser.aliases;
+    if (existingAliases.indexOf(alias) !== -1) {
+      // User already has this alias; no-op.
+      return;
+    }
+    if (this._aliases.has(alias)) {
+      // Some other user has this alias; fail.
+      throw new Error(
+        `addAlias: alias ${NodeAddress.toString(alias)} already bound`
+      );
+    }
+    this._aliases.add(alias);
+    const updatedAliases = existingAliases.slice();
+    updatedAliases.push(alias);
+    const updatedUser = {
+      id: existingUser.id,
+      name: existingUser.name,
+      aliases: updatedAliases,
+    };
+    this._users.set(userId, updatedUser);
+  }
+
+  /**
+   * Remove an alias from a user.
+   *
+   * Will no-op if the user doesn't have that alias.
+   *
+   * Will fail if the user does not exist.
+   *
+   * Will fail if the alias is in fact the user's innate address.
+   */
+  removeAlias(userId: UserId, alias: NodeAddressT): Ledger {
+    return this._act({type: "REMOVE_ALIAS", userId, alias});
+  }
+  _removeAlias(userId: UserId, alias: NodeAddressT) {
+    const existingUser = this._users.get(userId);
+    if (existingUser == null) {
+      throw new Error(`removeAlias: no user matching id ${userId}`);
+    }
+    if (alias === userAddress(userId)) {
+      throw new Error(`removeAlias: cannot remove user's innate address`);
+    }
+    const existingAliases = existingUser.aliases;
+    const idx = existingAliases.indexOf(alias);
+    if (idx === -1) {
+      // User is already not bound to this alias. No-op.
+      return;
+    }
+    const aliases = existingAliases.slice();
+    aliases.splice(idx, 1);
+    this._aliases.delete(alias);
+    this._users.set(userId, {
+      id: userId,
+      name: existingUser.name,
+      aliases,
+    });
+  }
+
+  /**
+   * Retrieve the log of all actions in the Ledger's history.
+   *
+   * May be used to reconstruct the Ledger after serialization.
+   */
+  actionLog(): LedgerLog {
+    return this._actionLog;
+  }
+
+  /**
+   * Reconstruct a Ledger from a LedgerLog.
+   */
+  static fromActionLog(log: LedgerLog): Ledger {
+    const ledger = new Ledger();
+    for (const a of log) {
+      ledger._act(a);
+    }
+    return ledger;
+  }
+
+  _act(a: Action): Ledger {
+    switch (a.type) {
+      case "ADD_USER":
+        this._addUser(a.user);
+        break;
+      case "RENAME_USER":
+        this._renameUser(a.userId, a.newName);
+        break;
+      case "REMOVE_USER":
+        this._removeUser(a.userId);
+        break;
+      case "ADD_ALIAS":
+        this._addAlias(a.userId, a.alias);
+        break;
+      case "REMOVE_ALIAS":
+        this._removeAlias(a.userId, a.alias);
+        break;
+      default:
+        throw new Error(`Unknown type: ${(a.type: empty)}`);
+    }
+    this._actionLog.push(a);
+    return this;
+  }
+}
+
+/**
+ * The log of all Actions in the Ledger.
+ *
+ * This is an opaque type; clients must not modify the log, since they
+ * could put it in an inconsistent state.
+ */
+export opaque type LedgerLog = $ReadOnlyArray<Action>;
+
+/**
+ * The Actions are used to store the history of Ledger changes.
+ */
+type Action = AddUser | RenameUser | RemoveUser | AddAlias | RemoveAlias;
+
+type AddUser = {|
+  +type: "ADD_USER",
+  +user: User,
+|};
+type RenameUser = {|
+  +type: "RENAME_USER",
+  +userId: UserId,
+  +newName: Username,
+|};
+type RemoveUser = {|
+  +type: "REMOVE_USER",
+  +userId: UserId,
+|};
+type AddAlias = {|
+  +type: "ADD_ALIAS",
+  +userId: UserId,
+  +alias: NodeAddressT,
+|};
+type RemoveAlias = {|
+  +type: "REMOVE_ALIAS",
+  +userId: UserId,
+  +alias: NodeAddressT,
+|};

--- a/src/ledger/ledger.test.js
+++ b/src/ledger/ledger.test.js
@@ -1,13 +1,16 @@
 // @flow
 
-import deepFreeze from "deep-freeze";
 import cloneDeep from "lodash.clonedeep";
-import {fromString as uuidFromString} from "../util/uuid";
+import {random as randomUuid} from "../util/uuid";
 import {NodeAddress} from "../core/graph";
 import {Ledger} from "./ledger";
-import {usernameFromString, userAddress} from "./user";
+import {userAddress} from "./user";
 
 describe("ledger/ledger", () => {
+  function setFakeDate(ts: number) {
+    jest.spyOn(global.Date, "now").mockImplementationOnce(() => ts);
+  }
+
   // Verify that a method fails, throwing an error, without mutating the ledger.
   function failsWithoutMutation(
     ledger: Ledger,
@@ -19,279 +22,254 @@ describe("ledger/ledger", () => {
     expect(copy).toEqual(ledger);
   }
 
-  const fooAddress = NodeAddress.fromParts(["foo"]);
-  const foo = deepFreeze({
-    id: uuidFromString("YVZhbGlkVXVpZEF0TGFzdA"),
-    name: usernameFromString("foo"),
-    aliases: [fooAddress],
-  });
-  const barAddress = NodeAddress.fromParts(["bar"]);
-  const bar = deepFreeze({
-    id: uuidFromString("XVZhbGlkVXVpZEF0TGFzdA"),
-    name: usernameFromString("bar"),
-    aliases: [barAddress],
-  });
-  const nameConflict = deepFreeze({
-    id: foo.id,
-    name: bar.name,
-    aliases: foo.aliases,
-  });
-  const aliasConflict = deepFreeze({
-    id: foo.id,
-    name: foo.name,
-    aliases: bar.aliases,
-  });
+  const a1 = NodeAddress.fromParts(["a1"]);
 
   describe("user updates", () => {
-    describe("addUser", () => {
+    describe("createUser", () => {
       it("works", () => {
-        const ledger = new Ledger().addUser(foo);
-        expect(ledger.users()).toEqual([foo]);
+        setFakeDate(123);
+        const l = new Ledger();
+        const id = l.createUser("foo");
+        const foo = l.userById(id);
+        expect(l.users()).toEqual([foo]);
+        expect(l.actionLog()).toEqual([
+          {
+            type: "CREATE_USER",
+            username: "foo",
+            version: 1,
+            timestamp: 123,
+            userId: id,
+          },
+        ]);
       });
-      it("is idempotent", () => {
-        const ledger = new Ledger().addUser(foo).addUser(foo);
-        expect(ledger.users()).toEqual([foo]);
+      it("throws an error if the username is invalid", () => {
+        const ledger = new Ledger();
+        const thunk = () => ledger.createUser("foo bar");
+        failsWithoutMutation(ledger, thunk, "invalid username");
+        expect(ledger.users()).toEqual([]);
       });
-      it("fails if the user's name is taken by another user", () => {
-        const ledger = new Ledger().addUser(bar);
-        failsWithoutMutation(
-          ledger,
-          (l) => l.addUser(nameConflict),
-          "addUser: username already claimed"
-        );
-      });
-      it("fails if one of the user's aliases is already claimed", () => {
-        const ledger = new Ledger().addUser(bar);
-        failsWithoutMutation(
-          ledger,
-          (l) => l.addUser(aliasConflict),
-          "addUser: alias already claimed"
-        );
-      });
-      it("fails if a different user exists at that id", () => {
-        const ledger = new Ledger().addUser(foo);
-        failsWithoutMutation(
-          ledger,
-          (l) => l.addUser(aliasConflict),
-          "addUser: conflicting user with id"
-        );
-      });
-      it("fails if the user's own innate address is already taken", () => {
-        // Weird edge case where another user has been explicitly linked to the
-        // new user's innate address
-        const ledger = new Ledger()
-          .addUser(foo)
-          .addAlias(foo.id, userAddress(bar.id));
-        failsWithoutMutation(
-          ledger,
-          (l) => l.addUser(bar),
-          "addUser: innate address already claimed"
-        );
+      it("throws an error if the username is taken", () => {
+        const ledger = new Ledger();
+        ledger.createUser("foo");
+        const thunk = () => ledger.createUser("foo");
+        failsWithoutMutation(ledger, thunk, "username already taken");
       });
     });
 
     describe("renameUser", () => {
       it("works", () => {
-        const ledger = new Ledger().addUser(foo).renameUser(foo.id, bar.name);
-        const expected = {id: foo.id, name: bar.name, aliases: foo.aliases};
-        expect(ledger.users()).toEqual([expected]);
+        const ledger = new Ledger();
+        setFakeDate(0);
+        const id = ledger.createUser("foo");
+        setFakeDate(1);
+        ledger.renameUser(id, "bar");
+        const user = ledger.userById(id);
+
+        expect(user).toEqual({id, name: "bar", aliases: []});
+        expect(ledger.userByUsername("bar")).toEqual(user);
+        expect(ledger.userByUsername("foo")).toEqual(undefined);
+        expect(ledger.users()).toEqual([user]);
+
+        expect(ledger.actionLog()).toEqual([
+          {
+            type: "CREATE_USER",
+            version: 1,
+            username: "foo",
+            timestamp: 0,
+            userId: id,
+          },
+          {
+            type: "RENAME_USER",
+            version: 1,
+            newName: "bar",
+            userId: id,
+            timestamp: 1,
+          },
+        ]);
       });
-      it("is idempotent", () => {
-        const ledger = new Ledger()
-          .addUser(foo)
-          .renameUser(foo.id, bar.name)
-          .renameUser(foo.id, bar.name);
-        const expected = {id: foo.id, name: bar.name, aliases: foo.aliases};
-        expect(ledger.users()).toEqual([expected]);
+      it("fails if the user already has that name", () => {
+        const ledger = new Ledger();
+        const id = ledger.createUser("foo");
+        const thunk = () => ledger.renameUser(id, "foo");
+        failsWithoutMutation(
+          ledger,
+          thunk,
+          "renameUser: user already has name"
+        );
       });
       it("fails on nonexistent user id", () => {
         const ledger = new Ledger();
         failsWithoutMutation(
           ledger,
-          (l) => l.renameUser(foo.id, bar.name),
+          (l) => l.renameUser(randomUuid(), "bar"),
           "renameUser: no user matches id"
         );
       });
       it("fails on username conflict", () => {
-        const thunk = () =>
-          new Ledger().addUser(foo).addUser(bar).renameUser(foo.id, bar.name);
-        expect(thunk).toThrowError("renameUser: conflict on username bar");
+        const ledger = new Ledger();
+        const fooId = ledger.createUser("foo");
+        ledger.createUser("bar");
+        const thunk = () => ledger.renameUser(fooId, "bar");
+        failsWithoutMutation(
+          ledger,
+          thunk,
+          "renameUser: conflict on username bar"
+        );
       });
-    });
-
-    describe("removeUser", () => {
-      it("works", () => {
-        const ledger = new Ledger().addUser(foo).removeUser(foo.id);
-        expect(ledger.users()).toEqual([]);
-      });
-      it("is idempotent", () => {
-        const ledger = new Ledger()
-          .addUser(foo)
-          .removeUser(foo.id)
-          .removeUser(foo.id);
-        expect(ledger.users()).toEqual([]);
-      });
-      it("frees up the username", () => {
-        const ledger = new Ledger()
-          .addUser(foo)
-          .removeUser(foo.id)
-          .addUser(nameConflict);
-        expect(ledger.users()).toEqual([nameConflict]);
-      });
-      it("frees up the aliases", () => {
-        const ledger = new Ledger()
-          .addUser(foo)
-          .removeUser(foo.id)
-          .addUser(aliasConflict);
-        expect(ledger.users()).toEqual([aliasConflict]);
-      });
-      it("frees up the user's innate address", () => {
-        const ledger = new Ledger()
-          .addUser(foo)
-          .addUser(bar)
-          .removeUser(foo.id)
-          .addAlias(bar.id, userAddress(foo.id));
-        expect(ledger.users()).toEqual([
-          {
-            id: bar.id,
-            name: bar.name,
-            aliases: [barAddress, userAddress(foo.id)],
-          },
-        ]);
-      });
-      it("removed useres may be re-added", () => {
-        // Verifies that we are cleaning the innate address from the list of
-        // restricted addresses when we remove the user.
-        const ledger = new Ledger()
-          .addUser(foo)
-          .removeUser(foo.id)
-          .addUser(foo);
-        expect(ledger.users()).toEqual([foo]);
+      it("fails on invalid username", () => {
+        const ledger = new Ledger();
+        const fooId = ledger.createUser("foo");
+        const thunk = () => ledger.renameUser(fooId, "foo bar");
+        failsWithoutMutation(ledger, thunk, "invalid username");
       });
     });
 
     describe("addAlias", () => {
       it("works", () => {
-        const ledger = new Ledger().addUser(foo).addAlias(foo.id, barAddress);
-        const expected = {
-          id: foo.id,
-          name: foo.name,
-          aliases: [fooAddress, barAddress],
-        };
-        expect(ledger.users()).toEqual([expected]);
-      });
-      it("is idemptoent", () => {
-        const ledger = new Ledger()
-          .addUser(foo)
-          .addAlias(foo.id, barAddress)
-          .addAlias(foo.id, barAddress);
-        const expected = {
-          id: foo.id,
-          name: foo.name,
-          aliases: [fooAddress, barAddress],
-        };
-        expect(ledger.users()).toEqual([expected]);
-      });
-      it("errors if there's no matching user", () => {
-        const ledger = new Ledger().addUser(foo);
-        failsWithoutMutation(
-          ledger,
-          (l) => l.addAlias(bar.id, barAddress),
-          "addAlias: no matching userId"
-        );
-      });
-      it("errors if the address is another user's innate address", () => {
-        const ledger = new Ledger().addUser(foo).addUser(bar);
-        const innateAddress = userAddress(foo.id);
-        failsWithoutMutation(
-          ledger,
-          (l) => l.addAlias(bar.id, innateAddress),
-          `addAlias: alias ${NodeAddress.toString(innateAddress)} already bound`
-        );
-      });
-      it("errors if the address is another user's alias", () => {
-        const ledger = new Ledger().addUser(foo).addUser(bar);
-        failsWithoutMutation(
-          ledger,
-          (l) => l.addAlias(bar.id, fooAddress),
-          `addAlias: alias ${NodeAddress.toString(fooAddress)} already bound`
-        );
-      });
-    });
-
-    describe("removeAlias", () => {
-      it("works", () => {
-        const ledger = new Ledger()
-          .addUser(foo)
-          .removeAlias(foo.id, fooAddress);
-        const expected = {
-          id: foo.id,
-          name: foo.name,
-          aliases: [],
-        };
-        expect(ledger.users()).toEqual([expected]);
-      });
-      it("is idempotent", () => {
-        const ledger = new Ledger()
-          .addUser(foo)
-          .removeAlias(foo.id, fooAddress)
-          .removeAlias(foo.id, fooAddress);
-        const expected = {
-          id: foo.id,
-          name: foo.name,
-          aliases: [],
-        };
-        expect(ledger.users()).toEqual([expected]);
+        const ledger = new Ledger();
+        setFakeDate(0);
+        const id = ledger.createUser("foo");
+        setFakeDate(1);
+        ledger.addAlias(id, a1);
+        const user = ledger.userById(id);
+        expect(user).toEqual({id, name: "foo", aliases: [a1]});
+        expect(ledger.actionLog()).toEqual([
+          {
+            type: "CREATE_USER",
+            version: 1,
+            timestamp: 0,
+            userId: id,
+            username: "foo",
+          },
+          {
+            type: "ADD_ALIAS",
+            version: 1,
+            timestamp: 1,
+            userId: id,
+            alias: a1,
+          },
+        ]);
       });
       it("errors if there's no matching user", () => {
         const ledger = new Ledger();
         failsWithoutMutation(
           ledger,
-          (l) => l.removeAlias(foo.id, fooAddress),
-          "removeAlias: no user matching id"
+          (l) => l.addAlias(randomUuid(), a1),
+          "addAlias: no matching userId"
+        );
+      });
+      it("throws an error if the user already has that alias", () => {
+        const ledger = new Ledger();
+        const id = ledger.createUser("foo");
+        ledger.addAlias(id, a1);
+        const thunk = () => ledger.addAlias(id, a1);
+        failsWithoutMutation(ledger, thunk, "user already has alias");
+      });
+      it("errors if the address is another user's alias", () => {
+        const ledger = new Ledger();
+        const id1 = ledger.createUser("foo");
+        const id2 = ledger.createUser("bar");
+        ledger.addAlias(id1, a1);
+        const thunk = () => ledger.addAlias(id2, a1);
+        failsWithoutMutation(
+          ledger,
+          thunk,
+          `addAlias: alias ${NodeAddress.toString(a1)} already bound`
         );
       });
       it("errors if the address is the user's innate address", () => {
-        const ledger = new Ledger().addUser(foo);
+        const ledger = new Ledger();
+        const id = ledger.createUser("foo");
+        const innateAddress = userAddress(id);
+        const thunk = () => ledger.addAlias(id, innateAddress);
         failsWithoutMutation(
           ledger,
-          (l) => l.removeAlias(foo.id, userAddress(foo.id)),
-          "removeAlias: cannot remove user's innate address"
+          thunk,
+          `addAlias: alias ${NodeAddress.toString(innateAddress)} already bound`
         );
       });
-      it("frees the alias so it may be re-added", () => {
-        const ledger = new Ledger()
-          .addUser(foo)
-          .addUser(bar)
-          .removeAlias(foo.id, fooAddress)
-          .addAlias(bar.id, fooAddress);
-        const expectedFoo = {id: foo.id, name: foo.name, aliases: []};
-        const expectedBar = {
-          id: bar.id,
-          name: bar.name,
-          aliases: [barAddress, fooAddress],
-        };
-        expect(ledger.users()).toEqual([expectedFoo, expectedBar]);
+      it("errors if the address is another user's innate address", () => {
+        const ledger = new Ledger();
+        const id1 = ledger.createUser("foo");
+        const innateAddress = userAddress(id1);
+        const id2 = ledger.createUser("bar");
+        const thunk = () => ledger.addAlias(id2, innateAddress);
+        failsWithoutMutation(
+          ledger,
+          thunk,
+          `addAlias: alias ${NodeAddress.toString(innateAddress)} already bound`
+        );
       });
     });
-  });
-
-  describe("user getters", () => {
-    it("userById works", () => {
-      const ledger = new Ledger().addUser(foo);
-      expect(ledger.userById(foo.id)).toEqual(foo);
-      expect(ledger.userById(bar.id)).toEqual(undefined);
-    });
-    it("userByUsername works", () => {
-      const ledger = new Ledger().addUser(foo);
-      expect(ledger.userByUsername(foo.name)).toEqual(foo);
-      expect(ledger.userByUsername(bar.name)).toEqual(undefined);
-      ledger.renameUser(foo.id, bar.name);
-      expect(ledger.userByUsername(foo.name)).toEqual(undefined);
-      expect(ledger.userByUsername(bar.name)).toEqual({
-        id: foo.id,
-        name: bar.name,
-        aliases: foo.aliases,
+    describe("removeAlias", () => {
+      it("works", () => {
+        const ledger = new Ledger();
+        setFakeDate(0);
+        const id = ledger.createUser("foo");
+        setFakeDate(1);
+        ledger.addAlias(id, a1);
+        setFakeDate(2);
+        ledger.removeAlias(id, a1);
+        const user = ledger.userById(id);
+        expect(user).toEqual({id, name: "foo", aliases: []});
+        expect(ledger.actionLog()).toEqual([
+          {
+            type: "CREATE_USER",
+            version: 1,
+            timestamp: 0,
+            userId: id,
+            username: "foo",
+          },
+          {
+            type: "ADD_ALIAS",
+            version: 1,
+            timestamp: 1,
+            userId: id,
+            alias: a1,
+          },
+          {
+            type: "REMOVE_ALIAS",
+            version: 1,
+            timestamp: 2,
+            userId: id,
+            alias: a1,
+          },
+        ]);
+      });
+      it("errors if there's no matching user", () => {
+        const ledger = new Ledger();
+        failsWithoutMutation(
+          ledger,
+          (l) => l.removeAlias(randomUuid(), a1),
+          "removeAlias: no user matching id"
+        );
+      });
+      it("throws an error if the user doesn't already has that alias", () => {
+        const ledger = new Ledger();
+        const id = ledger.createUser("foo");
+        const thunk = () => ledger.removeAlias(id, a1);
+        failsWithoutMutation(ledger, thunk, "user does not have alias");
+      });
+      it("errors if the address is the user's innate address", () => {
+        const ledger = new Ledger();
+        const id = ledger.createUser("foo");
+        const innateAddress = userAddress(id);
+        const thunk = () => ledger.removeAlias(id, innateAddress);
+        failsWithoutMutation(
+          ledger,
+          thunk,
+          `removeAlias: cannot remove user's innate address`
+        );
+      });
+      it("frees the alias to be re-added", () => {
+        const ledger = new Ledger();
+        const id1 = ledger.createUser("foo");
+        const id2 = ledger.createUser("bar");
+        ledger.addAlias(id1, a1);
+        ledger.removeAlias(id1, a1);
+        ledger.addAlias(id2, a1);
+        const u2 = ledger.userById(id2);
+        expect(u2).toEqual({id: id2, name: "bar", aliases: [a1]});
       });
     });
   });
@@ -303,12 +281,12 @@ describe("ledger/ledger", () => {
       expect(Ledger.fromActionLog(emptyLog)).toEqual(new Ledger());
     });
     it("actionLog and fromActionLog compose to identity", () => {
-      const ledger = new Ledger()
-        .addUser(foo)
-        .addUser(bar)
-        .removeAlias(foo.id, fooAddress)
-        .removeUser(bar.id)
-        .addAlias(foo.id, barAddress);
+      const ledger = new Ledger();
+      const id1 = ledger.createUser("foo");
+      const id2 = ledger.createUser("bar");
+      ledger.addAlias(id1, a1);
+      ledger.removeAlias(id1, a1);
+      ledger.addAlias(id2, a1);
       expect(Ledger.fromActionLog(ledger.actionLog())).toEqual(ledger);
     });
   });

--- a/src/ledger/ledger.test.js
+++ b/src/ledger/ledger.test.js
@@ -1,0 +1,315 @@
+// @flow
+
+import deepFreeze from "deep-freeze";
+import cloneDeep from "lodash.clonedeep";
+import {fromString as uuidFromString} from "../util/uuid";
+import {NodeAddress} from "../core/graph";
+import {Ledger} from "./ledger";
+import {usernameFromString, userAddress} from "./user";
+
+describe("ledger/ledger", () => {
+  // Verify that a method fails, throwing an error, without mutating the ledger.
+  function failsWithoutMutation(
+    ledger: Ledger,
+    operation: (Ledger) => any,
+    message: string
+  ) {
+    const copy = cloneDeep(ledger);
+    expect(() => operation(ledger)).toThrow(message);
+    expect(copy).toEqual(ledger);
+  }
+
+  const fooAddress = NodeAddress.fromParts(["foo"]);
+  const foo = deepFreeze({
+    id: uuidFromString("YVZhbGlkVXVpZEF0TGFzdA"),
+    name: usernameFromString("foo"),
+    aliases: [fooAddress],
+  });
+  const barAddress = NodeAddress.fromParts(["bar"]);
+  const bar = deepFreeze({
+    id: uuidFromString("XVZhbGlkVXVpZEF0TGFzdA"),
+    name: usernameFromString("bar"),
+    aliases: [barAddress],
+  });
+  const nameConflict = deepFreeze({
+    id: foo.id,
+    name: bar.name,
+    aliases: foo.aliases,
+  });
+  const aliasConflict = deepFreeze({
+    id: foo.id,
+    name: foo.name,
+    aliases: bar.aliases,
+  });
+
+  describe("user updates", () => {
+    describe("addUser", () => {
+      it("works", () => {
+        const ledger = new Ledger().addUser(foo);
+        expect(ledger.users()).toEqual([foo]);
+      });
+      it("is idempotent", () => {
+        const ledger = new Ledger().addUser(foo).addUser(foo);
+        expect(ledger.users()).toEqual([foo]);
+      });
+      it("fails if the user's name is taken by another user", () => {
+        const ledger = new Ledger().addUser(bar);
+        failsWithoutMutation(
+          ledger,
+          (l) => l.addUser(nameConflict),
+          "addUser: username already claimed"
+        );
+      });
+      it("fails if one of the user's aliases is already claimed", () => {
+        const ledger = new Ledger().addUser(bar);
+        failsWithoutMutation(
+          ledger,
+          (l) => l.addUser(aliasConflict),
+          "addUser: alias already claimed"
+        );
+      });
+      it("fails if a different user exists at that id", () => {
+        const ledger = new Ledger().addUser(foo);
+        failsWithoutMutation(
+          ledger,
+          (l) => l.addUser(aliasConflict),
+          "addUser: conflicting user with id"
+        );
+      });
+      it("fails if the user's own innate address is already taken", () => {
+        // Weird edge case where another user has been explicitly linked to the
+        // new user's innate address
+        const ledger = new Ledger()
+          .addUser(foo)
+          .addAlias(foo.id, userAddress(bar.id));
+        failsWithoutMutation(
+          ledger,
+          (l) => l.addUser(bar),
+          "addUser: innate address already claimed"
+        );
+      });
+    });
+
+    describe("renameUser", () => {
+      it("works", () => {
+        const ledger = new Ledger().addUser(foo).renameUser(foo.id, bar.name);
+        const expected = {id: foo.id, name: bar.name, aliases: foo.aliases};
+        expect(ledger.users()).toEqual([expected]);
+      });
+      it("is idempotent", () => {
+        const ledger = new Ledger()
+          .addUser(foo)
+          .renameUser(foo.id, bar.name)
+          .renameUser(foo.id, bar.name);
+        const expected = {id: foo.id, name: bar.name, aliases: foo.aliases};
+        expect(ledger.users()).toEqual([expected]);
+      });
+      it("fails on nonexistent user id", () => {
+        const ledger = new Ledger();
+        failsWithoutMutation(
+          ledger,
+          (l) => l.renameUser(foo.id, bar.name),
+          "renameUser: no user matches id"
+        );
+      });
+      it("fails on username conflict", () => {
+        const thunk = () =>
+          new Ledger().addUser(foo).addUser(bar).renameUser(foo.id, bar.name);
+        expect(thunk).toThrowError("renameUser: conflict on username bar");
+      });
+    });
+
+    describe("removeUser", () => {
+      it("works", () => {
+        const ledger = new Ledger().addUser(foo).removeUser(foo.id);
+        expect(ledger.users()).toEqual([]);
+      });
+      it("is idempotent", () => {
+        const ledger = new Ledger()
+          .addUser(foo)
+          .removeUser(foo.id)
+          .removeUser(foo.id);
+        expect(ledger.users()).toEqual([]);
+      });
+      it("frees up the username", () => {
+        const ledger = new Ledger()
+          .addUser(foo)
+          .removeUser(foo.id)
+          .addUser(nameConflict);
+        expect(ledger.users()).toEqual([nameConflict]);
+      });
+      it("frees up the aliases", () => {
+        const ledger = new Ledger()
+          .addUser(foo)
+          .removeUser(foo.id)
+          .addUser(aliasConflict);
+        expect(ledger.users()).toEqual([aliasConflict]);
+      });
+      it("frees up the user's innate address", () => {
+        const ledger = new Ledger()
+          .addUser(foo)
+          .addUser(bar)
+          .removeUser(foo.id)
+          .addAlias(bar.id, userAddress(foo.id));
+        expect(ledger.users()).toEqual([
+          {
+            id: bar.id,
+            name: bar.name,
+            aliases: [barAddress, userAddress(foo.id)],
+          },
+        ]);
+      });
+      it("removed useres may be re-added", () => {
+        // Verifies that we are cleaning the innate address from the list of
+        // restricted addresses when we remove the user.
+        const ledger = new Ledger()
+          .addUser(foo)
+          .removeUser(foo.id)
+          .addUser(foo);
+        expect(ledger.users()).toEqual([foo]);
+      });
+    });
+
+    describe("addAlias", () => {
+      it("works", () => {
+        const ledger = new Ledger().addUser(foo).addAlias(foo.id, barAddress);
+        const expected = {
+          id: foo.id,
+          name: foo.name,
+          aliases: [fooAddress, barAddress],
+        };
+        expect(ledger.users()).toEqual([expected]);
+      });
+      it("is idemptoent", () => {
+        const ledger = new Ledger()
+          .addUser(foo)
+          .addAlias(foo.id, barAddress)
+          .addAlias(foo.id, barAddress);
+        const expected = {
+          id: foo.id,
+          name: foo.name,
+          aliases: [fooAddress, barAddress],
+        };
+        expect(ledger.users()).toEqual([expected]);
+      });
+      it("errors if there's no matching user", () => {
+        const ledger = new Ledger().addUser(foo);
+        failsWithoutMutation(
+          ledger,
+          (l) => l.addAlias(bar.id, barAddress),
+          "addAlias: no matching userId"
+        );
+      });
+      it("errors if the address is another user's innate address", () => {
+        const ledger = new Ledger().addUser(foo).addUser(bar);
+        const innateAddress = userAddress(foo.id);
+        failsWithoutMutation(
+          ledger,
+          (l) => l.addAlias(bar.id, innateAddress),
+          `addAlias: alias ${NodeAddress.toString(innateAddress)} already bound`
+        );
+      });
+      it("errors if the address is another user's alias", () => {
+        const ledger = new Ledger().addUser(foo).addUser(bar);
+        failsWithoutMutation(
+          ledger,
+          (l) => l.addAlias(bar.id, fooAddress),
+          `addAlias: alias ${NodeAddress.toString(fooAddress)} already bound`
+        );
+      });
+    });
+
+    describe("removeAlias", () => {
+      it("works", () => {
+        const ledger = new Ledger()
+          .addUser(foo)
+          .removeAlias(foo.id, fooAddress);
+        const expected = {
+          id: foo.id,
+          name: foo.name,
+          aliases: [],
+        };
+        expect(ledger.users()).toEqual([expected]);
+      });
+      it("is idempotent", () => {
+        const ledger = new Ledger()
+          .addUser(foo)
+          .removeAlias(foo.id, fooAddress)
+          .removeAlias(foo.id, fooAddress);
+        const expected = {
+          id: foo.id,
+          name: foo.name,
+          aliases: [],
+        };
+        expect(ledger.users()).toEqual([expected]);
+      });
+      it("errors if there's no matching user", () => {
+        const ledger = new Ledger();
+        failsWithoutMutation(
+          ledger,
+          (l) => l.removeAlias(foo.id, fooAddress),
+          "removeAlias: no user matching id"
+        );
+      });
+      it("errors if the address is the user's innate address", () => {
+        const ledger = new Ledger().addUser(foo);
+        failsWithoutMutation(
+          ledger,
+          (l) => l.removeAlias(foo.id, userAddress(foo.id)),
+          "removeAlias: cannot remove user's innate address"
+        );
+      });
+      it("frees the alias so it may be re-added", () => {
+        const ledger = new Ledger()
+          .addUser(foo)
+          .addUser(bar)
+          .removeAlias(foo.id, fooAddress)
+          .addAlias(bar.id, fooAddress);
+        const expectedFoo = {id: foo.id, name: foo.name, aliases: []};
+        const expectedBar = {
+          id: bar.id,
+          name: bar.name,
+          aliases: [barAddress, fooAddress],
+        };
+        expect(ledger.users()).toEqual([expectedFoo, expectedBar]);
+      });
+    });
+  });
+
+  describe("user getters", () => {
+    it("userById works", () => {
+      const ledger = new Ledger().addUser(foo);
+      expect(ledger.userById(foo.id)).toEqual(foo);
+      expect(ledger.userById(bar.id)).toEqual(undefined);
+    });
+    it("userByUsername works", () => {
+      const ledger = new Ledger().addUser(foo);
+      expect(ledger.userByUsername(foo.name)).toEqual(foo);
+      expect(ledger.userByUsername(bar.name)).toEqual(undefined);
+      ledger.renameUser(foo.id, bar.name);
+      expect(ledger.userByUsername(foo.name)).toEqual(undefined);
+      expect(ledger.userByUsername(bar.name)).toEqual({
+        id: foo.id,
+        name: bar.name,
+        aliases: foo.aliases,
+      });
+    });
+  });
+
+  describe("state reconstruction", () => {
+    it("fromActionLog with an empty action log results in an empty ledger", () => {
+      const emptyLog = new Ledger().actionLog();
+      expect(emptyLog).toEqual([]);
+      expect(Ledger.fromActionLog(emptyLog)).toEqual(new Ledger());
+    });
+    it("actionLog and fromActionLog compose to identity", () => {
+      const ledger = new Ledger()
+        .addUser(foo)
+        .addUser(bar)
+        .removeAlias(foo.id, fooAddress)
+        .removeUser(bar.id)
+        .addAlias(foo.id, barAddress);
+      expect(Ledger.fromActionLog(ledger.actionLog())).toEqual(ledger);
+    });
+  });
+});


### PR DESCRIPTION
This starts work on the Ledger module, which will accumulate instance
state for user identity updates, and Grain distribution.

A key requirement is that we durably store every state change, and are
able to replay it. This way we can have an auditable history of Grain
distributions, of when users' aliases changed, etc. (We need to keep the
user alias changes alongside the Grain distribution history, because
when users link or unlink aliases, we need to update the lifetime
distributions for each address accordingly.)

For now, we just handle user identity state, although we will enhance
the module with Grain distribution history in a future commit.

From an implementation perspective, the Ledger provides an imperative
API that is similar in feel to the Graph APIs. Under the hood, every
mutating API call constructs an "action", which is added to the action
log, and then processes that action. This way we can serialize the
history of actions and replay them later. I've taken care to ensure that
the ledger can't get into an inconsistent state, i.e. any action which
fails will fail before modifying the ledger state. This property is
tested.

Test plan: There are a lot of edge cases to handle, e.g. handling users'
"innate" addresses, ensuring that addresses and usernames are unlinked
when a user is removed, and so forth. Unit tests are quite
comprehensive.