### PR TITLE
Fix local sharness failure

### DIFF
--- a/sharness/test_no_raw_anchor_elements.t
+++ b/sharness/test_no_raw_anchor_elements.t
@@ -25,6 +25,7 @@ test_expect_success "application components must use <Link> instead of <a>" '
         ":(exclude,top)*/snapshots/*" \
         ":(exclude,top)src/plugins/discourse/references.test.js" \
         ":(exclude,top)src/plugins/discourse/createGraph.test.js" \
+        ":(exclude,top)src/plugins/discourse/nodesAndEdges.test.js" \
         ":(exclude,top)src/plugins/initiatives/htmlTemplate.test.js" \
         ":(exclude,top)src/webutil/Link.js" \
         ;


### PR DESCRIPTION
This is a sharness failure that was induced by #2037. For some reason,
the failure only appears locally, not on CI, which is why #2037 merged.
I'm tracking this at #2047.

Test plan: `yarn test` passes locally