### PR TITLE
Simplify Grain Allocation module

### DIFF
--- a/src/ledger/grain.js
+++ b/src/ledger/grain.js
@@ -1,5 +1,7 @@
 // @flow
 
+import * as P from "../util/combo";
+
 /**
  * This module contains the types for tracking Grain, which is the native
  * project-specific, cred-linked token created in SourceCred instances. In
@@ -182,3 +184,5 @@ export function fromApproximateFloat(f: number): Grain {
 export function toFloatRatio(numerator: Grain, denominator: Grain): number {
   return Number(numerator) / Number(denominator);
 }
+
+export const parser: P.Parser<Grain> = P.fmap(P.string, fromString);

--- a/src/ledger/grainAllocation.test.js
+++ b/src/ledger/grainAllocation.test.js
@@ -2,16 +2,11 @@
 
 import deepFreeze from "deep-freeze";
 import {NodeAddress} from "../core/graph";
-import {ONE, ZERO, fromApproximateFloat} from "./grain";
 import {
-  GRAIN_ALLOCATION_VERSION_1,
-  createGrainAllocation,
+  computeDistribution,
+  computeAllocation,
   type CredHistory,
-  type BalancedV1,
-  type ImmediateV1,
-  type GrainReceipt,
-  type GrainAllocationV1,
-  type AllocationStrategy,
+  type PolicyType,
 } from "./grainAllocation";
 import * as G from "./grain";
 
@@ -46,77 +41,30 @@ describe("src/ledger/grainAllocation", () => {
     singlePersonInterval,
   ]);
 
-  const immediateStrategy: ImmediateV1 = deepFreeze({
-    type: "IMMEDIATE",
-    version: 1,
-  });
-
-  const balancedStrategy: BalancedV1 = deepFreeze({
-    type: "BALANCED",
-    version: 1,
-  });
-
-  describe.each([[immediateStrategy], [balancedStrategy]])(
+  describe.each([["IMMEDIATE"], ["BALANCED"]])(
     "Common Tests for %o",
-    (strategy: AllocationStrategy) => {
-      const BUDGET = ONE;
-
-      it("throws an error if given an unsupported strategy", () => {
-        const unsupportedStrategy = {
-          ...strategy,
-          version: 2,
-        };
-        expect(() =>
-          createGrainAllocation(
-            unsupportedStrategy,
-            BUDGET,
-            credHistory,
-            new Map()
-          )
-        ).toThrowError(`Unsupported ${strategy.type} version: 2`);
-      });
-
-      it("throws an error if given an unsupported strategy and an empty credHistory", () => {
-        const unsupportedStrategy = {
-          ...strategy,
-          version: 2,
-        };
-        expect(() =>
-          createGrainAllocation(unsupportedStrategy, BUDGET, [], new Map())
-        ).toThrowError(`Unsupported ${strategy.type} version: 2`);
-      });
+    (policyType: PolicyType) => {
+      const policy = deepFreeze({policyType, budget: G.ONE});
 
       describe("it should return an empty allocation when", () => {
         const emptyAllocation = deepFreeze({
-          version: GRAIN_ALLOCATION_VERSION_1,
-          strategy,
-          budget: BUDGET,
+          policy,
           receipts: [],
         });
 
         it("the budget is zero", () => {
-          const actual = createGrainAllocation(
-            strategy,
-            ZERO,
-            credHistory,
-            new Map()
-          );
+          const zeroPolicy = {budget: G.ZERO, policyType};
+          const actual = computeAllocation(zeroPolicy, credHistory, new Map());
 
           expect(actual).toEqual({
-            ...emptyAllocation,
-            budget: ZERO,
+            policy: zeroPolicy,
+            receipts: [],
           });
         });
 
-        it("there are no cred scores at all", () => {
-          const actual = createGrainAllocation(strategy, BUDGET, [], new Map());
-          expect(actual).toEqual(emptyAllocation);
-        });
-
         it("all the cred sums to 0", () => {
-          const actual = createGrainAllocation(
-            strategy,
-            BUDGET,
+          const actual = computeAllocation(
+            policy,
             [
               {
                 intervalEndMs: 500,
@@ -136,196 +84,155 @@ describe("src/ledger/grainAllocation", () => {
   );
 
   describe("immediateAllocation", () => {
-    const BUDGET = ONE;
-
-    const createImmediateAllocation = (
-      receipts: $ReadOnlyArray<GrainReceipt>
-    ): GrainAllocationV1 => {
-      return {
-        version: GRAIN_ALLOCATION_VERSION_1,
-        strategy: immediateStrategy,
-        budget: BUDGET,
-        receipts,
-      };
-    };
+    const policy = deepFreeze({policyType: "IMMEDIATE", budget: G.ONE});
 
     it("handles an interval with even cred distribution", () => {
-      const result = createGrainAllocation(
-        immediateStrategy,
-        BUDGET,
-        [evenInterval],
-        new Map()
-      );
+      const result = computeAllocation(policy, [evenInterval], new Map());
       const HALF = G.fromApproximateFloat(0.5);
       const expectedReceipts = [
         {address: foo, amount: HALF},
         {address: bar, amount: HALF},
       ];
-      const expectedAllocation = createImmediateAllocation(expectedReceipts);
-      expect(result).toEqual(expectedAllocation);
+      expect(result).toEqual({policy, receipts: expectedReceipts});
     });
     it("handles an interval with un-even cred distribution", () => {
-      const result = createGrainAllocation(
-        immediateStrategy,
-        BUDGET,
-        [unevenInterval],
-        new Map()
-      );
+      const result = computeAllocation(policy, [unevenInterval], new Map());
       const ONE_TENTH = G.fromApproximateFloat(0.1);
       const NINE_TENTHS = G.fromApproximateFloat(0.9);
       const expectedReceipts = [
         {address: foo, amount: NINE_TENTHS},
         {address: bar, amount: ONE_TENTH},
       ];
-      const expectedAllocation = createImmediateAllocation(expectedReceipts);
-      expect(result).toEqual(expectedAllocation);
+      expect(result).toEqual({policy, receipts: expectedReceipts});
     });
     it("handles an interval with one cred recipient", () => {
-      const result = createGrainAllocation(
-        immediateStrategy,
-        BUDGET,
+      const result = computeAllocation(
+        policy,
         [singlePersonInterval],
         new Map()
       );
-      const expectedReceipts = [{address: bar, amount: BUDGET}];
-      const expectedAllocation = createImmediateAllocation(expectedReceipts);
-      expect(result).toEqual(expectedAllocation);
+      const expectedReceipts = [{address: bar, amount: G.ONE}];
+      expect(result).toEqual({policy, receipts: expectedReceipts});
     });
   });
 
   describe("balancedAllocation", () => {
-    const BUDGET = fromApproximateFloat(14);
-
-    const createBalancedAllocation = (
-      receipts: $ReadOnlyArray<GrainReceipt>,
-      budget: G.Grain
-    ) => {
-      return {
-        version: GRAIN_ALLOCATION_VERSION_1,
-        strategy: balancedStrategy,
-        budget,
-        receipts,
-      };
-    };
+    const policy = {policyType: "BALANCED", budget: G.fromApproximateFloat(14)};
 
     it("should only pay Foo if Foo is sufficiently underpaid", () => {
-      const lifetimeAllocations = new Map([
-        [foo, ZERO],
-        [bar, fromApproximateFloat(99)],
+      const alreadyPaid = new Map([
+        [foo, G.ZERO],
+        [bar, G.fromApproximateFloat(99)],
       ]);
       const expectedReceipts = [
-        {address: foo, amount: fromApproximateFloat(14)},
+        {address: foo, amount: G.fromApproximateFloat(14)},
       ];
-      const expectedAllocation = createBalancedAllocation(
-        expectedReceipts,
-        BUDGET
-      );
-      const actual = createGrainAllocation(
-        balancedStrategy,
-        BUDGET,
-        credHistory,
-        lifetimeAllocations
-      );
-      expect(expectedAllocation).toEqual(actual);
+      const actual = computeAllocation(policy, credHistory, alreadyPaid);
+      expect(actual).toEqual({policy, receipts: expectedReceipts});
     });
     it("should divide according to cred if everyone is already balanced paid", () => {
-      const lifetimeAllocations = new Map([
-        [foo, fromApproximateFloat(5)],
-        [bar, fromApproximateFloat(2)],
+      const alreadyPaid = new Map([
+        [foo, G.fromApproximateFloat(5)],
+        [bar, G.fromApproximateFloat(2)],
       ]);
 
       // Total cred is foo: 10, bar: 4, past allocations are exactly half this
       // Since we are distributing 14g, we expect it to be proportional to
       // their cred scores since past allocations are already "balanced"
       const expectedReceipts = [
-        {address: foo, amount: fromApproximateFloat(10)},
-        {address: bar, amount: fromApproximateFloat(4)},
+        {address: foo, amount: G.fromApproximateFloat(10)},
+        {address: bar, amount: G.fromApproximateFloat(4)},
       ];
 
-      const expectedAllocation = createBalancedAllocation(
-        expectedReceipts,
-        BUDGET
-      );
-
-      const actual = createGrainAllocation(
-        balancedStrategy,
-        BUDGET,
-        credHistory,
-        lifetimeAllocations
-      );
-      expect(expectedAllocation).toEqual(actual);
+      const actual = computeAllocation(policy, credHistory, alreadyPaid);
+      expect(actual).toEqual({policy, receipts: expectedReceipts});
     });
     it("'top off' users who were slightly underpaid", () => {
       // Foo is exactly 1 grain behind where they "should" be
-      const lifetimeAllocations = new Map([
-        [foo, fromApproximateFloat(4)],
-        [bar, fromApproximateFloat(2)],
+      const alreadyPaid = new Map([
+        [foo, G.fromApproximateFloat(4)],
+        [bar, G.fromApproximateFloat(2)],
       ]);
 
-      const BUDGET15 = fromApproximateFloat(15);
+      const policy15 = {
+        policyType: "BALANCED",
+        budget: G.fromApproximateFloat(15),
+      };
 
       const expectedReceipts = [
-        {address: foo, amount: fromApproximateFloat(11)},
-        {address: bar, amount: fromApproximateFloat(4)},
+        {address: foo, amount: G.fromApproximateFloat(11)},
+        {address: bar, amount: G.fromApproximateFloat(4)},
       ];
 
-      const expectedAllocation = createBalancedAllocation(
-        expectedReceipts,
-        BUDGET15
-      );
-
-      const actual = createGrainAllocation(
-        balancedStrategy,
-        BUDGET15,
-        credHistory,
-        lifetimeAllocations
-      );
-      expect(expectedAllocation).toEqual(actual);
+      const actual = computeAllocation(policy15, credHistory, alreadyPaid);
+      expect(actual).toEqual({
+        policy: policy15,
+        receipts: expectedReceipts,
+      });
     });
 
     it("should handle the case where one user has no historical earnings", () => {
-      const lifetimeAllocations = new Map([[foo, fromApproximateFloat(5)]]);
+      const alreadyPaid = new Map([[foo, G.fromApproximateFloat(5)]]);
 
       const expectedReceipts = [
-        {address: bar, amount: fromApproximateFloat(2)},
+        {address: bar, amount: G.fromApproximateFloat(2)},
       ];
-      const BUDGET2 = fromApproximateFloat(2);
+      const policy2 = {
+        policyType: "BALANCED",
+        budget: G.fromApproximateFloat(2),
+      };
 
-      const expectedAllocation = createBalancedAllocation(
-        expectedReceipts,
-        BUDGET2
-      );
-
-      const actual = createGrainAllocation(
-        balancedStrategy,
-        BUDGET2,
+      const actual = computeAllocation(policy2, credHistory, alreadyPaid);
+      expect(actual).toEqual({policy: policy2, receipts: expectedReceipts});
+    });
+    it.skip("TODO(@decentralion): FIX THIS", () => {
+      const alreadyPaid = new Map([[foo, G.fromApproximateFloat(5)]]);
+      computeAllocation(
+        {policyType: "BALANCED", budget: G.fromApproximateFloat(5)},
         credHistory,
-        lifetimeAllocations
+        alreadyPaid
       );
-      expect(expectedAllocation).toEqual(actual);
     });
     it("should not break if a user has earnings but no cred", () => {
-      const lifetimeAllocations = new Map([
-        [NodeAddress.fromParts(["zoink"]), fromApproximateFloat(10)],
+      const alreadyPaid = new Map([
+        [NodeAddress.fromParts(["zoink"]), G.fromApproximateFloat(10)],
       ]);
 
       const expectedReceipts = [
-        {address: foo, amount: fromApproximateFloat(10)},
-        {address: bar, amount: fromApproximateFloat(4)},
+        {address: foo, amount: G.fromApproximateFloat(10)},
+        {address: bar, amount: G.fromApproximateFloat(4)},
       ];
 
-      const expectedAllocation = createBalancedAllocation(
-        expectedReceipts,
-        BUDGET
-      );
+      const actual = computeAllocation(policy, credHistory, alreadyPaid);
+      expect(actual).toEqual({receipts: expectedReceipts, policy});
+    });
+  });
 
-      const actual = createGrainAllocation(
-        balancedStrategy,
-        BUDGET,
-        credHistory,
-        lifetimeAllocations
+  describe("computeDistribution", () => {
+    it("handles the case with no policies", () => {
+      const distribution = computeDistribution([], credHistory, new Map());
+      expect(distribution).toEqual({credTimestamp: 30, allocations: []});
+    });
+    it("includes the credTimestamp from the latest cred slice", () => {
+      const tsForHistory = (history) =>
+        computeDistribution([], history, new Map()).credTimestamp;
+      expect(tsForHistory(credHistory)).toEqual(30);
+      expect(tsForHistory(credHistory.slice(0, 2))).toEqual(20);
+      expect(tsForHistory(credHistory.slice(0, 1))).toEqual(10);
+    });
+    it("throws an error on an empty history", () => {
+      expect(() => computeDistribution([], [], new Map())).toThrowError(
+        "empty credHistory"
       );
-      expect(expectedAllocation).toEqual(actual);
+    });
+    it("throws an error on a history with an invalid timestamp", () => {
+      const bad = [NaN, Infinity, -Infinity];
+      for (const b of bad) {
+        const badHistory = [{intervalEndMs: b, cred: new Map()}];
+        expect(() =>
+          computeDistribution([], badHistory, new Map())
+        ).toThrowError("invalid credTimestamp");
+      }
     });
   });
 });


### PR DESCRIPTION
The GrainAllocation module was pretty messy, in part because we weren't
sure about the scope when we were writing it. Therefore, we included
some unncessary concepts, like putting version numbers in many of the
module's data types. In reality, since the Ledger is responsible for
serialization, all concerns around versioning should live in its Action
data types; we don't need to think about versions here.

Also, while writing the Ledger I realized that we want a first class
concept of "Strategy + Budget", and need a first class concept of
"Allocations + timestamp of the Cred used to generate them". Thus, I've
re-written the allocation module to expose the Policy and Distribution
types, respectively.

The overall result is a simpler module, and pulling some logic out of
the Grain Ledger and into the Allocations. We could probably go further
(see notes in comments) but I think this is fine for now.

Along the way, I accidentally found an instance of a nasty bug that I've
suspected exists: we can break the BALANCED distribution method so that
it tries to distribute more Grain than is in its budget. I left a
skipped test case as a repro, will address this in another commit.

Also: I added a parser to the module.

Test plan: Unit tests updated, run `yarn test`