### PR TITLE
Reify a PluginId type

### DIFF
--- a/src/api/pluginId.js
+++ b/src/api/pluginId.js
@@ -1,0 +1,32 @@
+// @flow
+
+import * as P from "../util/combo";
+
+/**
+ * A PluginId uniquely identifies a Plugin.
+ *
+ * Each PluginId takes a `owner/name` format, as in
+ * `sourcecred/github`.
+ *
+ * PluginIds are canonically lower-case.
+ */
+export opaque type PluginId: string = string;
+
+const regex = /^[a-z0-9-]+$/;
+
+export function fromString(s: string): PluginId {
+  s = s.toLowerCase();
+  const pieces = s.split("/");
+  if (pieces.length !== 2) {
+    throw new Error(`PluginId must have exactly one "/" separator; got "${s}"`);
+  }
+  if (!pieces[0].match(regex)) {
+    throw new Error(`plugin owner not valid: "${pieces[0]}"`);
+  }
+  if (!pieces[1].match(regex)) {
+    throw new Error(`plugin name not valid: "${pieces[1]}"`);
+  }
+  return s;
+}
+
+export const parser: P.Parser<PluginId> = P.fmap(P.string, fromString);

--- a/src/api/pluginId.test.js
+++ b/src/api/pluginId.test.js
@@ -1,0 +1,36 @@
+// @flow
+
+import {fromString} from "./pluginId";
+
+describe("api/pluginId", () => {
+  function fail(s, msg) {
+    expect(() => fromString(s)).toThrowError(msg);
+  }
+  it("accepts a valid PluginId", () => {
+    expect(fromString("sourcecred/github")).toEqual("sourcecred/github");
+  });
+  it("lower-cases the PluginId", () => {
+    expect(fromString("SourceCred/GitHub")).toEqual("sourcecred/github");
+  });
+  it("rejects invalid owner", () => {
+    fail("foo bar/baz", `plugin owner not valid: "foo bar"`);
+  });
+  it("rejects invalid name", () => {
+    fail("foo/bar baz", `plugin name not valid: "bar baz"`);
+  });
+  it("rejects empty owner", () => {
+    fail("/baz", `plugin owner not valid: ""`);
+  });
+  it("rejects empty name", () => {
+    fail("foo/", `plugin name not valid: ""`);
+  });
+  it("rejects string without a separator", () => {
+    fail("foom", `PluginId must have exactly one "/" separator; got "foom"`);
+  });
+  it("rejects string without too many separators", () => {
+    fail(
+      "foom/bar/baz",
+      `PluginId must have exactly one "/" separator; got "foom/bar/baz"`
+    );
+  });
+});

--- a/src/cli/cliPlugin.js
+++ b/src/cli/cliPlugin.js
@@ -4,8 +4,10 @@ import type {PluginDeclaration} from "../analysis/pluginDeclaration";
 import type {WeightedGraph} from "../core/weightedGraph";
 import type {ReferenceDetector} from "../core/references/referenceDetector";
 import type {TaskReporter} from "../util/taskReporter";
