### PR TITLE
Implement Initiatives plugin for new CLI

### DIFF
--- a/src/api/bundledPlugins.js
+++ b/src/api/bundledPlugins.js
@@ -4,6 +4,7 @@ import type {Plugin} from "./plugin";
 import {GithubPlugin} from "../plugins/github/plugin";
 import {DiscoursePlugin} from "../plugins/discourse/plugin";
 import {DiscordPlugin} from "../plugins/experimental-discord/plugin";
+import {InitiativesPlugin} from "../plugins/initiatives/plugin";
 
 /**
  * Returns an object mapping owner-name pairs to CLI plugin
@@ -15,5 +16,6 @@ export function bundledPlugins(): {[pluginId: string]: Plugin} {
     "sourcecred/github": new GithubPlugin(),
     "sourcecred/discourse": new DiscoursePlugin(),
     "sourcecred/discord": new DiscordPlugin(),
+    "sourcecred/initiatives": new InitiativesPlugin(),
   };
 }

--- a/src/plugins/initiatives/__snapshots__/initiativesDirectory.test.js.snap
+++ b/src/plugins/initiatives/__snapshots__/initiativesDirectory.test.js.snap
@@ -67,6 +67,7 @@ Map {
           "contributors": Array [
             "https://foo.bar/C/contrib-user",
           ],
+          "timestampIso": "2020-01-01T22:01:57.700Z",
           "title": "Add test contrib",
           "weight": 10,
         },
@@ -89,6 +90,7 @@ Map {
           "contributors": Array [
             "https://foo.bar/C/ref-user",
           ],
+          "timestampIso": "2020-01-03T22:01:57.700Z",
           "title": "Add test reference",
         },
       ],
@@ -210,7 +212,7 @@ exports[`plugins/initiatives/initiativesDirectory loadDirectory should handle an
             \\"https://foo.bar/C/contrib-user\\"
           ],
           \\"key\\": \\"add-test-contrib\\",
-          \\"timestampMs\\": 1578520917733,
+          \\"timestampMs\\": 1577916117700,
           \\"title\\": \\"Add test contrib\\",
           \\"weight\\": 10
         }
@@ -245,7 +247,7 @@ exports[`plugins/initiatives/initiativesDirectory loadDirectory should handle an
             \\"https://foo.bar/C/ref-user\\"
           ],
           \\"key\\": \\"add-test-reference\\",
-          \\"timestampMs\\": 1578520917733,
+          \\"timestampMs\\": 1578088917700,
           \\"title\\": \\"Add test reference\\",
           \\"weight\\": null
         }

--- a/src/plugins/initiatives/example/initiative-C.json
+++ b/src/plugins/initiatives/example/initiative-C.json
@@ -17,6 +17,7 @@
         {
           "title": "Add test contrib",
           "weight": 10,
+          "timestampIso": "2020-01-01T22:01:57.700Z",
           "contributors": ["https://foo.bar/C/contrib-user"]
         }
       ]
@@ -34,6 +35,7 @@
       "entries": [
         {
           "title": "Add test reference",
+          "timestampIso": "2020-01-03T22:01:57.700Z",
           "contributors": ["https://foo.bar/C/ref-user"]
         }
       ]

--- a/src/plugins/initiatives/initiativesDirectory.js
+++ b/src/plugins/initiatives/initiativesDirectory.js
@@ -6,7 +6,6 @@ import globby from "globby";
 import {type URL} from "../../core/references";
 import {type NodeAddressT} from "../../core/graph";
 import * as Timestamp from "../../util/timestamp";
-import {compatReader} from "../../backend/compatIO";
 import {normalizeEdgeSpec} from "./edgeSpec";
 import {
   type ReferenceDetector,
@@ -19,10 +18,11 @@ import {
 } from "./initiative";
 import {
   type InitiativeFile,
-  fromJSON,
   initiativeFileURL,
   initiativeFileId,
 } from "./initiativeFile";
+import {loadJson} from "../../util/disk";
+import {parser as initiativeParser} from "./parseInitiative";
 
 /**
  * Represents an Initiatives directory.
@@ -108,7 +108,6 @@ export async function _readFiles(
   fileNames: $ReadOnlyArray<string>
 ): Promise<NamesToInitiativeFiles> {
   const map: NamesToInitiativeFiles = new Map();
-  const readInitiativeFile = compatReader(fromJSON, "Initiative");
 
   // Sorting to be careful about predictability.
   // The eventual output of $ReadOnlyArray<Initiative> is ordered, so we'll see
@@ -116,7 +115,7 @@ export async function _readFiles(
   const sortedFileNames = [...fileNames].sort();
   for (const fileName of sortedFileNames) {
     const filePath = path.join(localPath, fileName);
-    const initiativeFile = await readInitiativeFile(filePath);
+    const initiativeFile = await loadJson(filePath, initiativeParser);
     map.set(fileName, initiativeFile);
   }
 

--- a/src/plugins/initiatives/initiativesDirectory.test.js
+++ b/src/plugins/initiatives/initiativesDirectory.test.js
@@ -156,7 +156,7 @@ describe("plugins/initiatives/initiativesDirectory", () => {
       const p = _readFiles(localPath, fileNames);
 
       // Then
-      await expect(p).rejects.toThrow("Could not find Initiative file at:");
+      await expect(p).rejects.toThrow("ENOENT: no such file or directory");
     });
 
     it("should throw when directory is not a directory", async () => {
@@ -173,7 +173,7 @@ describe("plugins/initiatives/initiativesDirectory", () => {
       const p = _readFiles(localPath, fileNames);
 
       // Then
-      await expect(p).rejects.toThrow("Could not find Initiative file at:");
+      await expect(p).rejects.toThrow("ENOTDIR: not a directory");
     });
   });
 

--- a/src/plugins/initiatives/parseInitiative.js
+++ b/src/plugins/initiatives/parseInitiative.js
@@ -33,10 +33,13 @@ const NodeEntryParser = C.object(
   }
 );
 
-const EdgeSpecParser = C.object({
-  urls: C.array(URLParser),
-  entries: C.array(NodeEntryParser),
-});
+const EdgeSpecParser = C.object(
+  {},
+  {
+    urls: C.array(URLParser),
+    entries: C.array(NodeEntryParser),
+  }
+);
 
 const Parse_020: C.Parser<InitiativeFileV020> = C.object(CommonFields, {
   contributions: EdgeSpecParser,

--- a/src/plugins/initiatives/plugin.js
+++ b/src/plugins/initiatives/plugin.js
@@ -1,0 +1,82 @@
+// @flow
+import type {Plugin, PluginDirectoryContext} from "../../api/plugin";
+import type {PluginDeclaration} from "../../analysis/pluginDeclaration";
+import {parser, type InitiativesConfig} from "./config";
+import {declaration} from "./declaration";
+import {join as pathJoin} from "path";
+import type {ReferenceDetector} from "../../core/references";
+import type {WeightedGraph} from "../../core/weightedGraph";
+import {weightsForDeclaration} from "../../analysis/pluginDeclaration";
+import {createWeightedGraph} from "./createGraph";
+import {
+  type PluginId,
+  fromString as pluginIdFromString,
+} from "../../api/pluginId";
+import {loadJson} from "../../util/disk";
+import {loadDirectory as _loadDirectory} from "./initiativesDirectory";
+import * as Weights from "../../core/weights";
+
+async function loadConfig(
+  dirContext: PluginDirectoryContext
+): Promise<InitiativesConfig> {
+  const dirname = dirContext.configDirectory();
+  const path = pathJoin(dirname, "config.json");
+  return loadJson(path, parser);
+}
+
+const DIRECTORY_ENV_VAR_NAME = "SOURCECRED_INITIATIVES_DIRECTORY";
+
+function getDirectoryFromEnv(): string {
+  const rawDir = process.env[DIRECTORY_ENV_VAR_NAME] || "initiatives";
+  if (rawDir == null) {
+    throw new Error(
+      `No initiatives directory provided: set ${DIRECTORY_ENV_VAR_NAME}`
+    );
+  }
+  return rawDir;
+}
+
+export class InitiativesPlugin implements Plugin {
+  id: PluginId = pluginIdFromString("sourcecred/initiatives");
+
+  declaration(): PluginDeclaration {
+    return declaration;
+  }
+
+  // We dont need to load any data since all the initiative files are on disk
+  async load(): Promise<void> {}
+
+  async graph(
+    ctx: PluginDirectoryContext,
+    rd: ReferenceDetector
+  ): Promise<WeightedGraph> {
+    const {remoteUrl} = await loadConfig(ctx);
+    const localPath = getDirectoryFromEnv();
+
+    const {initiatives} = await _loadDirectory({
+      remoteUrl,
+      localPath,
+    });
+
+    const {graph, weights} = createWeightedGraph(initiatives, rd);
+
+    const declarationWeights = weightsForDeclaration(declaration);
+    const combinedWeights = Weights.merge([weights, declarationWeights]);
+
+    return {graph, weights: combinedWeights};
+  }
+
+  async referenceDetector(
+    ctx: PluginDirectoryContext
+  ): Promise<ReferenceDetector> {
+    const {remoteUrl} = await loadConfig(ctx);
+    const localPath = getDirectoryFromEnv();
+
+    const {referenceDetector} = await _loadDirectory({
+      remoteUrl,
+      localPath,
+    });
+
+    return referenceDetector;
+  }
+}

--- a/src/plugins/initiatives/plugin.js
+++ b/src/plugins/initiatives/plugin.js
@@ -17,23 +17,14 @@ import {loadDirectory as _loadDirectory} from "./initiativesDirectory";
 import * as Weights from "../../core/weights";
 
 async function loadConfig(
-  dirContext: PluginDirectoryContext
+  ctx: PluginDirectoryContext
 ): Promise<InitiativesConfig> {
-  const dirname = dirContext.configDirectory();
-  const path = pathJoin(dirname, "config.json");
+  const path = pathJoin(ctx.configDirectory(), "config.json");
   return loadJson(path, parser);
 }
 
-const DIRECTORY_ENV_VAR_NAME = "SOURCECRED_INITIATIVES_DIRECTORY";
-
-function getDirectoryFromEnv(): string {
-  const rawDir = process.env[DIRECTORY_ENV_VAR_NAME] || "initiatives";
-  if (rawDir == null) {
-    throw new Error(
-      `No initiatives directory provided: set ${DIRECTORY_ENV_VAR_NAME}`
-    );
-  }
-  return rawDir;
+function getDirectoryFromContext(ctx: PluginDirectoryContext): string {
+  return pathJoin(ctx.configDirectory(), "initiatives");
 }
 
 export class InitiativesPlugin implements Plugin {
@@ -51,7 +42,7 @@ export class InitiativesPlugin implements Plugin {
     rd: ReferenceDetector
   ): Promise<WeightedGraph> {
     const {remoteUrl} = await loadConfig(ctx);
-    const localPath = getDirectoryFromEnv();
+    const localPath = getDirectoryFromContext(ctx);
 
     const {initiatives} = await _loadDirectory({
       remoteUrl,
@@ -70,7 +61,7 @@ export class InitiativesPlugin implements Plugin {
     ctx: PluginDirectoryContext
   ): Promise<ReferenceDetector> {
     const {remoteUrl} = await loadConfig(ctx);
-    const localPath = getDirectoryFromEnv();
+    const localPath = getDirectoryFromContext(ctx);
 
     const {referenceDetector} = await _loadDirectory({
       remoteUrl,


### PR DESCRIPTION
Sets up a cli2 plugin for the Initiatives plugin and registers it in the bundled plugins. This is for the current 0.2.0 initiative format, so it doesn't work with node addresses yet. Also still need to get the hack fix from #1878 in before this will work properly for MetaGame's instance.

Test Plan: Create an initiatives directory with some example initiatives in the example instance and check if they are successfully loaded into the graph