### PR TITLE
add computeDistribution

### DIFF
--- a/src/ledger/computeDistribution.js
+++ b/src/ledger/computeDistribution.js
@@ -1,0 +1,66 @@
+// @flow
+
+import * as uuid from "../util/uuid";
+import {type TimestampMs} from "../util/timestamp";
+import {
+  type AllocationPolicy,
+  type AllocationIdentity,
+  computeAllocation,
+} from "./grainAllocation";
+import {type CredAccountData} from "./credAccounts";
+import {type Distribution} from "./distribution";
+
+/**
+ * Compute a single Distribution using CredAccountData.
+ *
+ * The distribution will include the provided policies.
+ * It will be computed using only Cred intervals that are finished as of the
+ * effectiveTimestamp.
+ *
+ * Note: This method is untested as it is just a bit of plubming; flow gives me
+ * confidence that the semantics are correct. The helper method
+ * _allocationIdentities is tested, as it handles some naunces e.g. slicing
+ * down the cred interval data.
+ */
+export function computeDistribution(
+  policies: $ReadOnlyArray<AllocationPolicy>,
+  accountsData: CredAccountData,
+  effectiveTimestamp: TimestampMs
+): Distribution {
+  const allocationIdentities = _allocationIdentities(
+    accountsData,
+    effectiveTimestamp
+  );
+  const allocations = policies.map((p) =>
+    computeAllocation(p, allocationIdentities)
+  );
+  const distribution = {
+    id: uuid.random(),
+    allocations,
+    credTimestamp: effectiveTimestamp,
+  };
+  return distribution;
+}
+
+export function _allocationIdentities(
+  accountsData: CredAccountData,
+  effectiveTimestamp: TimestampMs
+): $ReadOnlyArray<AllocationIdentity> {
+  const activeAccounts = accountsData.accounts.filter(
+    ({account}) => account.active
+  );
+  const allocationIdentities = activeAccounts.map((x) => ({
+    id: x.account.identity.id,
+    paid: x.account.paid,
+    cred: x.cred,
+  }));
+  const numIntervals = accountsData.intervalEndpoints.filter(
+    (x) => x <= effectiveTimestamp
+  ).length;
+  const timeSlicedAllocationIdentities = allocationIdentities.map((x) => ({
+    id: x.id,
+    paid: x.paid,
+    cred: x.cred.slice(0, numIntervals),
+  }));
+  return timeSlicedAllocationIdentities;
+}

--- a/src/ledger/computeDistribution.test.js
+++ b/src/ledger/computeDistribution.test.js
@@ -1,0 +1,63 @@
+// @flow
+
+import {Ledger} from "./ledger";
+import {NodeAddress} from "../core/graph";
+import {_allocationIdentities} from "./computeDistribution";
+import * as G from "./grain";
+
+describe("ledger/computeDistribution", () => {
+  describe("_allocationIdentities", () => {
+    it("only includes active GrainAccounts", () => {
+      const ledger = new Ledger();
+      const active = ledger.createIdentity("USER", "active");
+      ledger._allocateGrain(active, G.fromString("1"));
+      ledger.activate(active);
+      ledger.createIdentity("USER", "inactive");
+      const accounts = ledger.accounts().map((a) => ({
+        account: a,
+        cred: [1, 2, 3],
+        totalCred: 6,
+      }));
+      const unclaimedAliases = [
+        {
+          address: NodeAddress.empty,
+          cred: [4, 5, 6],
+          totalCred: 15,
+          description: "irrelevant",
+        },
+      ];
+      const accountsData = {
+        intervalEndpoints: [123, 125, 127],
+        accounts,
+        unclaimedAliases,
+      };
+      const expectedAllocationIdentites = [
+        {id: active, cred: [1, 2, 3], paid: "1"},
+      ];
+      expect(_allocationIdentities(accountsData, 999)).toEqual(
+        expectedAllocationIdentites
+      );
+    });
+    it("time slices the cred as expected", () => {
+      const ledger = new Ledger();
+      const active = ledger.createIdentity("USER", "active");
+      ledger._allocateGrain(active, G.fromString("1"));
+      ledger.activate(active);
+      ledger.createIdentity("USER", "inactive");
+      const accounts = ledger.accounts().map((a) => ({
+        account: a,
+        cred: [1, 2, 3],
+        totalCred: 6,
+      }));
+      const accountsData = {
+        intervalEndpoints: [123, 125, 127],
+        accounts,
+        unclaimedAliases: [],
+      };
+      const expectedAllocationIdentites = [{id: active, cred: [1], paid: "1"}];
+      expect(_allocationIdentities(accountsData, 123)).toEqual(
+        expectedAllocationIdentites
+      );
+    });
+  });
+});


### PR DESCRIPTION
This commit adds a small, moderately tested module for actually
computing Grain distributions using the cred account data, some
allocation policies, and a cred effective timestamp (i.e. gives us the
ability to simulate a distribution for a past interval).

Test plan: `yarn test`