### PR TITLE
Factor Discourse node and edge helper methods out

### DIFF
--- a/src/plugins/discourse/createGraph.js
+++ b/src/plugins/discourse/createGraph.js
@@ -1,211 +1,14 @@
 // @flow
 
-import {Graph, EdgeAddress, type Node, type Edge} from "../../core/graph";
-import {
-  type PostId,
-  type TopicId,
-  type Post,
-  type Topic,
-  type LikeAction,
-} from "./fetch";
+import {Graph, type Edge} from "../../core/graph";
+import {type PostId, type TopicId, type Post, type LikeAction} from "./fetch";
 import {type ReadRepository} from "./mirrorRepository";
 import {
-  authorsPostEdgeType,
-  authorsTopicEdgeType,
-  postRepliesEdgeType,
-  topicContainsPostEdgeType,
-  likesEdgeType,
-  createsLikeEdgeType,
-  referencesTopicEdgeType,
-  referencesUserEdgeType,
-  referencesPostEdgeType,
-} from "./declaration";
-import {userAddress, topicAddress, postAddress, likeAddress} from "./address";
-import {
   type DiscourseReference,
-  type DiscourseTopicReference,
-  type DiscourseUserReference,
   parseLinks,
   linksToReferences,
 } from "./references";
-
-export function userNode(serverUrl: string, username: string): Node {
-  const url = `${serverUrl}/u/${username}/`;
-  const description = `[@${username}](${url})`;
-  return {
-    address: userAddress(serverUrl, username),
-    description,
-    timestampMs: null,
-  };
-}
-
-export function topicNode(serverUrl: string, topic: Topic): Node {
-  const url = `${serverUrl}/t/${String(topic.id)}`;
-  const description = `[${topic.title}](${url})`;
-  const address = topicAddress(serverUrl, topic.id);
-  return {address, description, timestampMs: topic.timestampMs};
-}
-
-export function postNode(
-  serverUrl: string,
-  post: Post,
-  description: string
-): Node {
-  const address = postAddress(serverUrl, post.id);
-  return {timestampMs: post.timestampMs, address, description};
-}
-
-export function likeNode(
-  serverUrl: string,
-  like: LikeAction,
-  postDescription: string
-): Node {
-  const address = likeAddress(serverUrl, like);
-  const description = `❤️ by ${like.username} on ${postDescription}`;
-  return {timestampMs: like.timestampMs, address, description};
-}
-
-export function authorsTopicEdge(serverUrl: string, topic: Topic): Edge {
-  const address = EdgeAddress.append(
-    authorsTopicEdgeType.prefix,
-    serverUrl,
-    topic.authorUsername,
-    String(topic.id)
-  );
-  return {
-    address,
-    timestampMs: topic.timestampMs,
-    src: userAddress(serverUrl, topic.authorUsername),
-    dst: topicAddress(serverUrl, topic.id),
-  };
-}
-
-export function authorsPostEdge(serverUrl: string, post: Post): Edge {
-  const address = EdgeAddress.append(
-    authorsPostEdgeType.prefix,
-    serverUrl,
-    post.authorUsername,
-    String(post.id)
-  );
-  return {
-    address,
-    timestampMs: post.timestampMs,
-    src: userAddress(serverUrl, post.authorUsername),
-    dst: postAddress(serverUrl, post.id),
-  };
-}
-
-export function topicContainsPostEdge(serverUrl: string, post: Post): Edge {
-  const address = EdgeAddress.append(
-    topicContainsPostEdgeType.prefix,
-    serverUrl,
-    String(post.topicId),
-    String(post.id)
-  );
-  return {
-    address,
-    timestampMs: post.timestampMs,
-    src: topicAddress(serverUrl, post.topicId),
-    dst: postAddress(serverUrl, post.id),
-  };
-}
-
-export function postRepliesEdge(
-  serverUrl: string,
-  post: Post,
-  basePostId: PostId
-): Edge {
-  const address = EdgeAddress.append(
-    postRepliesEdgeType.prefix,
-    serverUrl,
-    String(post.id),
-    String(basePostId)
-  );
-  return {
-    address,
-    timestampMs: post.timestampMs,
-    src: postAddress(serverUrl, post.id),
-    dst: postAddress(serverUrl, basePostId),
-  };
-}
-
-export function createsLikeEdge(serverUrl: string, like: LikeAction): Edge {
-  const address = EdgeAddress.append(
-    createsLikeEdgeType.prefix,
-    serverUrl,
-    like.username,
-    String(like.postId)
-  );
-  return {
-    address,
-    timestampMs: like.timestampMs,
-    src: userAddress(serverUrl, like.username),
-    dst: likeAddress(serverUrl, like),
-  };
-}
-
-export function likesEdge(serverUrl: string, like: LikeAction): Edge {
-  const address = EdgeAddress.append(
-    likesEdgeType.prefix,
-    serverUrl,
-    like.username,
-    String(like.postId)
-  );
-  return {
-    address,
-    timestampMs: like.timestampMs,
-    src: likeAddress(serverUrl, like),
-    dst: postAddress(serverUrl, like.postId),
-  };
-}
-
-export function referencesTopicEdge(
-  serverUrl: string,
-  post: Post,
-  reference: DiscourseTopicReference
-): Edge {
-  const address = EdgeAddress.append(
-    referencesTopicEdgeType.prefix,
-    serverUrl,
-    String(post.id),
-    String(reference.topicId)
-  );
-  const src = postAddress(serverUrl, post.id);
-  const dst = topicAddress(serverUrl, reference.topicId);
-  return {src, dst, timestampMs: post.timestampMs, address};
-}
-
-export function referencesPostEdge(
-  serverUrl: string,
-  post: Post,
-  referredPostId: PostId
-): Edge {
-  const address = EdgeAddress.append(
-    referencesPostEdgeType.prefix,
-    serverUrl,
-    String(post.id),
-    String(referredPostId)
-  );
-  const src = postAddress(serverUrl, post.id);
-  const dst = postAddress(serverUrl, referredPostId);
-  return {src, dst, timestampMs: post.timestampMs, address};
-}
-
-export function referencesUserEdge(
-  serverUrl: string,
-  post: Post,
-  reference: DiscourseUserReference
-): Edge {
-  const address = EdgeAddress.append(
-    referencesUserEdgeType.prefix,
-    serverUrl,
-    String(post.id),
-    reference.username
-  );
-  const src = postAddress(serverUrl, post.id);
-  const dst = userAddress(serverUrl, reference.username);
-  return {src, dst, timestampMs: post.timestampMs, address};
-}
+import * as NE from "./nodesAndEdges";
 
 export function createGraph(serverUrl: string, data: ReadRepository): Graph {
   const gc = new _GraphCreator(serverUrl, data);
@@ -230,13 +33,13 @@ class _GraphCreator {
     this.postIdToDescription = new Map();
 
     for (const username of data.users()) {
-      this.graph.addNode(userNode(serverUrl, username));
+      this.graph.addNode(NE.userNode(serverUrl, username));
     }
 
     for (const topic of data.topics()) {
       this.topicIdToTitle.set(topic.id, topic.title);
-      this.graph.addNode(topicNode(serverUrl, topic));
-      this.graph.addEdge(authorsTopicEdge(serverUrl, topic));
+      this.graph.addNode(NE.topicNode(serverUrl, topic));
+      this.graph.addEdge(NE.authorsTopicEdge(serverUrl, topic));
     }
 
     for (const post of data.posts()) {
@@ -256,9 +59,9 @@ class _GraphCreator {
   }
 
   addPost(post: Post, description: string) {
-    this.graph.addNode(postNode(this.serverUrl, post, description));
-    this.graph.addEdge(authorsPostEdge(this.serverUrl, post));
-    this.graph.addEdge(topicContainsPostEdge(this.serverUrl, post));
+    this.graph.addNode(NE.postNode(this.serverUrl, post, description));
+    this.graph.addEdge(NE.authorsPostEdge(this.serverUrl, post));
+    this.graph.addEdge(NE.topicContainsPostEdge(this.serverUrl, post));
     this.maybeAddPostRepliesEdge(post);
 
     const discourseReferences = linksToReferences(
@@ -275,9 +78,9 @@ class _GraphCreator {
   addLike(like: LikeAction) {
     const postDescription =
       this.postIdToDescription.get(like.postId) || "[unknown post]";
-    this.graph.addNode(likeNode(this.serverUrl, like, postDescription));
-    this.graph.addEdge(likesEdge(this.serverUrl, like));
-    this.graph.addEdge(createsLikeEdge(this.serverUrl, like));
+    this.graph.addNode(NE.likeNode(this.serverUrl, like, postDescription));
+    this.graph.addEdge(NE.likesEdge(this.serverUrl, like));
+    this.graph.addEdge(NE.createsLikeEdge(this.serverUrl, like));
   }
 
   /**
@@ -300,7 +103,9 @@ class _GraphCreator {
         replyToPostIndex
       );
       if (basePostId != null) {
-        this.graph.addEdge(postRepliesEdge(this.serverUrl, post, basePostId));
+        this.graph.addEdge(
+          NE.postRepliesEdge(this.serverUrl, post, basePostId)
+        );
       }
     }
   }
@@ -316,7 +121,7 @@ class _GraphCreator {
     }
     switch (reference.type) {
       case "TOPIC": {
-        return referencesTopicEdge(this.serverUrl, post, reference);
+        return NE.referencesTopicEdge(this.serverUrl, post, reference);
       }
       case "POST": {
         const referredPostId = this.data.findPostInTopic(
@@ -327,10 +132,10 @@ class _GraphCreator {
           // Maybe a bad link, or the post or topic was deleted.
           return null;
         }
-        return referencesPostEdge(this.serverUrl, post, referredPostId);
+        return NE.referencesPostEdge(this.serverUrl, post, referredPostId);
       }
       case "USER": {
-        return referencesUserEdge(this.serverUrl, post, reference);
+        return NE.referencesUserEdge(this.serverUrl, post, reference);
       }
       default: {
         throw new Error(

--- a/src/plugins/discourse/nodesAndEdges.js
+++ b/src/plugins/discourse/nodesAndEdges.js
@@ -1,0 +1,198 @@
+// @flow
+
+import {EdgeAddress, type Node, type Edge} from "../../core/graph";
+import {type PostId, type Post, type Topic, type LikeAction} from "./fetch";
+import {
+  authorsPostEdgeType,
+  authorsTopicEdgeType,
+  postRepliesEdgeType,
+  topicContainsPostEdgeType,
+  likesEdgeType,
+  createsLikeEdgeType,
+  referencesTopicEdgeType,
+  referencesUserEdgeType,
+  referencesPostEdgeType,
+} from "./declaration";
+import {userAddress, topicAddress, postAddress, likeAddress} from "./address";
+import {
+  type DiscourseTopicReference,
+  type DiscourseUserReference,
+} from "./references";
+
+export function userNode(serverUrl: string, username: string): Node {
+  const url = `${serverUrl}/u/${username}/`;
+  const description = `[@${username}](${url})`;
+  return {
+    address: userAddress(serverUrl, username),
+    description,
+    timestampMs: null,
+  };
+}
+
+export function topicNode(serverUrl: string, topic: Topic): Node {
+  const url = `${serverUrl}/t/${String(topic.id)}`;
+  const description = `[${topic.title}](${url})`;
+  const address = topicAddress(serverUrl, topic.id);
+  return {address, description, timestampMs: topic.timestampMs};
+}
+
+export function postNode(
+  serverUrl: string,
+  post: Post,
+  description: string
+): Node {
+  const address = postAddress(serverUrl, post.id);
+  return {timestampMs: post.timestampMs, address, description};
+}
+
+export function likeNode(
+  serverUrl: string,
+  like: LikeAction,
+  postDescription: string
+): Node {
+  const address = likeAddress(serverUrl, like);
+  const description = `❤️ by ${like.username} on ${postDescription}`;
+  return {timestampMs: like.timestampMs, address, description};
+}
+
+export function authorsTopicEdge(serverUrl: string, topic: Topic): Edge {
+  const address = EdgeAddress.append(
+    authorsTopicEdgeType.prefix,
+    serverUrl,
+    topic.authorUsername,
+    String(topic.id)
+  );
+  return {
+    address,
+    timestampMs: topic.timestampMs,
+    src: userAddress(serverUrl, topic.authorUsername),
+    dst: topicAddress(serverUrl, topic.id),
+  };
+}
+
+export function authorsPostEdge(serverUrl: string, post: Post): Edge {
+  const address = EdgeAddress.append(
+    authorsPostEdgeType.prefix,
+    serverUrl,
+    post.authorUsername,
+    String(post.id)
+  );
+  return {
+    address,
+    timestampMs: post.timestampMs,
+    src: userAddress(serverUrl, post.authorUsername),
+    dst: postAddress(serverUrl, post.id),
+  };
+}
+
+export function topicContainsPostEdge(serverUrl: string, post: Post): Edge {
+  const address = EdgeAddress.append(
+    topicContainsPostEdgeType.prefix,
+    serverUrl,
+    String(post.topicId),
+    String(post.id)
+  );
+  return {
+    address,
+    timestampMs: post.timestampMs,
+    src: topicAddress(serverUrl, post.topicId),
+    dst: postAddress(serverUrl, post.id),
+  };
+}
+
+export function postRepliesEdge(
+  serverUrl: string,
+  post: Post,
+  basePostId: PostId
+): Edge {
+  const address = EdgeAddress.append(
+    postRepliesEdgeType.prefix,
+    serverUrl,
+    String(post.id),
+    String(basePostId)
+  );
+  return {
+    address,
+    timestampMs: post.timestampMs,
+    src: postAddress(serverUrl, post.id),
+    dst: postAddress(serverUrl, basePostId),
+  };
+}
+
+export function createsLikeEdge(serverUrl: string, like: LikeAction): Edge {
+  const address = EdgeAddress.append(
+    createsLikeEdgeType.prefix,
+    serverUrl,
+    like.username,
+    String(like.postId)
+  );
+  return {
+    address,
+    timestampMs: like.timestampMs,
+    src: userAddress(serverUrl, like.username),
+    dst: likeAddress(serverUrl, like),
+  };
+}
+
+export function likesEdge(serverUrl: string, like: LikeAction): Edge {
+  const address = EdgeAddress.append(
+    likesEdgeType.prefix,
+    serverUrl,
+    like.username,
+    String(like.postId)
+  );
+  return {
+    address,
+    timestampMs: like.timestampMs,
+    src: likeAddress(serverUrl, like),
+    dst: postAddress(serverUrl, like.postId),
+  };
+}
+
+export function referencesTopicEdge(
+  serverUrl: string,
+  post: Post,
+  reference: DiscourseTopicReference
+): Edge {
+  const address = EdgeAddress.append(
+    referencesTopicEdgeType.prefix,
+    serverUrl,
+    String(post.id),
+    String(reference.topicId)
+  );
+  const src = postAddress(serverUrl, post.id);
+  const dst = topicAddress(serverUrl, reference.topicId);
+  return {src, dst, timestampMs: post.timestampMs, address};
+}
+
+export function referencesPostEdge(
+  serverUrl: string,
+  post: Post,
+  referredPostId: PostId
+): Edge {
+  const address = EdgeAddress.append(
+    referencesPostEdgeType.prefix,
+    serverUrl,
+    String(post.id),
+    String(referredPostId)
+  );
+  const src = postAddress(serverUrl, post.id);
+  const dst = postAddress(serverUrl, referredPostId);
+  return {src, dst, timestampMs: post.timestampMs, address};
+}
+
+export function referencesUserEdge(
+  serverUrl: string,
+  post: Post,
+  reference: DiscourseUserReference
+): Edge {
+  const address = EdgeAddress.append(
+    referencesUserEdgeType.prefix,
+    serverUrl,
+    String(post.id),
+    reference.username
+  );
+  const src = postAddress(serverUrl, post.id);
+  const dst = userAddress(serverUrl, reference.username);
+  return {src, dst, timestampMs: post.timestampMs, address};
+}

--- a/src/plugins/discourse/nodesAndEdges.test.js
+++ b/src/plugins/discourse/nodesAndEdges.test.js
@@ -1,0 +1,272 @@
+// @flow
+
+import type {LikeAction} from "./fetch";
+import {NodeAddress, EdgeAddress} from "../../core/graph";
+import * as NE from "./nodesAndEdges";
+
+import {userAddress, postAddress, likeAddress} from "./address";
+
+describe("plugins/discourse/nodesAndEdges", () => {
+  function example() {
+    const url = "https://url.com";
+    const topic = {
+      id: 1,
+      title: "first topic",
+      timestampMs: 0,
+      authorUsername: "decentralion",
+      categoryId: 1,
+      bumpedMs: 0,
+    };
+    const post1 = {
+      id: 1,
+      topicId: 1,
+      indexWithinTopic: 1,
+      replyToPostIndex: null,
+      timestampMs: 0,
+      authorUsername: "decentralion",
+      cooked: `<p>Some references:
+      // A reference to a topic...
+      <a href="https://url.com/t/first-topic/1">First topic</a>
+      // A reference to a post (the slug doesn't matter)
+      <a href="https://url.com/t/irrelevant-slug/1/2?u=bla">Second post</a>
+      // A reference to a user
+      <a href="/u/decentralion">@decentralion</a>
+      // A non-reference as the url is wrong
+      <a href="https://boo.com/t/first-topic/1/3">Wrong url</a>
+      // No post matching this index in topic, so no reference
+      <a href="https://url.com/t/first-topic/1/99">No post</a>
+      // A reference to a post with different capitalization
+      <a href="https://URL.com/t/irrelevant-slug/1/3?u=bla">Third post</a>
+      </p>`,
+    };
+    const post2 = {
+      id: 2,
+      topicId: 1,
+      indexWithinTopic: 2,
+      // N.B. weird but realistic: replies to the first post get a
+      // replyToPostIndex of null, not 1
+      replyToPostIndex: null,
+      timestampMs: 1,
+      authorUsername: "wchargin",
+      cooked: "<h1>Hello</h1>",
+    };
+    const post3 = {
+      id: 3,
+      topicId: 1,
+      indexWithinTopic: 3,
+      replyToPostIndex: 2,
+      timestampMs: 1,
+      authorUsername: "mzargham",
+      cooked: "<h1>Hello</h1>",
+    };
+    const likes: $ReadOnlyArray<LikeAction> = [
+      {timestampMs: 3, username: "mzargham", postId: 2},
+      {timestampMs: 4, username: "decentralion", postId: 3},
+    ];
+    const posts = [post1, post2, post3];
+    return {topic, url, posts, likes};
+  }
+
+  describe("nodes are constructed correctly", () => {
+    it("for users", () => {
+      const {url} = example();
+      const node = NE.userNode(url, "decentralion");
+      expect(node.description).toMatchInlineSnapshot(
+        `"[@decentralion](https://url.com/u/decentralion/)"`
+      );
+      expect(node.timestampMs).toEqual(null);
+      expect(NodeAddress.toParts(node.address)).toMatchInlineSnapshot(`
+                                Array [
+                                  "sourcecred",
+                                  "discourse",
+                                  "user",
+                                  "https://url.com",
+                                  "decentralion",
+                                ]
+                        `);
+    });
+
+    it("for topics", () => {
+      const {url, topic} = example();
+      const node = NE.topicNode(url, topic);
+      expect(node.description).toMatchInlineSnapshot(
+        `"[first topic](https://url.com/t/1)"`
+      );
+      expect(node.timestampMs).toEqual(topic.timestampMs);
+      expect(NodeAddress.toParts(node.address)).toMatchInlineSnapshot(`
+                                Array [
+                                  "sourcecred",
+                                  "discourse",
+                                  "topic",
+                                  "https://url.com",
+                                  "1",
+                                ]
+                        `);
+    });
+
+    it("for posts", () => {
+      const {url, posts} = example();
+      const description = "[#2 on first topic](https://url.com/t/1/2)";
+      const node = NE.postNode(url, posts[1], description);
+      expect(node.description).toEqual(description);
+      expect(node.timestampMs).toEqual(posts[1].timestampMs);
+      expect(NodeAddress.toParts(node.address)).toMatchInlineSnapshot(`
+                                Array [
+                                  "sourcecred",
+                                  "discourse",
+                                  "post",
+                                  "https://url.com",
+                                  "2",
+                                ]
+                        `);
+    });
+
+    it("for likes", () => {
+      const {url, likes, posts} = example();
+      const like = likes[0];
+      const post = posts[1];
+      expect(like.postId).toEqual(post.id);
+      const postDescription = `[#2 on first topic](https://url.com/t/1/2)`;
+      const node = NE.likeNode(url, like, postDescription);
+      expect(node.description).toMatchInlineSnapshot(
+        `"❤️ by mzargham on [#2 on first topic](https://url.com/t/1/2)"`
+      );
+      expect(node.timestampMs).toEqual(like.timestampMs);
+      expect(NodeAddress.toParts(node.address)).toMatchInlineSnapshot(`
+        Array [
+          "sourcecred",
+          "discourse",
+          "like",
+          "https://url.com",
+          "mzargham",
+          "2",
+        ]
+      `);
+    });
+  });
+
+  describe("edges are constructed correctly", () => {
+    it("for authorsTopic", () => {
+      const {url, topic} = example();
+      const expectedSrc = NE.userNode(url, topic.authorUsername).address;
+      const expectedDst = NE.topicNode(url, topic).address;
+      const edge = NE.authorsTopicEdge(url, topic);
+      expect(edge.src).toEqual(expectedSrc);
+      expect(edge.dst).toEqual(expectedDst);
+      expect(edge.timestampMs).toEqual(topic.timestampMs);
+      expect(EdgeAddress.toParts(edge.address)).toMatchInlineSnapshot(`
+                        Array [
+                          "sourcecred",
+                          "discourse",
+                          "authors",
+                          "topic",
+                          "https://url.com",
+                          "decentralion",
+                          "1",
+                        ]
+                  `);
+    });
+    it("for authorsPost", () => {
+      const {url, posts, topic} = example();
+      const post = posts[1];
+      const expectedSrc = NE.userNode(url, post.authorUsername).address;
+      const expectedDst = NE.postNode(url, post, topic.title).address;
+      const edge = NE.authorsPostEdge(url, post);
+      expect(edge.src).toEqual(expectedSrc);
+      expect(edge.dst).toEqual(expectedDst);
+      expect(edge.timestampMs).toEqual(post.timestampMs);
+      expect(EdgeAddress.toParts(edge.address)).toMatchInlineSnapshot(`
+                        Array [
+                          "sourcecred",
+                          "discourse",
+                          "authors",
+                          "post",
+                          "https://url.com",
+                          "wchargin",
+                          "2",
+                        ]
+                  `);
+    });
+    it("for topicContainsPost", () => {
+      const {url, posts, topic} = example();
+      const post = posts[1];
+      const expectedSrc = NE.topicNode(url, topic).address;
+      const expectedDst = NE.postNode(url, post, topic.title).address;
+      const edge = NE.topicContainsPostEdge(url, post);
+      expect(edge.src).toEqual(expectedSrc);
+      expect(edge.dst).toEqual(expectedDst);
+      expect(edge.timestampMs).toEqual(post.timestampMs);
+      expect(EdgeAddress.toParts(edge.address)).toMatchInlineSnapshot(`
+                        Array [
+                          "sourcecred",
+                          "discourse",
+                          "topicContainsPost",
+                          "https://url.com",
+                          "1",
+                          "2",
+                        ]
+                  `);
+    });
+    it("for postReplies", () => {
+      const {url, posts, topic} = example();
+      const post = posts[2];
+      const basePost = posts[1];
+      const expectedSrc = NE.postNode(url, post, topic.title).address;
+      const expectedDst = NE.postNode(url, basePost, topic.title).address;
+      const edge = NE.postRepliesEdge(url, post, basePost.id);
+      expect(edge.src).toEqual(expectedSrc);
+      expect(edge.dst).toEqual(expectedDst);
+      expect(edge.timestampMs).toEqual(post.timestampMs);
+      expect(EdgeAddress.toParts(edge.address)).toMatchInlineSnapshot(`
+                        Array [
+                          "sourcecred",
+                          "discourse",
+                          "replyTo",
+                          "https://url.com",
+                          "3",
+                          "2",
+                        ]
+                  `);
+    });
+    it("for likes", () => {
+      const {url, likes} = example();
+      const like = likes[0];
+      const expectedSrc = likeAddress(url, like);
+      const expectedDst = postAddress(url, like.postId);
+      const edge = NE.likesEdge(url, like);
+      expect(edge.src).toEqual(expectedSrc);
+      expect(edge.dst).toEqual(expectedDst);
+      expect(edge.timestampMs).toEqual(like.timestampMs);
+      expect(EdgeAddress.toParts(edge.address)).toMatchInlineSnapshot(`
+        Array [
+          "sourcecred",
+          "discourse",
+          "likes",
+          "https://url.com",
+          "mzargham",
+          "2",
+        ]
+      `);
+    });
+    it("for createsLike", () => {
+      const {url, likes} = example();
+      const like = likes[0];
+      const expectedSrc = userAddress(url, like.username);
+      const expectedDst = likeAddress(url, like);
+      const edge = NE.createsLikeEdge(url, like);
+      expect(edge.src).toEqual(expectedSrc);
+      expect(edge.dst).toEqual(expectedDst);
+      expect(edge.timestampMs).toEqual(like.timestampMs);
+      expect(EdgeAddress.toParts(edge.address)).toMatchInlineSnapshot(`
+        Array [
+          "sourcecred",
+          "discourse",
+          "createsLike",
+          "https://url.com",
+          "mzargham",
+          "2",
+        ]
+      `);
+    });
+  });
+});


### PR DESCRIPTION
This commit reorganizes the Discourse helper methods for creating graph
nodes and edges into a helper module called `nodesAndEdges`. This will
create some breathing room for a rewrite of the createGraph module,
without feeling like that module will be over-cluttered. Conceptually,
the exact details of manipulating address structures to create graph
nodes and edges is "below the fold", we'd rather focus on the logic of
weaving the data together into a Graph.

I've moved the unit tests that particularly tested node/edge creation
into the associated module.

Test plan: `yarn test` passes. This is a really simple reorg, that's
amply sufficient.