### PR TITLE
Grain: Implement a parser for stringified floats

### DIFF
--- a/src/ledger/grain.js
+++ b/src/ledger/grain.js
@@ -202,7 +202,7 @@ export function fromFloatString(
   if (typeof x !== "string") {
     throw new Error(`not a string: ${x}`);
   }
-  if (Number.isNaN(parseFloat(x))) {
+  if (!(isFinite(x) && x.trim())) {
     throw new Error(`input not a valid number: ${x}`);
   }
 

--- a/src/ledger/grain.js
+++ b/src/ledger/grain.js
@@ -179,6 +179,45 @@ export function fromInteger(x: number): Grain {
 }
 
 /**
+ * Accept human-readable numbers strings and convert them to precise grain amounts
+ *
+ * This is most useful for processing form input values before passing them
+ * into the ledger, since all form fields return strings
+ *
+ * In this case, a "float string" is a string that returns a number value
+ * when passed into `parseFloat`
+ *
+ * The reason to circumvent any floating point values is to avoid losses in
+ * precision. By modifying the string directly in a predictable pattern, we can
+ * convert uer-generated floating point values to grain at full fidelity, and avoid
+ * any fuzzy floating point arithmetic
+ *
+ * The tradeoff here is around versatility. Values with more decimals than the
+ * allowable precision will yield an error when passed in.
+ */
+export function fromFloatString(
+  x: string,
+  precision: number = DECIMAL_PRECISION
+): Grain {
+  if (typeof x !== "string") {
+    throw new Error(`not a string: ${x}`);
+  }
+  if (Number.isNaN(parseFloat(x))) {
+    throw new Error(`input not a valid number: ${x}`);
+  }
+
+  const [whole = "", dec = ""] = x.split(".");
+  if (dec.length > precision) {
+    throw new Error(
+      `Provided decimals ${dec.length} exceed allowable precision ${precision}`
+    );
+  }
+  const paddedDecimal = dec.padEnd(precision, "0");
+
+  return BigInt(`${whole}${paddedDecimal}`).toString();
+}
+
+/**
  * Approximately create a grain balance from a float.
  *
  * This method tries to convert the floating point `amt` into a grain

--- a/src/ledger/grain.test.js
+++ b/src/ledger/grain.test.js
@@ -179,7 +179,7 @@ describe("src/ledger/grain", () => {
         const thunk = () => G.fromFloatString(bad);
         expect(thunk).toThrowError(`not a string: ${bad}`);
       }
-      for (const bad of ["a", "Bob", " ", ""]) {
+      for (const bad of ["a", "Bob", " ", "", "Infinity", "-Infinity"]) {
         const thunk = () => G.fromFloatString(bad);
         expect(thunk).toThrowError(`not a valid number: ${bad}`);
       }

--- a/src/ledger/grain.test.js
+++ b/src/ledger/grain.test.js
@@ -173,6 +173,12 @@ describe("src/ledger/grain", () => {
     it("handles falsy numbers correctly", () => {
       expect(G.fromFloatString("0")).toEqual(G.fromInteger(0));
     });
+    it("handles negative values", () => {
+      expect(G.fromFloatString("-5")).toEqual(G.fromInteger(-5));
+      expect(G.fromFloatString("-3.625")).toEqual(
+        G.multiplyFloat(G.ONE, -3.625)
+      );
+    });
     it("rejects non-floatstring inputs", () => {
       for (const bad of [9, 1.2, NaN, Infinity, -Infinity]) {
         //$FlowIgnore intentional invalid inputs

--- a/src/ledger/grain.test.js
+++ b/src/ledger/grain.test.js
@@ -90,7 +90,7 @@ describe("src/ledger/grain", () => {
     });
   });
 
-  describe("conversion from strings", () => {
+  describe("G.fromString", () => {
     it("fromString works on valid Grain values", () => {
       expect(G.fromString(G.ONE)).toEqual(G.ONE);
     });
@@ -152,6 +152,49 @@ describe("src/ledger/grain", () => {
       for (const bad of [1.2, NaN, Infinity, -Infinity]) {
         const thunk = () => G.fromInteger(bad);
         expect(thunk).toThrowError(`not an integer: ${bad}`);
+      }
+    });
+  });
+
+  describe.only("G.fromFloatString", () => {
+    it("converts human-readable floats to grain", () => {
+      expect(G.fromFloatString("1.25")).toEqual(G.multiplyFloat(G.ONE, 1.25));
+      expect(G.fromFloatString("0.252525")).toEqual(
+        G.multiplyFloat(G.ONE, 0.252525)
+      );
+      expect(G.fromFloatString((55e5).toString())).toEqual(G.fromInteger(55e5));
+      expect(G.fromFloatString("5798.453463776456463539")).toEqual(
+        "5798453463776456463539"
+      );
+      expect(G.fromFloatString("5798.45346377645646353")).toEqual(
+        "5798453463776456463530"
+      );
+    });
+    it("handles falsy numbers correctly", () => {
+      expect(G.fromFloatString("0")).toEqual(G.fromInteger(0));
+    });
+    it("rejects non-floatstring inputs", () => {
+      for (const bad of [9, 1.2, NaN, Infinity, -Infinity]) {
+        //$FlowIgnore intentional invalid inputs
+        const thunk = () => G.fromFloatString(bad);
+        expect(thunk).toThrowError(`not a string: ${bad}`);
+      }
+      for (const bad of ["a", "Bob", " ", ""]) {
+        const thunk = () => G.fromFloatString(bad);
+        expect(thunk).toThrowError(`not a valid number: ${bad}`);
+      }
+    });
+    it("rejects excessive precision", () => {
+      for (const bad of [
+        ["0.125", 2],
+        ["0.575645643453", 11],
+        ["5798.4534637764564635439", G.DECIMAL_PRECISION],
+      ]) {
+        const thunk = () => G.fromFloatString(...bad);
+        const [, dec = ""] = bad[0].split(".");
+        expect(thunk).toThrowError(
+          `Provided decimals ${dec.length} exceed allowable precision ${bad[1]}`
+        );
       }
     });
   });

--- a/src/ledger/grain.test.js
+++ b/src/ledger/grain.test.js
@@ -156,7 +156,7 @@ describe("src/ledger/grain", () => {
     });
   });
 
-  describe.only("G.fromFloatString", () => {
+  describe("G.fromFloatString", () => {
     it("converts human-readable floats to grain", () => {
       expect(G.fromFloatString("1.25")).toEqual(G.multiplyFloat(G.ONE, 1.25));
       expect(G.fromFloatString("0.252525")).toEqual(


### PR DESCRIPTION
This is most useful for processing form input values before passing them
into the ledger, since all form fields return strings

In this case, a "float string" is a string that returns a number value
when passed into `parseFloat`

The reason to circumvent any floating point values is to avoid losses in
precision. By modifying the string directly in a predictable pattern, we can
convert uer-generated floating point values to grain at full fidelity, and avoid
any fuzzy floating point arithmetic

The tradeoff here is around versatility. Values with more decimals than the
allowable precision will yield an error when passed in.

test-plan: thorough unit tests are included