### PR TITLE
End-to-end implementation of Discord server fetch

### DIFF
--- a/src/plugins/discord/__snapshots__/fetch.test.js.snap
+++ b/src/plugins/discord/__snapshots__/fetch.test.js.snap
@@ -1,0 +1,278 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`plugins/discord/fetcher passes snapshot tests fetches channels 1`] = `
+Array [
+  Object {
+    "id": "678348980756938813",
+    "name": "Text Channels",
+    "type": "GUILD_CATEGORY",
+  },
+  Object {
+    "id": "678348980798881844",
+    "name": "Voice Channels",
+    "type": "GUILD_CATEGORY",
+  },
+  Object {
+    "id": "678348980849213472",
+    "name": "general",
+    "type": "GUILD_TEXT",
+  },
+  Object {
+    "id": "678348980878573661",
+    "name": "General",
+    "type": "GUILD_VOICE",
+  },
+  Object {
+    "id": "678394406507905129",
+    "name": "pagination",
+    "type": "GUILD_TEXT",
+  },
+  Object {
+    "id": "678696874869522446",
+    "name": "notmymessage",
+    "type": "GUILD_TEXT",
+  },
+]
+`;
+
+exports[`plugins/discord/fetcher passes snapshot tests fetches emojis 1`] = `
+Array [
+  Object {
+    "authorId": "143776454050709505",
+    "channelId": "678394406507905129",
+    "emoji": Object {
+      "id": "678399364418502669",
+      "name": "sourcecred",
+    },
+    "messageId": "678394436757094410",
+  },
+  Object {
+    "authorId": "439050857921904640",
+    "channelId": "678394406507905129",
+    "emoji": Object {
+      "id": "678399364418502669",
+      "name": "sourcecred",
+    },
+    "messageId": "678394436757094410",
+  },
+]
+`;
+
+exports[`plugins/discord/fetcher passes snapshot tests fetches members 1`] = `
+Array [
+  Object {
+    "nick": null,
+    "user": Object {
+      "bot": false,
+      "discriminator": "5887",
+      "id": "143776454050709505",
+      "username": "Beanow",
+    },
+  },
+  Object {
+    "nick": null,
+    "user": Object {
+      "bot": false,
+      "discriminator": "1337",
+      "id": "420341518948237331",
+      "username": "decentralion",
+    },
+  },
+  Object {
+    "nick": null,
+    "user": Object {
+      "bot": false,
+      "discriminator": "8658",
+      "id": "432981598858903585",
+      "username": "wchargin",
+    },
+  },
+  Object {
+    "nick": null,
+    "user": Object {
+      "bot": false,
+      "discriminator": "2386",
+      "id": "439050857921904640",
+      "username": "Brian Litwin",
+    },
+  },
+  Object {
+    "nick": null,
+    "user": Object {
+      "bot": true,
+      "discriminator": "1705",
+      "id": "678351352770068560",
+      "username": "CredBot-Beanow",
+    },
+  },
+  Object {
+    "nick": null,
+    "user": Object {
+      "bot": true,
+      "discriminator": "3557",
+      "id": "728738433199112280",
+      "username": "sts-credbot",
+    },
+  },
+]
+`;
+
+exports[`plugins/discord/fetcher passes snapshot tests fetches messages 1`] = `
+Array [
+  Object {
+    "authorId": "143776454050709505",
+    "channelId": "678394406507905129",
+    "content": "5",
+    "id": "678394436757094410",
+    "mentions": Array [],
+    "nonUserAuthor": false,
+    "reactionEmoji": Array [
+      Object {
+        "id": "678399364418502669",
+        "name": "sourcecred",
+      },
+    ],
+    "timestampMs": 1581812237682,
+  },
+  Object {
+    "authorId": "143776454050709505",
+    "channelId": "678394406507905129",
+    "content": "4",
+    "id": "678394433233747978",
+    "mentions": Array [],
+    "nonUserAuthor": false,
+    "reactionEmoji": Array [],
+    "timestampMs": 1581812236842,
+  },
+  Object {
+    "authorId": "143776454050709505",
+    "channelId": "678394406507905129",
+    "content": "3",
+    "id": "678394431149178940",
+    "mentions": Array [],
+    "nonUserAuthor": false,
+    "reactionEmoji": Array [],
+    "timestampMs": 1581812236345,
+  },
+  Object {
+    "authorId": "143776454050709505",
+    "channelId": "678394406507905129",
+    "content": "2",
+    "id": "678394428569813013",
+    "mentions": Array [],
+    "nonUserAuthor": false,
+    "reactionEmoji": Array [],
+    "timestampMs": 1581812235730,
+  },
+  Object {
+    "authorId": "143776454050709505",
+    "channelId": "678394406507905129",
+    "content": "1",
+    "id": "678394426153893948",
+    "mentions": Array [],
+    "nonUserAuthor": false,
+    "reactionEmoji": Array [],
+    "timestampMs": 1581812235154,
+  },
+  Object {
+    "authorId": "143776454050709505",
+    "channelId": "678394406507905129",
+    "content": "10",
+    "id": "678394455849566208",
+    "mentions": Array [],
+    "nonUserAuthor": false,
+    "reactionEmoji": Array [],
+    "timestampMs": 1581812242234,
+  },
+  Object {
+    "authorId": "143776454050709505",
+    "channelId": "678394406507905129",
+    "content": "9",
+    "id": "678394451462193154",
+    "mentions": Array [],
+    "nonUserAuthor": false,
+    "reactionEmoji": Array [],
+    "timestampMs": 1581812241188,
+  },
+  Object {
+    "authorId": "143776454050709505",
+    "channelId": "678394406507905129",
+    "content": "8",
+    "id": "678394448497082388",
+    "mentions": Array [],
+    "nonUserAuthor": false,
+    "reactionEmoji": Array [],
+    "timestampMs": 1581812240481,
+  },
+  Object {
+    "authorId": "143776454050709505",
+    "channelId": "678394406507905129",
+    "content": "7",
+    "id": "678394445351092275",
+    "mentions": Array [],
+    "nonUserAuthor": false,
+    "reactionEmoji": Array [],
+    "timestampMs": 1581812239731,
+  },
+  Object {
+    "authorId": "143776454050709505",
+    "channelId": "678394406507905129",
+    "content": "6",
+    "id": "678394442301833247",
+    "mentions": Array [],
+    "nonUserAuthor": false,
+    "reactionEmoji": Array [],
+    "timestampMs": 1581812239004,
+  },
+  Object {
+    "authorId": "143776454050709505",
+    "channelId": "678394406507905129",
+    "content": "15",
+    "id": "678394480184918016",
+    "mentions": Array [],
+    "nonUserAuthor": false,
+    "reactionEmoji": Array [],
+    "timestampMs": 1581812248036,
+  },
+  Object {
+    "authorId": "143776454050709505",
+    "channelId": "678394406507905129",
+    "content": "14",
+    "id": "678394477106167818",
+    "mentions": Array [],
+    "nonUserAuthor": false,
+    "reactionEmoji": Array [],
+    "timestampMs": 1581812247302,
+  },
+  Object {
+    "authorId": "143776454050709505",
+    "channelId": "678394406507905129",
+    "content": "13",
+    "id": "678394473428025354",
+    "mentions": Array [],
+    "nonUserAuthor": false,
+    "reactionEmoji": Array [],
+    "timestampMs": 1581812246425,
+  },
+  Object {
+    "authorId": "143776454050709505",
+    "channelId": "678394406507905129",
+    "content": "12",
+    "id": "678394469048909841",
+    "mentions": Array [],
+    "nonUserAuthor": false,
+    "reactionEmoji": Array [],
+    "timestampMs": 1581812245381,
+  },
+  Object {
+    "authorId": "143776454050709505",
+    "channelId": "678394406507905129",
+    "content": "11",
+    "id": "678394468373626890",
+    "mentions": Array [],
+    "nonUserAuthor": false,
+    "reactionEmoji": Array [],
+    "timestampMs": 1581812245220,
+  },
+]
+`;

