### PR TITLE
Temporarily fix #1807 for the initiatives plugin

### DIFF
--- a/src/cli/graph.test.js
+++ b/src/cli/graph.test.js
@@ -1,0 +1,21 @@
+// @flow
+
+import {get} from "../util/null";
+import {Ledger} from "../ledger/ledger";
+import {_hackyIdentityNameReferenceDetector} from "./graph";
+
+describe("cli/graph", () => {
+  describe("hacky reference detector", () => {
+    it("works", () => {
+      const ledger = new Ledger();
+      const id = ledger.createIdentity("USER", "steven");
+      const {identity} = get(ledger.account(id));
+      const {addressFromUrl} = _hackyIdentityNameReferenceDetector(ledger);
+      expect(addressFromUrl("steven")).toEqual(identity.address);
+      expect(addressFromUrl("Steven")).toEqual(identity.address);
+      expect(addressFromUrl("@steven")).toEqual(identity.address);
+      expect(addressFromUrl("@Steven")).toEqual(identity.address);
+      expect(addressFromUrl("stuball")).toEqual(undefined);
+    });
+  });
+});

--- a/src/plugins/initiatives/parseInitiative.js
+++ b/src/plugins/initiatives/parseInitiative.js
@@ -25,7 +25,9 @@ const NodeEntryParser = C.object(
   {
     title: C.string,
     timestampIso: TimestampParser,
-    contributors: C.array(URLParser),
+    // Conceputally should use URLParser, but we allow strings
+    // as part of a hack fix to https://github.com/sourcecred/sourcecred/issues/1807
+    contributors: C.array(C.string),
   },
   {
     key: C.string,
@@ -45,7 +47,9 @@ const Parse_020: C.Parser<InitiativeFileV020> = C.object(CommonFields, {
   contributions: EdgeSpecParser,
   dependencies: EdgeSpecParser,
   references: EdgeSpecParser,
-  champions: C.array(URLParser),
+  // Conceputally should use URLParser, but we allow strings
+  // as part of a hack fix to https://github.com/sourcecred/sourcecred/issues/1807
+  champions: C.array(C.string),
 });
 
 const Parse_010: C.Parser<InitiativeFileV010> = (() => {


### PR DESCRIPTION
This commit implements a temporary/hacky fix to close #1807 for the
Initiatives plugin. The basic problem is that the initiatives plugin was
written before the Ledger, and designed to be updated by hand, so we
reference users via URL (e.g. GitHub account url). However, if that user
hasn't interacted with the project's GitHub repos, they won't be in the
Graph and the reference will fail.

This commit adds support for referencing identities in the Ledger by
writing their identity name, e.g. referencing an Identity named "steven"
by `@steven` or just `steven`. This breaks the stated contract for the
Initiatives plugin, but we're planning to deprecate and replace all of
the current data model, so adding some technical debt is OK. And we need
this to unblock beta launch because both MetaGame and SourceCred still
have old-style initiatives.

Test plan: I used this to load SourceCred's Cred (which includes
identities specified in this way) and verified through the explorer UI
that those identities were receiving Cred as expected.