+import type {PluginId} from "../api/pluginId";
 
 export interface CliPlugin {
+  +id: PluginId;
   declaration(): PluginDeclaration;
   load(PluginDirectoryContext, TaskReporter): Promise<void>;
   graph(

--- a/src/cli/common.js
+++ b/src/cli/common.js
@@ -4,15 +4,12 @@ import {join as pathJoin} from "path";
 import fs from "fs-extra";
 
 import type {PluginDirectoryContext} from "./cliPlugin";
-import {parse as parseConfig, type InstanceConfig} from "./instanceConfig";
+import {parser as configParser, type InstanceConfig} from "./instanceConfig";
 import * as C from "../util/combo";
 
-export async function loadInstanceConfig(
-  baseDir: string
-): Promise<InstanceConfig> {
+export function loadInstanceConfig(baseDir: string): Promise<InstanceConfig> {
   const projectFilePath = pathJoin(baseDir, "sourcecred.json");
-  const contents = await fs.readFile(projectFilePath);
-  return Promise.resolve(parseConfig(JSON.parse(contents)));
+  return loadJson(projectFilePath, configParser);
 }
 
 // Make a directory, if it doesn't exist.

--- a/src/cli/graph.js
+++ b/src/cli/graph.js
@@ -9,12 +9,14 @@ import * as NullUtil from "../util/null";
 import {LoggingTaskReporter} from "../util/taskReporter";
 import {CascadingReferenceDetector} from "../core/references/cascadingReferenceDetector";
 import type {Command} from "./command";
+import {type InstanceConfig} from "./instanceConfig";
 import {
   makePluginDir,
   loadInstanceConfig,
   pluginDirectoryContext,
 } from "./common";
 import {toJSON as weightedGraphToJSON} from "../core/weightedGraph";
+import * as pluginId from "../api/pluginId";
 
 function die(std, message) {
   std.err("fatal: " + message);
@@ -25,19 +27,20 @@ const graphCommand: Command = async (args, std) => {
   const taskReporter = new LoggingTaskReporter();
   taskReporter.start("graph");
   const baseDir = process.cwd();
-  const config = await loadInstanceConfig(baseDir);
+  const config: InstanceConfig = await loadInstanceConfig(baseDir);
 
   let pluginsToLoad = [];
   if (args.length === 0) {
     pluginsToLoad = config.bundledPlugins.keys();
   } else {
     for (const arg of args) {
-      if (config.bundledPlugins.has(arg)) {
-        pluginsToLoad.push(arg);
+      const id = pluginId.fromString(arg);
+      if (config.bundledPlugins.has(id)) {
+        pluginsToLoad.push(id);
       } else {
         return die(
           std,
-          `can't find plugin ${arg}; remember to use fully scoped name, as in sourcecred/github`
+          `can't find plugin ${id}; remember to use fully scoped name, as in sourcecred/github`
         );
       }
     }

--- a/src/cli/load.js
+++ b/src/cli/load.js
@@ -4,6 +4,7 @@ import * as NullUtil from "../util/null";
 import type {Command} from "./command";
 import {loadInstanceConfig, pluginDirectoryContext} from "./common";
 import {LoggingTaskReporter} from "../util/taskReporter";
+import * as pluginId from "../api/pluginId";
 
 function die(std, message) {
   std.err("fatal: " + message);
@@ -18,12 +19,13 @@ const loadCommand: Command = async (args, std) => {
     pluginsToLoad = config.bundledPlugins.keys();
   } else {
     for (const arg of args) {
-      if (config.bundledPlugins.has(arg)) {
-        pluginsToLoad.push(arg);
+      const id = pluginId.fromString(arg);
+      if (config.bundledPlugins.has(id)) {
+        pluginsToLoad.push(id);
       } else {
         return die(
           std,
-          `can't find plugin ${arg}; remember to use fully scoped name, as in sourcecred/github`
+          `can't find plugin ${id}; remember to use fully scoped name, as in sourcecred/github`
         );
       }
     }

--- a/src/plugins/discourse/cliPlugin.js
+++ b/src/plugins/discourse/cliPlugin.js
@@ -17,6 +17,10 @@ import {Fetcher} from "./fetch";
 import {Mirror} from "./mirror";
 import {DiscourseReferenceDetector} from "./referenceDetector";
 import {type TaskReporter} from "../../util/taskReporter";
+import {
+  type PluginId,
+  fromString as pluginIdFromString,
+} from "../../api/pluginId";
 
 async function loadConfig(
   dirContext: PluginDirectoryContext
@@ -37,6 +41,8 @@ async function repository(
 }
 
 export class DiscourseCliPlugin implements CliPlugin {
+  id: PluginId = pluginIdFromString("sourcecred/discourse");
+
   declaration(): PluginDeclaration {
     return declaration;
   }

--- a/src/plugins/experimental-discord/cliPlugin.js
+++ b/src/plugins/experimental-discord/cliPlugin.js
@@ -17,6 +17,10 @@ import {weightsForDeclaration} from "../../analysis/pluginDeclaration";
 import {createGraph} from "./createGraph";
 import * as Model from "./models";
 import {SqliteMirrorRepository} from "./mirrorRepository";
+import {
+  type PluginId,
+  fromString as pluginIdFromString,
+} from "../../api/pluginId";
 
 async function loadConfig(
   dirContext: PluginDirectoryContext
@@ -38,6 +42,8 @@ function getTokenFromEnv(): DiscordToken {
 }
 
 export class DiscordCliPlugin implements CliPlugin {
+  id: PluginId = pluginIdFromString("sourcecred/discord");
+
   declaration(): PluginDeclaration {
     return declaration;
   }

--- a/src/plugins/github/cliPlugin.js
+++ b/src/plugins/github/cliPlugin.js
@@ -23,6 +23,10 @@ import {validateToken, type GithubToken} from "./token";
 import {weightsForDeclaration} from "../../analysis/pluginDeclaration";
 import {type TaskReporter} from "../../util/taskReporter";
 import {repoIdToString} from "./repoId";
+import {
+  type PluginId,
+  fromString as pluginIdFromString,
+} from "../../api/pluginId";
 
 const TOKEN_ENV_VAR_NAME = "SOURCECRED_GITHUB_TOKEN";
 
@@ -57,6 +61,8 @@ function getTokenFromEnv(): GithubToken {
 }
 
 export class GithubCliPlugin implements CliPlugin {
+  id: PluginId = pluginIdFromString("sourcecred/github");
+
   declaration(): PluginDeclaration {
     return declaration;
   }


### PR DESCRIPTION
This commit adds a PluginId type, which is an opaque subtype of string
with an `owner/name` structure, modeled after GitHub repoIds.

This gives us type safety so that we always validate potential PluginIds
early, and error clearly if they are not valid. Yay!

I put the PluginId type in the `api` folder; I'm planning to migrate
most of the CLI logic into `src/api`. Also, I took an opportunity to
clean up the `InstanceConfig` parser, which was written before we got a
good feel for how to use the parser module.

Test plan: Unit tests added, `yarn flow` passes, and for sanity I
verified that the `load` and `graph` commands work properly when given
an explicit PluginId.