### PR TITLE
add grain.sum

### DIFF
--- a/src/ledger/grain.js
+++ b/src/ledger/grain.js
@@ -288,4 +288,16 @@ export function splitBudget(
   return pieces;
 }
 
+/**
+ * Sum a sequence of Grain values.
+ */
+export function sum(xs: Iterable<Grain>): Grain {
+  // $FlowExpectedError
+  let total = 0n;
+  for (const x of xs) {
+    total += BigInt(x);
+  }
+  return total.toString();
+}
+
 export const parser: P.Parser<Grain> = P.fmap(P.string, fromString);

--- a/src/ledger/grain.test.js
+++ b/src/ledger/grain.test.js
@@ -262,4 +262,17 @@ describe("src/ledger/grain", () => {
       });
     });
   });
+
+  describe("sum", () => {
+    const n = (x: number) => G.fromString(x.toString());
+    it("handles the empty case", () => {
+      expect(G.sum([])).toEqual(n(0));
+    });
+    it("handles a few numbers", () => {
+      expect(G.sum([n(1), n(2), n(3)])).toEqual(n(6));
+    });
+    it("handles negative numbers", () => {
+      expect(G.sum([n(1), n(-2), n(-3)])).toEqual(n(-4));
+    });
+  });
 });


### PR DESCRIPTION
Useful method for summing sequences of Grain value; also faster than is
possible using the exported APIs.

Test plan: Unit tests added