### PR TITLE
Identities own their addresses

### DIFF
--- a/src/ledger/__snapshots__/ledger.test.js.snap
+++ b/src/ledger/__snapshots__/ledger.test.js.snap
@@ -2,8 +2,8 @@
 
 exports[`ledger/ledger state reconstruction serialized ledger snapshots as expected 1`] = `
 "[
-{\\"action\\":{\\"identity\\":{\\"aliases\\":[],\\"id\\":\\"YVZhbGlkVXVpZEF0TGFzdA\\",\\"name\\":\\"foo\\"},\\"type\\":\\"CREATE_IDENTITY\\",\\"version\\":\\"1\\"},\\"ledgerTimestamp\\":1,\\"version\\":\\"1\\"},
-{\\"action\\":{\\"identity\\":{\\"aliases\\":[],\\"id\\":\\"URgLrCxgvjHxtGJ9PgmckQ\\",\\"name\\":\\"bar\\"},\\"type\\":\\"CREATE_IDENTITY\\",\\"version\\":\\"1\\"},\\"ledgerTimestamp\\":2,\\"version\\":\\"1\\"},
+{\\"action\\":{\\"identity\\":{\\"address\\":\\"N\\\\u0000sourcecred\\\\u0000core\\\\u0000IDENTITY\\\\u0000YVZhbGlkVXVpZEF0TGFzdA\\\\u0000\\",\\"aliases\\":[],\\"id\\":\\"YVZhbGlkVXVpZEF0TGFzdA\\",\\"name\\":\\"foo\\"},\\"type\\":\\"CREATE_IDENTITY\\",\\"version\\":\\"1\\"},\\"ledgerTimestamp\\":1,\\"version\\":\\"1\\"},
+{\\"action\\":{\\"identity\\":{\\"address\\":\\"N\\\\u0000sourcecred\\\\u0000core\\\\u0000IDENTITY\\\\u0000URgLrCxgvjHxtGJ9PgmckQ\\\\u0000\\",\\"aliases\\":[],\\"id\\":\\"URgLrCxgvjHxtGJ9PgmckQ\\",\\"name\\":\\"bar\\"},\\"type\\":\\"CREATE_IDENTITY\\",\\"version\\":\\"1\\"},\\"ledgerTimestamp\\":2,\\"version\\":\\"1\\"},
 {\\"action\\":{\\"alias\\":\\"N\\\\u0000a1\\\\u0000\\",\\"identityId\\":\\"YVZhbGlkVXVpZEF0TGFzdA\\",\\"type\\":\\"ADD_ALIAS\\",\\"version\\":\\"1\\"},\\"ledgerTimestamp\\":3,\\"version\\":\\"1\\"},
 {\\"action\\":{\\"alias\\":\\"N\\\\u0000a1\\\\u0000\\",\\"identityId\\":\\"YVZhbGlkVXVpZEF0TGFzdA\\",\\"retroactivePaid\\":\\"0\\",\\"type\\":\\"REMOVE_ALIAS\\",\\"version\\":\\"1\\"},\\"ledgerTimestamp\\":4,\\"version\\":\\"1\\"},
 {\\"action\\":{\\"alias\\":\\"N\\\\u0000a1\\\\u0000\\",\\"identityId\\":\\"URgLrCxgvjHxtGJ9PgmckQ\\",\\"type\\":\\"ADD_ALIAS\\",\\"version\\":\\"1\\"},\\"ledgerTimestamp\\":5,\\"version\\":\\"1\\"},

--- a/src/ledger/identity.js
+++ b/src/ledger/identity.js
@@ -48,6 +48,8 @@ export type Identity = {|
   // UUID, assigned when the identity is created.
   +id: IdentityId,
   +name: IdentityName,
+  // The identity's own node address.
+  +address: NodeAddressT,
   // Every other node in the graph that this identity corresponds to.
   // Does not include the identity's "own" address, i.e. the result
   // of calling (identityAddress(identity.id)).
@@ -55,8 +57,10 @@ export type Identity = {|
 |};
 
 export function newIdentity(name: string): Identity {
+  const id = randomUuid();
   return {
-    id: randomUuid(),
+    id,
+    address: NodeAddress.append(IDENTITY_PREFIX, id),
     name: identityNameFromString(name),
     aliases: [],
   };
@@ -82,13 +86,9 @@ export function identityNameFromString(identityName: string): IdentityName {
   return identityName.toLowerCase();
 }
 
-export function identityAddress(id: IdentityId): NodeAddressT {
-  return NodeAddress.append(IDENTITY_PREFIX, id);
-}
-
-export function graphNode({id, name}: Identity): GraphNode {
+export function graphNode({name, address}: Identity): GraphNode {
   return {
-    address: identityAddress(id),
+    address,
     description: name,
     timestampMs: null,
   };
@@ -102,5 +102,6 @@ export const identityNameParser: C.Parser<IdentityName> = C.fmap(
 export const identityParser: C.Parser<Identity> = C.object({
   id: uuidParser,
   name: identityNameParser,
+  address: NodeAddress.parser,
   aliases: C.array(NodeAddress.parser),
 });

--- a/src/ledger/identity.test.js
+++ b/src/ledger/identity.test.js
@@ -4,29 +4,24 @@ import deepFreeze from "deep-freeze";
 import {fromString as uuidFromString} from "../util/uuid";
 import {NodeAddress} from "../core/graph";
 import {
-  identityAddress,
   identityNameFromString,
-  IDENTITY_PREFIX,
   graphNode,
   type Identity,
   newIdentity,
 } from "./identity";
 
 describe("ledger/identity", () => {
-  const uuid = uuidFromString("YVZhbGlkVXVpZEF0TGFzdA");
-  const name = identityNameFromString("foo");
-  const example: Identity = deepFreeze({
-    id: uuid,
-    name,
-    aliases: [NodeAddress.empty],
-  });
+  const example: Identity = deepFreeze(newIdentity("foo"));
   describe("newIdentity", () => {
-    it("makes a new identity without aliases", () => {
-      expect(newIdentity("foo")).toEqual({
-        id: expect.anything(),
-        name: "foo",
-        aliases: [],
-      });
+    it("new identities don't have aliases", () => {
+      const identity = newIdentity("foo");
+      expect(identity.aliases).toEqual([]);
+    });
+    it("identity addresses are as expected", () => {
+      const identity = newIdentity("foo");
+      expect(identity.address).toEqual(
+        NodeAddress.fromParts(["sourcecred", "core", "IDENTITY", identity.id])
+      );
     });
     it("includes a valid UUID", () => {
       const ident = newIdentity("foo");
@@ -38,15 +33,10 @@ describe("ledger/identity", () => {
       expect(fail).toThrowError("invalid identityName");
     });
   });
-  it("identityAddress works", () => {
-    expect(identityAddress(uuid)).toEqual(
-      NodeAddress.append(IDENTITY_PREFIX, uuid)
-    );
-  });
   it("graphNode works", () => {
     const node = graphNode(example);
     expect(node.description).toEqual(example.name);
-    expect(node.address).toEqual(identityAddress(uuid));
+    expect(node.address).toEqual(example.address);
     expect(node.timestampMs).toEqual(null);
   });
   describe("identityNameFromString", () => {


### PR DESCRIPTION
This commit refactors how identity addressing works. Instead of there
being a function, `identityAddress`, which generates the identity's
address from its id, the identity instead has its own address directly
set on the identity object.

Besides being a bit cleaner, this frees us for a future commit which
will give identities different subtypes (USER, BOT, ORGANIZATION,
PROJECT); at that point, computing the addresses will be more of a pain.

Test plan: Unit tests updated; `yarn test` passes.

Part of work towards #1941 