### PR TITLE
remove Ledger action versioning

### DIFF
--- a/src/ledger/__snapshots__/ledger.test.js.snap
+++ b/src/ledger/__snapshots__/ledger.test.js.snap
@@ -2,12 +2,12 @@
 
 exports[`ledger/ledger state reconstruction serialized ledger snapshots as expected 1`] = `
 "[
-{\\"action\\":{\\"identity\\":{\\"address\\":\\"N\\\\u0000sourcecred\\\\u0000core\\\\u0000IDENTITY\\\\u0000USER\\\\u0000YVZhbGlkVXVpZEF0TGFzdA\\\\u0000\\",\\"aliases\\":[],\\"id\\":\\"YVZhbGlkVXVpZEF0TGFzdA\\",\\"name\\":\\"steven\\",\\"subtype\\":\\"USER\\"},\\"type\\":\\"CREATE_IDENTITY\\",\\"version\\":\\"1\\"},\\"ledgerTimestamp\\":1,\\"version\\":\\"1\\"},
-{\\"action\\":{\\"identity\\":{\\"address\\":\\"N\\\\u0000sourcecred\\\\u0000core\\\\u0000IDENTITY\\\\u0000ORGANIZATION\\\\u0000URgLrCxgvjHxtGJ9PgmckQ\\\\u0000\\",\\"aliases\\":[],\\"id\\":\\"URgLrCxgvjHxtGJ9PgmckQ\\",\\"name\\":\\"crystal-gems\\",\\"subtype\\":\\"ORGANIZATION\\"},\\"type\\":\\"CREATE_IDENTITY\\",\\"version\\":\\"1\\"},\\"ledgerTimestamp\\":2,\\"version\\":\\"1\\"},
-{\\"action\\":{\\"alias\\":\\"N\\\\u0000a1\\\\u0000\\",\\"identityId\\":\\"YVZhbGlkVXVpZEF0TGFzdA\\",\\"type\\":\\"ADD_ALIAS\\",\\"version\\":\\"1\\"},\\"ledgerTimestamp\\":3,\\"version\\":\\"1\\"},
-{\\"action\\":{\\"identityId\\":\\"YVZhbGlkVXVpZEF0TGFzdA\\",\\"type\\":\\"TOGGLE_ACTIVATION\\",\\"version\\":\\"1\\"},\\"ledgerTimestamp\\":4,\\"version\\":\\"1\\"},
-{\\"action\\":{\\"identityId\\":\\"URgLrCxgvjHxtGJ9PgmckQ\\",\\"type\\":\\"TOGGLE_ACTIVATION\\",\\"version\\":\\"1\\"},\\"ledgerTimestamp\\":4,\\"version\\":\\"1\\"},
-{\\"action\\":{\\"distribution\\":{\\"allocations\\":[{\\"id\\":\\"yYNur0NEEkh7fMaUn6n9QQ\\",\\"policy\\":{\\"budget\\":\\"100\\",\\"policyType\\":\\"IMMEDIATE\\"},\\"receipts\\":[{\\"amount\\":\\"50\\",\\"id\\":\\"YVZhbGlkVXVpZEF0TGFzdA\\"},{\\"amount\\":\\"50\\",\\"id\\":\\"URgLrCxgvjHxtGJ9PgmckQ\\"}]}],\\"credTimestamp\\":1,\\"id\\":\\"f9xPz9YGH0PuBpPAg2824Q\\"},\\"type\\":\\"DISTRIBUTE_GRAIN\\",\\"version\\":\\"1\\"},\\"ledgerTimestamp\\":4,\\"version\\":\\"1\\"},
-{\\"action\\":{\\"amount\\":\\"10\\",\\"from\\":\\"YVZhbGlkVXVpZEF0TGFzdA\\",\\"memo\\":null,\\"to\\":\\"URgLrCxgvjHxtGJ9PgmckQ\\",\\"type\\":\\"TRANSFER_GRAIN\\",\\"version\\":\\"1\\"},\\"ledgerTimestamp\\":5,\\"version\\":\\"1\\"}
+{\\"action\\":{\\"identity\\":{\\"address\\":\\"N\\\\u0000sourcecred\\\\u0000core\\\\u0000IDENTITY\\\\u0000USER\\\\u0000YVZhbGlkVXVpZEF0TGFzdA\\\\u0000\\",\\"aliases\\":[],\\"id\\":\\"YVZhbGlkVXVpZEF0TGFzdA\\",\\"name\\":\\"steven\\",\\"subtype\\":\\"USER\\"},\\"type\\":\\"CREATE_IDENTITY\\"},\\"ledgerTimestamp\\":1,\\"version\\":\\"1\\"},
+{\\"action\\":{\\"identity\\":{\\"address\\":\\"N\\\\u0000sourcecred\\\\u0000core\\\\u0000IDENTITY\\\\u0000ORGANIZATION\\\\u0000URgLrCxgvjHxtGJ9PgmckQ\\\\u0000\\",\\"aliases\\":[],\\"id\\":\\"URgLrCxgvjHxtGJ9PgmckQ\\",\\"name\\":\\"crystal-gems\\",\\"subtype\\":\\"ORGANIZATION\\"},\\"type\\":\\"CREATE_IDENTITY\\"},\\"ledgerTimestamp\\":2,\\"version\\":\\"1\\"},
+{\\"action\\":{\\"alias\\":\\"N\\\\u0000a1\\\\u0000\\",\\"identityId\\":\\"YVZhbGlkVXVpZEF0TGFzdA\\",\\"type\\":\\"ADD_ALIAS\\"},\\"ledgerTimestamp\\":3,\\"version\\":\\"1\\"},
+{\\"action\\":{\\"identityId\\":\\"YVZhbGlkVXVpZEF0TGFzdA\\",\\"type\\":\\"TOGGLE_ACTIVATION\\"},\\"ledgerTimestamp\\":4,\\"version\\":\\"1\\"},
+{\\"action\\":{\\"identityId\\":\\"URgLrCxgvjHxtGJ9PgmckQ\\",\\"type\\":\\"TOGGLE_ACTIVATION\\"},\\"ledgerTimestamp\\":4,\\"version\\":\\"1\\"},
+{\\"action\\":{\\"distribution\\":{\\"allocations\\":[{\\"id\\":\\"yYNur0NEEkh7fMaUn6n9QQ\\",\\"policy\\":{\\"budget\\":\\"100\\",\\"policyType\\":\\"IMMEDIATE\\"},\\"receipts\\":[{\\"amount\\":\\"50\\",\\"id\\":\\"YVZhbGlkVXVpZEF0TGFzdA\\"},{\\"amount\\":\\"50\\",\\"id\\":\\"URgLrCxgvjHxtGJ9PgmckQ\\"}]}],\\"credTimestamp\\":1,\\"id\\":\\"f9xPz9YGH0PuBpPAg2824Q\\"},\\"type\\":\\"DISTRIBUTE_GRAIN\\"},\\"ledgerTimestamp\\":4,\\"version\\":\\"1\\"},
+{\\"action\\":{\\"amount\\":\\"10\\",\\"from\\":\\"YVZhbGlkVXVpZEF0TGFzdA\\",\\"memo\\":null,\\"to\\":\\"URgLrCxgvjHxtGJ9PgmckQ\\",\\"type\\":\\"TRANSFER_GRAIN\\"},\\"ledgerTimestamp\\":5,\\"version\\":\\"1\\"}
 ]"
 `;

