### PR TITLE
jsonLog: don't depend on fs

### DIFF
--- a/src/util/jsonLog.js
+++ b/src/util/jsonLog.js
@@ -1,7 +1,6 @@
 // @flow
 
 import stringify from "json-stable-stringify";
-import fs from "fs-extra";
 import * as C from "./combo";
 
 /**
@@ -49,17 +48,5 @@ export class JsonLog<T: C.JsonObject> {
   static fromString(log: string, parser: C.Parser<T>): JsonLog<T> {
     const items = C.array(parser).parseOrThrow(JSON.parse(log));
     return new JsonLog().append(items);
-  }
-
-  async writeJsonLog(path: string): Promise<void> {
-    await fs.writeFile(path, this.toString());
-  }
-
-  static async readJsonLog(
-    path: string,
-    parser: C.Parser<T>
-  ): Promise<JsonLog<T>> {
-    const logString = await fs.readFile(path);
-    return JsonLog.fromString(logString.toString(), parser);
   }
 }

--- a/src/util/jsonLog.test.js
+++ b/src/util/jsonLog.test.js
@@ -2,7 +2,6 @@
 
 import {JsonLog} from "./jsonLog";
 import * as C from "./combo";
-import tmp from "tmp";
 
 describe("util/jsonLog", () => {
   it("initializes to an empty log", () => {
@@ -54,13 +53,5 @@ describe("util/jsonLog", () => {
     const log = JsonLog.fromString(logString, parser);
     const items = Array.from(log.values());
     expect(items).toEqual(ts);
-  });
-
-  it("writes and reads to a log file correctly", async () => {
-    const fname = tmp.tmpNameSync();
-    const log = new JsonLog().append([1, 2, 3]);
-    await log.writeJsonLog(fname);
-    const log2 = await JsonLog.readJsonLog(fname, C.number);
-    expect(log).toEqual(log2);
   });
 });


### PR DESCRIPTION
This modifies the jsonLog module so it doesn't directly depend on fs, as
that made it impossible to depend on in the browser. Any code that needs
to serialize/read JsonLogs from disk can use the existing `toString` and
`fromString` methods.

Test plan: `yarn test`