### PR TITLE
WIP - Update Relative History Routing to V4 API

### DIFF
--- a/flow-typed/npm/history_v4.x.x.js
+++ b/flow-typed/npm/history_v4.x.x.js
@@ -28,8 +28,8 @@ declare module "history/createBrowserHistory" {
     goBack(): void,
     goForward(): void,
     listen: Function,
-    block(message: string): typeof Unblock,
-    block((location: BrowserLocation, action: Action) => string): typeof Unblock,
+    block(message: ?string): typeof Unblock,
+    block((location: BrowserLocation, action: Action) => ?string): typeof Unblock,
   }
 
   declare type BrowserHistoryOpts = {
@@ -76,7 +76,7 @@ declare module "history/createMemoryHistory" {
     // Memory only
     canGo?: (n: number) => boolean,
     listen: Function,
-    block(message: string): typeof Unblock,
+    block(message: ?string): typeof Unblock,
     block((location: MemoryLocation, action: Action) => ?string): typeof Unblock,
   }
 
@@ -118,8 +118,8 @@ declare module "history/createHashHistory" {
     goBack(): void,
     goForward(): void,
     listen: Function,
-    block(message: string): typeof Unblock,
-    block((location: HashLocation, action: Action) => string): typeof Unblock,
+    block(message: ?string): typeof Unblock,
+    block((location: HashLocation, action: Action) => ?string): typeof Unblock,
     push(path: string): void,
   }
 

--- a/src/webutil/createRelativeHistory.js
+++ b/src/webutil/createRelativeHistory.js
@@ -25,7 +25,7 @@
  *     `window.location` is always represented in browser-space.
  *
  *   - Interactions with React Router are in React-space. In particular,
- *     the result of `getCurrentLocation()` is in React-space, and the
+ *     the contents of `location` is in React-space, and the
  *     argument to `createHref` is in React-space. This is
  *     necessary/convenient because it is an assumption of React Router
  *     (e.g., actual route data must be specified thus).
@@ -65,10 +65,10 @@ export default function createRelativeHistory(
   delegate: History,
   basename: string
 ): History {
-  if (!delegate.getCurrentLocation) {
+  if (!delegate.location) {
     // (The `Router` component of `react-router` uses the same check.)
     throw new Error(
-      "delegate: expected history@3 implementation, got: " + String(delegate)
+      "delegate: expected history@4 implementation, got:" + String(delegate)
     );
   }
   if (typeof basename !== "string") {
@@ -80,7 +80,7 @@ export default function createRelativeHistory(
   if (!basename.endsWith("/")) {
     throw new Error("basename: must end in slash: " + basename);
   }
-  verifyBasename(delegate.getCurrentLocation().pathname);
+  verifyBasename(delegate.location.pathname);
 
   interface Lens {
     (pathname: string): string;
@@ -131,7 +131,7 @@ export default function createRelativeHistory(
   });
   const browserToDom = lens((path) => {
     verifyBasename(path);
-    const current = delegate.getCurrentLocation().pathname;
+    const current = delegate.location.pathname;
     verifyBasename(current);
     const relativeRoot = current
       .slice(basename.length)

--- a/src/webutil/testUtil.js
+++ b/src/webutil/testUtil.js
@@ -26,3 +26,56 @@ export function configureAphrodite() {
     StyleSheetTestUtils.clearBufferAndResumeStyleInjection();
   });
 }
+
+export const relativeEntries = [
+  {
+    hash: "",
+    pathname: "/foo/bar/",
+    search: "",
+    state: undefined,
+  },
+  {hash: "", pathname: "/1/", search: "", state: undefined},
+  {hash: "", pathname: "/2/", search: "", state: undefined},
+  {hash: "", pathname: "/3/", search: "", state: undefined},
+  {hash: "", pathname: "/4/", search: "", state: undefined},
+  {hash: "", pathname: "/5/", search: "", state: undefined},
+];
+
+export const memoryEntries = [
+  {
+    pathname: "/my/gateway/foo/bar/",
+    search: "",
+    hash: "",
+    state: undefined,
+  },
+  {
+    pathname: "/my/gateway/1/",
+    search: "",
+    hash: "",
+    state: undefined,
+  },
+  {
+    pathname: "/my/gateway/2/",
+    search: "",
+    hash: "",
+    state: undefined,
+  },
+  {
+    pathname: "/my/gateway/3/",
+    search: "",
+    hash: "",
+    state: undefined,
+  },
+  {
+    pathname: "/my/gateway/4/",
+    search: "",
+    hash: "",
+    state: undefined,
+  },
+  {
+    pathname: "/my/gateway/5/",
+    search: "",
+    hash: "",
+    state: undefined,
+  },
+];


### PR DESCRIPTION
The history V4 api has several changes:
- no `getCurrentLocation` method. The location state is accessed directly. (but only modified through hooks)
- private methods are no longer stored in the history object. Methods from V3 that aren't meant to be accessed publicly have been removed from the history context, and thus those methods have been removed here.
- the addtion of a `block` method, which prevents path changes within the react app when called

One of the trickier changes was exposing the delegate location state in a way that still conforms to the API. Canonical history implementations maintain their own state, rather than relying on nested history's state. Using a proxy handler, `relativeHistory` is able to handle top-level get requests without maintaining any of it's own state.

test plan: Unit tests have been updated to accomodate these changes and, ensure that the new endpoints are behaving as expected. Manual integration testing is also conducted using the [example instance](https://github.com/sourcecred/example-instance)

and executing the following shell commands:
```bash
# pick either this python server:
alias serve="python -m SimpleHttpServer 6060"
# or this javascript server:
yarn global add serve
alias serve="serve -l 6060" 
# then test each of these cases:
cd example-instance && serve  # then localhost:6060 should show a working frontend
cd .. && serve # then localhost:6060/example-instance should show a working frontend
```


## Remaining Tasks
- [x] add `action` prop
- [x] add `length` prop
- [x] add `location` prop
- [x] add `index` prop
- [x] add `entries` prop
- [x] add `block` method
- [x] polish comments to add new details
- [x] split changes into semantically atomic commits
- [x] write a helpful PR description
- [ ] conduct integration tests