### PR TITLE
Start the DiskInstance class

### DIFF
--- a/src/api/diskInstance.js
+++ b/src/api/diskInstance.js
@@ -1,0 +1,103 @@
+// @flow
+
+import {join} from "path";
+import fs from "fs-extra";
+import {type PluginId} from "./pluginId";
+import {type Plugin} from "./plugin";
+import {rawParser} from "./instanceConfig";
+import {type TaskReporter, SilentTaskReporter} from "../util/taskReporter";
+
+export class DiskInstance {
+  +_instanceDirectory: string;
+  +_plugins: $ReadOnlyMap<PluginId, Plugin>;
+  +_taskReporter: TaskReporter;
+
+  constructor(
+    instanceDirectory: string,
+    plugins: $ReadOnlyMap<PluginId, Plugin>,
+    // The TaskReporter that will receive task timing info from Plugin methods.
+    // Defaults to the SilentTaskReporter.
+    taskReporter: ?TaskReporter
+  ) {
+    this._instanceDirectory = instanceDirectory;
+    this._plugins = plugins;
+    this._taskReporter = taskReporter || new SilentTaskReporter();
+  }
+
+  /**
+   * Gets the filesystem directory containing this Instance.
+   */
+  instanceDirectory(): string {
+    return this._instanceDirectory;
+  }
+
+  /**
+   * Gets the Plugins that are active in this instance.
+   */
+  plugins(): $ReadOnlyArray<Plugin> {
+    return Array.from(this._plugins.values());
+  }
+
+  /**
+   * Instantiate a DiskInstance from an existing SourceCred directory.
+   *
+   * Arguments:
+   * - instanceDirectory: a valid SourceCred instance directory (i.e. has a
+   *   sourcecred.json file)
+   * - availablePlugins: runtime instantiations of all the bundled plugins
+   *   present in the instance
+   * - taskReporter: an optional TaskReporter that will receive logging info
+   *   from plugins as they progress in loads, etc.
+   *   Defaults to the SilentTaskReporter.
+   */
+  static async instantiate(
+    instanceDirectory: string,
+    availablePlugins: $ReadOnlyArray<Plugin>,
+    taskReporter: ?TaskReporter
+  ) {
+    try {
+      var stat = await fs.lstat(instanceDirectory);
+    } catch (e) {
+      if (e.code === "ENOENT") {
+        throw new Error(
+          `cannot load instance: ${instanceDirectory} doesn't exist`
+        );
+      }
+      throw new Error(`cannot load instance: ${e}`);
+    }
+    if (!stat.isDirectory()) {
+      throw new Error(
+        `cannot load instance: ${instanceDirectory} is not a directory`
+      );
+    }
+
+    const configPath = join(instanceDirectory, "sourcecred.json");
+    try {
+      var configContents = await fs.readFile(configPath);
+    } catch (e) {
+      if (e.code === "ENOENT") {
+        throw new Error(
+          `no sourcecred.json file present in ${instanceDirectory}`
+        );
+      }
+      throw new Error(`error loading sourcecred.json: ${e}`);
+    }
+    try {
+      var config = rawParser.parseOrThrow(JSON.parse(configContents));
+    } catch (e) {
+      throw new Error(`error parsing sourcecred.json: ${e}`);
+    }
+    const {bundledPlugins} = config;
+    const pluginSet = new Set(bundledPlugins);
+    const plugins = new Map(availablePlugins.map((p) => [p.id, p]));
+    const result = new Map();
+    for (const id of pluginSet) {
+      const plugin = plugins.get(id);
+      if (plugin == null) {
+        throw new Error(`plugin ${id} not available`);
+      }
+      result.set(id, plugin);
+    }
+    return new DiskInstance(instanceDirectory, result, taskReporter);
+  }
+}

