### PR TITLE
ledger: remove removeAlias

### DIFF
--- a/src/ledger/__snapshots__/ledger.test.js.snap
+++ b/src/ledger/__snapshots__/ledger.test.js.snap
@@ -2,10 +2,8 @@
 
 exports[`ledger/ledger state reconstruction serialized ledger snapshots as expected 1`] = `
 "[
-{\\"action\\":{\\"identity\\":{\\"address\\":\\"N\\\\u0000sourcecred\\\\u0000core\\\\u0000IDENTITY\\\\u0000USER\\\\u0000YVZhbGlkVXVpZEF0TGFzdA\\\\u0000\\",\\"aliases\\":[],\\"id\\":\\"YVZhbGlkVXVpZEF0TGFzdA\\",\\"name\\":\\"foo\\",\\"subtype\\":\\"USER\\"},\\"type\\":\\"CREATE_IDENTITY\\",\\"version\\":\\"1\\"},\\"ledgerTimestamp\\":1,\\"version\\":\\"1\\"},
-{\\"action\\":{\\"identity\\":{\\"address\\":\\"N\\\\u0000sourcecred\\\\u0000core\\\\u0000IDENTITY\\\\u0000USER\\\\u0000URgLrCxgvjHxtGJ9PgmckQ\\\\u0000\\",\\"aliases\\":[],\\"id\\":\\"URgLrCxgvjHxtGJ9PgmckQ\\",\\"name\\":\\"bar\\",\\"subtype\\":\\"USER\\"},\\"type\\":\\"CREATE_IDENTITY\\",\\"version\\":\\"1\\"},\\"ledgerTimestamp\\":2,\\"version\\":\\"1\\"},
-{\\"action\\":{\\"alias\\":\\"N\\\\u0000a1\\\\u0000\\",\\"identityId\\":\\"YVZhbGlkVXVpZEF0TGFzdA\\",\\"type\\":\\"ADD_ALIAS\\",\\"version\\":\\"1\\"},\\"ledgerTimestamp\\":3,\\"version\\":\\"1\\"},
-{\\"action\\":{\\"alias\\":\\"N\\\\u0000a1\\\\u0000\\",\\"identityId\\":\\"YVZhbGlkVXVpZEF0TGFzdA\\",\\"retroactivePaid\\":\\"0\\",\\"type\\":\\"REMOVE_ALIAS\\",\\"version\\":\\"1\\"},\\"ledgerTimestamp\\":4,\\"version\\":\\"1\\"},
-{\\"action\\":{\\"alias\\":\\"N\\\\u0000a1\\\\u0000\\",\\"identityId\\":\\"URgLrCxgvjHxtGJ9PgmckQ\\",\\"type\\":\\"ADD_ALIAS\\",\\"version\\":\\"1\\"},\\"ledgerTimestamp\\":5,\\"version\\":\\"1\\"}
+{\\"action\\":{\\"identity\\":{\\"address\\":\\"N\\\\u0000sourcecred\\\\u0000core\\\\u0000IDENTITY\\\\u0000USER\\\\u0000YVZhbGlkVXVpZEF0TGFzdA\\\\u0000\\",\\"aliases\\":[],\\"id\\":\\"YVZhbGlkVXVpZEF0TGFzdA\\",\\"name\\":\\"steven\\",\\"subtype\\":\\"USER\\"},\\"type\\":\\"CREATE_IDENTITY\\",\\"version\\":\\"1\\"},\\"ledgerTimestamp\\":1,\\"version\\":\\"1\\"},
+{\\"action\\":{\\"identity\\":{\\"address\\":\\"N\\\\u0000sourcecred\\\\u0000core\\\\u0000IDENTITY\\\\u0000ORGANIZATION\\\\u0000URgLrCxgvjHxtGJ9PgmckQ\\\\u0000\\",\\"aliases\\":[],\\"id\\":\\"URgLrCxgvjHxtGJ9PgmckQ\\",\\"name\\":\\"crystal-gems\\",\\"subtype\\":\\"ORGANIZATION\\"},\\"type\\":\\"CREATE_IDENTITY\\",\\"version\\":\\"1\\"},\\"ledgerTimestamp\\":2,\\"version\\":\\"1\\"},
+{\\"action\\":{\\"alias\\":\\"N\\\\u0000a1\\\\u0000\\",\\"identityId\\":\\"YVZhbGlkVXVpZEF0TGFzdA\\",\\"type\\":\\"ADD_ALIAS\\",\\"version\\":\\"1\\"},\\"ledgerTimestamp\\":3,\\"version\\":\\"1\\"}
 ]"
 `;


### PR DESCRIPTION
We'll eventually need a way to unlink an alias from an account, e.g. if
the alias was fraudulently connected. But I'm not sure that `removeAlias`
is the right API; maybe we'll really need `transferAlias`. For now, I'm removing
it, so we can figure out the right API when we know the design space a little better.

For the time being, in the
event of fraud it will be possible to de-activate the attacker's grain
account, thus removing their ability to earn or transfer Grain.

Test plan: Just a removal. `yarn test`.