### PR TITLE
Represent Grain as Strings at rest

### DIFF
--- a/src/grain/grain.js
+++ b/src/grain/grain.js
@@ -22,17 +22,48 @@
  * [BigInt]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/BigInt
  * [flow]: https://github.com/facebook/flow/issues/6639
  */
-export type Grain = number;
+export opaque type Grain: string = string;
 
-// $FlowExpectedError
-export const ZERO = 0n;
+export const ZERO: Grain = "0";
 
 // How many digits of precision there are in "one" grain
 export const DECIMAL_PRECISION = 18;
 
 // One "full" grain
 // $FlowExpectedError
-export const ONE = 10n ** BigInt(DECIMAL_PRECISION);
+export const ONE: Grain = (10n ** BigInt(DECIMAL_PRECISION)).toString();
+
+export function add(a: Grain, b: Grain): Grain {
+  return (BigInt(a) + BigInt(b)).toString();
+}
+export function sub(a: Grain, b: Grain): Grain {
+  return (BigInt(a) - BigInt(b)).toString();
+}
+export function mul(a: Grain, b: Grain): Grain {
+  return (BigInt(a) * BigInt(b)).toString();
+}
+export function div(a: Grain, b: Grain): Grain {
+  return (BigInt(a) / BigInt(b)).toString();
+}
+export function lt(a: Grain, b: Grain): boolean {
+  return BigInt(a) < BigInt(b);
+}
+export function gt(a: Grain, b: Grain): boolean {
+  return BigInt(a) > BigInt(b);
+}
+export function lte(a: Grain, b: Grain): boolean {
+  return BigInt(a) <= BigInt(b);
+}
+export function gte(a: Grain, b: Grain): boolean {
+  return BigInt(a) >= BigInt(b);
+}
+export function eq(a: Grain, b: Grain): boolean {
+  return BigInt(a) === BigInt(b);
+}
+
+export function fromString(s: string): Grain {
+  return BigInt(s).toString();
+}
 
 export const DEFAULT_SUFFIX = "g";
 
@@ -69,8 +100,8 @@ export function format(
       `decimals must be integer in range [0..${DECIMAL_PRECISION}]`
     );
   }
