### PR TITLE
Copy built site files instead of using a symlink

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "description": "a tool for communities to measure and reward value creation",
   "homepage": "https://sourcecred.io",
   "repository": "github:sourcecred/sourcecred",
-  "version": "0.7.0-beta-3",
+  "version": "0.7.0-beta-4",
   "private": false,
   "dependencies": {
     "aphrodite": "^2.4.0",
@@ -106,7 +106,7 @@
     "prettify": "prettier --write '**/*.js'",
     "check-pretty": "prettier --list-different '**/*.js'",
     "start": "NODE_ENV=development webpack-dev-server --config config/webpack.config.web.js",
-    "build": "run-p build:* && ln -sf ../build ./bin/site-template && chmod +x ./bin/sourcecred.js",
+    "build": "run-p build:* && cp -r ./build ./bin/site-template && chmod +x ./bin/sourcecred.js",
     "build:frontend": "NODE_ENV=production webpack --config config/webpack.config.web.js",
     "build:backend": "NODE_ENV=development webpack --config config/webpack.config.backend.js",
     "api": "webpack --config config/webpack.config.api.js",
@@ -155,9 +155,6 @@
       "mjs"
     ]
   },
-  "files": [
-    "/bin",
-    "/build"
-  ],
+  "files": ["/bin"],
   "bin": "./bin/sourcecred.js"
 }


### PR DESCRIPTION
The published NPM package has a broken symlink error when trying to run the `sourcecred site` command.
This copies the built files instead and removes the build folder from the published package.json

Test Plan: Install new version of NPM package in the example instance and ensure that running `yarn site` succeeds