### PR TITLE
add `newIdentity` method

### DIFF
--- a/src/ledger/__snapshots__/ledger.test.js.snap
+++ b/src/ledger/__snapshots__/ledger.test.js.snap
@@ -2,8 +2,8 @@
 
 exports[`ledger/ledger state reconstruction serialized ledger snapshots as expected 1`] = `
 "[
-{\\"action\\":{\\"identityId\\":\\"YVZhbGlkVXVpZEF0TGFzdA\\",\\"identityName\\":\\"foo\\",\\"type\\":\\"CREATE_IDENTITY\\",\\"version\\":\\"1\\"},\\"ledgerTimestamp\\":1,\\"version\\":\\"1\\"},
-{\\"action\\":{\\"identityId\\":\\"URgLrCxgvjHxtGJ9PgmckQ\\",\\"identityName\\":\\"bar\\",\\"type\\":\\"CREATE_IDENTITY\\",\\"version\\":\\"1\\"},\\"ledgerTimestamp\\":2,\\"version\\":\\"1\\"},
+{\\"action\\":{\\"identity\\":{\\"aliases\\":[],\\"id\\":\\"YVZhbGlkVXVpZEF0TGFzdA\\",\\"name\\":\\"foo\\"},\\"type\\":\\"CREATE_IDENTITY\\",\\"version\\":\\"1\\"},\\"ledgerTimestamp\\":1,\\"version\\":\\"1\\"},
+{\\"action\\":{\\"identity\\":{\\"aliases\\":[],\\"id\\":\\"URgLrCxgvjHxtGJ9PgmckQ\\",\\"name\\":\\"bar\\"},\\"type\\":\\"CREATE_IDENTITY\\",\\"version\\":\\"1\\"},\\"ledgerTimestamp\\":2,\\"version\\":\\"1\\"},
 {\\"action\\":{\\"alias\\":\\"N\\\\u0000a1\\\\u0000\\",\\"identityId\\":\\"YVZhbGlkVXVpZEF0TGFzdA\\",\\"type\\":\\"ADD_ALIAS\\",\\"version\\":\\"1\\"},\\"ledgerTimestamp\\":3,\\"version\\":\\"1\\"},
 {\\"action\\":{\\"alias\\":\\"N\\\\u0000a1\\\\u0000\\",\\"identityId\\":\\"YVZhbGlkVXVpZEF0TGFzdA\\",\\"retroactivePaid\\":\\"0\\",\\"type\\":\\"REMOVE_ALIAS\\",\\"version\\":\\"1\\"},\\"ledgerTimestamp\\":4,\\"version\\":\\"1\\"},
 {\\"action\\":{\\"alias\\":\\"N\\\\u0000a1\\\\u0000\\",\\"identityId\\":\\"URgLrCxgvjHxtGJ9PgmckQ\\",\\"type\\":\\"ADD_ALIAS\\",\\"version\\":\\"1\\"},\\"ledgerTimestamp\\":5,\\"version\\":\\"1\\"},

--- a/src/ledger/identity.js
+++ b/src/ledger/identity.js
@@ -23,7 +23,11 @@
  * isn't being used as a transaction ledger.
  *
  */
-import {type Uuid, parser as uuidParser} from "../util/uuid";
+import {
+  type Uuid,
+  parser as uuidParser,
+  random as randomUuid,
+} from "../util/uuid";
 import * as C from "../util/combo";
 import {
   type NodeAddressT,
@@ -49,6 +53,14 @@ export type Identity = {|
   // of calling (identityAddress(identity.id)).
   +aliases: $ReadOnlyArray<NodeAddressT>,
 |};
+
+export function newIdentity(name: string): Identity {
+  return {
+    id: randomUuid(),
+    name: identityNameFromString(name),
+    aliases: [],
+  };
+}
 
 // It's not in the typical [owner, name] format because it isn't provided by a plugin.
 // Instead, it's a raw type owned by SourceCred project.

--- a/src/ledger/identity.test.js
+++ b/src/ledger/identity.test.js
@@ -9,6 +9,7 @@ import {
   IDENTITY_PREFIX,
   graphNode,
   type Identity,
+  newIdentity,
 } from "./identity";
 
 describe("ledger/identity", () => {
@@ -18,6 +19,24 @@ describe("ledger/identity", () => {
     id: uuid,
     name,
     aliases: [NodeAddress.empty],
+  });
+  describe("newIdentity", () => {
+    it("makes a new identity without aliases", () => {
+      expect(newIdentity("foo")).toEqual({
+        id: expect.anything(),
+        name: "foo",
+        aliases: [],
+      });
+    });
+    it("includes a valid UUID", () => {
+      const ident = newIdentity("foo");
+      // Should not error
+      uuidFromString(ident.id);
+    });
+    it("errors on invalid names", () => {
+      const fail = () => newIdentity("bad string");
+      expect(fail).toThrowError("invalid identityName");
+    });
   });
   it("identityAddress works", () => {
     expect(identityAddress(uuid)).toEqual(


### PR DESCRIPTION
This moves responsibility for constructing identity objects out of the
ledger and into the identity module itself. This will set up future
improvements like having the identity own a subtype and directly own its
address.

This adds one new failure mode for the ledger: if it is provided a
CREATE_IDENTITY operation with an identity that already has aliases,
that should fail. I've added a test for this case.

Test plan: `yarn test` passes; coverage on the ledger is still 100%.

Part of work on #1941.