-  const isNegative = grain < 0;
-  let digits = [...grain.toString()];
+  const isNegative = grain[0] === "-";
+  let digits = [...grain];
   if (isNegative) {
     // Remove the negative sign for consistency, we'll prepend it back at the end
     digits = digits.slice(1, digits.length);
@@ -122,7 +153,7 @@ export function format(
  * https://observablehq.com/@decentralion/grain-arithmetic
  */
 export function multiplyFloat(grain: Grain, num: number): Grain {
-  return BigInt(Math.floor(Number(grain) * num));
+  return BigInt(Math.floor(Number(grain) * num)).toString();
 }
 
 /**

--- a/src/grain/grain.test.js
+++ b/src/grain/grain.test.js
@@ -1,73 +1,73 @@
 // @flow
 
-import {
-  format,
-  ONE,
-  DECIMAL_PRECISION,
-  ZERO,
-  fromApproximateFloat,
-  multiplyFloat,
-  toFloatRatio,
-} from "./grain";
+import * as G from "./grain";
 
 describe("src/grain/grain", () => {
-  describe("format", () => {
-    // $FlowExpectedError
-    const almostOne = ONE - 1n;
+  describe("G.format", () => {
+    const almostOne = G.sub(G.ONE, G.fromString("1"));
 
     it("correctly rounds to smallest integer when decimals==0", () => {
-      expect(format(ZERO)).toEqual("0g");
-      expect(format(fromApproximateFloat(0.1))).toEqual("0g");
-      expect(format(almostOne)).toEqual("0g");
-      expect(format(ONE)).toEqual("1g");
-      expect(format(fromApproximateFloat(1.5))).toEqual("1g");
-      expect(format(fromApproximateFloat(42))).toEqual("42g");
+      expect(G.format(G.ZERO)).toEqual("0g");
+      expect(G.format(G.fromApproximateFloat(0.1))).toEqual("0g");
+      expect(G.format(almostOne)).toEqual("0g");
+      expect(G.format(G.ONE)).toEqual("1g");
+      expect(G.format(G.fromApproximateFloat(1.5))).toEqual("1g");
+      expect(G.format(G.fromApproximateFloat(42))).toEqual("42g");
     });
-    it("correctly adds comma formatting for large numbers", () => {
-      expect(format(fromApproximateFloat(1337))).toEqual("1,337g");
-      expect(format(fromApproximateFloat(1337), 1)).toEqual("1,337.0g");
-      expect(format(fromApproximateFloat(1337.11))).toEqual("1,337g");
-      expect(format(fromApproximateFloat(1337.11), 1)).toEqual("1,337.1g");
-      expect(format(fromApproximateFloat(1337042.42), 0)).toEqual("1,337,042g");
-      expect(format(fromApproximateFloat(1337042.42), 2)).toEqual(
+    it("correctly G.adds comma G.formatting for large numbers", () => {
+      expect(G.format(G.fromApproximateFloat(1337))).toEqual("1,337g");
+      expect(G.format(G.fromApproximateFloat(1337), 1)).toEqual("1,337.0g");
+      expect(G.format(G.fromApproximateFloat(1337.11))).toEqual("1,337g");
+      expect(G.format(G.fromApproximateFloat(1337.11), 1)).toEqual("1,337.1g");
+      expect(G.format(G.fromApproximateFloat(1337042.42), 0)).toEqual(
+        "1,337,042g"
+      );
+      expect(G.format(G.fromApproximateFloat(1337042.42), 2)).toEqual(
         "1,337,042.42g"
       );
     });
     it("correctly handles negative numbers", () => {
-      expect(format(fromApproximateFloat(-0.1))).toEqual("-0g");
-      expect(format(fromApproximateFloat(-1.5))).toEqual("-1g");
-      expect(format(fromApproximateFloat(-42))).toEqual("-42g");
-      expect(format(fromApproximateFloat(-1.5), 1)).toEqual("-1.5g");
-      expect(format(fromApproximateFloat(-1.5), 1)).toEqual("-1.5g");
-      expect(format(fromApproximateFloat(-1337042.42), 0)).toEqual(
+      expect(G.format(G.fromApproximateFloat(-0.1))).toEqual("-0g");
+      expect(G.format(G.fromApproximateFloat(-1.5))).toEqual("-1g");
+      expect(G.format(G.fromApproximateFloat(-42))).toEqual("-42g");
+      expect(G.format(G.fromApproximateFloat(-1.5), 1)).toEqual("-1.5g");
+      expect(G.format(G.fromApproximateFloat(-1.5), 1)).toEqual("-1.5g");
+      expect(G.format(G.fromApproximateFloat(-1337042.42), 0)).toEqual(
         "-1,337,042g"
       );
-      expect(format(fromApproximateFloat(-1337042.42), 2)).toEqual(
+      expect(G.format(G.fromApproximateFloat(-1337042.42), 2)).toEqual(
         "-1,337,042.42g"
       );
     });
     it("handles full precision", () => {
-      expect(format(ZERO, DECIMAL_PRECISION)).toEqual("0.000000000000000000g");
-      expect(format(ONE, DECIMAL_PRECISION)).toEqual("1.000000000000000000g");
-      expect(format(fromApproximateFloat(0.1), DECIMAL_PRECISION)).toEqual(
-        "0.100000000000000000g"
+      expect(G.format(G.ZERO, G.DECIMAL_PRECISION)).toEqual(
+        "0.000000000000000000g"
       );
-      // $FlowExpectedError
-      expect(format(-12345n, DECIMAL_PRECISION)).toEqual(
+      expect(G.format(G.ONE, G.DECIMAL_PRECISION)).toEqual(
+        "1.000000000000000000g"
+      );
+      expect(
+        G.format(G.fromApproximateFloat(0.1), G.DECIMAL_PRECISION)
+      ).toEqual("0.100000000000000000g");
+      expect(G.format(G.fromString("-12345"), G.DECIMAL_PRECISION)).toEqual(
         "-0.000000000000012345g"
       );
-      // $FlowExpectedError
-      expect(format((ONE / 100n) * 133704242n, DECIMAL_PRECISION)).toEqual(
+      const v = G.mul(G.fromApproximateFloat(0.01), G.fromString("133704242"));
+      expect(G.format(v, G.DECIMAL_PRECISION)).toEqual(
         "1,337,042.420000000000000000g"
       );
     });
     it("supports alternative suffixes", () => {
-      expect(format(fromApproximateFloat(1.5), 0, "SEEDS")).toEqual("1SEEDS");
-      expect(format(fromApproximateFloat(42), 0, "SEEDS")).toEqual("42SEEDS");
-      expect(format(fromApproximateFloat(-1.5), 1, "SEEDS")).toEqual(
+      expect(G.format(G.fromApproximateFloat(1.5), 0, "SEEDS")).toEqual(
+        "1SEEDS"
+      );
+      expect(G.format(G.fromApproximateFloat(42), 0, "SEEDS")).toEqual(
+        "42SEEDS"
+      );
+      expect(G.format(G.fromApproximateFloat(-1.5), 1, "SEEDS")).toEqual(
         "-1.5SEEDS"
       );
-      expect(format(fromApproximateFloat(-1337042.42), 0, "SEEDS")).toEqual(
+      expect(G.format(G.fromApproximateFloat(-1337042.42), 0, "SEEDS")).toEqual(
         "-1,337,042SEEDS"
       );
     });
@@ -76,74 +76,87 @@ describe("src/grain/grain", () => {
         -1,
         -0.5,
         0.33,
-        DECIMAL_PRECISION + 1,
+        G.DECIMAL_PRECISION + 1,
         Infinity,
         -Infinity,
         NaN,
       ];
       for (const bad of badValues) {
-        expect(() => format(ONE, bad)).toThrowError("must be integer in range");
+        expect(() => G.format(G.ONE, bad)).toThrowError(
+          "must be integer in range"
+        );
       }
     });
   });
 
-  describe("multiplyFloat", () => {
+  describe("conversion from strings", () => {
+    it("fromString works on valid Grain values", () => {
+      expect(G.fromString(G.ONE)).toEqual(G.ONE);
+    });
+    it("fromString errors on invalid Grain values", () => {
+      expect(() => G.fromString("123.4")).toThrowError(
+        "Cannot convert 123.4 to a BigInt"
+      );
+    });
+  });
+
+  describe("G.multiplyFloat", () => {
     it("behaves reasonably for tiny grain values", () => {
-      // $FlowExpectedError
-      expect(multiplyFloat(1n, 5)).toEqual(5n);
+      expect(G.multiplyFloat(G.fromString("1"), 5)).toEqual(G.fromString("5"));
     });
     it("behaves reasonably for larger grain values", () => {
-      // $FlowExpectedError
-      expect(multiplyFloat(ONE, 2)).toEqual(2n * ONE);
+      expect(G.multiplyFloat(G.ONE, 2)).toEqual(
+        G.mul(G.fromString("2"), G.ONE)
+      );
     });
     it("has small error on large grain values", () => {
       // To compare with arbitrary precision results, see:
       // https://observablehq.com/@decentralion/grain-arithmetic
 
       // Within 1 attoGrain of "true" value
-      // $FlowExpectedError
-      expect(multiplyFloat(ONE, 1 / 1337)).toEqual(747943156320119n);
+      expect(G.multiplyFloat(G.ONE, 1 / 1337)).toEqual(
+        G.fromString("747943156320119")
+      );
 
       // Within 300 attoGrain of "true" value
-      // $FlowExpectedError
-      expect(multiplyFloat(ONE, Math.PI)).toEqual(3141592653589793280n);
+      expect(G.multiplyFloat(G.ONE, Math.PI)).toEqual(
+        G.fromString("3141592653589793280")
+      );
     });
   });
-  describe("fromApproximateFloat", () => {
-    it("fromApproximateFloat(1) === ONE", () => {
-      expect(fromApproximateFloat(1)).toEqual(ONE);
+  describe("G.fromApproximateFloat", () => {
+    it("G.fromApproximateFloat(1) === G.ONE", () => {
+      expect(G.fromApproximateFloat(1)).toEqual(G.ONE);
     });
-    it("fromApproximateFloat(0.1) === ONE / 10", () => {
-      // $FlowExpectedError
-      expect(fromApproximateFloat(0.1)).toEqual(ONE / 10n);
+    it("G.fromApproximateFloat(0.1) === G.ONE / 10", () => {
+      const tenth = G.div(G.ONE, G.fromString("10"));
+      expect(G.fromApproximateFloat(0.1)).toEqual(tenth);
     });
   });
 
   describe("toFloatRatio", () => {
+    const two = G.mul(G.ONE, G.fromString("2"));
+    const three = G.mul(G.ONE, G.fromString("3"));
+    const five = G.mul(G.ONE, G.fromString("5"));
     it("handles a one-to-one ratio", () => {
-      expect(toFloatRatio(ONE, ONE)).toEqual(1);
+      expect(G.toFloatRatio(G.ONE, G.ONE)).toEqual(1);
     });
     it("handles a larger numerator", () => {
-      // $FlowExpectedError
-      expect(toFloatRatio(ONE * 2n, ONE)).toEqual(2);
+      expect(G.toFloatRatio(two, G.ONE)).toEqual(2);
     });
     it("handles fractional numbers", () => {
-      // $FlowExpectedError
-      expect(toFloatRatio(ONE * 5n, ONE * 2n)).toEqual(2.5);
+      expect(G.toFloatRatio(five, two)).toEqual(2.5);
     });
     it("calculates repeating decimal ratios", () => {
-      // $FlowExpectedError
-      expect(toFloatRatio(ONE * 5n, ONE * 3n)).toEqual(5 / 3);
+      expect(G.toFloatRatio(five, three)).toEqual(5 / 3);
     });
     it("approximates correctly when Grain values are not exactly equal", () => {
-      // $FlowExpectedError
-      const almostOne = ONE - 1n;
-      expect(toFloatRatio(ONE, almostOne)).toEqual(1);
+      const almostOne = G.sub(G.ONE, G.fromString("1"));
+      expect(G.toFloatRatio(G.ONE, almostOne)).toEqual(1);
     });
     it("handles irrational numbers", () => {
-      const bigPi = multiplyFloat(ONE, Math.PI);
-      // $FlowExpectedError
-      expect(toFloatRatio(bigPi, ONE * 2n)).toEqual(Math.PI / 2);
+      const bigPi = G.multiplyFloat(G.ONE, Math.PI);
+      expect(G.toFloatRatio(bigPi, two)).toEqual(Math.PI / 2);
     });
   });
 });


### PR DESCRIPTION
This commit modifies the grain module so that we store Grain values as
strings at rest (the full string representation of the BigInt). This
allows us to get rid of a number of flow hacks around Grain usage, and
allows us to include Grain directly in JSON objects without needing to
worry about changing serialization.

The downside is that we now need to use methods for all the basic
operations on Grain (e.g. Grain.add, Grain.sub), and that there's more
performance overhead when using Grain.

This is an alternative to #1936, which I discussed with @wchargin and we
decided was too hacky.

Test plan: All unit tests updated; `yarn test` passes.