### PR TITLE
Add the `cli/grain` command for distributing Grain

### DIFF
--- a/config/webpack.config.web.js
+++ b/config/webpack.config.web.js
@@ -89,6 +89,26 @@ async function makeConfig(
           "/config/",
           express.static(path.join(developmentInstancePath, "config"))
         );
+        app.use(
+          "/data/",
+          express.static(path.join(developmentInstancePath, "data"))
+        );
+
+        // configure the dev server to support writing the ledger to disk
+        app.use(express.text());
+        const ledgerPath = path.join(
+          developmentInstancePath,
+          "data/ledger.json"
+        );
+
+        app.post("/data/ledger.json", (req, res) => {
+          try {
+            fs.writeFileSync(ledgerPath, req.body, "utf8");
+          } catch (e) {
+            res.status(500).send(`error saving ledger.json file: ${e}`);
+          }
+          res.status(201).end();
+        });
       },
     },
     output: {

--- a/src/api/grainConfig.js
+++ b/src/api/grainConfig.js
@@ -1,0 +1,57 @@
+// @flow
+
+import {type DistributionPolicy} from "../ledger/applyDistributions";
+import * as G from "../ledger/grain";
+import * as C from "../util/combo";
+import * as NullUtil from "../util/null";
+
+export type GrainConfig = {|
+  +immediatePerWeek: number,
+  +balancedPerWeek: number,
+  +maxSimultaneousDistributions?: number,
+|};
+
+export const parser: C.Parser<GrainConfig> = C.object(
+  {
+    immediatePerWeek: C.number,
+    balancedPerWeek: C.number,
+  },
+  {
+    maxSimultaneousDistributions: C.number,
+  }
+);
+
+export function toDistributionPolicy(x: GrainConfig): DistributionPolicy {
+  if (!isNonnegativeInteger(x.immediatePerWeek)) {
+    throw new Error(
+      `immediate budget must be nonnegative integer, got ${x.immediatePerWeek}`
+    );
+  }
+  if (!isNonnegativeInteger(x.balancedPerWeek)) {
+    throw new Error(
+      `balanced budget must be nonnegative integer, got ${x.balancedPerWeek}`
+    );
+  }
+  const allocationPolicies = [];
+  if (x.immediatePerWeek > 0) {
+    allocationPolicies.push({
+      budget: G.fromInteger(x.immediatePerWeek),
+      policyType: "IMMEDIATE",
+    });
+  }
+  if (x.balancedPerWeek > 0) {
+    allocationPolicies.push({
+      budget: G.fromInteger(x.balancedPerWeek),
+      policyType: "BALANCED",
+    });
+  }
+  const maxSimultaneousDistributions = NullUtil.orElse(
+    x.maxSimultaneousDistributions,
+    Infinity
+  );
+  return {allocationPolicies, maxSimultaneousDistributions};
+}
+
+function isNonnegativeInteger(x: number): boolean {
+  return x >= 0 && isFinite(x) && Math.floor(x) === x;
+}

--- a/src/cli/grain.js
+++ b/src/cli/grain.js
@@ -1,0 +1,76 @@
+// @flow
+
+import fs from "fs-extra";
+import {join} from "path";
+import {loadJson, loadJsonWithDefault} from "../util/disk";
+import {fromJSON as credResultFromJson} from "../analysis/credResult";
+import {CredView} from "../analysis/credView";
+import {Ledger, parser as ledgerParser} from "../ledger/ledger";
+import {applyDistributions} from "../ledger/applyDistributions";
+import {computeCredAccounts} from "../ledger/credAccounts";
+import stringify from "json-stable-stringify";
+import * as G from "../ledger/grain";
+
+import * as GrainConfig from "../api/grainConfig";
+import type {Command} from "./command";
+
+function die(std, message) {
+  std.err("fatal: " + message);
+  return 1;
+}
+
+const grainCommand: Command = async (args, std) => {
+  if (args.length !== 0) {
+    return die(std, "usage: sourcecred grain");
+  }
+
+  const baseDir = process.cwd();
+  const grainConfigPath = join(baseDir, "config", "grain.json");
+  const grainConfig = await loadJson(grainConfigPath, GrainConfig.parser);
+  const distributionPolicy = GrainConfig.toDistributionPolicy(grainConfig);
+
+  const credResultPath = join(baseDir, "output", "credResult.json");
+  const credResultJson = JSON.parse(await fs.readFile(credResultPath));
+  const credResult = credResultFromJson(credResultJson);
+  const credView = new CredView(credResult);
+
+  const ledgerPath = join(baseDir, "data", "ledger.json");
+  const ledger = await loadJsonWithDefault(
+    ledgerPath,
+    ledgerParser,
+    () => new Ledger()
+  );
+
+  const distributions = applyDistributions(
+    distributionPolicy,
+    credView,
+    ledger
+  );
+
+  let totalDistributed = G.ZERO;
+  const recipientIdentities = new Set();
+  for (const {allocations} of distributions) {
+    for (const {receipts} of allocations) {
+      for (const {amount, id} of receipts) {
+        totalDistributed = G.add(amount, totalDistributed);
+        recipientIdentities.add(id);
+      }
+    }
+  }
+
+  console.log(
+    `Distributed ${G.format(totalDistributed)} to ${
+      recipientIdentities.size
+    } identities in ${distributions.length} distributions`
+  );
+
+  await fs.writeFile(ledgerPath, ledger.serialize());
+
+  const credAccounts = computeCredAccounts(ledger, credView);
+  const accountsPath = join(baseDir, "output", "accounts.json");
+  await fs.writeFile(accountsPath, stringify(credAccounts));
+
+  return 0;
+};
+
+export default grainCommand;

--- a/src/cli/sourcecred.js
+++ b/src/cli/sourcecred.js
@@ -9,6 +9,7 @@ import score from "./score";
 import site from "./site";
 import go from "./go";
 import admin from "./admin";
+import grain from "./grain";
 import help from "./help";
 
 const sourcecred: Command = async (args, std) => {
@@ -35,6 +36,8 @@ const sourcecred: Command = async (args, std) => {
       return go(args.slice(1), std);
     case "admin":
       return admin(args.slice(1), std);
+    case "grain":
+      return grain(args.slice(1), std);
     default:
       std.err("fatal: unknown command: " + JSON.stringify(args[0]));
       std.err("fatal: run 'sourcecred help' for commands and usage");

--- a/src/ledger/applyDistributions.js
+++ b/src/ledger/applyDistributions.js
@@ -1,0 +1,79 @@
+// @flow
+
+import {type TimestampMs} from "../util/timestamp";
+import {Ledger} from "./ledger";
+import {type AllocationPolicy} from "./grainAllocation";
+import {CredView} from "../analysis/credView";
+import {computeCredAccounts} from "./credAccounts";
+import {computeDistribution} from "./computeDistribution";
+import {type Distribution} from "./distribution";
+
+export type DistributionPolicy = {|
+  // Each distribution will include each of the specified allocation policies
+  +allocationPolicies: $ReadOnlyArray<AllocationPolicy>,
+  // How many old distributions we may create (e.g. if the project has never
+  // had a Grain distribution in the past, do you want to create distributions
+  // going back the whole history, or limit to only 1 or 2 recent distributions).
+  +maxSimultaneousDistributions: number,
+|};
+
+/**
+ * Iteratively compute and distribute Grain, based on the provided CredView,
+ * into the provided Ledger, according to the specified DistributionPolicy.
+ *
+ * Here are some examples of how it works:
+ *
+ * - The last time there was a distribution was two days ago. Since then,
+ *   no new Cred Intervals have been completed. This method will no-op.
+ *
+ * - The last time there was a distribution was last week. Since then, one new
+ *   Cred Interval has been completed. The method will apply one Distribution.
+ *
+ * - The last time there was a distribution was a month ago. Since then, four
+ *   Cred Intervals have been completed. The method will apply four Distributions,
+ *   unless maxOldDistributions is set to a lower number (e.g. 2), in which case
+ *   that maximum number of distributions will be applied.
+ *
+ * It returns the list of applied distributions, which may be helpful for
+ * diagnostics, printing a summary, etc.
+ */
+export function applyDistributions(
+  policy: DistributionPolicy,
+  view: CredView,
+  ledger: Ledger
+): $ReadOnlyArray<Distribution> {
+  const credIntervals = view.credResult().credData.intervalEnds;
+  const distributionIntervals = _chooseDistributionIntervals(
+    credIntervals,
+    ledger.lastDistributionTimestamp(),
+    policy.maxSimultaneousDistributions
+  );
+  return distributionIntervals.map((endpoint) => {
+    // Recompute for every endpoint because the Ledger will be in a different state
+    // (wrt paid balances)
+    const accountsData = computeCredAccounts(ledger, view);
+    const distribution = computeDistribution(
+      policy.allocationPolicies,
+      accountsData,
+      endpoint
+    );
+    ledger.distributeGrain(distribution);
+    return distribution;
+  });
+}
+
+export function _chooseDistributionIntervals(
+  credIntervals: $ReadOnlyArray<TimestampMs>,
+  lastDistributionTimestamp: TimestampMs,
+  maxSimultaneousDistributions: number
+): $ReadOnlyArray<TimestampMs> {
+  // Slice off the final interval--we may assume that it is not yet finished.
+  const completeIntervals = credIntervals.slice(0, credIntervals.length - 1);
+  const undistributedIntervals = completeIntervals.filter(
+    (i) => i > lastDistributionTimestamp
+  );
+  return undistributedIntervals.slice(
+    undistributedIntervals.length - maxSimultaneousDistributions,
+    undistributedIntervals.length
+  );
+}

--- a/src/ledger/applyDistributions.test.js
+++ b/src/ledger/applyDistributions.test.js
@@ -1,0 +1,60 @@
+// @flow
+
+import {_chooseDistributionIntervals} from "./applyDistributions";
+
+describe("ledger/applyDistributions", () => {
+  describe("_chooseDistributionIntervals", () => {
+    it("handles a case where we want to distribute for every interval except latest", () => {
+      const credIntervals = [1, 2, 3];
+      const lastDistributionTimestamp = -Infinity;
+      const maxSimultaneousDistributions = Infinity;
+      const expected = [1, 2];
+      expect(
+        _chooseDistributionIntervals(
+          credIntervals,
+          lastDistributionTimestamp,
+          maxSimultaneousDistributions
+        )
+      ).toEqual(expected);
+    });
+    it("handles the case where maxSimultaneousDistributions === 0", () => {
+      const credIntervals = [1, 2, 3];
+      const lastDistributionTimestamp = -Infinity;
+      const maxSimultaneousDistributions = 0;
+      const expected = [];
+      expect(
+        _chooseDistributionIntervals(
+          credIntervals,
+          lastDistributionTimestamp,
+          maxSimultaneousDistributions
+        )
+      ).toEqual(expected);
+    });
+    it("handles the case where we've already distributed for the finished intervals", () => {
+      const credIntervals = [1, 2, 3];
+      const lastDistributionTimestamp = 2;
+      const maxSimultaneousDistributions = 0;
+      const expected = [];
+      expect(
+        _chooseDistributionIntervals(
+          credIntervals,
+          lastDistributionTimestamp,
+          maxSimultaneousDistributions
+        )
+      ).toEqual(expected);
+    });
+    it("handles the case where we're limited by maxSimultaneousDistributions", () => {
+      const credIntervals = [1, 2, 3];
+      const lastDistributionTimestamp = -Infinity;
+      const maxSimultaneousDistributions = 1;
+      const expected = [2];
+      expect(
+        _chooseDistributionIntervals(
+          credIntervals,
+          lastDistributionTimestamp,
+          maxSimultaneousDistributions
+        )
+      ).toEqual(expected);
+    });
+  });
+});


### PR DESCRIPTION
This adds a new CLI command, `sourcecred grain`, which distributes
Grain. This happens based on a GrainConfig file, at `config/grain.json`.

The GrainConfig has a basic policy where you specify how much gets
distributed using the IMMEDIATE and BALANCED strategies. You also
specify how many weeks worth of distributions can be done at once.

This parameter is relevant because SC wants to create one distribution
per week, so that if (for example) you forgot to run the script for the
past 4 weeks, it will create 4 distributions for you. However, you might
not want this, or you might want to go back only a little while... e.g.
if you're running SC for the first time on an old project and don't want
to issue hundreds of distributions worth of Grain. So you can tune it
via the `maxSimultaneousDistributions` parameter, which defaults to
Infinity if unset.

Test plan: Tested via actual Grain distributions. This is the kind of
"wire everything together" code that's annoying to test and unlikely to
have subtle bugs, so the unit testing is spotty.