### PR TITLE
Script to generate ledger from legacy project.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
   },
   "devDependencies": {
     "@babel/core": "^7.8.7",
+    "@babel/node": "^7.8.7",
     "@babel/plugin-proposal-class-properties": "^7.8.3",
     "@babel/plugin-syntax-bigint": "^7.8.3",
     "@babel/preset-env": "^7.8.7",
@@ -109,6 +110,7 @@
     "build:backend": "NODE_ENV=development webpack --config config/webpack.config.backend.js",
     "api": "webpack --config config/webpack.config.api.js",
     "test": "node ./config/test.js",
+    "createLedger": "babel-node ./scripts/createLedgerFromLegacyProject.js",
     "unit": "BABEL_ENV=test NODE_ENV=test jest --env=jsdom",
     "sharness": "make -sC ./sharness prove PROVE_OPTS=-f TEST_OPTS='--chain-lint'",
     "sharness-full": "make -sC ./sharness prove PROVE_OPTS=-vf TEST_OPTS='-v --chain-lint --long'",

--- a/scripts/createLedgerFromLegacyProject.js
+++ b/scripts/createLedgerFromLegacyProject.js
@@ -1,0 +1,102 @@
+// @flow
+import fs from "fs-extra";
+import path from "path";
+
+import * as C from "../src/util/combo";
+import type {Identity} from "../src/plugins/identity/identity";
+import {Ledger} from "../src/ledger/ledger";
+import type {NodeAddressT} from "../src/core/graph";
+import {resolveAlias} from "../src/plugins/identity/alias";
+import {identityNameFromString} from "../src/ledger/identity";
+
+const URL_PATTERN = /https?:\/\/(www\.)?[-a-zA-Z0-9@:%._+~#=]{1,256}\.[a-zA-Z0-9()]{1,6}\b([-a-zA-Z0-9()@:%_+.~#?&//=]*)/;
+
+type LegacyProject = [
+  {|
+    type: "sourcecred/project",
+    version: string,
+  |},
+  {
+    discourseServer: {|
+      serverUrl: string,
+    |},
+    identities: Array<Identity>,
+  }
+];
+
+const projectParser: C.Parser<LegacyProject> = C.tuple([
+  C.object({
+    type: C.exactly(["sourcecred/project"]),
+    version: C.string,
+  }),
+  C.object({
+    discourseServer: C.object({
+      serverUrl: C.fmap(C.string, validateUrl),
+    }),
+    identities: C.array(
+      C.object({
+        username: C.string,
+        aliases: C.array(C.string),
+      })
+    ),
+  }),
+]);
+
+function validateUrl(url: string): string {
+  if (!url.match(URL_PATTERN)) {
+    throw new Error(`invalid URL: ${url}`);
+  }
+  return url;
+}
+
+function parseProject(raw: C.JsonObject): LegacyProject {
+  return projectParser.parseOrThrow(raw);
+}
+
+async function loadProject(instanceDirectory: string): Promise<LegacyProject> {
+  const jsonPath = path.join(instanceDirectory, "project.json");
+  try {
+    const contents = await fs.readFile(jsonPath);
+    return parseProject(JSON.parse(contents));
+  } catch (e) {
+    if (e.message.startsWith("ENOENT:")) {
+      throw `project from directory "${instanceDirectory}" not loaded`;
+    }
+    throw e;
+  }
+}
+
+export async function loadLedger(legacyDir: string): Promise<Ledger> {
+  const [_, {identities, discourseServer}] = await loadProject(legacyDir);
+
+  const aliasParser: C.Parser<NodeAddressT[]> = C.array(
+    C.fmap(C.string, (a) => resolveAlias(a, discourseServer.serverUrl))
+  );
+
+  const ledger = new Ledger();
+
+  identities.forEach(({username, aliases}) => {
+    username = username.replace("_", "-");
+    const userId = ledger.createIdentity("USER", username);
+    const addresses = aliasParser.parseOrThrow(aliases);
+    addresses.forEach((a) => {
+      ledger.addAlias(userId, a);
+    });
+  });
+
+  return ledger;
+}
+
+async function main() {
+  const args = process.argv.slice(2);
+  if (args.length !== 1) {
+    throw new Error(
+      "Please provide the path to the legacy SourceCred instance"
+    );
+  }
+
+  const ledger = await loadLedger(args[0]);
+  console.log(ledger.serialize());
+}
+
+main();

--- a/src/util/uuid.js
+++ b/src/util/uuid.js
@@ -32,7 +32,7 @@ function isClean(s: string): boolean {
 function randomUuidUnchecked(): string {
   const bytes = getRandomValues(new Uint8Array(16));
   const blob = [...bytes].map((n) => String.fromCharCode(n)).join("");
-  return btoa(blob).slice(0, -2); // drop "==" padding
+  return base64Encode(blob).slice(0, -2); // drop "==" padding
 }
 
 // Generate this many uniformly random UUIDs looking for a clean one.

--- a/yarn.lock
+++ b/yarn.lock
@@ -269,6 +269,20 @@
     chalk "^2.0.0"
     js-tokens "^4.0.0"
 
+"@babel/node@^7.8.7":
+  version "7.10.4"
+  resolved "https://registry.yarnpkg.com/@babel/node/-/node-7.10.4.tgz#f246ac8a63dddbd5f084fd90be58ee0b904378b7"
+  integrity sha512-U41uyQkG0J1ezCb8KCdhDJotQF68Z/OsUbcgdxaC0M4JoXKZVdaKQJ+ecnr7aaWjNLt0Vee6Vddj6VL4JEMJnQ==
+  dependencies:
+    "@babel/register" "^7.10.4"
+    commander "^4.0.1"
+    core-js "^3.2.1"
+    lodash "^4.17.13"
+    node-environment-flags "^1.0.5"
+    regenerator-runtime "^0.13.4"
+    resolve "^1.13.1"
+    v8flags "^3.1.1"
+
 "@babel/parser@^7.1.0", "@babel/parser@^7.7.0", "@babel/parser@^7.7.5", "@babel/parser@^7.8.6", "@babel/parser@^7.9.6":
   version "7.9.6"
   resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.9.6.tgz#3b1bbb30dabe600cd72db58720998376ff653bc7"
@@ -844,6 +858,17 @@
     "@babel/plugin-transform-react-jsx-development" "^7.9.0"
     "@babel/plugin-transform-react-jsx-self" "^7.9.0"
     "@babel/plugin-transform-react-jsx-source" "^7.9.0"
+
+"@babel/register@^7.10.4":
+  version "7.10.4"
+  resolved "https://registry.yarnpkg.com/@babel/register/-/register-7.10.4.tgz#53004ba8b04c4af3cbd84508e03ad150669746e4"
+  integrity sha512-whHmgGiWNVyTVnYTSawtDWhaeYsc+noeU8Rmi+MPnbGhDYmr5QpEDMrQcIA07D2RUv0BlThPcN89XcHCqq/O4g==
+  dependencies:
+    find-cache-dir "^2.0.0"
+    lodash "^4.17.13"
+    make-dir "^2.1.0"
+    pirates "^4.0.0"
+    source-map-support "^0.5.16"
 
 "@babel/runtime@^7.1.2":
   version "7.10.5"
@@ -2833,6 +2858,11 @@ commander@^2.11.0, commander@^2.19.0, commander@^2.20.0:
   resolved "https://registry.yarnpkg.com/commander/-/commander-2.20.3.tgz#fd485e84c03eb4881c20722ba48035e8531aeb33"
   integrity sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==
 
+commander@^4.0.1:
+  version "4.1.1"
+  resolved "https://registry.yarnpkg.com/commander/-/commander-4.1.1.tgz#9fd602bd936294e9e9ef46a3f4d6964044b18068"
+  integrity sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==
+
 commondir@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/commondir/-/commondir-1.0.1.tgz#ddd800da0c66127393cca5950ea968a3aaf1253b"
@@ -3011,6 +3041,11 @@ core-js@^2.4.0, core-js@^2.6.10:
   version "2.6.11"
   resolved "https://registry.yarnpkg.com/core-js/-/core-js-2.6.11.tgz#38831469f9922bded8ee21c9dc46985e0399308c"
   integrity sha512-5wjnpaT/3dV+XB4borEsnAYQchn00XSgTAWKDkEqv+K8KevjbzmofK6hfJ9TZIlpj2N0xQpazy7PiRQiWHqzWg==
+
+core-js@^3.2.1:
+  version "3.6.5"
+  resolved "https://registry.yarnpkg.com/core-js/-/core-js-3.6.5.tgz#7395dc273af37fb2e50e9bd3d9fe841285231d1a"
+  integrity sha512-vZVEEwZoIsI+vPEuoF9Iqf5H7/M3eeQqWlQnYa8FSKKePuYTf5MWnxb5SDAzCa60b3JBRS5g9b+Dq7b1y/RCrA==
 
 core-util-is@1.0.2, core-util-is@~1.0.0:
   version "1.0.2"
@@ -4524,7 +4559,7 @@ finalhandler@~1.1.2:
     statuses "~1.5.0"
     unpipe "~1.0.0"
 
-find-cache-dir@^2.1.0:
+find-cache-dir@^2.0.0, find-cache-dir@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/find-cache-dir/-/find-cache-dir-2.1.0.tgz#8d0f94cd13fe43c6c7c261a0d86115ca918c05f7"
   integrity sha512-Tq6PixE0w/VMFfCgbONnkiQIVol/JJL7nRMi20fqzA4NRs9AfeqMGeRdPi3wIhYkxjeBaWh2rxwapn5Tu3IqOQ==
@@ -6710,7 +6745,7 @@ lru-cache@^5.1.1:
   dependencies:
     yallist "^3.0.2"
 
-make-dir@^2.0.0:
+make-dir@^2.0.0, make-dir@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/make-dir/-/make-dir-2.1.0.tgz#5f0310e18b8be898cc07009295a30ae41e91e6f5"
   integrity sha512-LS9X+dc8KLxXCb8dni79fLIIUA5VyZoyjSMCwTluaXA0o27cCK0bhXkpgw+sTXVpPy/lSO57ilRixqk0vDmtRA==
@@ -7122,6 +7157,14 @@ node-abi@^2.7.0:
   dependencies:
     semver "^5.4.1"
 
+node-environment-flags@^1.0.5:
+  version "1.0.6"
+  resolved "https://registry.yarnpkg.com/node-environment-flags/-/node-environment-flags-1.0.6.tgz#a30ac13621f6f7d674260a54dede048c3982c088"
+  integrity sha512-5Evy2epuL+6TM0lCQGpFIj6KwiEsGh1SrHUhTbNX+sLbBtjidPZFAnVK9y5yU1+h//RitLbRHTIMyxQPtxMdHw==
+  dependencies:
+    object.getownpropertydescriptors "^2.0.3"
+    semver "^5.7.0"
+
 node-fetch@2.6.0:
   version "2.6.0"
   resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.6.0.tgz#e633456386d4aa55863f676a7ab0daa8fdecb0fd"
@@ -7370,6 +7413,14 @@ object.fromentries@^2.0.0, object.fromentries@^2.0.2:
     es-abstract "^1.17.0-next.1"
     function-bind "^1.1.1"
     has "^1.0.3"
+
+object.getownpropertydescriptors@^2.0.3:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/object.getownpropertydescriptors/-/object.getownpropertydescriptors-2.1.0.tgz#369bf1f9592d8ab89d712dced5cb81c7c5352649"
+  integrity sha512-Z53Oah9A3TdLoblT7VKJaTDdXdT+lQO+cNpKVnya5JDe9uLvzu1YyY1yFDFrcxrlRgWrEFH0jJtD/IbuwjcEVg==
+  dependencies:
+    define-properties "^1.1.3"
+    es-abstract "^1.17.0-next.1"
 
 object.pick@^1.3.0:
   version "1.3.0"
@@ -7781,7 +7832,7 @@ pinkie@^2.0.0:
   resolved "https://registry.yarnpkg.com/pinkie/-/pinkie-2.0.4.tgz#72556b80cfa0d48a974e80e77248e80ed4f7f870"
   integrity sha1-clVrgM+g1IqXToDnckjoDtT3+HA=
 
-pirates@^4.0.1:
+pirates@^4.0.0, pirates@^4.0.1:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/pirates/-/pirates-4.0.1.tgz#643a92caf894566f91b2b986d2c66950a8e2fb87"
   integrity sha512-WuNqLTbMI3tmfef2TKxlQmAiLHKtFhlsCZnPIpuv2Ow0RDVO8lfy1Opf4NUzlMXLjPl+Men7AuVdX6TA+s+uGA==
@@ -9369,7 +9420,7 @@ source-map-resolve@^0.5.0, source-map-resolve@^0.5.2:
     source-map-url "^0.4.0"
     urix "^0.1.0"
 
-source-map-support@^0.5.6, source-map-support@~0.5.12:
+source-map-support@^0.5.16, source-map-support@^0.5.6, source-map-support@~0.5.12:
   version "0.5.19"
   resolved "https://registry.yarnpkg.com/source-map-support/-/source-map-support-0.5.19.tgz#a98b62f86dcaf4f67399648c085291ab9e8fed61"
   integrity sha512-Wonm7zOCIJzBGQdB+thsPar0kYuCIzYvxZwlBa87yi/Mdjv7Tip2cyVbLj5o0cFPN4EVkuTwb3GDDyUx2DGnGw==
@@ -10366,6 +10417,13 @@ v8-to-istanbul@^4.1.3:
     "@types/istanbul-lib-coverage" "^2.0.1"
     convert-source-map "^1.6.0"
     source-map "^0.7.3"
+
+v8flags@^3.1.1:
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/v8flags/-/v8flags-3.2.0.tgz#b243e3b4dfd731fa774e7492128109a0fe66d656"
+  integrity sha512-mH8etigqMfiGWdeXpaaqGfs6BndypxusHHcv2qSHyZkGEznCd/qAXCWWRzeowtL54147cktFOC4P5y+kl8d8Jg==
+  dependencies:
+    homedir-polyfill "^1.0.1"
 
 validate-npm-package-license@^3.0.1:
   version "3.0.4"


### PR DESCRIPTION
Usage: `yarn createLedger <legacy-instance-dir>`

Loads the project.json file from the given instance directory, instantiates a Ledger, and fills it with
users and aliases based on the identities specified in the project.json. Prints the resulting eventLog to
stdout.

The users and their aliases are created in the same order as they are defined in the project.json. Note that the current credit instance has an invalid username for @s-ben ("s_ben"). Underscores are not allowed by the ledger, so it will need to be updated before this will actually work.

*TestPlan:* Run the createLedger command on the SourceCred cred instance and check if the generated eventLog is correct

Paired with: @decentralion 

Progress towards: #1976