--- a/src/plugins/discord/fetch.js
+++ b/src/plugins/discord/fetch.js
@@ -1,0 +1,103 @@
+// @flow
+
+import fetch from "isomorphic-fetch";
+
+import {DepaginatedFetcher, getPages} from "./mirror";
+import {DiscordFetcher, type FetchOptions} from "./fetcher";
+import * as Model from "./models";
+import {type Snowflake} from "./models";
+import Database from "better-sqlite3";
+import {fetchDiscord} from "./mirror";
+import {SqliteMirror} from "./sqliteMirror";
+
+export const DISCORD_SERVER = "https://discordapp.com/api";
+const DISCORD_TOKEN_ENV_NAME = "SOURCECRED_DISCORD_BOT_TOKEN";
+
+function buildDepaginatedFetcher(
+  guildId: Snowflake,
+  discordFetcher: DiscordFetcher
+): DepaginatedFetcher {
+  return {
+    channels(): Promise<$ReadOnlyArray<Model.Channel>> {
+      return discordFetcher.channels(guildId);
+    },
+    members(): Promise<$ReadOnlyArray<Model.GuildMember>> {
+      const getMembers = (after: Snowflake) => {
+        return discordFetcher.members(guildId, after);
+      };
+      return getPages(getMembers, "0");
+    },
+    messages(channel: Snowflake): Promise<$ReadOnlyArray<Model.Message>> {
+      const getMessages = (after: Snowflake) => {
+        return discordFetcher.messages(channel, after);
+      };
+      return getPages(getMessages, "0");
+    },
+    reactions(
+      channel: Snowflake,
+      message: Snowflake,
+      emoji: Model.Emoji
+    ): Promise<$ReadOnlyArray<Model.Reaction>> {
+      const getReactions = (after: Snowflake) => {
+        return discordFetcher.reactions(channel, message, emoji, after);
+      };
+      return getPages(getReactions, "0");
+    },
+  };
+}
+
+function getTokenFromEnv(): string {
+  const token = process.env[DISCORD_TOKEN_ENV_NAME];
+  if (token == null) {
+    throw new Error(
+      `No Discord token provided: please set ${DISCORD_TOKEN_ENV_NAME}`
+    );
+  }
+  return token;
+}
+
+export function buildDiscordFetch(fetch: typeof fetch) {
+  return async (endpoint: string) => {
+    const fetchOptions = {
+      method: "GET",
+      headers: {
+        Accept: "application/json",
+        Authorization: `Bot ${getTokenFromEnv()}`,
+      },
+    };
+    const url = new URL(`${DISCORD_SERVER}${endpoint}`).href;
+    const resp = await fetch(url, fetchOptions);
+    // TODO: Error handling
+    return await resp.json();
+  };
+}
+
+function buildSqliteMirror(guildId: string) {
+  const db = new Database(`discord_${guildId}`);
+  return new SqliteMirror(db, guildId);
+}
+
+export async function fetchDiscordServer(
+  guildId: Snowflake,
+  fetch: (string) => Promise<any>,
+  fetchOptions: FetchOptions,
+  sqliteMirror: SqliteMirror
+) {
+  const fetcher = new DiscordFetcher(fetch, fetchOptions);
+  const depaginatedFetcher = buildDepaginatedFetcher(guildId, fetcher);
+  await fetchDiscord(sqliteMirror, depaginatedFetcher);
+}
+
+export async function makefetchDiscordServer(guildId: Snowflake) {
+  const fetchOptions = {
+    membersLimit: 100,
+    messagesLimit: 100,
+    reactionsLimit: 100,
+  };
+  return fetchDiscordServer(
+    guildId,
+    fetch,
+    fetchOptions,
+    buildSqliteMirror(guildId)
+  );
+}

