### PR TITLE
Add `fromInteger` to the grain module

### DIFF
--- a/src/ledger/grain.js
+++ b/src/ledger/grain.js
@@ -168,6 +168,17 @@ export function multiplyFloat(grain: Grain, num: number): Grain {
 }
 
 /**
+ * Convert an integer number (in floating-point representation) into a precise
+ * Grain value.
+ */
+export function fromInteger(x: number): Grain {
+  if (!isFinite(x) || Math.floor(x) !== x) {
+    throw new Error(`not an integer: ${x}`);
+  }
+  return (BigInt(ONE) * BigInt(x)).toString();
+}
+
+/**
  * Approximately create a grain balance from a float.
  *
  * This method tries to convert the floating point `amt` into a grain

--- a/src/ledger/grain.test.js
+++ b/src/ledger/grain.test.js
@@ -133,6 +133,28 @@ describe("src/ledger/grain", () => {
       );
     });
   });
+
+  describe("G.fromInteger", () => {
+    it("works on 0", () => {
+      expect(G.fromInteger(0)).toEqual("0");
+    });
+    it("works on 1", () => {
+      expect(G.fromInteger(1)).toEqual(G.ONE);
+    });
+    it("works on 3", () => {
+      expect(G.fromInteger(3)).toEqual("3000000000000000000");
+    });
+    it("works on -3", () => {
+      expect(G.fromInteger(-3)).toEqual("-3000000000000000000");
+    });
+    it("errors for non-integers", () => {
+      for (const bad of [1.2, NaN, Infinity, -Infinity]) {
+        const thunk = () => G.fromInteger(bad);
+        expect(thunk).toThrowError(`not an integer: ${bad}`);
+      }
+    });
+  });
+
   describe("G.fromApproximateFloat", () => {
     it("G.fromApproximateFloat(1) === G.ONE", () => {
       expect(G.fromApproximateFloat(1)).toEqual(G.ONE);


### PR DESCRIPTION
This adds a method for converting integer floats into precise Grain
values.

Unit tests added.