### PR TITLE
Allow inclusion of Grain in JSON objects

### DIFF
--- a/src/grain/grain.test.js
+++ b/src/grain/grain.test.js
@@ -1,5 +1,7 @@
 // @flow
 
+import stringify from "json-stable-stringify";
+import deepFreeze from "deep-freeze";
 import {
   format,
   ONE,
@@ -8,7 +10,9 @@ import {
   fromApproximateFloat,
   multiplyFloat,
   toFloatRatio,
+  grainParser,
 } from "./grain";
+import * as C from "../util/combo";
 
 describe("src/grain/grain", () => {
   describe("format", () => {
@@ -144,6 +148,38 @@ describe("src/grain/grain", () => {
       const bigPi = multiplyFloat(ONE, Math.PI);
       // $FlowExpectedError
       expect(toFloatRatio(bigPi, ONE * 2n)).toEqual(Math.PI / 2);
+    });
+  });
+
+  describe("serialization and parsing", () => {
+    // It's not a proper JSON object, since it has BigInts,
+    // but we can pretend it is because:
+    // 1. We're already lying to Flow and claiming BigInts are numbers
+    // 2. We've patched the BigInt prototype to provide a sane toJSON method
+    // (just serialize it as a string)
+    // 3. We've written a Grain parser which accomodates either raw BigInts, or
+    // stringified BigInts
+    const example: C.JsonObject = deepFreeze({
+      zero: ZERO,
+      one: ONE,
+    });
+    const parser = C.object({zero: grainParser, one: grainParser});
+    it("parses BigInt Grain values at runtime", () => {
+      expect(parser.parseOrThrow(example)).toEqual(example);
+    });
+    it("parses Grain values that were secretly stringified", () => {
+      const objectified = JSON.parse(stringify(example));
+      expect(parser.parseOrThrow(objectified)).toEqual(example);
+    });
+    it("errors for values that are not BigInts or strings", () => {
+      expect(() => grainParser.parseOrThrow(123)).toThrowError(
+        "expected string, got number"
+      );
+    });
+    it("errors for invalid strings", () => {
+      expect(() => grainParser.parseOrThrow("123.4")).toThrowError(
+        "Cannot convert 123.4 to a BigInt"
+      );
     });
   });
 });


### PR DESCRIPTION
We store Grain as BigInts, and we would really like to be able to write
types that include Grain values, and treat them like JSON objects. That
would allow us to store events that include Grain values directly into
logs that are persisted to disk, and not need to worry with processing
each value for serialization and deserialization.

However, we have a problem, in that BigInts do not have a native
`toJSON` method. Therefore, this commit modifies the Grain module so
that on module load time, it overrides the BigInt prototype to include a
`toJSON` method which outputs the string representation, which is an
injection. Then, we provide a `grainParser` which will correctly parse
either raw BigInts, or stringified BigInts.

The net result is that you can stringify object containing Grain values
to your hearts content, and parse them using the provided parser, and
never need to think about the hacks that went into this! Brilliant!

The only downsides are:
1. We are modifying a global prototype (but the modification is so
reasonable that the MDN docs propose it), and
2. From the perspective of the parser, any logical Grain value has two
equivalent representations (string and BigInt)

Frankly, I think this is worth it and would happily sign my name onto
this hack.

Test plan: Unit tests included, check them out.