### PR TITLE
Rebrand `TestTaskReporter` to `SilentTaskReporter`

### DIFF
--- a/src/plugins/discourse/mirror.test.js
+++ b/src/plugins/discourse/mirror.test.js
@@ -19,7 +19,7 @@ import {
 } from "./fetch";
 import * as MapUtil from "../../util/map";
 import * as NullUtil from "../../util/null";
-import {TestTaskReporter} from "../../util/taskReporter";
+import {SilentTaskReporter} from "../../util/taskReporter";
 
 type TopicOptions = {|
   // Defaults to: 1 (synonymous to "uncategorized")
@@ -364,7 +364,7 @@ describe("plugins/discourse/mirror", () => {
       ...options,
       ...(optionOverrides || {}),
     });
-    const reporter = new TestTaskReporter();
+    const reporter = new SilentTaskReporter();
     return {fetcher, mirror, reporter, url, repo};
   };
 

--- a/src/plugins/initiatives/loader.test.js
+++ b/src/plugins/initiatives/loader.test.js
@@ -1,7 +1,7 @@
 // @flow
 
 import path from "path";
-import {TestTaskReporter} from "../../util/taskReporter";
+import {SilentTaskReporter} from "../../util/taskReporter";
 import {MappedReferenceDetector} from "../../core/references";
 import {weightsForDeclaration} from "../../analysis/pluginDeclaration";
 import {type InitiativesDirectory} from "./initiativesDirectory";
@@ -12,7 +12,7 @@ describe("plugins/initiatives/loader", () => {
   describe("loadDirectory", () => {
     it("should report correct tasks", async () => {
       // Given
-      const reporter = new TestTaskReporter();
+      const reporter = new SilentTaskReporter();
       const dir: InitiativesDirectory = {
         localPath: path.join(__dirname, "example"),
         remoteUrl: "http://example.com/initiatives",

--- a/src/util/taskReporter.js
+++ b/src/util/taskReporter.js
@@ -63,18 +63,21 @@ export class LoggingTaskReporter implements TaskReporter {
 
 export type TaskEntry = {taskId: TaskId, type: "START" | "FINISH"};
 /**
- * TestTaskReporter is a mock TaskReporter for testing purposes.
+ * SilentTaskReporter is a task reporter that collects some information, but does not
+ * emit any visible notifications.
+ *
+ * It can be used for testing purposes, or as a default TaskReporter for cases where
+ * we don't want to default to emitting anything to console.
  *
  * Rather than emitting any messages or taking timing information, it allows retrieving
  * the sequence of task updates that were sent to the reporter.
- *
  * This makes it easy for test code to verify that the TaskReporter was sent the right
  * sequence of tasks.
  *
  * Callers can also check what tasks are still active (e.g. to verify that there are no
  * active tasks unfinished at the end of a method.)
  */
-export class TestTaskReporter implements TaskReporter {
+export class SilentTaskReporter implements TaskReporter {
   _activeTasks: Set<TaskId>;
   _entries: TaskEntry[];
   constructor() {

--- a/src/util/taskReporter.test.js
+++ b/src/util/taskReporter.test.js
@@ -2,7 +2,7 @@
 
 import {
   LoggingTaskReporter,
-  TestTaskReporter,
+  SilentTaskReporter,
   formatTimeElapsed,
   startMessage,
   finishMessage,
@@ -110,27 +110,27 @@ describe("util/taskReporter", () => {
     });
   });
 
-  describe("TestTaskReporter", () => {
+  describe("SilentTaskReporter", () => {
     it("errors when starting a task twice", () => {
-      const fail = () => new TestTaskReporter().start("foo").start("foo");
+      const fail = () => new SilentTaskReporter().start("foo").start("foo");
       expect(fail).toThrow("task foo already active");
     });
     it("errors when finishing a task twice", () => {
       const fail = () =>
-        new TestTaskReporter().start("foo").finish("foo").finish("foo");
+        new SilentTaskReporter().start("foo").finish("foo").finish("foo");
       expect(fail).toThrow("task foo not active");
     });
     it("errors when finishing an unstarted test", () => {
-      const fail = () => new TestTaskReporter().finish("foo");
+      const fail = () => new SilentTaskReporter().finish("foo");
       expect(fail).toThrow("task foo not active");
     });
     it("works for starting a task", () => {
-      const reporter = new TestTaskReporter().start("foo");
+      const reporter = new SilentTaskReporter().start("foo");
       expect(reporter.entries()).toEqual([{type: "START", taskId: "foo"}]);
       expect(reporter.activeTasks()).toEqual(["foo"]);
     });
     it("works for starting and finishing a task", () => {
-      const reporter = new TestTaskReporter().start("foo").finish("foo");
+      const reporter = new SilentTaskReporter().start("foo").finish("foo");
       expect(reporter.entries()).toEqual([
         {type: "START", taskId: "foo"},
         {type: "FINISH", taskId: "foo"},
@@ -138,7 +138,7 @@ describe("util/taskReporter", () => {
       expect(reporter.activeTasks()).toEqual([]);
     });
     it("works for starting two tasks and finishing one", () => {
-      const reporter = new TestTaskReporter()
+      const reporter = new SilentTaskReporter()
         .start("foo")
         .start("bar")
         .finish("foo");
@@ -148,6 +148,20 @@ describe("util/taskReporter", () => {
         {type: "FINISH", taskId: "foo"},
       ]);
       expect(reporter.activeTasks()).toEqual(["bar"]);
+    });
+    it("doesn't emit anything to the console", () => {
+      let usedConsole = false;
+      jest.spyOn(console, "log").mockImplementation(() => {
+        usedConsole = true;
+      });
+      jest.spyOn(console, "error").mockImplementation(() => {
+        usedConsole = true;
+      });
+      jest.spyOn(console, "warn").mockImplementation(() => {
+        usedConsole = true;
+      });
+      new SilentTaskReporter().start("foo").start("bar").finish("foo");
+      expect(usedConsole).toEqual(false);
     });
   });
 });


### PR DESCRIPTION
We will want a TaskReporter which doesn't have any side-effects,
so we can use it as a default option in situations (such as loading
plugin data) that expect one to be available. This default
TaskReporter should not have any side-effects. Happily, we have a
candidate available: the `TestTaskReporter` already exists.

This commit renames it, and adds an additional test showing that the
reporter does not emit anything to console.

Test plan: `yarn test` passing is sufficient.