### PR TITLE
user: remove createUser

### DIFF
--- a/src/ledger/user.js
+++ b/src/ledger/user.js
@@ -23,11 +23,7 @@
  * isn't being used as a transaction ledger.
  *
  */
-import {
-  type Uuid,
-  parser as uuidParser,
-  random as randomUuid,
-} from "../util/uuid";
+import {type Uuid, parser as uuidParser} from "../util/uuid";
 import * as C from "../util/combo";
 import {
   type NodeAddressT,
@@ -61,17 +57,6 @@ export const USER_PREFIX = NodeAddress.fromParts([
   "core",
   "USER",
 ]);
-
-/**
- * Create a new user, assigning a random id.
- */
-export function createUser(name: string): User {
-  return {
-    id: randomUuid(),
-    name,
-    aliases: [],
-  };
-}
 
 /**
  * Parse a Username from a string.

--- a/src/ledger/user.test.js
+++ b/src/ledger/user.test.js
@@ -4,7 +4,6 @@ import deepFreeze from "deep-freeze";
 import {fromString as uuidFromString} from "../util/uuid";
 import {NodeAddress} from "../core/graph";
 import {
-  createUser,
   userAddress,
   usernameFromString,
   USER_PREFIX,
@@ -19,13 +18,6 @@ describe("ledger/user", () => {
     id: uuid,
     name,
     aliases: [NodeAddress.empty],
-  });
-  it("createUser works", () => {
-    const user = createUser(name);
-    expect(user.aliases).toEqual([]);
-    expect(user.name).toEqual(name);
-    // Verify it is a valid UUID
-    uuidFromString(user.id);
   });
   it("userAddress works", () => {
     expect(userAddress(uuid)).toEqual(NodeAddress.append(USER_PREFIX, uuid));


### PR DESCRIPTION
Latest ledger design in #1916 takes over responsibility for generating
the UserId explicitly, so we don't need this method. Also, it wasn't
typesafe!

Test plan: simple remove, `yarn test` suffices