### PR TITLE
implement grain transfer interface

### DIFF
--- a/src/ui/components/AccountSelector.js
+++ b/src/ui/components/AccountSelector.js
@@ -97,7 +97,6 @@ export const menuStyles = (isOpen: boolean) => ({
   zIndex: 1000,
   listStyle: "none",
   padding: 0,
-  //left: "135px",
 });
 
 export const comboboxStyles = {display: "inline-block"};

--- a/src/ui/components/AccountSelector.js
+++ b/src/ui/components/AccountSelector.js
@@ -1,0 +1,103 @@
+// @flow
+
+import React, {useState} from "react";
+import {Ledger, type Account} from "../../ledger/ledger";
+import {useCombobox} from "downshift";
+
+type DropdownProps = {|
+  +ledger: Ledger,
+  +setCurrentIdentity: (Account) => void,
+|};
+
+export default function AccountDropdown({
+  setCurrentIdentity,
+  ledger,
+}: DropdownProps) {
+  const items = ledger.accounts().filter((a) => a.active);
+  const [inputItems, setInputItems] = useState<$ReadOnlyArray<Account>>(items);
+  const [inputValue, setInputValue] = useState<string>("");
+  const {
+    isOpen,
+    getToggleButtonProps,
+    getMenuProps,
+    getInputProps,
+    getComboboxProps,
+    highlightedIndex,
+    getItemProps,
+  } = useCombobox({
+    inputValue,
+    items: inputItems,
+    onStateChange: ({inputValue, type, selectedItem}) => {
+      switch (type) {
+        case useCombobox.stateChangeTypes.InputChange:
+          setInputValue(inputValue);
+          setInputItems(
+            items.filter((item) =>
+              item.identity.name
+                .toLowerCase()
+                .startsWith(inputValue.toLowerCase())
+            )
+          );
+          break;
+        case useCombobox.stateChangeTypes.InputKeyDownEnter:
+        case useCombobox.stateChangeTypes.ItemClick:
+        case useCombobox.stateChangeTypes.InputBlur:
+          if (selectedItem) {
+            setCurrentIdentity(selectedItem);
+            setInputValue(selectedItem.identity.name);
+          } else {
+            setInputValue("");
+          }
+
+          break;
+        default:
+          break;
+      }
+    },
+  });
+
+  return (
+    <div>
+      <div style={comboboxStyles} {...getComboboxProps()}>
+        <input {...getInputProps()} />
+        <button
+          type="button"
+          {...getToggleButtonProps()}
+          aria-label="toggle menu"
+        >
+          &#8595;
+        </button>
+      </div>
+      <ul {...getMenuProps()} style={menuStyles(isOpen)}>
+        {isOpen &&
+          inputItems.map((item, index) => (
+            <li
+              style={
+                highlightedIndex === index ? {backgroundColor: "#bde4ff"} : {}
+              }
+              key={`${item.identity.id}`}
+              {...getItemProps({item, index})}
+            >
+              {item.identity.name}
+            </li>
+          ))}
+      </ul>
+    </div>
+  );
+}
+
+export const menuStyles = (isOpen: boolean) => ({
+  maxHeight: "180px",
+  overflowY: "auto",
+  width: "135px",
+  margin: 0,
+  border: isOpen ? "1px solid black" : 0,
+  background: "white",
+  position: "absolute",
+  zIndex: 1000,
+  listStyle: "none",
+  padding: 0,
+  //left: "135px",
+});
+
+export const comboboxStyles = {display: "inline-block"};

--- a/src/ui/components/AdminApp.js
+++ b/src/ui/components/AdminApp.js
@@ -9,6 +9,7 @@ import fakeDataProvider from "ra-data-fakerest";
 import {Explorer} from "./Explorer";
 import {LedgerAdmin} from "./LedgerAdmin";
 import {GrainAccountOverview} from "./GrainAccountOverview";
+import {TransferGrain} from "./TransferGrain";
 import {load, type LoadResult, type LoadSuccess} from "../load";
 import {withRouter} from "react-router-dom";
 import AppBar from "./AppBar";
@@ -45,6 +46,9 @@ const customRoutes = (loadResult: LoadSuccess) => [
       credView={loadResult.credView}
       initialLedger={loadResult.ledger}
     />
+  </Route>,
+  <Route key="transfer" exact path="/transfer">
+    <TransferGrain initialLedger={loadResult.ledger} />
   </Route>,
 ];
 

--- a/src/ui/components/Menu.js
+++ b/src/ui/components/Menu.js
@@ -6,6 +6,7 @@ import {MenuItemLink, getResources} from "react-admin";
 import {type LoadSuccess} from "../load";
 import TrendingUpIcon from "@material-ui/icons/TrendingUp";
 import DefaultIcon from "@material-ui/icons/ViewList";
+import TransformIcon from "@material-ui/icons/Transform";
 
 type menuProps = {|onMenuClick: Function|};
 
