### PR TITLE
Ledger: throw error for unknown action versions

### DIFF
--- a/src/ledger/ledger.js
+++ b/src/ledger/ledger.js
@@ -114,7 +114,10 @@ export class Ledger {
     });
     return NullUtil.get(this._usernameToId.get(username));
   }
-  _createUser(username: Username, userId: UserId) {
+  _createUser({username, userId, version}: CreateUserV1) {
+    if (version !== 1) {
+      throw new Error(`createUser: unrecognized version ${version}`);
+    }
     if (this._usernameToId.has(username)) {
       // This user already exists; return.
       throw new Error(`createUser: username already taken: ${username}`);
@@ -147,7 +150,10 @@ export class Ledger {
       timestamp: _getTimestamp(),
     });
   }
-  _renameUser(userId: UserId, newName: Username) {
+  _renameUser({userId, newName, version}: RenameUserV1) {
+    if (version !== 1) {
+      throw new Error(`renameUser: unrecognized version ${version}`);
+    }
     const existingUser = this._users.get(userId);
     if (existingUser == null) {
       throw new Error(`renameUser: no user matches id ${userId}`);
@@ -194,7 +200,10 @@ export class Ledger {
       timestamp: _getTimestamp(),
     });
   }
-  _addAlias(userId: UserId, alias: NodeAddressT) {
+  _addAlias({userId, alias, version}: AddAliasV1) {
+    if (version !== 1) {
+      throw new Error(`addAlias: unrecognized version ${version}`);
+    }
     const existingUser = this._users.get(userId);
     if (existingUser == null) {
       throw new Error(`addAlias: no matching userId ${userId}`);
@@ -244,7 +253,10 @@ export class Ledger {
       timestamp: _getTimestamp(),
     });
   }
-  _removeAlias(userId: UserId, alias: NodeAddressT) {
+  _removeAlias({userId, alias, version}: RemoveAliasV1) {
+    if (version !== 1) {
+      throw new Error(`removeAlias: unrecognized version ${version}`);
+    }
     const existingUser = this._users.get(userId);
     if (existingUser == null) {
       throw new Error(`removeAlias: no user matching id ${userId}`);
@@ -296,16 +308,16 @@ export class Ledger {
   _act(a: Action): Ledger {
     switch (a.type) {
       case "CREATE_USER":
-        this._createUser(a.username, a.userId);
+        this._createUser(a);
         break;
       case "RENAME_USER":
-        this._renameUser(a.userId, a.newName);
+        this._renameUser(a);
         break;
       case "ADD_ALIAS":
-        this._addAlias(a.userId, a.alias);
+        this._addAlias(a);
         break;
       case "REMOVE_ALIAS":
-        this._removeAlias(a.userId, a.alias);
+        this._removeAlias(a);
         break;
       // istanbul ignore next: unreachable per Flow
       default:

--- a/src/ledger/ledger.test.js
+++ b/src/ledger/ledger.test.js
@@ -54,6 +54,12 @@ describe("ledger/ledger", () => {
         const thunk = () => ledger.createUser("foo");
         failsWithoutMutation(ledger, thunk, "username already taken");
       });
+      it("throws on unrecognized version", () => {
+        // $FlowExpectedError
+        expect(() => new Ledger()._createUser({version: 1337})).toThrowError(
+          "unrecognized version"
+        );
+      });
     });
 
     describe("renameUser", () => {
@@ -121,6 +127,12 @@ describe("ledger/ledger", () => {
         const fooId = ledger.createUser("foo");
         const thunk = () => ledger.renameUser(fooId, "foo bar");
         failsWithoutMutation(ledger, thunk, "invalid username");
+      });
+      it("throws on unrecognized version", () => {
+        // $FlowExpectedError
+        expect(() => new Ledger()._renameUser({version: 1337})).toThrowError(
+          "unrecognized version"
+        );
       });
     });
 
@@ -200,6 +212,12 @@ describe("ledger/ledger", () => {
           `addAlias: alias ${NodeAddress.toString(innateAddress)} already bound`
         );
       });
+      it("throws on unrecognized version", () => {
+        // $FlowExpectedError
+        expect(() => new Ledger()._addAlias({version: 1337})).toThrowError(
+          "unrecognized version"
+        );
+      });
     });
     describe("removeAlias", () => {
       it("works", () => {
@@ -270,6 +288,12 @@ describe("ledger/ledger", () => {
         ledger.addAlias(id2, a1);
         const u2 = ledger.userById(id2);
         expect(u2).toEqual({id: id2, name: "bar", aliases: [a1]});
+      });
+      it("throws on unrecognized version", () => {
+        // $FlowExpectedError
+        expect(() => new Ledger()._removeAlias({version: 1337})).toThrowError(
+          "unrecognized version"
+        );
       });
     });
   });


### PR DESCRIPTION
This updates the Ledger so that it properly throws an error if it
discovers that one of its actions has an unrecognized version.

Test plan: Unit tests added; coverage still at 100%.