### PR TITLE
Add a UI for showing Grain balances

### DIFF
--- a/config/webpack.config.web.js
+++ b/config/webpack.config.web.js
@@ -86,6 +86,10 @@ async function makeConfig(
           express.static(path.join(developmentInstancePath, "output"))
         );
         app.use(
+          "/data/",
+          express.static(path.join(developmentInstancePath, "data"))
+        );
+        app.use(
           "/config/",
           express.static(path.join(developmentInstancePath, "config"))
         );

--- a/src/ui/components/AdminApp.js
+++ b/src/ui/components/AdminApp.js
@@ -8,6 +8,7 @@ import pink from "@material-ui/core/colors/pink";
 import fakeDataProvider from "ra-data-fakerest";
 import {Explorer} from "./Explorer";
 import {LedgerAdmin} from "./LedgerAdmin";
+import {GrainAccountOverview} from "./GrainAccountOverview";
 import {load, type LoadResult, type LoadSuccess} from "../load";
 import {withRouter} from "react-router-dom";
 import AppBar from "./AppBar";
@@ -32,6 +33,12 @@ const customRoutes = (loadResult: LoadSuccess) => [
   </Route>,
   <Route key="root" exact path="/">
     <Redirect to="/explorer" />
+  </Route>,
+  <Route key="grain" exact path="/grain">
+    <GrainAccountOverview
+      credView={loadResult.credView}
+      ledger={loadResult.ledger}
+    />
   </Route>,
   <Route key="admin" exact path="/admin">
     <LedgerAdmin

--- a/src/ui/components/GrainAccountOverview.js
+++ b/src/ui/components/GrainAccountOverview.js
@@ -1,0 +1,64 @@
+// @flow
+
+import React from "react";
+import {type CredAccount, computeCredAccounts} from "../../ledger/credAccounts";
+import {Ledger} from "../../ledger/ledger";
+import {CredView} from "../../analysis/credView";
+import * as G from "../../ledger/grain";
+
+export type Props = {|
+  +ledger: Ledger,
+  +credView: CredView,
+|};
+
+export class GrainAccountOverview extends React.Component<Props> {
+  render() {
+    const {accounts} = computeCredAccounts(
+      this.props.ledger,
+      this.props.credView
+    );
+    function comparator(a: CredAccount, b: CredAccount) {
+      if (a.account.balance === b.account.balance) {
+        return 0;
+      }
+      return G.gt(a.account.balance, b.account.balance) ? -1 : 1;
+    }
+    const sortedAccounts = accounts.slice().sort(comparator);
+    return (
+      <div>
+        <table
+          style={{
+            width: "100%",
+            marginLeft: "80px",
+            marginRight: "80px",
+            tableLayout: "fixed",
+            margin: "0 auto",
+            padding: "20px 10px",
+            color: "white",
+          }}
+        >
+          <thead>
+            <tr style={{fontSize: "1.4em"}}>
+              <th style={{textAlign: "left"}}>Username</th>
+              <th style={{textAlign: "left"}}>Active?</th>
+              <th style={{textAlign: "left"}}>Current Balance</th>
+              <th style={{textAlign: "left"}}>Grain Earned</th>
+            </tr>
+          </thead>
+          <tbody>{sortedAccounts.map((a) => AccountRow(a))}</tbody>
+        </table>
+      </div>
+    );
+  }
+}
+
+function AccountRow({account}: CredAccount) {
+  return (
+    <tr>
+      <td>{account.identity.name}</td>
+      <td>{account.active ? "✅" : "🛑"}</td>
+      <td>{G.format(account.balance)}</td>
+      <td>{G.format(account.paid)}</td>
+    </tr>
+  );
+}

--- a/src/ui/components/Menu.js
+++ b/src/ui/components/Menu.js
@@ -40,6 +40,13 @@ const Menu = ({bundledPlugins}: LoadSuccess) => ({onMenuClick}: menuProps) => {
           );
         })}
       <MenuItemLink
+        to="/grain"
+        primaryText="Grain Accounts"
+        leftIcon={<DefaultIcon />}
+        onClick={onMenuClick}
+        sidebarIsOpen={open}
+      />
+      <MenuItemLink
         to="/admin"
         primaryText="Ledger Admin"
         leftIcon={<DefaultIcon />}


### PR DESCRIPTION
This commit adds a UI for displaying Grain balances. The UI shows, for
each account:
- if their account is active
- what their current balance is
- how much Grain they've earned across time

Later we'll want to augment this with info showing when they earned the
Grain, their balances over time, etc.

Test plan: Run `yarn start` and navigate to the grain accounts page.
You'll see a UI showing the grain in our test instance.