@@ -50,6 +51,13 @@ const Menu = ({bundledPlugins}: LoadSuccess) => ({onMenuClick}: menuProps) => {
         to="/admin"
         primaryText="Ledger Admin"
         leftIcon={<DefaultIcon />}
+        onClick={onMenuClick}
+        sidebarIsOpen={open}
+      />
+      <MenuItemLink
+        to="/transfer"
+        primaryText="Transfer Grain"
+        leftIcon={<TransformIcon />}
         onClick={onMenuClick}
         sidebarIsOpen={open}
       />

--- a/src/ui/components/TransferGrain.js
+++ b/src/ui/components/TransferGrain.js
@@ -1,0 +1,117 @@
+// @flow
+
+import React, {useState} from "react";
+import {
+  div,
+  format,
+  gt,
+  fromInteger,
+  fromApproximateFloat, // TODO: utilize `fromFloatString`
+  type Grain,
+} from "../../ledger/grain";
+import {type Identity} from "../../ledger/identity";
+import {Ledger, type Account} from "../../ledger/ledger";
+import AccountDropdown from "./AccountSelector";
+
+export type Props = {|
+  +initialLedger: Ledger,
+|};
+
+export const TransferGrain = ({initialLedger}: Props) => {
+  const [ledger, setLedger] = useState<Ledger>(initialLedger);
+  const [sourceIdentity, setSourceIdentity] = useState<Identity | null>(null);
+  const [destIdentity, setDestIdentity] = useState<Identity | null>(null);
+  const [amount, setAmount] = useState<string>("0");
+  const [maxAmount, setMaxAmount] = useState<Grain>(fromInteger(0));
+  const [memo, setMemo] = useState<string>("");
+
+  const setSender = (acct: Account) => {
+    setMaxAmount(acct.balance);
+    setSourceIdentity(acct.identity);
+  };
+
+  const setReceiver = (acct: Account) => {
+    setDestIdentity(acct.identity);
+  };
+
+  const submitTransfer = (e) => {
+    e.preventDefault();
+    if (sourceIdentity && destIdentity) {
+      const nextLedger = ledger.transferGrain({
+        from: sourceIdentity.id,
+        to: destIdentity.id,
+        amount: fromApproximateFloat(parseFloat(amount)),
+        memo: memo,
+      });
+      setLedger(nextLedger);
+      setAmount(fromInteger(0));
+      setSender(nextLedger.account(sourceIdentity.id));
+      setMemo("");
+    }
+  };
+
+  return (
+    <div
+      style={{
+        width: "80%",
+        margin: "0 auto",
+        background: "white",
+        padding: "0 5em 5em",
+      }}
+    >
+      <h1>Transfer Grain</h1>
+      <form onSubmit={(e) => submitTransfer(e)}>
+        <label>From</label>
+        <AccountDropdown ledger={ledger} setCurrentIdentity={setSender} />
+        <br />
+        <label>To</label>
+        <AccountDropdown ledger={ledger} setCurrentIdentity={setReceiver} />
+        <p>
+          <label htmlFor="amount">Amount</label> <br />
+          <input
+            type="number"
+            name="amount"
+            min="0"
+            placeholder={`max: ${maxAmount}`}
+            required
+            value={amount}
+            onChange={(e) => setAmount(e.currentTarget.value)}
+          />
+          <span>{` max: ${format(maxAmount, 5)}`}</span>
+        </p>
+        <p>
+          <label htmlFor="memo">Memo</label> <br />
+          <input
+            type="text"
+            name="memo"
+            value={memo}
+            onChange={(e) => setMemo(e.currentTarget.value)}
+          />
+        </p>
+        <input
+          disabled={
+            !Number(amount) ||
+            gt(fromApproximateFloat(parseFloat(amount)), maxAmount)
+          }
+          type="submit"
+          value="transfer grain"
+        />
+        <br />
+        <input
+          type="button"
+          value="save ledger to disk"
+          onClick={() => {
+            fetch("data/ledger.json", {
+              headers: {
+                Accept: "text/plain",
+                "Content-Type": "text/plain",
+              },
+              method: "POST",
+              body: ledger.serialize(),
+            });
+          }}
+        />
+      </form>
+    </div>
+  );
+};

--- a/src/ui/components/TransferGrain.js
+++ b/src/ui/components/TransferGrain.js
@@ -6,7 +6,7 @@ import {
   format,
   gt,
   fromInteger,
-  fromApproximateFloat, // TODO: utilize `fromFloatString`
+  fromFloatString,
   type Grain,
 } from "../../ledger/grain";
 import {type Identity} from "../../ledger/identity";
@@ -40,7 +40,7 @@ export const TransferGrain = ({initialLedger}: Props) => {
       const nextLedger = ledger.transferGrain({
         from: sourceIdentity.id,
         to: destIdentity.id,
-        amount: fromApproximateFloat(parseFloat(amount)),
+        amount: fromFloatString(amount),
         memo: memo,
       });
       setLedger(nextLedger);
@@ -72,12 +72,13 @@ export const TransferGrain = ({initialLedger}: Props) => {
             type="number"
             name="amount"
             min="0"
+            step="any"
             placeholder={`max: ${maxAmount}`}
             required
             value={amount}
             onChange={(e) => setAmount(e.currentTarget.value)}
           />
-          <span>{` max: ${format(maxAmount, 5)}`}</span>
+          <span>{sourceIdentity && ` max: ${format(maxAmount, 5)}`}</span>
         </p>
         <p>
           <label htmlFor="memo">Memo</label> <br />
@@ -91,7 +92,8 @@ export const TransferGrain = ({initialLedger}: Props) => {
         <input
           disabled={
             !Number(amount) ||
-            gt(fromApproximateFloat(parseFloat(amount)), maxAmount)
+            !(sourceIdentity && destIdentity) ||
+            gt(fromFloatString(amount), maxAmount)
           }
           type="submit"
           value="transfer grain"


### PR DESCRIPTION
this interface allows for grain transfers between user identities. There
are validations in place to ensure an amount exceeding the senders
balance cannot be submitted.

Currently there is no completely lossless library function for
converting a stringified float to grain. This is needed to maintain
fidelity between the frontend and the backend and is currently
WIP (#2034)

test-plan: send grain between accounts. try to send a grain amount
exceeding the sender's balance. Ensure the entered value is stored
correctly in the ledger.json file.