### PR TITLE
ledger enforces timestamp ordering

### DIFF
--- a/src/ledger/ledger.test.js
+++ b/src/ledger/ledger.test.js
@@ -903,6 +903,25 @@ describe("ledger/ledger", () => {
     });
   });
 
+  describe("timestamps", () => {
+    it("out-of-order events are illegal", () => {
+      const ledger = new Ledger();
+      setFakeDate(3);
+      ledger.createUser("foo");
+      setFakeDate(2);
+      const thunk = () => ledger.createUser("foo");
+      failsWithoutMutation(ledger, thunk, "out-of-order timestamp");
+    });
+    it("non-numeric timestamps are illegal", () => {
+      const ledger = new Ledger();
+      for (const bad of [NaN, Infinity, -Infinity]) {
+        setFakeDate(bad);
+        const thunk = () => ledger.createUser("foo");
+        failsWithoutMutation(ledger, thunk, "invalid timestamp");
+      }
+    });
+  });
+
   describe("state reconstruction", () => {
     // This is a ledger which has had at least one of every
     // supported Action.


### PR DESCRIPTION
This commit modifies the ledger so that it enforces that actions are
always in timestamp order. Though we don't yet need this to be true,
I feel like adding this invariant will make it easier to reason about
the ledger in the future... and it's just a sensible property.

Test plan: The ledger now throws if there are out-of-order events, and
unit tests verify this.