### PR TITLE
Refactor plugin config parsers to use disk util

### DIFF
--- a/src/plugins/discourse/config.js
+++ b/src/plugins/discourse/config.js
@@ -8,7 +8,7 @@ export type DiscourseConfig = {|
   +mirrorOptions?: $Shape<MirrorOptions>,
 |};
 
-const parser: Combo.Parser<DiscourseConfig> = (() => {
+export const parser: Combo.Parser<DiscourseConfig> = (() => {
   const C = Combo;
   return C.object(
     {
@@ -27,7 +27,3 @@ const parser: Combo.Parser<DiscourseConfig> = (() => {
     }
   );
 })();
-
-export function parseConfig(raw: Combo.JsonObject): DiscourseConfig {
-  return parser.parseOrThrow(raw);
-}

--- a/src/plugins/discourse/plugin.js
+++ b/src/plugins/discourse/plugin.js
@@ -1,16 +1,15 @@
 // @flow
 
 import Database from "better-sqlite3";
-import fs from "fs-extra";
 import {join as pathJoin} from "path";
 
 import type {Plugin, PluginDirectoryContext} from "../../api/plugin";
 import type {PluginDeclaration} from "../../analysis/pluginDeclaration";
-import type {ReferenceDetector} from "../../core/references/referenceDetector";
+import type {ReferenceDetector} from "../../core/references";
 import type {WeightedGraph} from "../../core/weightedGraph";
 import {createGraph} from "./createGraph";
 import {declaration} from "./declaration";
-import {parseConfig, type DiscourseConfig} from "./config";
+import {parser, type DiscourseConfig} from "./config";
 import {weightsForDeclaration} from "../../analysis/pluginDeclaration";
 import {SqliteMirrorRepository} from "./mirrorRepository";
 import {Fetcher} from "./fetch";
@@ -21,14 +20,14 @@ import {
   type PluginId,
   fromString as pluginIdFromString,
 } from "../../api/pluginId";
+import {loadJson} from "../../util/disk";
 
 async function loadConfig(
   dirContext: PluginDirectoryContext
 ): Promise<DiscourseConfig> {
   const dirname = dirContext.configDirectory();
   const path = pathJoin(dirname, "config.json");
-  const contents = await fs.readFile(path);
-  return Promise.resolve(parseConfig(JSON.parse(contents)));
+  return loadJson(path, parser);
 }
 
 async function repository(

--- a/src/plugins/experimental-discord/config.js
+++ b/src/plugins/experimental-discord/config.js
@@ -24,11 +24,7 @@ export type DiscordConfig = {|
   +reactionWeights: EmojiWeightMap,
 |};
 
-export function parseConfig(raw: Combo.JsonObject): DiscordConfig {
-  return parser.parseOrThrow(raw);
-}
-
-const parser: Combo.Parser<DiscordConfig> = (() => {
+export const parser: Combo.Parser<DiscordConfig> = (() => {
   const C = Combo;
   return C.object({
     guildId: C.string,

--- a/src/plugins/experimental-discord/config.test.js
+++ b/src/plugins/experimental-discord/config.test.js
@@ -1,6 +1,6 @@
 // @flow
 
-import {type DiscordConfig, parseConfig} from "./config";
+import {type DiscordConfig, parser} from "./config";
 
 describe("plugins/experimental-discord/config", () => {
   it("can load a basic config", () => {
@@ -11,7 +11,7 @@ describe("plugins/experimental-discord/config", () => {
         ":sourcecred:626763367893303303": 16,
       },
     };
-    const parsed: DiscordConfig = parseConfig(raw);
+    const parsed: DiscordConfig = parser.parseOrThrow(raw);
     expect(parsed).toEqual(raw);
   });
 });

--- a/src/plugins/experimental-discord/plugin.js
+++ b/src/plugins/experimental-discord/plugin.js
@@ -4,14 +4,13 @@ import Database from "better-sqlite3";
 
 import type {Plugin, PluginDirectoryContext} from "../../api/plugin";
 import type {PluginDeclaration} from "../../analysis/pluginDeclaration";
-import {parseConfig, type DiscordConfig, type DiscordToken} from "./config";
+import {parser, type DiscordConfig, type DiscordToken} from "./config";
 import {declaration} from "./declaration";
 import {join as pathJoin} from "path";
-import fs from "fs-extra";
 import {type TaskReporter} from "../../util/taskReporter";
 import {Fetcher} from "./fetcher";
 import {Mirror} from "./mirror";
-import type {ReferenceDetector} from "../../core/references/referenceDetector";
+import type {ReferenceDetector} from "../../core/references";
 import type {WeightedGraph} from "../../core/weightedGraph";
 import {weightsForDeclaration} from "../../analysis/pluginDeclaration";
 import {createGraph} from "./createGraph";
@@ -21,14 +20,14 @@ import {
   type PluginId,
   fromString as pluginIdFromString,
 } from "../../api/pluginId";
+import {loadJson} from "../../util/disk";
 
 async function loadConfig(
   dirContext: PluginDirectoryContext
 ): Promise<DiscordConfig> {
   const dirname = dirContext.configDirectory();
   const path = pathJoin(dirname, "config.json");
-  const contents = await fs.readFile(path);
-  return Promise.resolve(parseConfig(JSON.parse(contents)));
+  return loadJson(path, parser);
 }
 
 const TOKEN_ENV_VAR_NAME = "SOURCECRED_DISCORD_TOKEN";

--- a/src/plugins/github/config.js
+++ b/src/plugins/github/config.js
@@ -21,7 +21,7 @@ type JsonObject =
   | JsonObject[]
   | {[string]: JsonObject};
 
-const parser: Combo.Parser<GithubConfig> = (() => {
+export const parser: Combo.Parser<GithubConfig> = (() => {
   const C = Combo;
   return C.object({
     repoIds: C.rename(
@@ -30,7 +30,3 @@ const parser: Combo.Parser<GithubConfig> = (() => {
     ),
   });
 })();
-
-export function parse(raw: Combo.JsonObject): GithubConfig {
-  return parser.parseOrThrow(raw);
-}

--- a/src/plugins/github/plugin.js
+++ b/src/plugins/github/plugin.js
@@ -1,14 +1,12 @@
 // @flow
 
 import Database from "better-sqlite3";
-import fs from "fs-extra";
 import {join as pathJoin} from "path";
-
 import fetchGithubRepo, {fetchGithubRepoFromCache} from "./fetchGithubRepo";
 import type {CacheProvider} from "../../backend/cache";
 import type {Plugin, PluginDirectoryContext} from "../../api/plugin";
 import type {PluginDeclaration} from "../../analysis/pluginDeclaration";
-import type {ReferenceDetector} from "../../core/references/referenceDetector";
+import type {ReferenceDetector} from "../../core/references";
 import {
   type WeightedGraph,
   merge as mergeWeightedGraph,
@@ -18,7 +16,7 @@ import {RelationalView} from "./relationalView";
 import {createGraph} from "./createGraph";
 import {declaration} from "./declaration";
 import {fromRelationalViews as referenceDetectorFromRelationalViews} from "./referenceDetector";
-import {parse as parseConfig, type GithubConfig} from "./config";
+import {parser, type GithubConfig} from "./config";
 import {validateToken, type GithubToken} from "./token";
 import {weightsForDeclaration} from "../../analysis/pluginDeclaration";
 import {type TaskReporter} from "../../util/taskReporter";
@@ -27,6 +25,7 @@ import {
   type PluginId,
   fromString as pluginIdFromString,
 } from "../../api/pluginId";
+import {loadJson} from "../../util/disk";
 
 const TOKEN_ENV_VAR_NAME = "SOURCECRED_GITHUB_TOKEN";
 
@@ -35,8 +34,7 @@ async function loadConfig(
 ): Promise<GithubConfig> {
   const dirname = dirContext.configDirectory();
   const path = pathJoin(dirname, "config.json");
-  const contents = await fs.readFile(path);
-  return Promise.resolve(parseConfig(JSON.parse(contents)));
+  return loadJson(path, parser);
 }
 
 // Shim to interface with `fetchGithubRepo`; TODO: refactor that to just


### PR DESCRIPTION
We have a nice util to handle loading a file with a parser but the plugins were not using it, this refactors them to use loadJson from the disk utils.

Inspired by this comment from @decentralion: https://github.com/sourcecred/sourcecred/pull/1999#discussion_r455397536

Test Plan: Ensure CLI is still able to load config files correctly