### PR TITLE
add ledger file logic to the dev server

### DIFF
--- a/config/webpack.config.web.js
+++ b/config/webpack.config.web.js
@@ -89,6 +89,26 @@ async function makeConfig(
           "/config/",
           express.static(path.join(developmentInstancePath, "config"))
         );
+        app.use(
+          "/data/",
+          express.static(path.join(developmentInstancePath, "data"))
+        );
+
+        // configure the dev server to support writing the ledger to disk
+        app.use(express.text());
+        const ledgerPath = path.join(
+          developmentInstancePath,
+          "data/ledger.json"
+        );
+
+        app.post("/data/ledger.json", (req, res) => {
+          try {
+            fs.writeFileSync(ledgerPath, req.body, "utf8");
+          } catch (e) {
+            res.status(500).send(`error saving ledger.json file: ${e}`);
+          }
+          res.status(201).end();
+        });
       },
     },
     output: {


### PR DESCRIPTION
This is required to get the frontend working with the dev service, since the dev server had no knowledge of ledger.json up to this point.

test-plan: the admin frontend should be able to read and modify the
ledger.json file using the dev service just like it would from the
sourcecred CLI. If you get a 404 error starting out, add an empty array
to the example instance in the data/ledger.json file