### PR TITLE
Create parser for Initiative Files

### DIFF
--- a/src/plugins/initiatives/initiativeFile.js
+++ b/src/plugins/initiatives/initiativeFile.js
@@ -30,7 +30,9 @@ export type InitiativeFileV020 = {|
   +champions?: $ReadOnlyArray<URL>,
 |};
 
-const upgradeFrom010 = (file: InitiativeFileV010): InitiativeFileV020 => ({
+export const upgradeFrom010 = (
+  file: InitiativeFileV010
+): InitiativeFileV020 => ({
   ...file,
   contributions: {urls: file.contributions},
   dependencies: {urls: file.dependencies},
@@ -52,7 +54,10 @@ const upgrades = {
   "0.1.0": upgradeFrom010,
 };
 
-const COMPAT_INFO = {type: "sourcecred/initiativeFile", version: "0.2.0"};
+export const COMPAT_INFO = {
+  type: "sourcecred/initiativeFile",
+  version: "0.2.0",
+};
 
 export function fromJSON(j: Compatible<any>): InitiativeFile {
   return fromCompat(COMPAT_INFO, j, upgrades);

--- a/src/plugins/initiatives/initiativeFile.js
+++ b/src/plugins/initiatives/initiativeFile.js
@@ -44,10 +44,10 @@ export type InitiativeFileV010 = {|
   +timestampIso: TimestampISO,
   +weight: InitiativeWeight,
   +completed: boolean,
-  +dependencies: $ReadOnlyArray<URL>,
-  +references: $ReadOnlyArray<URL>,
-  +contributions: $ReadOnlyArray<URL>,
-  +champions: $ReadOnlyArray<URL>,
+  +dependencies?: $ReadOnlyArray<URL>,
+  +references?: $ReadOnlyArray<URL>,
+  +contributions?: $ReadOnlyArray<URL>,
+  +champions?: $ReadOnlyArray<URL>,
 |};
 
 const upgrades = {

--- a/src/plugins/initiatives/parseInitiative.js
+++ b/src/plugins/initiatives/parseInitiative.js
@@ -21,31 +21,29 @@ const CommonFields = {
   completed: C.boolean,
 };
 
-const Parse_020: C.Parser<InitiativeFileV020> = (() => {
-  const NodeEntryParser = C.object(
-    {
-      title: C.string,
-      timestampIso: TimestampParser,
-      contributors: C.array(URLParser),
-    },
-    {
-      key: C.string,
-      weight: C.number,
-    }
-  );
+const NodeEntryParser = C.object(
+  {
+    title: C.string,
+    timestampIso: TimestampParser,
+    contributors: C.array(URLParser),
+  },
+  {
+    key: C.string,
+    weight: C.number,
+  }
+);
 
-  const EdgeSpecParser = C.object({
-    urls: C.array(URLParser),
-    entries: C.array(NodeEntryParser),
-  });
+const EdgeSpecParser = C.object({
+  urls: C.array(URLParser),
+  entries: C.array(NodeEntryParser),
+});
 
-  return C.object(CommonFields, {
-    contributions: EdgeSpecParser,
-    dependencies: EdgeSpecParser,
-    references: EdgeSpecParser,
-    champions: C.array(URLParser),
-  });
-})();
+const Parse_020: C.Parser<InitiativeFileV020> = C.object(CommonFields, {
+  contributions: EdgeSpecParser,
+  dependencies: EdgeSpecParser,
+  references: EdgeSpecParser,
+  champions: C.array(URLParser),
+});
 
 const Parse_010: C.Parser<InitiativeFileV010> = (() => {
   return C.object(CommonFields, {

--- a/src/plugins/initiatives/parseInitiative.js
+++ b/src/plugins/initiatives/parseInitiative.js
@@ -7,16 +7,16 @@ import type {
   InitiativeFileV010,
   InitiativeFileV020,
 } from "./initiativeFile";
-import type {Compatible} from "../../util/compat";
 import {_validateUrl} from "./initiativesDirectory";
+import {fromISO, toISO} from "../../util/timestamp";
 
 const URLParser = C.fmap(C.string, _validateUrl);
 
-export type InitiativesFile = Compatible<InitiativeFile>;
+const TimestampParser = C.fmap(C.string, (t) => toISO(fromISO(t)));
 
 const CommonFields = {
   title: C.string,
-  timestampIso: C.string,
+  timestampIso: TimestampParser,
   weight: C.object({incomplete: C.number, complete: C.number}),
   completed: C.boolean,
 };
@@ -25,7 +25,7 @@ const Parse_020: C.Parser<InitiativeFileV020> = (() => {
   const NodeEntryParser = C.object(
     {
       title: C.string,
-      timestampIso: C.string,
+      timestampIso: TimestampParser,
       contributors: C.array(URLParser),
     },
     {
@@ -56,7 +56,7 @@ const Parse_010: C.Parser<InitiativeFileV010> = (() => {
   });
 })();
 
-export const parser: C.Parser<InitiativesFile> = compatibleParser(
+export const parser: C.Parser<InitiativeFile> = compatibleParser(
   COMPAT_INFO.type,
   {
     "0.2.0": Parse_020,

--- a/src/plugins/initiatives/parseInitiative.js
+++ b/src/plugins/initiatives/parseInitiative.js
@@ -1,0 +1,65 @@
+// @flow
+import * as C from "../../util/combo";
+import {compatibleParser} from "../../util/compat";
+import {COMPAT_INFO, upgradeFrom010} from "./initiativeFile";
+import type {
+  InitiativeFile,
+  InitiativeFileV010,
+  InitiativeFileV020,
+} from "./initiativeFile";
+import type {Compatible} from "../../util/compat";
+import {_validateUrl} from "./initiativesDirectory";
+
+const URLParser = C.fmap(C.string, _validateUrl);
+
+export type InitiativesFile = Compatible<InitiativeFile>;
+
+const CommonFields = {
+  title: C.string,
+  timestampIso: C.string,
+  weight: C.object({incomplete: C.number, complete: C.number}),
+  completed: C.boolean,
+};
+
+const Parse_020: C.Parser<InitiativeFileV020> = (() => {
+  const NodeEntryParser = C.object(
+    {
+      title: C.string,
+      timestampIso: C.string,
+      contributors: C.array(URLParser),
+    },
+    {
+      key: C.string,
+      weight: C.number,
+    }
+  );
+
+  const EdgeSpecParser = C.object({
+    urls: C.array(URLParser),
+    entries: C.array(NodeEntryParser),
+  });
+
+  return C.object(CommonFields, {
+    contributions: EdgeSpecParser,
+    dependencies: EdgeSpecParser,
+    references: EdgeSpecParser,
+    champions: C.array(URLParser),
+  });
+})();
+
+const Parse_010: C.Parser<InitiativeFileV010> = (() => {
+  return C.object(CommonFields, {
+    contributions: C.array(URLParser),
+    dependencies: C.array(URLParser),
+    references: C.array(URLParser),
+    champions: C.array(URLParser),
+  });
+})();
+
+export const parser: C.Parser<InitiativesFile> = compatibleParser(
+  COMPAT_INFO.type,
+  {
+    "0.2.0": Parse_020,
+    "0.1.0": C.fmap(Parse_010, upgradeFrom010),
+  }
+);

--- a/src/util/timestamp.js
+++ b/src/util/timestamp.js
@@ -29,7 +29,7 @@ export function toISO(timestampLike: TimestampMs | number): TimestampISO {
 /**
  * Creates a TimestampMs from a TimestampISO.
  */
-export function fromISO(timestampISO: TimestampISO): TimestampMs {
+export function fromISO(timestampISO: TimestampISO | string): TimestampMs {
   if (typeof timestampISO !== "string") {
     throw new TypeError(
       `TimestampISO values must be strings, ` +


### PR DESCRIPTION
This parser will be used in the Initiatives Plugin for the new CLI. It supports both v0.1.0 and v0.2.0
Initiative files.

TestPlan: Sanity check that all the right fields are there and that upgrade strategy makes sense