### PR TITLE
Remove console.log in discord/fetcher

### DIFF
--- a/src/plugins/discord/fetcher.js
+++ b/src/plugins/discord/fetcher.js
@@ -59,7 +59,6 @@ export class DiscordFetcher {
 
   async channels(guildId: Snowflake): Promise<$ReadOnlyArray<Model.Channel>> {
     const response = await this._fetch(`/guilds/${guildId}/channels`);
-    console.log(response);
     return response.map((x) => ({
       id: x.id,
       name: x.name,


### PR DESCRIPTION
Slipped through review of #1949.

Test plan: I no longer see `console.log` appearing when I run `yarn
unit`.

@BrianLitwin before I merge this, can you tell me if https://github.com/sourcecred/sourcecred/pull/1949#pullrequestreview-446208980 are also bugs that shouldn't have slipped into #1949?