### PR TITLE
Fix a test flake

### DIFF
--- a/src/ledger/ledger.test.js
+++ b/src/ledger/ledger.test.js
@@ -337,6 +337,7 @@ describe("ledger/ledger", () => {
     it("activating an already-active account is a no-op", () => {
       function ex() {
         const ledger = ledgerWithIdentities();
+        setFakeDate(3);
         ledger.activate(id1);
         return ledger;
       }


### PR DESCRIPTION
This fixes a flaky test encountered by @topocount in #2015. The issue
was that we constructed to ledgers and expected equality, but didn't
mock out the date for one of the events, so depending on test timing the
two ledgers could have different timestamps.

Test plan: `yarn test` and grounded confidence that this test won't flake
in the same way again.

If we see another failure like this, I should probably just mock the
date implementation permanently for the whole module.