### PR TITLE
Publish SourceCred with executable binary

### DIFF
--- a/config/webpack.config.backend.js
+++ b/config/webpack.config.backend.js
@@ -72,6 +72,7 @@ module.exports = {
   plugins: [
     new RemoveBuildDirectoryPlugin(),
     new webpack.DefinePlugin(env.individuallyStringified),
+    new webpack.BannerPlugin({banner: "#!/usr/bin/env node", raw: true}),
   ],
   mode: process.env.NODE_ENV,
 };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,9 @@
 {
   "name": "sourcecred",
-  "version": "0.7.0-beta-1",
+  "description": "a tool for communities to measure and reward value creation",
+  "homepage": "https://sourcecred.io",
+  "repository": "github:sourcecred/sourcecred",
+  "version": "0.7.0-beta-3",
   "private": false,
   "dependencies": {
     "aphrodite": "^2.4.0",
@@ -95,7 +98,7 @@
     "prettify": "prettier --write '**/*.js'",
     "check-pretty": "prettier --list-different '**/*.js'",
     "start": "NODE_ENV=development webpack-dev-server --config config/webpack.config.web.js",
-    "build": "run-p build:* && ln -sf ../build ./bin/site-template",
+    "build": "run-p build:* && ln -sf ../build ./bin/site-template && chmod +x ./bin/sourcecred.js",
     "build:frontend": "NODE_ENV=production webpack --config config/webpack.config.web.js",
     "build:backend": "NODE_ENV=development webpack --config config/webpack.config.backend.js",
     "api": "webpack --config config/webpack.config.api.js",
@@ -146,5 +149,6 @@
   "files": [
     "/bin",
     "/build"
-  ]
+  ],
+  "bin": "./bin/sourcecred.js"
 }


### PR DESCRIPTION
This updates our build so that we include a shebang at the top of
`bin/sourcecred.js`, mark it executable, and make it the binary entry
point for the package.

As a result, dependents can install the `sourcecred` command via npm and
conveniently use it. Also, local invocation no longer needs to be
preceded with `node`, i.e. `./bin/sourcecred.js ARGS` is sufficient.

Test plan:

Verify that `yarn test --full` passes; and that
`./bin/sourcecred.js --version` prints the version.

Also, see sourcecred/example-instance#1, which uses a prerelease package
published from this commit.