### PR TITLE
Create config parser for Initiatives Plugin

### DIFF
--- a/src/plugins/initiatives/config.js
+++ b/src/plugins/initiatives/config.js
@@ -1,0 +1,12 @@
+// @flow
+
+import * as C from "../../util/combo";
+import {_validateUrl} from "./initiativesDirectory";
+
+export type InitiativesConfig = {|
+  +remoteUrl: string,
+|};
+
+export const parser: C.Parser<InitiativesConfig> = C.object({
+  remoteUrl: C.fmap(C.string, _validateUrl),
+});


### PR DESCRIPTION
Setups up the parser to be used in the Initiatives plugin for the new CLI

TestPlan: Check to see if the parser has the required fields (i.e. remoteUrl)