### PR TITLE
Create the `diskUtil` module

### DIFF
--- a/src/cli/common.js
+++ b/src/cli/common.js
@@ -1,29 +1,17 @@
 // @flow
 
 import {join as pathJoin} from "path";
-import fs from "fs-extra";
+import {loadJson, mkdirx} from "../util/disk";
 
 import type {PluginDirectoryContext} from "../api/plugin";
 import {
   parser as configParser,
   type InstanceConfig,
 } from "../api/instanceConfig";
-import * as C from "../util/combo";
 
 export function loadInstanceConfig(baseDir: string): Promise<InstanceConfig> {
   const projectFilePath = pathJoin(baseDir, "sourcecred.json");
   return loadJson(projectFilePath, configParser);
-}
-
-// Make a directory, if it doesn't exist.
-function mkdirx(path: string) {
-  try {
-    fs.mkdirSync(path);
-  } catch (e) {
-    if (e.code !== "EEXIST") {
-      throw e;
-    }
-  }
 }
 
 export function makePluginDir(
@@ -59,54 +47,4 @@ export function pluginDirectoryContext(
       return cacheDir;
     },
   };
-}
-
-/**
- * Load and parse a JSON file from disk.
- *
- * If the file cannot be read, then an error is thrown.
- * If parsing fails, an error is thrown.
- */
-export async function loadJson<T>(
-  path: string,
-  parser: C.Parser<T>
-): Promise<T> {
-  const contents = await fs.readFile(path);
-  return parser.parseOrThrow(JSON.parse(contents));
-}
-
-/**
- * Load and parse a JSON file from disk, with a default to use if the file is
- * not found.
- *
- * This is intended as a convenience for situations where the user may
- * optionally provide configuration in a json file saved to disk.
- *
- * The default must be provided as a function that returns a default, to
- * accommodate situations where the object may be mutable, or where constructing
- * the default may be expensive.
- *
- * If no file is present at that location, then the default constructor is
- * invoked to create a default value, and that is returned.
- *
- * If attempting to load the file fails for any reason other than ENOENT
- * (e.g. the path actually is a directory), then the error is thrown.
- *
- * If parsing fails, an error is thrown.
- */
-export async function loadJsonWithDefault<T>(
-  path: string,
-  parser: C.Parser<T>,
-  def: () => T
-): Promise<T> {
-  try {
-    const contents = await fs.readFile(path);
-    return parser.parseOrThrow(JSON.parse(contents));
-  } catch (e) {
-    if (e.code === "ENOENT") {
-      return def();
-    } else {
-      throw e;
-    }
-  }
 }

--- a/src/cli/score.js
+++ b/src/cli/score.js
@@ -5,7 +5,8 @@ import stringify from "json-stable-stringify";
 import {join as pathJoin} from "path";
 
 import type {Command} from "./command";
-import {makePluginDir, loadInstanceConfig, loadJsonWithDefault} from "./common";
+import {makePluginDir, loadInstanceConfig} from "./common";
+import {loadJsonWithDefault} from "../util/disk";
 import {fromJSON as weightedGraphFromJSON} from "../core/weightedGraph";
 import {
   type WeightedGraph,

--- a/src/util/disk.js
+++ b/src/util/disk.js
@@ -1,0 +1,67 @@
+// @flow
+
+import fs from "fs-extra";
+import * as P from "./combo";
+
+/**
+ * Make a directory, if it doesn't already exist.
+ */
+export function mkdirx(path: string) {
+  try {
+    fs.mkdirSync(path);
+  } catch (e) {
+    if (e.code !== "EEXIST") {
+      throw e;
+    }
+  }
+}
+
+/**
+ * Load and parse a JSON file from disk.
+ *
+ * If the file cannot be read, then an error is thrown.
+ * If parsing fails, an error is thrown.
+ */
+export async function loadJson<T>(
+  path: string,
+  parser: P.Parser<T>
+): Promise<T> {
+  const contents = await fs.readFile(path);
+  return parser.parseOrThrow(JSON.parse(contents));
+}
+
+/**
+ * Load and parse a JSON file from disk, with a default to use if the file is
+ * not found.
+ *
+ * This is intended as a convenience for situations where the user may
+ * optionally provide configuration in a json file saved to disk.
+ *
+ * The default must be provided as a function that returns a default, to
+ * accommodate situations where the object may be mutable, or where constructing
+ * the default may be expensive.
+ *
+ * If no file is present at that location, then the default constructor is
+ * invoked to create a default value, and that is returned.
+ *
+ * If attempting to load the file fails for any reason other than ENOENT
+ * (e.g. the path actually is a directory), then the error is thrown.
+ *
+ * If parsing fails, an error is thrown.
+ */
+export async function loadJsonWithDefault<T>(
+  path: string,
+  parser: P.Parser<T>,
+  def: () => T
+): Promise<T> {
+  try {
+    const contents = await fs.readFile(path);
+    return parser.parseOrThrow(JSON.parse(contents));
+  } catch (e) {
+    if (e.code === "ENOENT") {
+      return def();
+    } else {
+      throw e;
+    }
+  }
+}


### PR DESCRIPTION
This module contains some convenience helpers for interacting with files
on disk, creating directories, etc. They are factored out of
`cli/common` (we're going to start needing them in the `api` subdir
too).

Test plan: Existing tests ported, and wrote some tests for `mkdirx`.