### PR TITLE
implement ledger identity editor POC

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "d3-time": "^1.1.0",
     "d3-time-format": "^2.2.3",
     "deep-freeze": "^0.0.1",
+    "downshift": "^5.4.7",
     "express": "^4.17.1",
     "fs-extra": "^9.0.0",
     "get-random-values": "^1.2.0",

--- a/src/ui/components/AdminApp.js
+++ b/src/ui/components/AdminApp.js
@@ -7,6 +7,7 @@ import {createMuiTheme} from "@material-ui/core/styles";
 import pink from "@material-ui/core/colors/pink";
 import fakeDataProvider from "ra-data-fakerest";
 import {Explorer} from "./Explorer";
+import {LedgerAdmin} from "./LedgerAdmin";
 import {load, type LoadResult, type LoadSuccess} from "../load";
 import {withRouter} from "react-router-dom";
 import AppBar from "./AppBar";
@@ -31,6 +32,9 @@ const customRoutes = (loadResult: LoadSuccess) => [
   </Route>,
   <Route key="root" exact path="/">
     <Redirect to="/explorer" />
+  </Route>,
+  <Route key="admin" exact path="/admin">
+    <LedgerAdmin credView={loadResult.credView} />
   </Route>,
 ];
 

--- a/src/ui/components/AliasSelector.js
+++ b/src/ui/components/AliasSelector.js
@@ -1,0 +1,162 @@
+// @flow
+
+import React, {useState, useMemo} from "react";
+import {useCombobox, useMultipleSelection} from "downshift";
+import {Ledger} from "../../ledger/ledger";
+import {type Identity} from "../../ledger/identity";
+import {CredView} from "../../analysis/credView";
+import {type NodeAddressT} from "../../core/graph";
+import Markdown from "react-markdown";
+
+type Props = {|
+  +currentIdentity: Identity | null,
+  +ledger: Ledger,
+  +credView: CredView,
+  +setLedger: (Ledger) => void,
+  +setCurrentIdentity: (Identity) => void,
+|};
+
+export function AliasSelector({
+  currentIdentity,
+  ledger,
+  setLedger,
+  setCurrentIdentity,
+  credView,
+}: Props) {
+  const [inputValue, setInputValue] = useState("");
+  const {
+    getSelectedItemProps,
+    getDropdownProps,
+    addSelectedItem,
+    removeSelectedItem,
+    selectedItems,
+  } = useMultipleSelection({
+    initialSelectedItems: [],
+  });
+  useMemo(() => {
+    selectedItems.forEach((item) => {
+      removeSelectedItem(item);
+    });
+    if (currentIdentity) {
+      currentIdentity.aliases.forEach((aliasAddress) =>
+        addSelectedItem(aliasAddress)
+      );
+    }
+  }, [currentIdentity]);
+
+  const getNodeDescription = (nodeAddress: NodeAddressT): string => {
+    const node = credView.node(nodeAddress);
+    if (node) {
+      return node.description;
+    }
+    return "";
+  };
+
+  const getFilteredItems = (items) =>
+    items.filter(
+      (item) =>
+        !ledger._aliases.has(item) &&
+        getNodeDescription(item)
+          .toLowerCase()
+          .startsWith(inputValue.toLowerCase())
+    );
+
+  const {
+    isOpen,
+    getToggleButtonProps,
+    getMenuProps,
+    getInputProps,
+    getComboboxProps,
+    highlightedIndex,
+    getItemProps,
+    selectItem,
+  } = useCombobox({
+    inputValue,
+    items: getFilteredItems(credView.userNodes().map((i) => i.address)),
+    onStateChange: ({inputValue, type, selectedItem}) => {
+      switch (type) {
+        case useCombobox.stateChangeTypes.InputChange:
+          setInputValue(inputValue);
+          break;
+        case useCombobox.stateChangeTypes.InputKeyDownEnter:
+        case useCombobox.stateChangeTypes.ItemClick:
+        case useCombobox.stateChangeTypes.InputBlur:
+          if (selectedItem && currentIdentity) {
+            setLedger(ledger.addAlias(currentIdentity.id, selectedItem));
+            setCurrentIdentity(ledger.account(currentIdentity.id).identity);
+            setInputValue("");
+            addSelectedItem(selectedItem);
+            selectItem(null);
+          }
+
+          break;
+        default:
+          break;
+      }
+    },
+  });
+  return (
+    <div style={{visibility: currentIdentity ? "visible" : "hidden"}}>
+      <label>
+        <h2>Aliases:</h2>
+      </label>
+      <div>
+        {selectedItems.map((selectedItem, index) => (
+          <span
+            key={`selected-item-${index}`}
+            {...getSelectedItemProps({selectedItem, index})}
+          >
+            <Markdown
+              renderers={{paragraph: "span"}}
+              source={getNodeDescription(selectedItem)}
+            />
+            <br />
+          </span>
+        ))}
+        <div style={comboboxStyles} {...getComboboxProps()}>
+          <input
+            {...getInputProps(getDropdownProps({preventKeyAction: isOpen}))}
+          />
+          <button {...getToggleButtonProps()} aria-label={"toggle menu"}>
+            &#8595;
+          </button>
+        </div>
+      </div>
+      <ul {...getMenuProps()} style={menuMultipleStyles}>
+        {isOpen &&
+          getFilteredItems(credView.userNodes().map((i) => i.address)).map(
+            (item, index) => (
+              <li
+                style={
+                  highlightedIndex === index ? {backgroundColor: "#bde4ff"} : {}
+                }
+                key={`${item}${index}`}
+                {...getItemProps({item, index})}
+              >
+                <Markdown
+                  renderers={{paragraph: "span"}}
+                  source={getNodeDescription(item)}
+                />
+              </li>
+            )
+          )}
+      </ul>
+    </div>
+  );
+}
+
+const comboboxStyles = {display: "inline-block", marginLeft: "5px"};
+
+const menuMultipleStyles = {
+  maxHeight: "180px",
+  overflowY: "auto",
+  width: "135px",
+  margin: 0,
+  borderTop: 0,
+  background: "white",
+  position: "absolute",
+  zIndex: 1000,
+  listStyle: "none",
+  padding: 0,
+  //right: "40px",
+};

