### PR TITLE
don't render anything for empty aliases

### DIFF
--- a/src/ui/components/AliasSelector.js
+++ b/src/ui/components/AliasSelector.js
@@ -101,21 +101,18 @@ export function AliasSelector({
         <h2>Aliases:</h2>
       </label>
       <div>
-        {selectedItems.map(
-          (selectedItem, index) =>
-            getNodeDescription(selectedItem) && (
-              <span
-                key={`selected-item-${index}`}
-                {...getSelectedItemProps({selectedItem, index})}
-              >
-                <Markdown
-                  renderers={{paragraph: "span"}}
-                  source={getNodeDescription(selectedItem)}
-                />
-                <br />
-              </span>
-            )
-        )}
+        {selectedItems.filter(getNodeDescription).map((selectedItem, index) => (
+          <span
+            key={`selected-item-${index}`}
+            {...getSelectedItemProps({selectedItem, index})}
+          >
+            <Markdown
+              renderers={{paragraph: "span"}}
+              source={getNodeDescription(selectedItem)}
+            />
+            <br />
+          </span>
+        ))}
         <div style={comboboxStyles} {...getComboboxProps()}>
           <input
             {...getInputProps(getDropdownProps({preventKeyAction: isOpen}))}

--- a/src/ui/components/AliasSelector.js
+++ b/src/ui/components/AliasSelector.js
@@ -101,18 +101,21 @@ export function AliasSelector({
         <h2>Aliases:</h2>
       </label>
       <div>
-        {selectedItems.map((selectedItem, index) => (
-          <span
-            key={`selected-item-${index}`}
-            {...getSelectedItemProps({selectedItem, index})}
-          >
-            <Markdown
-              renderers={{paragraph: "span"}}
-              source={getNodeDescription(selectedItem)}
-            />
-            <br />
-          </span>
-        ))}
+        {selectedItems.map(
+          (selectedItem, index) =>
+            getNodeDescription(selectedItem) && (
+              <span
+                key={`selected-item-${index}`}
+                {...getSelectedItemProps({selectedItem, index})}
+              >
+                <Markdown
+                  renderers={{paragraph: "span"}}
+                  source={getNodeDescription(selectedItem)}
+                />
+                <br />
+              </span>
+            )
+        )}
         <div style={comboboxStyles} {...getComboboxProps()}>
           <input
             {...getInputProps(getDropdownProps({preventKeyAction: isOpen}))}


### PR DESCRIPTION
aliases connected to an identity get subsumed and no longer return when
naively queried from the graph after `$ sourcecred score` is executed.
This commit will not render anything in the ledger admin in these cases

test-plan: ensure no whitespace renders, including carriage returns,
  occur when an identity with linked aliases is rendered after
  credscores are recalculated.