### PR TITLE
Rename `DistributionPolicy` to `AllocationPolicy`

### DIFF
--- a/src/ledger/grainAllocation.js
+++ b/src/ledger/grainAllocation.js
@@ -34,7 +34,7 @@ export type Balanced = "BALANCED";
 export type Immediate = "IMMEDIATE";
 export type PolicyType = Immediate | Balanced;
 
-export type DistributionPolicy = {|
+export type AllocationPolicy = {|
   +policyType: PolicyType,
   +budget: G.Grain,
 |};
@@ -51,7 +51,7 @@ export type GrainReceipt = {|
 |};
 
 export type Allocation = {|
-  +policy: DistributionPolicy,
+  +policy: AllocationPolicy,
   +receipts: $ReadOnlyArray<GrainReceipt>,
 |};
 
@@ -62,7 +62,7 @@ export type CredTimeSlice = {|
 export type CredHistory = $ReadOnlyArray<CredTimeSlice>;
 
 export function computeDistribution(
-  policies: $ReadOnlyArray<DistributionPolicy>,
+  policies: $ReadOnlyArray<AllocationPolicy>,
   credHistory: CredHistory,
   lifetimePaid: $ReadOnlyMap<NodeAddressT, G.Grain>
 ): Distribution {
@@ -80,7 +80,7 @@ export function computeDistribution(
 }
 
 export function computeAllocation(
-  policy: DistributionPolicy,
+  policy: AllocationPolicy,
   credHistory: CredHistory,
   // A map from each address to the total amount of Grain already paid
   // to that Address, across time.
@@ -246,7 +246,7 @@ function computeBalancedReceipts(
   return receipts;
 }
 
-const policyParser: P.Parser<DistributionPolicy> = P.object({
+export const allocationPolicyParser: P.Parser<AllocationPolicy> = P.object({
   policyType: P.exactly(["IMMEDIATE", "BALANCED"]),
   budget: G.parser,
 });
@@ -255,7 +255,7 @@ const grainReceiptParser: P.Parser<GrainReceipt> = P.object({
   amount: G.parser,
 });
 export const allocationParser: P.Parser<Allocation> = P.object({
-  policy: policyParser,
+  policy: allocationPolicyParser,
   receipts: P.array(grainReceiptParser),
 });
 export const distributionParser: P.Parser<Distribution> = P.object({

--- a/src/ledger/ledger.js
+++ b/src/ledger/ledger.js
@@ -23,7 +23,7 @@ import {type TimestampMs} from "../util/timestamp";
 import * as NullUtil from "../util/null";
 import {parser as uuidParser} from "../util/uuid";
 import {
-  type DistributionPolicy,
+  type AllocationPolicy,
   computeDistribution,
   type CredHistory,
   type Distribution,
@@ -477,7 +477,7 @@ export class Ledger {
    * it might be a little cleaner.
    */
   distributeGrain(
-    policies: $ReadOnlyArray<DistributionPolicy>,
+    policies: $ReadOnlyArray<AllocationPolicy>,
     credHistory: CredHistory
   ): Ledger {
     const paidMap = this._computePaidMap(credHistory);

--- a/src/ledger/ledger.test.js
+++ b/src/ledger/ledger.test.js
@@ -4,7 +4,7 @@ import deepFreeze from "deep-freeze";
 import cloneDeep from "lodash.clonedeep";
 import {NodeAddress} from "../core/graph";
 import {Ledger, parser} from "./ledger";
-import {type DistributionPolicy, computeDistribution} from "./grainAllocation";
+import {type AllocationPolicy, computeDistribution} from "./grainAllocation";
 import {newIdentity} from "./identity";
 import * as G from "./grain";
 import * as uuid from "../util/uuid"; // for spy purposes
@@ -598,7 +598,7 @@ describe("ledger/ledger", () => {
         );
       });
       it("computes an IMMEDIATE allocation correctly", () => {
-        const policy: DistributionPolicy = {
+        const policy: AllocationPolicy = {
           budget: g("10"),
           policyType: "IMMEDIATE",
         };
@@ -636,7 +636,7 @@ describe("ledger/ledger", () => {
         ]);
       });
       it("computes a BALANCED allocation correctly", () => {
-        const policy: DistributionPolicy = {
+        const policy: AllocationPolicy = {
           budget: g("15"),
           policyType: "BALANCED",
         };
@@ -679,7 +679,7 @@ describe("ledger/ledger", () => {
       });
       it("BALANCED strategy accounts for unlinked aliases' retroactive paid", () => {
         // Sanity check since this property is important.
-        const p: DistributionPolicy = {
+        const p: AllocationPolicy = {
           budget: g("7"),
           policyType: "BALANCED",
         };


### PR DESCRIPTION
Each Distribution contains zero or more Grain Allocations. The type
called `DistributionPolicy` actually has a 1:1 correspondence with the
Allocations, so it makes more sense to call it `AllocationPolicy`.

Test plan: It's just a rename; `yarn test` passes.