--- a/src/ui/components/LedgerAdmin.js
+++ b/src/ui/components/LedgerAdmin.js
@@ -1,0 +1,106 @@
+// @flow
+
+import React, {useState} from "react";
+import {type Identity} from "../../ledger/identity";
+import {Ledger} from "../../ledger/ledger";
+import {CredView} from "../../analysis/credView";
+import {AliasSelector} from "./AliasSelector";
+
+export type Props = {|
+  +credView: CredView,
+|};
+
+export const LedgerAdmin = ({credView}: Props) => {
+  const [ledger, setLedger] = useState<Ledger>(new Ledger());
+  const [nextIdentityName, setIdentityName] = useState<string>("");
+  const [currentIdentity, setCurrentIdentity] = useState<Identity | null>(null);
+  const [promptString, setPromptString] = useState<string>("Add Identity:");
+
+  // TODO: fix any
+  function changeIdentityName(event: any) {
+    setIdentityName(event.target.value);
+  }
+
+  function createOrUpdateIdentity(event: any) {
+    event.preventDefault();
+    if (!currentIdentity) {
+      const newID = ledger.createIdentity("USER", nextIdentityName);
+      setLedger(ledger);
+      setIdentityName("");
+      setActiveIdentity(ledger.account(newID).identity);
+    } else {
+      const {id} = currentIdentity;
+      ledger.renameIdentity(id, nextIdentityName);
+      setLedger(ledger);
+      setIdentityName("");
+      setCurrentIdentity(null);
+    }
+  }
+
+  function setActiveIdentity(identity: Identity) {
+    const {name} = identity;
+    if (currentIdentity && name === currentIdentity.name) {
+      setIdentityName("");
+      setCurrentIdentity(null);
+      setPromptString("Add Identity: ");
+    } else {
+      setIdentityName(name);
+      setCurrentIdentity(identity);
+      setPromptString("Update Identity: ");
+    }
+  }
+  return (
+    <div
+      style={{
+        width: "80%",
+        margin: "0 auto",
+        background: "white",
+        padding: "0 5em 5em",
+      }}
+    >
+      <h1>Identities:</h1>
+      <ul>{renderIdentities()}</ul>
+      <h1>{promptString}</h1>
+      <form onSubmit={(e) => createOrUpdateIdentity(e)}>
+        <p>
+          <label htmlFor="Name">Name</label> <br />
+          <input
+            type="text"
+            name="Name"
+            value={nextIdentityName}
+            onChange={(e) => changeIdentityName(e)}
+          />
+        </p>
+        <input type="submit" value="Submit" />
+      </form>
+      <div>
+        {/* Warning: don't conditionally render this because it contains react hooks*/}
+        {AliasSelector({
+          currentIdentity,
+          ledger,
+          setLedger,
+          setCurrentIdentity,
+          credView,
+        })}
+      </div>
+    </div>
+  );
+
+  function renderIdentities() {
+    function renderIdentity(i: Identity) {
+      return (
+        <li onClick={() => setActiveIdentity(i)} key={i.id}>
+          {i.name}
+        </li>
+      );
+    }
+    return (
+      <div>
+        {ledger
+          .accounts()
+          .map((a) => a.identity)
+          .map(renderIdentity)}
+      </div>
+    );
+  }
+};

