### PR TITLE
Add a parser to the address module

### DIFF
--- a/src/core/address.js
+++ b/src/core/address.js
@@ -4,6 +4,7 @@ import stringify from "json-stable-stringify";
 import deepFreeze from "deep-freeze";
 
 import * as MapUtil from "../util/map";
+import * as C from "../util/combo";
 
 export interface AddressModule<Address: string> {
   /**
@@ -86,6 +87,13 @@ export interface AddressModule<Address: string> {
    * Throws an error if the string is not a valid Address.
    */
   fromRaw(raw: string): Address;
+
+  /**
+   * A parser for Addresses.
+   *
+   * Convenience wrapper `fromRaw`.
+   */
+  parser: C.Parser<Address>;
 }
 
 export type Options = {|
@@ -259,6 +267,8 @@ export function makeAddressModule(options: Options): AddressModule<string> {
     return address;
   }
 
+  const parser: C.Parser<Address> = C.fmap(C.string, fromRaw);
+
   const result = {
     assertValid,
     assertValidParts,
@@ -269,6 +279,7 @@ export function makeAddressModule(options: Options): AddressModule<string> {
     append,
     hasPrefix,
     fromRaw,
+    parser,
   };
   return deepFreeze(result);
 }

--- a/src/core/address.test.js
+++ b/src/core/address.test.js
@@ -191,6 +191,29 @@ describe("core/address", () => {
       });
     });
 
+    describe("parser", () => {
+      const {FooAddress, BarAddress} = makeModules();
+      function thunk(x: string) {
+        return () => FooAddress.parser.parseOrThrow(x);
+      }
+      it("parses a valid address", () => {
+        expect(FooAddress.parser.parseOrThrow(FooAddress.empty)).toEqual(
+          FooAddress.empty
+        );
+      });
+      it("rejects an empty string", () => {
+        expect(thunk("")).toThrow("address does not end with separator");
+      });
+      it("rejects a string that doesn't start with the right separator", () => {
+        expect(thunk("\0")).toThrow("expected FooAddress, got");
+      });
+      it("rejects an address from the wrong module", () => {
+        expect(thunk(BarAddress.empty)).toThrow(
+          "expected FooAddress, got BarAddress"
+        );
+      });
+    });
+
     describe("fromParts", () => {
       const {FooAddress, BarAddress} = makeModules();
 

--- a/src/core/weights.js
+++ b/src/core/weights.js
@@ -142,12 +142,10 @@ function deserialize_0_2_0(weights: SerializedWeights_0_2_0): Weights {
 }
 
 const Parse_0_2_0: C.Parser<SerializedWeights_0_2_0> = (() => {
-  const parseNodeAddress = C.fmap(C.string, NodeAddress.fromRaw);
-  const parseEdgeAddress = C.fmap(C.string, EdgeAddress.fromRaw);
   const parseEdgeWeight = C.object({forwards: C.number, backwards: C.number});
   return C.object({
-    nodeWeights: C.dict(C.number, parseNodeAddress),
-    edgeWeights: C.dict(parseEdgeWeight, parseEdgeAddress),
+    nodeWeights: C.dict(C.number, NodeAddress.parser),
+    edgeWeights: C.dict(parseEdgeWeight, EdgeAddress.parser),
   });
 })();
 

--- a/src/ledger/user.js
+++ b/src/ledger/user.js
@@ -90,5 +90,5 @@ export const usernameParser: C.Parser<Username> = C.fmap(
 export const userParser: C.Parser<User> = C.object({
   id: uuidParser,
   name: usernameParser,
-  aliases: C.array(C.fmap(C.string, NodeAddress.fromRaw)),
+  aliases: C.array(NodeAddress.parser),
 });


### PR DESCRIPTION
Use of parsers is becoming widespread in the codebase, and it's annoying
to not have a default parser written for one of our most fundamental
data types. (In particular, since we regularly use addresses as
identifiers, they are ubiquitous in serialized data.)

@wchargin advised against this because it makes the address module less
lightweight from a dependency perspective, I think the convenience is
worth it.

Test plan: Unit tests added; `yarn test` passes; grepped for existing
usage to replace it. Trivial change really.