### PR TITLE
refactor grain allocations

### DIFF
--- a/src/ledger/__snapshots__/ledger.test.js.snap
+++ b/src/ledger/__snapshots__/ledger.test.js.snap
@@ -4,6 +4,8 @@ exports[`ledger/ledger state reconstruction serialized ledger snapshots as expec
 "[
 {\\"action\\":{\\"identity\\":{\\"address\\":\\"N\\\\u0000sourcecred\\\\u0000core\\\\u0000IDENTITY\\\\u0000USER\\\\u0000YVZhbGlkVXVpZEF0TGFzdA\\\\u0000\\",\\"aliases\\":[],\\"id\\":\\"YVZhbGlkVXVpZEF0TGFzdA\\",\\"name\\":\\"steven\\",\\"subtype\\":\\"USER\\"},\\"type\\":\\"CREATE_IDENTITY\\",\\"version\\":\\"1\\"},\\"ledgerTimestamp\\":1,\\"version\\":\\"1\\"},
 {\\"action\\":{\\"identity\\":{\\"address\\":\\"N\\\\u0000sourcecred\\\\u0000core\\\\u0000IDENTITY\\\\u0000ORGANIZATION\\\\u0000URgLrCxgvjHxtGJ9PgmckQ\\\\u0000\\",\\"aliases\\":[],\\"id\\":\\"URgLrCxgvjHxtGJ9PgmckQ\\",\\"name\\":\\"crystal-gems\\",\\"subtype\\":\\"ORGANIZATION\\"},\\"type\\":\\"CREATE_IDENTITY\\",\\"version\\":\\"1\\"},\\"ledgerTimestamp\\":2,\\"version\\":\\"1\\"},
-{\\"action\\":{\\"alias\\":\\"N\\\\u0000a1\\\\u0000\\",\\"identityId\\":\\"YVZhbGlkVXVpZEF0TGFzdA\\",\\"type\\":\\"ADD_ALIAS\\",\\"version\\":\\"1\\"},\\"ledgerTimestamp\\":3,\\"version\\":\\"1\\"}
+{\\"action\\":{\\"alias\\":\\"N\\\\u0000a1\\\\u0000\\",\\"identityId\\":\\"YVZhbGlkVXVpZEF0TGFzdA\\",\\"type\\":\\"ADD_ALIAS\\",\\"version\\":\\"1\\"},\\"ledgerTimestamp\\":3,\\"version\\":\\"1\\"},
+{\\"action\\":{\\"distribution\\":{\\"allocations\\":[{\\"id\\":\\"yYNur0NEEkh7fMaUn6n9QQ\\",\\"policy\\":{\\"budget\\":\\"100\\",\\"policyType\\":\\"IMMEDIATE\\"},\\"receipts\\":[{\\"amount\\":\\"50\\",\\"id\\":\\"YVZhbGlkVXVpZEF0TGFzdA\\"},{\\"amount\\":\\"50\\",\\"id\\":\\"URgLrCxgvjHxtGJ9PgmckQ\\"}]}],\\"credTimestamp\\":1,\\"id\\":\\"f9xPz9YGH0PuBpPAg2824Q\\"},\\"type\\":\\"DISTRIBUTE_GRAIN\\",\\"version\\":\\"1\\"},\\"ledgerTimestamp\\":4,\\"version\\":\\"1\\"},
+{\\"action\\":{\\"amount\\":\\"10\\",\\"from\\":\\"YVZhbGlkVXVpZEF0TGFzdA\\",\\"memo\\":null,\\"to\\":\\"URgLrCxgvjHxtGJ9PgmckQ\\",\\"type\\":\\"TRANSFER_GRAIN\\",\\"version\\":\\"1\\"},\\"ledgerTimestamp\\":5,\\"version\\":\\"1\\"}
 ]"
 `;

--- a/src/ledger/distribution.js
+++ b/src/ledger/distribution.js
@@ -1,0 +1,18 @@
+// @flow
+
+import * as C from "../util/combo";
+import * as Uuid from "../util/uuid";
+import {type TimestampMs} from "../util/timestamp";
+import {type Allocation, allocationParser} from "./grainAllocation";
+
+export type Distribution = {|
+  +id: Uuid.Uuid,
+  +allocations: $ReadOnlyArray<Allocation>,
+  +credTimestamp: TimestampMs,
+|};
+
+export const parser: C.Parser<Distribution> = C.object({
+  id: Uuid.parser,
+  allocations: C.array(allocationParser),
+  credTimestamp: C.number,
+});

--- a/src/ledger/grainAllocation.test.js
+++ b/src/ledger/grainAllocation.test.js
@@ -1,232 +1,149 @@
 // @flow
 
-import deepFreeze from "deep-freeze";
-import {NodeAddress} from "../core/graph";
 import {
-  computeDistribution,
   computeAllocation,
-  type CredHistory,
-  type PolicyType,
+  type AllocationIdentity,
+  _validateAllocationBudget,
 } from "./grainAllocation";
 import * as G from "./grain";
+import {random as randomUuid, parser as uuidParser} from "../util/uuid";
 
 describe("src/ledger/grainAllocation", () => {
-  const foo = NodeAddress.fromParts(["foo"]);
-  const bar = NodeAddress.fromParts(["bar"]);
+  // concise helper for grain from a string
+  const g = (x: string) => G.fromString(x);
+  // concise helper for grain from a number
+  const ng = (x: number) => g(x.toString());
+  // concise helper for an allocation identity
+  function aid(paid: number, cred: $ReadOnlyArray<number>): AllocationIdentity {
+    return {id: randomUuid(), paid: ng(paid), cred};
+  }
+  const immediate = (n: number) => ({policyType: "IMMEDIATE", budget: ng(n)});
+  const balanced = (n: number) => ({policyType: "BALANCED", budget: ng(n)});
 
-  const unevenInterval = deepFreeze({
-    intervalEndMs: 10,
-    cred: new Map([
-      [foo, 9],
-      [bar, 1],
-    ]),
-  });
-
-  const evenInterval = deepFreeze({
-    intervalEndMs: 20,
-    cred: new Map([
-      [foo, 1],
-      [bar, 1],
-    ]),
-  });
-
-  const singlePersonInterval = deepFreeze({
-    intervalEndMs: 30,
-    cred: new Map([[bar, 2]]),
-  });
-
-  const credHistory: CredHistory = deepFreeze([
-    unevenInterval,
-    evenInterval,
-    singlePersonInterval,
-  ]);
-
-  describe.each([["IMMEDIATE"], ["BALANCED"]])(
-    "Common Tests for %o",
-    (policyType: PolicyType) => {
-      const policy = deepFreeze({policyType, budget: G.ONE});
-
-      it("it should return an empty allocation when the budget is zero", () => {
-        const zeroPolicy = {budget: G.ZERO, policyType};
-        const actual = computeAllocation(zeroPolicy, credHistory, new Map());
-
-        expect(actual).toEqual({
-          policy: zeroPolicy,
+  describe("computeAllocation", () => {
+    describe("validation", () => {
+      it("errors if there are no identities", () => {
+        const thunk = () => computeAllocation(immediate(5), []);
+        expect(thunk).toThrowError("must have at least one identity");
+      });
+      it("errors if the budget is negative", () => {
+        const id = aid(5, [1]);
+        const thunk = () => computeAllocation(immediate(-5), [id]);
+        expect(thunk).toThrowError("invalid budget");
+      });
+      it("errors if the total cred is zero", () => {
+        const thunk = () => computeAllocation(immediate(5), [aid(0, [0])]);
+        expect(thunk).toThrowError("cred is zero");
+      });
+      it("errors if there's negative paid", () => {
+        const thunk = () => computeAllocation(immediate(5), [aid(-1, [0])]);
+        expect(thunk).toThrowError("negative paid");
+      });
+      it("errors if there's NaN or Infinity in Cred", () => {
+        const thunk = () => computeAllocation(immediate(5), [aid(0, [NaN])]);
+        expect(thunk).toThrowError("invalid cred");
+      });
+      it("errors if there's inconsistent Cred lengths", () => {
+        const i1 = aid(0, [1]);
+        const i2 = aid(0, [1, 2]);
+        const thunk = () => computeAllocation(immediate(5), [i1, i2]);
+        expect(thunk).toThrowError("inconsistent cred length");
+      });
+      it("errors if the receipts don't match the budget", () => {
+        const badAllocation = {
+          policy: immediate(5),
+          id: randomUuid(),
           receipts: [],
-        });
-      });
-      it("should error when the Cred sums to 0", () => {
-        const fail = () =>
-          computeAllocation(
-            policy,
-            [
-              {
-                intervalEndMs: 500,
-                cred: new Map([
-                  [foo, 0],
-                  [bar, 0],
-                ]),
-              },
-            ],
-            new Map()
-          );
-
-        expect(fail).toThrowError("cred sums to 0");
-      });
-      it("should error when there is no Cred", () => {
-        const fail = () => computeAllocation(policy, [], new Map());
-        expect(fail).toThrowError("credHistory is empty");
-      });
-      it("should error when the budget is negative", () => {
-        const badPolicy = {...policy, budget: G.fromString("-100")};
-        const fail = () => computeAllocation(badPolicy, [], new Map());
-        expect(fail).toThrowError("invalid budget");
-      });
-    }
-  );
-
-  describe("immediateAllocation", () => {
-    const policy = deepFreeze({policyType: "IMMEDIATE", budget: G.ONE});
-
-    it("handles an interval with even cred distribution", () => {
-      const result = computeAllocation(policy, [evenInterval], new Map());
-      const HALF = G.fromApproximateFloat(0.5);
-      const expectedReceipts = [
-        {address: foo, amount: HALF},
-        {address: bar, amount: HALF},
-      ];
-      expect(result).toEqual({policy, receipts: expectedReceipts});
-    });
-    it("handles an interval with un-even cred distribution", () => {
-      const result = computeAllocation(policy, [unevenInterval], new Map());
-      const ONE_TENTH = G.fromApproximateFloat(0.1);
-      const NINE_TENTHS = G.fromApproximateFloat(0.9);
-      const expectedReceipts = [
-        {address: foo, amount: NINE_TENTHS},
-        {address: bar, amount: ONE_TENTH},
-      ];
-      expect(result).toEqual({policy, receipts: expectedReceipts});
-    });
-    it("handles an interval with one cred recipient", () => {
-      const result = computeAllocation(
-        policy,
-        [singlePersonInterval],
-        new Map()
-      );
-      const expectedReceipts = [{address: bar, amount: G.ONE}];
-      expect(result).toEqual({policy, receipts: expectedReceipts});
-    });
-  });
-
-  describe("balancedAllocation", () => {
-    const policy = {policyType: "BALANCED", budget: G.fromApproximateFloat(14)};
-
-    it("should only pay Foo if Foo is sufficiently underpaid", () => {
-      const alreadyPaid = new Map([
-        [foo, G.ZERO],
-        [bar, G.fromApproximateFloat(99)],
-      ]);
-      const expectedReceipts = [
-        {address: foo, amount: G.fromApproximateFloat(14)},
-      ];
-      const actual = computeAllocation(policy, credHistory, alreadyPaid);
-      expect(actual).toEqual({policy, receipts: expectedReceipts});
-    });
-    it("should divide according to cred if everyone is already balanced paid", () => {
-      const alreadyPaid = new Map([
-        [foo, G.fromApproximateFloat(5)],
-        [bar, G.fromApproximateFloat(2)],
-      ]);
-
-      // Total cred is foo: 10, bar: 4, past allocations are exactly half this
-      // Since we are distributing 14g, we expect it to be proportional to
-      // their cred scores since past allocations are already "balanced"
-      const expectedReceipts = [
-        {address: foo, amount: G.fromApproximateFloat(10)},
-        {address: bar, amount: G.fromApproximateFloat(4)},
-      ];
-
-      const actual = computeAllocation(policy, credHistory, alreadyPaid);
-      expect(actual).toEqual({policy, receipts: expectedReceipts});
-    });
-    it("'top off' users who were slightly underpaid", () => {
-      // Foo is exactly 1 grain behind where they "should" be
-      const alreadyPaid = new Map([
-        [foo, G.fromApproximateFloat(4)],
-        [bar, G.fromApproximateFloat(2)],
-      ]);
-
-      const policy15 = {
-        policyType: "BALANCED",
-        budget: G.fromApproximateFloat(15),
-      };
-
-      const expectedReceipts = [
-        {address: foo, amount: G.fromApproximateFloat(11)},
-        {address: bar, amount: G.fromApproximateFloat(4)},
-      ];
-
-      const actual = computeAllocation(policy15, credHistory, alreadyPaid);
-      expect(actual).toEqual({
-        policy: policy15,
-        receipts: expectedReceipts,
+        };
+        const thunk = () => _validateAllocationBudget(badAllocation);
+        expect(thunk).toThrow("has budget of 5 but distributed 0");
       });
     });
 
-    it("should handle the case where one user has no historical earnings", () => {
-      const alreadyPaid = new Map([[foo, G.fromApproximateFloat(5)]]);
-
-      const expectedReceipts = [
-        {address: bar, amount: G.fromApproximateFloat(2)},
-      ];
-      const policy2 = {
-        policyType: "BALANCED",
-        budget: G.fromApproximateFloat(2),
-      };
-
-      const actual = computeAllocation(policy2, credHistory, alreadyPaid);
-      expect(actual).toEqual({policy: policy2, receipts: expectedReceipts});
+    describe("immediate policy", () => {
+      it("splits based on just most recent cred", () => {
+        const policy = immediate(10);
+        const i1 = aid(100, [10, 2]);
+        const i2 = aid(0, [0, 3]);
+        const allocation = computeAllocation(policy, [i1, i2]);
+        const expectedReceipts = [
+          {id: i1.id, amount: ng(4)},
+          {id: i2.id, amount: ng(6)},
+        ];
+        const expectedAllocation = {
+          receipts: expectedReceipts,
+          id: uuidParser.parseOrThrow(allocation.id),
+          policy,
+        };
+        expect(allocation).toEqual(expectedAllocation);
+      });
+      it("handles 0 budget correctly", () => {
+        const policy = immediate(0);
+        const i1 = aid(3, [1, 1]);
+        const i2 = aid(0, [3, 0]);
+        const allocation = computeAllocation(policy, [i1, i2]);
+        const expectedReceipts = [
+          {id: i1.id, amount: ng(0)},
+          {id: i2.id, amount: ng(0)},
+        ];
+        const expectedAllocation = {
+          receipts: expectedReceipts,
+          id: uuidParser.parseOrThrow(allocation.id),
+          policy,
+        };
+        expect(allocation).toEqual(expectedAllocation);
+      });
     });
-    it("should not break if a user has earnings but no cred", () => {
-      const alreadyPaid = new Map([
-        [NodeAddress.fromParts(["zoink"]), G.fromApproximateFloat(10)],
-      ]);
 
-      const expectedReceipts = [
-        {address: foo, amount: G.fromApproximateFloat(10)},
-        {address: bar, amount: G.fromApproximateFloat(4)},
-      ];
-
-      const actual = computeAllocation(policy, credHistory, alreadyPaid);
-      expect(actual).toEqual({receipts: expectedReceipts, policy});
-    });
-  });
-
-  describe("computeDistribution", () => {
-    it("handles the case with no policies", () => {
-      const distribution = computeDistribution([], credHistory, new Map());
-      expect(distribution).toEqual({credTimestamp: 30, allocations: []});
-    });
-    it("includes the credTimestamp from the latest cred slice", () => {
-      const tsForHistory = (history) =>
-        computeDistribution([], history, new Map()).credTimestamp;
-      expect(tsForHistory(credHistory)).toEqual(30);
-      expect(tsForHistory(credHistory.slice(0, 2))).toEqual(20);
-      expect(tsForHistory(credHistory.slice(0, 1))).toEqual(10);
-    });
-    it("throws an error on an empty history", () => {
-      expect(() => computeDistribution([], [], new Map())).toThrowError(
-        "empty credHistory"
-      );
-    });
-    it("throws an error on a history with an invalid timestamp", () => {
-      const bad = [NaN, Infinity, -Infinity];
-      for (const b of bad) {
-        const badHistory = [{intervalEndMs: b, cred: new Map()}];
-        expect(() =>
-          computeDistribution([], badHistory, new Map())
-        ).toThrowError("invalid credTimestamp");
-      }
+    describe("balanced policy", () => {
+      it("splits based on lifetime Cred when there's no paid amounts", () => {
+        const policy = balanced(100);
+        const i1 = aid(0, [1, 1]);
+        const i2 = aid(0, [3, 0]);
+        const allocation = computeAllocation(policy, [i1, i2]);
+        const expectedReceipts = [
+          {id: i1.id, amount: ng(40)},
+          {id: i2.id, amount: ng(60)},
+        ];
+        const expectedAllocation = {
+          receipts: expectedReceipts,
+          id: uuidParser.parseOrThrow(allocation.id),
+          policy,
+        };
+        expect(allocation).toEqual(expectedAllocation);
+      });
+      it("takes past payment into account", () => {
+        const policy = balanced(20);
+        const i1 = aid(0, [1, 1]);
+        const i2 = aid(30, [3, 0]);
+        const allocation = computeAllocation(policy, [i1, i2]);
+        const expectedReceipts = [
+          {id: i1.id, amount: ng(20)},
+          {id: i2.id, amount: ng(0)},
+        ];
+        const expectedAllocation = {
+          receipts: expectedReceipts,
+          id: uuidParser.parseOrThrow(allocation.id),
+          policy,
+        };
+        expect(allocation).toEqual(expectedAllocation);
+      });
+      it("handles 0 budget correctly", () => {
+        const policy = balanced(0);
+        const i1 = aid(30, [1, 1]);
+        const i2 = aid(0, [3, 0]);
+        const allocation = computeAllocation(policy, [i1, i2]);
+        const expectedReceipts = [
+          {id: i1.id, amount: ng(0)},
+          {id: i2.id, amount: ng(0)},
+        ];
+        const expectedAllocation = {
+          receipts: expectedReceipts,
+          id: uuidParser.parseOrThrow(allocation.id),
+          policy,
+        };
+        expect(allocation).toEqual(expectedAllocation);
+      });
     });
   });
 });


### PR DESCRIPTION
Re-writes the grain allocation module, around the new assumption that we
only allocate to ids.

Also: dramatically cleans the interface, and validates the arguments to
the underlying receipt allocator (saving them from needing to
redundantly check that there are identities, that the budget is
nonnegative, etc) and validates the output (to ensure that sum receipts
is always equal to the budget).

Also: pulls the distribution type out to a new file, and patches the
`Ledger.distributeGrain` method to consume the new style Distributions.

Test plan: Unit tests rewritten; run `yarn test`