### PR TITLE
ledger tracks last distribution timestamp

### DIFF
--- a/src/ledger/ledger.js
+++ b/src/ledger/ledger.js
@@ -77,6 +77,7 @@ export class Ledger {
   _aliases: Map<NodeAddressT, IdentityId>;
   _accounts: Map<IdentityId, MutableAccount>;
   _latestTimestamp: TimestampMs = -Infinity;
+  _lastDistributionTimestamp: TimestampMs = -Infinity;
 
   constructor() {
     this._ledgerEventLog = new JsonLog();
@@ -350,6 +351,9 @@ export class Ledger {
         this._allocateGrain(id, amount);
       }
     }
+    if (distribution.credTimestamp > this._lastDistributionTimestamp) {
+      this._lastDistributionTimestamp = distribution.credTimestamp;
+    }
   }
 
   /**
@@ -439,6 +443,16 @@ export class Ledger {
    */
   serialize(): string {
     return this._ledgerEventLog.toString();
+  }
+
+  /**
+   * Return the cred-effective timestamp for the last Grain distribution.
+   *
+   * We provide this because we may want to have a policy that issues one
+   * distribution for each interval in the history of the project.
+   */
+  lastDistributionTimestamp(): TimestampMs {
+    return this._lastDistributionTimestamp;
   }
 
   _processAction(action: Action) {

--- a/src/ledger/ledger.test.js
+++ b/src/ledger/ledger.test.js
@@ -517,6 +517,28 @@ describe("ledger/ledger", () => {
         const thunk = () => ledger.distributeGrain(distribution);
         failsWithoutMutation(ledger, thunk, "distribute to inactive account");
       });
+      it("updates the last distribution timestamp", () => {
+        const l = new Ledger();
+        expect(l.lastDistributionTimestamp()).toEqual(-Infinity);
+        l.distributeGrain({
+          id: uuid.random(),
+          allocations: [],
+          credTimestamp: 100,
+        });
+        expect(l.lastDistributionTimestamp()).toEqual(100);
+        l.distributeGrain({
+          id: uuid.random(),
+          allocations: [],
+          credTimestamp: 50,
+        });
+        expect(l.lastDistributionTimestamp()).toEqual(100);
+        l.distributeGrain({
+          id: uuid.random(),
+          allocations: [],
+          credTimestamp: 102,
+        });
+        expect(l.lastDistributionTimestamp()).toEqual(102);
+      });
     });
 
     describe("transferGrain", () => {


### PR DESCRIPTION
We need this so we can have a grain policy that creates one distribution per interval for the history of the project.

Test plan: Unit tests