--- a/src/api/diskInstance.test.js
+++ b/src/api/diskInstance.test.js
@@ -1,0 +1,131 @@
+// @flow
+
+import tmp from "tmp";
+import fs from "fs-extra";
+import {type Plugin} from "./plugin";
+import {fromString as pluginIdFromString} from "./pluginId";
+import {NodeAddress, EdgeAddress} from "../core/graph";
+import * as WeightedGraph from "../core/weightedGraph";
+import {join} from "path";
+import {DiskInstance} from "./diskInstance";
+import {type RawInstanceConfig} from "./instanceConfig";
+import * as diskUtil from "../util/disk";
+import {SilentTaskReporter} from "../util/taskReporter";
+
+describe("api/diskInstance", () => {
+  const dummyPlugin: Plugin = {
+    id: pluginIdFromString("sourcecred/dummy"),
+    declaration: () => ({
+      name: "dummy",
+      nodeTypes: [],
+      edgeTypes: [],
+      nodePrefix: NodeAddress.empty,
+      edgePrefix: EdgeAddress.empty,
+      userTypes: [],
+    }),
+    load: async (pluginDirectoryContext) => {
+      const cache = pluginDirectoryContext.cacheDirectory();
+      const fpath = join(cache, "cache.txt");
+      await fs.writeFile(fpath, "loaded");
+    },
+    graph: async () => {
+      return WeightedGraph.empty();
+    },
+    referenceDetector: async () => {
+      return {addressFromUrl: () => undefined};
+    },
+  };
+
+  function setupInstanceDirectory(config: RawInstanceConfig) {
+    const dir = tmp.dirSync().name;
+    fs.writeFileSync(join(dir, "sourcecred.json"), JSON.stringify(config));
+    return dir;
+  }
+
+  async function example() {
+    const config = {bundledPlugins: [dummyPlugin.id]};
+    const dir = setupInstanceDirectory(config);
+    const reporter = new SilentTaskReporter();
+    const plugins = [dummyPlugin];
+    const instance = await DiskInstance.instantiate(dir, plugins, reporter);
+    return {config, dir, reporter, plugins, instance};
+  }
+
+  describe("constructor", () => {
+    it("defaults to a new SilentTaskReporter if none is provided", () => {
+      const plugins = new Map();
+      const instanceDirectory = "fake/path";
+      const instance = new DiskInstance(instanceDirectory, plugins);
+      expect(instance._taskReporter).toBeInstanceOf(SilentTaskReporter);
+    });
+  });
+
+  describe("accessors", () => {
+    it("can access the instance directory", async () => {
+      const {dir, instance} = await example();
+      expect(instance.instanceDirectory()).toEqual(dir);
+    });
+    it("can access the plugins", async () => {
+      const {plugins, instance} = await example();
+      expect(instance.plugins()).toEqual(plugins);
+    });
+  });
+
+  describe("instantiate", () => {
+    it("errors if the path does not exist", async () => {
+      const name = tmp.tmpNameSync();
+      const fail = DiskInstance.instantiate(name, []);
+      await expect(fail).rejects.toThrow(
+        `cannot load instance: ${name} doesn't exist`
+      );
+    });
+    it("errors if the path is not a directory", async () => {
+      const path = tmp.tmpNameSync();
+      fs.writeFileSync(path, "foo");
+      const fail = DiskInstance.instantiate(path, []);
+      await expect(fail).rejects.toThrow(
+        `cannot load instance: ${path} is not a directory`
+      );
+    });
+    it("errors if there is no config file", async () => {
+      const path = tmp.dirSync().name;
+      diskUtil.mkdirx(path);
+      const fail = DiskInstance.instantiate(path, []);
+      await expect(fail).rejects.toThrow(
+        `no sourcecred.json file present in ${path}`
+      );
+    });
+    it("errors if the config file can't isn't valid json", async () => {
+      const name = tmp.dirSync().name;
+      fs.writeFileSync(join(name, "sourcecred.json"), "oops");
+      const fail = DiskInstance.instantiate(name, []);
+      await expect(fail).rejects.toThrow("error parsing sourcecred.json");
+    });
+    it("errors if the config file can't be parsed", async () => {
+      const name = tmp.dirSync().name;
+      fs.writeFileSync(join(name, "sourcecred.json"), JSON.stringify("{}"));
+      const fail = DiskInstance.instantiate(name, []);
+      await expect(fail).rejects.toThrow("error parsing sourcecred.json");
+    });
+    it("errors if a plugin is not available", async () => {
+      const config = {bundledPlugins: [dummyPlugin.id]};
+      const dir = setupInstanceDirectory(config);
+      const fail = DiskInstance.instantiate(dir, []);
+      await expect(fail).rejects.toThrow(
+        "plugin sourcecred/dummy not available"
+      );
+    });
+    it("handles the case wth no plugins", async () => {
+      const config = {bundledPlugins: []};
+      const dir = setupInstanceDirectory(config);
+      const di = await DiskInstance.instantiate(dir, []);
+      expect(di.plugins()).toEqual([]);
+    });
+    it("works in a case with plugins", async () => {
+      const config = {bundledPlugins: [dummyPlugin.id]};
+      const dir = setupInstanceDirectory(config);
+      const di = await DiskInstance.instantiate(dir, [dummyPlugin]);
+      expect(di.plugins()).toEqual([dummyPlugin]);
+    });
+  });
+});

--- a/src/api/instanceConfig.js
+++ b/src/api/instanceConfig.js
@@ -9,7 +9,7 @@ export type InstanceConfig = {|
   +bundledPlugins: Map<pluginId.PluginId, Plugin>,
 |};
 
-type RawInstanceConfig = {|
+export type RawInstanceConfig = {|
   // Plugin identifier, like `sourcecred/identity`. Version number is
   // implicit from the SourceCred version. This is a stopgap until we have
   // a plugin system that admits external, dynamically loaded
@@ -17,7 +17,7 @@ type RawInstanceConfig = {|
   +bundledPlugins: $ReadOnlyArray<pluginId.PluginId>,
 |};
 
-const rawParser: P.Parser<RawInstanceConfig> = P.object({
+export const rawParser: P.Parser<RawInstanceConfig> = P.object({
   bundledPlugins: P.array(pluginId.parser),
 });
 


### PR DESCRIPTION
This class is going to abstract over interacting with SourceCred
instances that are on disk. This commit just starts the class with
extremely simple scope: it loads the appropriate plugins for a SC
instance, based on the contents of `sourcecred.json`, and it errors
if the `sourcecred.json` file can't be found, or if specified plugins
are unavailable. Since this needs to be async, it happens in a static
method, called `instantiate`.

I took care with this method to emit very clear errors when it fails,
communicating exactly what went wrong (baseDir wasn't a directory, or
there was no sourcecred.json file, or the sourcecred.json file was
invalid, etc). This way we will give the user helpful feedback when
there's something basic broken in their instance setup.

Test plan: See included tests; `yarn test` passes.