### PR TITLE
add `sourcecred go` command

### DIFF
--- a/sharness/load_test_instance.t
+++ b/sharness/load_test_instance.t
@@ -39,9 +39,7 @@ test_expect_success EXPENSIVE,SETUP,HAVE_GITHUB_TOKEN \
     "should load the example instance" '
     cp -r "${snapshot_directory}" . &&
     cd test-instance &&
-    node "${SOURCECRED_BIN}/sourcecred.js" load &&
-    node "${SOURCECRED_BIN}/sourcecred.js" graph &&
-    node "${SOURCECRED_BIN}/sourcecred.js" score &&
+    node "${SOURCECRED_BIN}/sourcecred.js" go &&
     rm -rf cache &&
     test_set_prereq LOADED
 '

--- a/src/cli/go.js
+++ b/src/cli/go.js
@@ -1,0 +1,32 @@
+// @flow
+
+import type {Command} from "./command";
+
+import load from "./load";
+import graph from "./graph";
+import score from "./score";
+
+function die(std, message) {
+  std.err("fatal: " + message);
+  return 1;
+}
+
+const goCommand: Command = async (args, std) => {
+  if (args.length !== 0) {
+    return die(std, "usage: sourcecred go");
+  }
+  const commandSequence = [
+    {name: "load", command: load},
+    {name: "graph", command: graph},
+    {name: "score", command: score},
+  ];
+  for (const {name, command} of commandSequence) {
+    const ret = await command([], std);
+    if (ret !== 0) {
+      return die(std, `go: failed on command ${name}`);
+    }
+  }
+  return 0;
+};
+
+export default goCommand;

--- a/src/cli/sourcecred.js
+++ b/src/cli/sourcecred.js
@@ -7,6 +7,7 @@ import load from "./load";
 import graph from "./graph";
 import score from "./score";
 import site from "./site";
+import go from "./go";
 import help from "./help";
 
 const sourcecred: Command = async (args, std) => {
@@ -29,6 +30,8 @@ const sourcecred: Command = async (args, std) => {
       return score(args.slice(1), std);
     case "site":
       return site(args.slice(1), std);
+    case "go":
+      return go(args.slice(1), std);
     default:
       std.err("fatal: unknown command: " + JSON.stringify(args[0]));
       std.err("fatal: run 'sourcecred help' for commands and usage");


### PR DESCRIPTION
The `go` command performs a full load, running the following commands in
sequence:
- load
- graph
- score

We don't include the `site` command, on the premise that the user might
have reasons to not include the site (e.g. they just want to use the
ouptut data for analysis), so we shouldn't add it for them. Also, if
they installed the site in the past, it will still be setup.

However, this does mean that downstream users who DO want a site should
be sure to run `sourcecred site` manually whenever they update
SourceCred versions.

Test plan: In a SC instance, run `sourcecred go` and observe that:
- in the success case, it runs the three commands in sequence
- in the failure case, it prints a message showing which command failed
(you can induce a failure by removing the cache, or unsetting
GitHub/Discord tokens).