--- a/src/plugins/discord/fetch.test.js
+++ b/src/plugins/discord/fetch.test.js
@@ -1,0 +1,74 @@
+// @flow
+
+import {fetchDiscordServer} from "./fetch.js";
+import base64url from "base64url";
+import path from "path";
+import fs from "fs-extra";
+import Database from "better-sqlite3";
+import {DISCORD_SERVER} from "./fetch";
+import {SqliteMirror} from "./sqliteMirror";
+
+const TEST_GUILD_ID = "678348980639498428";
+
+async function fetchSnapshot(endpoint: string): Promise<any> {
+  const snapshotDir = "src/plugins/discord/snapshots";
+  const url = `${DISCORD_SERVER}${endpoint}`;
+  const filename = base64url(url);
+  const file = path.join(snapshotDir, filename);
+  if (await fs.exists(file)) {
+    const contents = await fs.readFile(file);
+    const json = JSON.parse(contents);
+    return json;
+  } else {
+    return [];
+  }
+}
+
+describe("plugins/discord/fetcher", () => {
+  describe("passes snapshot tests", () => {
+    const fetch = async () => {
+      const fetchOptions = {
+        membersLimit: 10,
+        messagesLimit: 5,
+        reactionsLimit: 5,
+      };
+      const db = new Database(":memory:");
+      const mirror = new SqliteMirror(db, TEST_GUILD_ID);
+      await fetchDiscordServer(
+        TEST_GUILD_ID,
+        fetchSnapshot,
+        fetchOptions,
+        mirror
+      );
+      return mirror;
+    };
+
+    it("fetches members", async () => {
+      const mirror = await fetch();
+      const members = mirror.members();
+      expect(members.length).toBe(6);
+      expect(members).toMatchSnapshot();
+    });
+    it("fetches channels", async () => {
+      const mirror = await fetch();
+      const channels = mirror.channels();
+      expect(channels.length).toBe(6);
+      expect(channels).toMatchSnapshot();
+    });
+    it("fetches messages", async () => {
+      const mirror = await fetch();
+      const channelId = "678394406507905129";
+      const messages = mirror.messages(channelId);
+      expect(messages.length).toBe(15);
+      expect(messages).toMatchSnapshot();
+    });
+    it("fetches emojis", async () => {
+      const channelId = "678394406507905129";
+      const messageId = "678394436757094410";
+      const mirror = await fetch();
+      const reactions = mirror.reactions(channelId, messageId);
+      expect(reactions.length).toBe(2);
+      expect(reactions).toMatchSnapshot();
+    });
+  });
+});


### PR DESCRIPTION
End-to-end implementation of Discord server fetch plan.

Test plan:

Uses data from our test Discord instance to populate
the responses from several mock requests (channels,
members, messages, reactions) and uses snapshots to
test that this data is saved correctly in local db mirror.

Open to replacing the snapshot tests with something more
granular, like property tests. Motivation for using snapshots
is that theses snapshots should not change frequently.