--- a/src/ui/components/LedgerAdmin.js
+++ b/src/ui/components/LedgerAdmin.js
@@ -58,7 +58,8 @@ export const LedgerAdmin = ({credView}: Props) => {
         padding: "0 5em 5em",
       }}
     >
-      <h1>Identities:</h1>
+      <h1>Identities</h1>
+      {ledger.accounts().length > 0 && <h3>click one to update it</h3>}
       <ul>{renderIdentities()}</ul>
       <h1>{promptString}</h1>
       <form onSubmit={(e) => createOrUpdateIdentity(e)}>
@@ -72,6 +73,16 @@ export const LedgerAdmin = ({credView}: Props) => {
           />
         </p>
         <input type="submit" value="Submit" />
+        {currentIdentity && (
+          <>
+            <br />
+            <input
+              type="button"
+              value="New identity"
+              onClick={() => setActiveIdentity(currentIdentity)}
+            />
+          </>
+        )}
       </form>
       <div>
         {/* Warning: don't conditionally render AliasSelector because it contains react hooks*/}

--- a/src/ui/components/LedgerAdmin.js
+++ b/src/ui/components/LedgerAdmin.js
@@ -74,14 +74,14 @@ export const LedgerAdmin = ({credView}: Props) => {
         <input type="submit" value="Submit" />
       </form>
       <div>
-        {/* Warning: don't conditionally render this because it contains react hooks*/}
-        {AliasSelector({
-          currentIdentity,
-          ledger,
-          setLedger,
-          setCurrentIdentity,
-          credView,
-        })}
+        {/* Warning: don't conditionally render AliasSelector because it contains react hooks*/}
+        <AliasSelector
+          currentIdentity={currentIdentity}
+          ledger={ledger}
+          setLedger={setLedger}
+          setCurrentIdentity={setCurrentIdentity}
+          credView={credView}
+        />
       </div>
     </div>
   );

--- a/src/ui/components/LedgerAdmin.js
+++ b/src/ui/components/LedgerAdmin.js
@@ -17,25 +17,24 @@ export const LedgerAdmin = ({credView}: Props) => {
   const [promptString, setPromptString] = useState<string>("Add Identity:");
   const [checkboxSelected, setCheckBoxSelected] = useState<boolean>(false);
 
-  // TODO: fix any
-  function changeIdentityName(event: any) {
-    setIdentityName(event.target.value);
+  function changeIdentityName(event: SyntheticInputEvent<HTMLInputElement>) {
+    setIdentityName(event.currentTarget.value);
   }
 
-  function createOrUpdateIdentity(event: any) {
+  function createOrUpdateIdentity(
+    event: SyntheticInputEvent<HTMLInputElement>
+  ) {
     event.preventDefault();
     if (!currentIdentity) {
       const newID = ledger.createIdentity("USER", nextIdentityName);
-      setLedger(ledger);
-      setIdentityName("");
       setActiveIdentity(ledger.account(newID).identity);
     } else {
       const {id} = currentIdentity;
       ledger.renameIdentity(id, nextIdentityName);
-      setLedger(ledger);
       setIdentityName("");
       setCurrentIdentity(null);
     }
+    setLedger(ledger);
   }
 
   function toggleIdentityActivation({id}: Identity) {
@@ -88,7 +87,10 @@ export const LedgerAdmin = ({credView}: Props) => {
             onChange={(e) => changeIdentityName(e)}
           />
         </p>
-        <input type="submit" value="Submit" />
+        <input
+          type="submit"
+          value={currentIdentity ? "update username" : "create identity"}
+        />
         {currentIdentity && (
           <>
             <br />

--- a/src/ui/components/LedgerAdmin.js
+++ b/src/ui/components/LedgerAdmin.js
@@ -15,6 +15,7 @@ export const LedgerAdmin = ({credView}: Props) => {
   const [nextIdentityName, setIdentityName] = useState<string>("");
   const [currentIdentity, setCurrentIdentity] = useState<Identity | null>(null);
   const [promptString, setPromptString] = useState<string>("Add Identity:");
+  const [checkboxSelected, setCheckBoxSelected] = useState<boolean>(false);
 
   // TODO: fix any
   function changeIdentityName(event: any) {
@@ -37,15 +38,30 @@ export const LedgerAdmin = ({credView}: Props) => {
     }
   }
 
+  function toggleIdentityActivation({id}: Identity) {
+    let nextLedger;
+    if (ledger.account(id).active) {
+      nextLedger = ledger.deactivate(id);
+      setCheckBoxSelected(false);
+    } else {
+      nextLedger = ledger.activate(id);
+      setCheckBoxSelected(true);
+    }
+    setLedger(nextLedger);
+    setCurrentIdentity(nextLedger.account(id).identity);
+  }
+
   function setActiveIdentity(identity: Identity) {
     const {name} = identity;
     if (currentIdentity && name === currentIdentity.name) {
       setIdentityName("");
       setCurrentIdentity(null);
+      setCheckBoxSelected(false);
       setPromptString("Add Identity: ");
     } else {
       setIdentityName(name);
       setCurrentIdentity(identity);
+      setCheckBoxSelected(ledger.account(identity.id).active);
       setPromptString("Update Identity: ");
     }
   }
@@ -81,6 +97,15 @@ export const LedgerAdmin = ({credView}: Props) => {
               value="New identity"
               onClick={() => setActiveIdentity(currentIdentity)}
             />
+            <br />
+            <input
+              type="checkbox"
+              id="active"
+              name="active"
+              checked={checkboxSelected}
+              onChange={() => toggleIdentityActivation(currentIdentity)}
+            />
+            <label htmlFor="active">Account is active</label>
           </>
         )}
       </form>

--- a/src/ui/components/Menu.js
+++ b/src/ui/components/Menu.js
@@ -39,6 +39,13 @@ const Menu = ({bundledPlugins}: LoadSuccess) => ({onMenuClick}: menuProps) => {
             />
           );
         })}
+      <MenuItemLink
+        to="/admin"
+        primaryText="Ledger Admin"
+        leftIcon={<DefaultIcon />}
+        onClick={onMenuClick}
+        sidebarIsOpen={open}
+      />
     </>
   );
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -870,7 +870,7 @@
     pirates "^4.0.0"
     source-map-support "^0.5.16"
 
-"@babel/runtime@^7.1.2":
+"@babel/runtime@^7.1.2", "@babel/runtime@^7.10.2":
   version "7.10.5"
   resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.10.5.tgz#303d8bd440ecd5a491eae6117fd3367698674c5c"
   integrity sha512-otddXKhdNn7d0ptoFRHtMLa8LqDxLYwTjB4nYgM1yy5N6gU/MUf8zqyyLltCH3yAVitBzmwK4us+DD0l/MauAg==
@@ -2821,7 +2821,7 @@ compression@^1.7.4:
     safe-buffer "5.1.2"
     vary "~1.1.2"
 
-compute-scroll-into-view@^1.0.9:
+compute-scroll-into-view@^1.0.14, compute-scroll-into-view@^1.0.9:
   version "1.0.14"
   resolved "https://registry.yarnpkg.com/compute-scroll-into-view/-/compute-scroll-into-view-1.0.14.tgz#80e3ebb25d6aa89f42e533956cb4b16a04cfe759"
   integrity sha512-mKDjINe3tc6hGelUMNDzuhorIUZ7kS7BwyY0r2wQd2HOH2tRuJykiC06iSEX8y1TuhNzvz4GcJnK16mM2J1NMQ==
@@ -3642,6 +3642,16 @@ downshift@3.2.7:
     compute-scroll-into-view "^1.0.9"
     prop-types "^15.6.0"
     react-is "^16.5.2"
+
+downshift@^5.4.7:
+  version "5.4.7"
+  resolved "https://registry.yarnpkg.com/downshift/-/downshift-5.4.7.tgz#2ab7b0512cad33011ee6f29630f9a7bb74dff2b5"
+  integrity sha512-xaH0RNqwJ5pAsyk9qBmR9XJWmg1OOWMfrhzYv0NH2NjJxn77S3zBcfClw341UfhGyKg5v+qVqg/CQzvAgBNCXQ==
+  dependencies:
+    "@babel/runtime" "^7.10.2"
+    compute-scroll-into-view "^1.0.14"
+    prop-types "^15.7.2"
+    react-is "^16.13.1"
 
 duplexer@^0.1.1:
   version "0.1.1"
@@ -8308,7 +8318,7 @@ react-icons@^3.9.0:
   dependencies:
     camelcase "^5.0.0"
 
-react-is@^16.12.0, react-is@^16.5.2, react-is@^16.6.0, react-is@^16.7.0, react-is@^16.8.0, react-is@^16.8.1, react-is@^16.8.4, react-is@^16.8.6, react-is@^16.9.0:
+react-is@^16.12.0, react-is@^16.13.1, react-is@^16.5.2, react-is@^16.6.0, react-is@^16.7.0, react-is@^16.8.0, react-is@^16.8.1, react-is@^16.8.4, react-is@^16.8.6, react-is@^16.9.0:
   version "16.13.1"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.13.1.tgz#789729a4dc36de2999dc156dd6c1d9c18cea56a4"
   integrity sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==


### PR DESCRIPTION
The ledger identity editor enables users to collect grain by allowing
them to claim aliases from various plugins and unite them under a
single identity.

This editor allows for the creation and modification of identity
usernames, along with the assignment of aliases.

Note: aliases cannot yet be unassigned as there is no graceful way to
accomplish this in the backend yet.

test plan:
 - run the dev web server and browse to the ledger admin view.
 - Try to create an identity, then assign a couple aliases to it.
 - Click on the newly created identity name in the identities list to
 reset the view and create a new identity
 - Create a second identity and assign a couple more aliases to it.
 - Note that assigned aliases are no longer visible in the dropdown
 - click between users and ensure the name and alias lists repopulate
 with the correct information