### PR TITLE
ledger: include identities in accounts

### DIFF
--- a/src/cli/score.js
+++ b/src/cli/score.js
@@ -73,7 +73,7 @@ const scoreCommand: Command = async (args, std) => {
     ledgerParser,
     () => new Ledger()
   );
-  const identities = ledger.identities();
+  const identities = ledger.accounts().map((a) => a.identity);
   const contractedGraph = weightedGraph.graph.contractNodes(
     identityContractions(identities)
   );


### PR DESCRIPTION
The ledger module used to separately track identities and accounts. Now
each account has an associated identity. This removes a class of desync
issues, and more importantly, allows us to get all the info needed for
Grain distributions out of the ledger with a single API call.

(When distributing Grain, we need to know whether the account is active
and how much it's been paid, AND its address.)

Test plan: Unit tests updated, `yarn test` passes.