### PR TITLE
Initiative Editor Updates / Fixes

### DIFF
--- a/src/ui/components/Initiatives/InitiativeCreate.js
+++ b/src/ui/components/Initiatives/InitiativeCreate.js
@@ -1,23 +1,26 @@
 // @flow
 import React from "react";
-import { v4 as uuid } from "uuid";
-import { Create } from "react-admin";
-import { CredView } from "../../../analysis/credView";
-import { InitiativeForm } from "./InitiativeForm";
+import {v4 as uuid} from "uuid";
+import {Create} from "react-admin";
+import {CredView} from "../../../analysis/credView";
+import {InitiativeForm} from "./InitiativeForm";
 
 export const InitiativeCreate = (credView: CredView) => (props: Object) => {
-  const defaultInitiativeValues = React.useMemo(() => ({
-    id: uuid(),
-    title: '',
-    timestampMs: Date.now(),
-    champions: [],
-    dependencies: [],
-    references: [],
-    contributions: [],
-    weight: {incomplete: 0, complete: 0},
-    completed: false,
-  }), []);
-  
+  const defaultInitiativeValues = React.useMemo(
+    () => ({
+      id: uuid(),
+      title: "",
+      timestampMs: Date.now(),
+      champions: [],
+      dependencies: [],
+      references: [],
+      contributions: [],
+      weight: {incomplete: 0, complete: 0},
+      completed: false,
+    }),
+    []
+  );
+
   return (
     <Create title="Create New Initiative" {...props}>
       <InitiativeForm

--- a/src/ui/components/Initiatives/InitiativeCreate.js
+++ b/src/ui/components/Initiatives/InitiativeCreate.js
@@ -1,27 +1,14 @@
 // @flow
 import React from "react";
-import {v4 as uuid} from "uuid";
-import {
-  AutocompleteArrayInput,
-  DateInput,
-  ArrayInput,
-  NumberInput,
-  SimpleForm,
-  TextInput,
-  Create,
-  SimpleFormIterator,
-  BooleanInput,
-} from "react-admin";
-import {
-  getPlainDescFromMd,
-  dateFormatter,
-  dateParser,
-} from "../../initiativeUtils";
-import {CredView} from "../../../analysis/credView";
+import { v4 as uuid } from "uuid";
+import { Create } from "react-admin";
+import { CredView } from "../../../analysis/credView";
+import { InitiativeForm } from "./InitiativeForm";
 
 export const InitiativeCreate = (credView: CredView) => (props: Object) => {
-  const defaultInitiativeValues = {
+  const defaultInitiativeValues = React.useMemo(() => ({
     id: uuid(),
+    title: '',
     timestampMs: Date.now(),
     champions: [],
     dependencies: [],
@@ -29,90 +16,14 @@ export const InitiativeCreate = (credView: CredView) => (props: Object) => {
     contributions: [],
     weight: {incomplete: 0, complete: 0},
     completed: false,
-  };
+  }), []);
+  
   return (
     <Create title="Create New Initiative" {...props}>
-      <SimpleForm initialValues={defaultInitiativeValues}>
-        <TextInput
-          source="id"
-          label="Initiative ID"
-          disabled
-          type="hidden"
-          style={{display: "none"}}
-        />
-        <TextInput label="Title" source="title" />
-        <DateInput
-          format={dateFormatter}
-          parse={dateParser}
-          label="Date"
-          source="timestampMs"
-        />
-        <NumberInput
-          label="Weight While Incomplete"
-          source="weight.incomplete"
-        />
-        <NumberInput label="Weight When Completed" source="weight.complete" />
-        <BooleanInput label="Completed" source="completed" />
-        <AutocompleteArrayInput
-          source="champions"
-          allowDuplicates={false}
-          translateChoice={false}
-          choices={credView.userNodes()}
-          optionValue="address"
-          optionText={getPlainDescFromMd}
-          label="Champions"
-          suggestionLimit={10}
-        />
-        <AutocompleteArrayInput
-          source="dependencies"
-          allowDuplicates={false}
-          translateChoice={false}
-          choices={credView.nodes()}
-          optionValue="address"
-          optionText={getPlainDescFromMd}
-          label="Dependencies"
-          suggestionLimit={10}
-        />
-        <AutocompleteArrayInput
-          source="references"
-          allowDuplicates={false}
-          translateChoice={false}
-          choices={credView.nodes()}
-          optionValue="address"
-          optionText={getPlainDescFromMd}
-          label="References"
-          suggestionLimit={10}
-        />
-        <ArrayInput label="Contributions" source="contributions">
-          <SimpleFormIterator>
-            <TextInput
-              source="key"
-              label="Contribution Key"
-              disabled
-              initialValue={uuid()}
-              style={{display: "none"}}
-            />
-            <TextInput label="Contribution Name" source="title" />
-            <DateInput
-              format={dateFormatter}
-              parse={dateParser}
-              label="Date"
-              source="timestampMs"
-            />
-            <NumberInput label="Weight" source="weight" />
-            <AutocompleteArrayInput
-              source="contributors"
-              allowDuplicates={false}
-              translateChoice={false}
-              choices={credView.userNodes()}
-              optionValue="address"
-              optionText={getPlainDescFromMd}
-              label="Contributors"
-              suggestionLimit={10}
-            />
-          </SimpleFormIterator>
-        </ArrayInput>
-      </SimpleForm>
+      <InitiativeForm
+        initialValues={defaultInitiativeValues}
+        credView={credView}
+      />
     </Create>
   );
 };

--- a/src/ui/components/Initiatives/InitiativeEdit.js
+++ b/src/ui/components/Initiatives/InitiativeEdit.js
@@ -1,101 +1,14 @@
 // @flow
 import React from "react";
-import {v4 as uuid} from "uuid";
-import {
-  AutocompleteArrayInput,
-  DateInput,
-  ArrayInput,
-  NumberInput,
-  SimpleForm,
-  TextInput,
-  Edit,
-  SimpleFormIterator,
-  BooleanInput,
-} from "react-admin";
-import {
-  getPlainDescFromMd,
-  dateFormatter,
-  dateParser,
-} from "../../initiativeUtils";
+import {Edit} from "react-admin";
+
 import {CredView} from "../../../analysis/credView";
+import {InitiativeForm} from "./InitiativeForm";
 
 export const InitiativeEdit = (credView: CredView) => (props: Object) => {
   return (
     <Edit title="Edit Initiative" {...props}>
-      <SimpleForm>
-        <TextInput label="Title" source="title" />
-        <DateInput
-          format={dateFormatter}
-          parse={dateParser}
-          label="Date"
-          source="timestampMs"
-        />
-        <NumberInput
-          label="Weight While Incomplete"
-          source="weight.incomplete"
-        />
-        <NumberInput label="Weight When Completed" source="weight.complete" />
-        <BooleanInput label="Completed" source="completed" />
-        <AutocompleteArrayInput
-          source="champions"
-          allowDuplicates={false}
-          translateChoice={false}
-          choices={credView.userNodes()}
-          optionValue="address"
-          optionText={getPlainDescFromMd}
-          label="Champions"
-          suggestionLimit={10}
-        />
-        <AutocompleteArrayInput
-          source="dependencies"
-          allowDuplicates={false}
-          translateChoice={false}
-          choices={credView.nodes()}
-          optionValue="address"
-          optionText={getPlainDescFromMd}
-          label="Dependencies"
-          suggestionLimit={10}
-        />
-        <AutocompleteArrayInput
-          source="references"
-          allowDuplicates={false}
-          translateChoice={false}
-          choices={credView.nodes()}
-          optionValue="address"
-          optionText={getPlainDescFromMd}
-          label="References"
-          suggestionLimit={10}
-        />
-        <ArrayInput label="Contributions" source="contributions">
-          <SimpleFormIterator>
-            <TextInput
-              source="key"
-              label="Contribution Key"
-              disabled
-              initialValue={uuid()}
-              style={{display: "none"}}
-            />
-            <TextInput label="Contribution Name" source="title" />
-            <DateInput
-              format={dateFormatter}
-              parse={dateParser}
-              label="Date"
-              source="timestampMs"
-            />
-            <NumberInput label="Weight" source="weight" />
-            <AutocompleteArrayInput
-              source="contributors"
-              allowDuplicates={false}
-              translateChoice={false}
-              choices={credView.userNodes()}
-              optionValue="address"
-              optionText={getPlainDescFromMd}
-              label="Contributors"
-              suggestionLimit={10}
-            />
-          </SimpleFormIterator>
-        </ArrayInput>
-      </SimpleForm>
+      <InitiativeForm credView={credView} />
     </Edit>
   );
 };

--- a/src/ui/components/Initiatives/InitiativeForm.js
+++ b/src/ui/components/Initiatives/InitiativeForm.js
@@ -5,8 +5,6 @@ import {
   dateParser,
   getPlainDescFromMd,
 } from "../../initiativeUtils";
-import {v4 as uuid} from "uuid";
-
 import {CredView} from "../../../analysis/credView";
 import React from "react";
 import {
@@ -19,6 +17,7 @@ import {
   SimpleFormIterator,
   TextInput,
 } from "react-admin";
+import {InlineKeyField} from "./InlineKeyField";
 
 type InitiativeFormProps = {|
   initialValues?: InitiativeEntry,
@@ -32,13 +31,7 @@ export const InitiativeForm = ({
   const userNodes = React.useMemo(() => credView.userNodes(), [credView]);
   return (
     <SimpleForm initialValues={initialValues}>
-      <TextInput
-        source="id"
-        label="Initiative ID"
-        disabled
-        type="hidden"
-        style={{display: "none"}}
-      />
+      <TextInput source="id" label="Initiative ID" disabled />
       <TextInput label="Title" source="title" />
       <DateInput
         format={dateFormatter}
@@ -81,13 +74,7 @@ export const InitiativeForm = ({
       />
       <ArrayInput label="Contributions" source="contributions">
         <SimpleFormIterator>
-          <TextInput
-            source="key"
-            label="Contribution Key"
-            disabled
-            initialValue={uuid()}
-            style={{display: "none"}}
-          />
+          <InlineKeyField source="key" label="Contribution Key" />
           <TextInput label="Contribution Name" source="title" />
           <DateInput
             format={dateFormatter}

--- a/src/ui/components/Initiatives/InitiativeForm.js
+++ b/src/ui/components/Initiatives/InitiativeForm.js
@@ -1,0 +1,113 @@
+// @flow
+import type {InitiativeEntry} from "../../initiativeUtils";
+import {
+  dateFormatter,
+  dateParser,
+  getPlainDescFromMd,
+} from "../../initiativeUtils";
+import {v4 as uuid} from "uuid";
+
+import {CredView} from "../../../analysis/credView";
+import React from "react";
+import {
+  ArrayInput,
+  AutocompleteArrayInput,
+  BooleanInput,
+  DateInput,
+  NumberInput,
+  SimpleForm,
+  SimpleFormIterator,
+  TextInput,
+} from "react-admin";
+
+type InitiativeFormProps = {|
+  initialValues?: InitiativeEntry,
+  credView: CredView,
+|};
+export const InitiativeForm = ({
+  credView,
+  initialValues,
+}: InitiativeFormProps) => {
+  const allNodes = React.useMemo(() => credView.nodes(), [credView]);
+  const userNodes = React.useMemo(() => credView.userNodes(), [credView]);
+  return (
+    <SimpleForm initialValues={initialValues}>
+      <TextInput
+        source="id"
+        label="Initiative ID"
+        disabled
+        type="hidden"
+        style={{display: "none"}}
+      />
+      <TextInput label="Title" source="title" />
+      <DateInput
+        format={dateFormatter}
+        parse={dateParser}
+        label="Date"
+        source="timestampMs"
+      />
+      <NumberInput label="Weight While Incomplete" source="weight.incomplete" />
+      <NumberInput label="Weight When Completed" source="weight.complete" />
+      <BooleanInput label="Completed" source="completed" />
+      <AutocompleteArrayInput
+        source="champions"
+        allowDuplicates={false}
+        translateChoice={false}
+        choices={userNodes}
+        optionValue="address"
+        optionText={getPlainDescFromMd}
+        label="Champions"
+        suggestionLimit={10}
+      />
+      <AutocompleteArrayInput
+        source="dependencies"
+        allowDuplicates={false}
+        translateChoice={false}
+        choices={allNodes}
+        optionValue="address"
+        optionText={getPlainDescFromMd}
+        label="Dependencies"
+        suggestionLimit={10}
+      />
+      <AutocompleteArrayInput
+        source="references"
+        allowDuplicates={false}
+        translateChoice={false}
+        choices={allNodes}
+        optionValue="address"
+        optionText={getPlainDescFromMd}
+        label="References"
+        suggestionLimit={10}
+      />
+      <ArrayInput label="Contributions" source="contributions">
+        <SimpleFormIterator>
+          <TextInput
+            source="key"
+            label="Contribution Key"
+            disabled
+            initialValue={uuid()}
+            style={{display: "none"}}
+          />
+          <TextInput label="Contribution Name" source="title" />
+          <DateInput
+            format={dateFormatter}
+            parse={dateParser}
+            label="Date"
+            source="timestampMs"
+          />
+          <NumberInput label="Weight" source="weight" />
+          <AutocompleteArrayInput
+            source="contributors"
+            allowDuplicates={false}
+            translateChoice={false}
+            choices={userNodes}
+            optionValue="address"
+            optionText={getPlainDescFromMd}
+            label="Contributors"
+            suggestionLimit={10}
+          />
+        </SimpleFormIterator>
+      </ArrayInput>
+    </SimpleForm>
+  );
+};

--- a/src/ui/components/Initiatives/InlineKeyField.js
+++ b/src/ui/components/Initiatives/InlineKeyField.js
@@ -1,0 +1,36 @@
+// @flow
+import React from "react";
+import {v4 as uuid} from "uuid";
+import TextField from "@material-ui/core/TextField";
+import {useInput} from "react-admin";
+
+type Props = {|
+  source: string,
+  label: string,
+|};
+
+export const InlineKeyField = (props: Props) => {
+  const key = React.useMemo(() => uuid(), []);
+
+  const {
+    id,
+    input,
+    meta: {touched, error},
+    isRequired,
+  } = useInput({
+    ...props,
+    initialValue: key,
+  });
+
+  return (
+    <TextField
+      id={id}
+      {...input}
+      label={props.label}
+      error={!!(touched && error)}
+      helperText={touched && error}
+      required={isRequired}
+      disabled
+    />
+  );
+};

--- a/src/ui/components/InitiativesEditor.js
+++ b/src/ui/components/InitiativesEditor.js
@@ -2,17 +2,13 @@
 
 import React from "react";
 import {Admin, Resource, Loading} from "react-admin";
-import {
-  InitiativeList,
-  InitiativeCreate,
-  InitiativeEdit,
-} from "../components/Initiatives";
+import {InitiativeList, InitiativeCreate, InitiativeEdit} from "./Initiatives";
 import fakeDataProvider from "ra-data-fakerest";
 import {fakeInitiatives} from "../mock/fakeInitiatives";
 import {createMemoryHistory} from "history";
 import {createMuiTheme} from "@material-ui/core/styles";
 import pink from "@material-ui/core/colors/pink";
-import {load, type Props, type State} from "./ExplorerApp";
+import {load, type LoadResult} from "./ExplorerApp";
 
 const dataProvider = fakeDataProvider(fakeInitiatives, true);
 
@@ -25,50 +21,42 @@ const theme = createMuiTheme({
   },
 });
 
-export default class App extends React.Component<Props, State> {
-  constructor(props: Object) {
-    super(props);
-    this.state = {
-      loadResult: null,
-    };
-  }
-  async componentDidMount() {
-    this.setState({
-      loadResult: await load(),
-    });
-  }
+const InitiativesEditor = () => {
+  const [loadResult, setLoadResult] = React.useState<LoadResult | null>(null);
+  React.useEffect(() => {
+    load().then(setLoadResult);
+  }, []);
 
-  render() {
-    const {loadResult} = this.state;
-    if (!loadResult) {
-      return (
-        <Loading
-          loadingPrimary="Fetching cred details..."
-          loadingSecondary="Your patience is appreciated"
-        />
-      );
-    }
-    switch (loadResult.type) {
-      case "FAILURE":
-        return (
-          <div>
-            <h1>Load Failure</h1>
-            <p>Check console for details.</p>
-          </div>
-        );
-      case "SUCCESS":
-        return (
-          <Admin theme={theme} dataProvider={dataProvider} history={history}>
-            <Resource
-              name="initiatives"
-              list={InitiativeList}
-              create={InitiativeCreate(loadResult.credView)}
-              edit={InitiativeEdit(loadResult.credView)}
-            />
-          </Admin>
-        );
-      default:
-        throw new Error((loadResult.type: empty));
-    }
+  if (!loadResult) {
+    return (
+      <Loading
+        loadingPrimary="Fetching cred details..."
+        loadingSecondary="Your patience is appreciated"
+      />
+    );
   }
-}
+  switch (loadResult.type) {
+    case "FAILURE":
+      return (
+        <div>
+          <h1>Load Failure</h1>
+          <p>Check console for details.</p>
+        </div>
+      );
+    case "SUCCESS":
+      return (
+        <Admin theme={theme} dataProvider={dataProvider} history={history}>
+          <Resource
+            name="initiatives"
+            list={InitiativeList}
+            create={InitiativeCreate(loadResult.credView)}
+            edit={InitiativeEdit(loadResult.credView)}
+          />
+        </Admin>
+      );
+    default:
+      throw new Error((loadResult.type: empty));
+  }
+};
+
+export default InitiativesEditor;

--- a/src/ui/initiativeUtils.js
+++ b/src/ui/initiativeUtils.js
@@ -35,7 +35,7 @@ type ContributionEntry = {|
 |};
 
 export const getPlainDescFromMd = ({description}: {description: string}) =>
-  removeMd((description: string));
+  removeMd(description);
 
 declare type DateString = string;
 


### PR DESCRIPTION
This PR addresses some of my feedback on #1889. I was already implementing the changes locally to test it out, so thought I might as well save @topocount's time and push the changes myself.

Main changes:
- Consolidate implementation of the Initiatives form into a single reused component, deduplicating code in the InitiativeCreate and InitiativeEdit components
- useMemo for things that we don't want/need to run on every render
- Refactor InitiativeEditor component from component class to functional + hooks
- Fixed bug where multiple inline contributions were all being created with the same ID / key

Test Plan: Ensure that the initiative editor frontend still runs and that multiple inline contributions are created with unique IDs