--- a/src/ledger/ledger.js
+++ b/src/ledger/ledger.js
@@ -126,7 +126,6 @@ export class Ledger {
     const action = {
       type: "CREATE_IDENTITY",
       identity,
-      version: "1",
     };
     this._createAndProcessEvent(action);
     return NullUtil.get(this._identityNameToId.get(identity.name));
@@ -173,7 +172,6 @@ export class Ledger {
       type: "RENAME_IDENTITY",
       identityId,
       newName: identityNameFromString(newName),
-      version: "1",
     });
     return this;
   }
@@ -223,7 +221,6 @@ export class Ledger {
       type: "ADD_ALIAS",
       identityId,
       alias,
-      version: "1",
     });
     return this;
   }
@@ -279,7 +276,6 @@ export class Ledger {
     } else {
       this._createAndProcessEvent({
         type: "TOGGLE_ACTIVATION",
-        version: "1",
         identityId: id,
       });
       return this;
@@ -302,7 +298,6 @@ export class Ledger {
     if (active) {
       this._createAndProcessEvent({
         type: "TOGGLE_ACTIVATION",
-        version: "1",
         identityId: id,
       });
       return this;
@@ -325,7 +320,6 @@ export class Ledger {
   distributeGrain(distribution: Distribution): Ledger {
     this._createAndProcessEvent({
       type: "DISTRIBUTE_GRAIN",
-      version: "1",
       distribution,
     });
     return this;
@@ -382,7 +376,6 @@ export class Ledger {
       amount,
       memo,
       type: "TRANSFER_GRAIN",
-      version: "1",
     });
     return this;
   }
@@ -538,66 +531,55 @@ type Action =
 
 type CreateIdentity = {|
   +type: "CREATE_IDENTITY",
-  +version: "1",
   +identity: Identity,
 |};
 const createIdentityParser: C.Parser<CreateIdentity> = C.object({
   type: C.exactly(["CREATE_IDENTITY"]),
-  version: C.exactly(["1"]),
   identity: identityParser,
 });
 
 type RenameIdentity = {|
   +type: "RENAME_IDENTITY",
-  +version: "1",
   +identityId: IdentityId,
   +newName: IdentityName,
 |};
 const renameIdentityParser: C.Parser<RenameIdentity> = C.object({
   type: C.exactly(["RENAME_IDENTITY"]),
-  version: C.exactly(["1"]),
   identityId: uuidParser,
   newName: identityNameParser,
 });
 
 type AddAlias = {|
   +type: "ADD_ALIAS",
-  +version: "1",
   +identityId: IdentityId,
   +alias: NodeAddressT,
 |};
 const addAliasParser: C.Parser<AddAlias> = C.object({
   type: C.exactly(["ADD_ALIAS"]),
-  version: C.exactly(["1"]),
   identityId: uuidParser,
   alias: NodeAddress.parser,
 });
 
 type ToggleActivation = {|
   +type: "TOGGLE_ACTIVATION",
-  +version: "1",
   +identityId: IdentityId,
 |};
 const toggleActivationParser: C.Parser<ToggleActivation> = C.object({
   type: C.exactly(["TOGGLE_ACTIVATION"]),
-  version: C.exactly(["1"]),
   identityId: uuidParser,
 });
 
 type DistributeGrain = {|
   +type: "DISTRIBUTE_GRAIN",
-  +version: "1",
   +distribution: Distribution,
 |};
 const distributeGrainParser: C.Parser<DistributeGrain> = C.object({
   type: C.exactly(["DISTRIBUTE_GRAIN"]),
-  version: C.exactly(["1"]),
   distribution: distributionParser,
 });
 
 type TransferGrain = {|
   +type: "TRANSFER_GRAIN",
-  +version: "1",
   +from: IdentityId,
   +to: IdentityId,
   +amount: G.Grain,
@@ -605,7 +587,6 @@ type TransferGrain = {|
 |};
 const transferGrainParser: C.Parser<TransferGrain> = C.object({
   type: C.exactly(["TRANSFER_GRAIN"]),
-  version: C.exactly(["1"]),
   from: uuidParser,
   to: uuidParser,
   amount: G.parser,

--- a/src/ledger/ledger.test.js
+++ b/src/ledger/ledger.test.js
@@ -86,7 +86,6 @@ describe("ledger/ledger", () => {
             action: {
               type: "CREATE_IDENTITY",
               identity,
-              version: "1",
             },
           },
         ]);
@@ -106,7 +105,7 @@ describe("ledger/ledger", () => {
         const ledger = new Ledger();
         let identity = newIdentity("USER", "foo");
         identity = {...identity, aliases: [NodeAddress.empty]};
-        const action = {type: "CREATE_IDENTITY", identity, version: "1"};
+        const action = {type: "CREATE_IDENTITY", identity};
         const thunk = () => ledger._createIdentity(action);
         expect(thunk).toThrowError("new identities may not have aliases");
       });
@@ -136,7 +135,6 @@ describe("ledger/ledger", () => {
             version: "1",
             action: {
               type: "CREATE_IDENTITY",
-              version: "1",
               identity: initialIdentity,
             },
           },
@@ -145,7 +143,6 @@ describe("ledger/ledger", () => {
             version: "1",
             action: {
               type: "RENAME_IDENTITY",
-              version: "1",
               newName: "bar",
               identityId: id,
             },
@@ -204,7 +201,6 @@ describe("ledger/ledger", () => {
             version: "1",
             action: {
               type: "CREATE_IDENTITY",
-              version: "1",
               identity: expect.anything(),
             },
           },
@@ -213,7 +209,6 @@ describe("ledger/ledger", () => {
             version: "1",
             action: {
               type: "ADD_ALIAS",
-              version: "1",
               identityId: id,
               alias: a1,
             },
@@ -297,7 +292,7 @@ describe("ledger/ledger", () => {
         expect.anything(),
         {
           ledgerTimestamp: expect.anything(),
-          action: {type: "TOGGLE_ACTIVATION", version: "1", identityId: id1},
+          action: {type: "TOGGLE_ACTIVATION", identityId: id1},
           version: "1",
         },
       ]);
@@ -318,12 +313,12 @@ describe("ledger/ledger", () => {
         expect.anything(),
         {
           ledgerTimestamp: expect.anything(),
-          action: {type: "TOGGLE_ACTIVATION", version: "1", identityId: id1},
+          action: {type: "TOGGLE_ACTIVATION", identityId: id1},
           version: "1",
         },
         {
           ledgerTimestamp: expect.anything(),
-          action: {type: "TOGGLE_ACTIVATION", version: "1", identityId: id1},
+          action: {type: "TOGGLE_ACTIVATION", identityId: id1},
           version: "1",
         },
       ]);
@@ -391,7 +386,7 @@ describe("ledger/ledger", () => {
           {
             version: "1",
             ledgerTimestamp: 2,
-            action: {type: "DISTRIBUTE_GRAIN", version: "1", distribution},
+            action: {type: "DISTRIBUTE_GRAIN", distribution},
           },
         ]);
       });
@@ -580,7 +575,6 @@ describe("ledger/ledger", () => {
             version: "1",
             action: {
               type: "TRANSFER_GRAIN",
-              version: "1",
               amount: "80",
               memo: "test",
               from: id1,


### PR DESCRIPTION
This removes the version field from the ledger actions. Since writing
the Ledger, I've made many breaking changes. (Which has been fine, since
we don't have any ledgers in production yet.)  Over the course of making
those breaking changes, I've noticed that bumping a version on an
individual action never has felt like a useful affordance. Most of the
changes affect the semantics of the system as a whole; but the
individual primitives are quite stable.

We're more likely to need versioning on the whole Ledger, with upgrade
paths, than we are to need versioning on individual actions. And if we
do need to make a new version of a specific action, we can just put a
version suffix in the type field.

Test plan: `yarn test` suffices.