### PR TITLE
ledger test code uses deterministic ids and dates

### DIFF
--- a/src/ledger/__snapshots__/ledger.test.js.snap
+++ b/src/ledger/__snapshots__/ledger.test.js.snap
@@ -2,8 +2,8 @@
 
 exports[`ledger/ledger state reconstruction serialized ledger snapshots as expected 1`] = `
 "[
-{\\"action\\":{\\"identity\\":{\\"address\\":\\"N\\\\u0000sourcecred\\\\u0000core\\\\u0000IDENTITY\\\\u0000USER\\\\u0000YVZhbGlkVXVpZEF0TGFzdA\\\\u0000\\",\\"aliases\\":[],\\"id\\":\\"YVZhbGlkVXVpZEF0TGFzdA\\",\\"name\\":\\"steven\\",\\"subtype\\":\\"USER\\"},\\"type\\":\\"CREATE_IDENTITY\\"},\\"ledgerTimestamp\\":1,\\"version\\":\\"1\\"},
-{\\"action\\":{\\"identity\\":{\\"address\\":\\"N\\\\u0000sourcecred\\\\u0000core\\\\u0000IDENTITY\\\\u0000ORGANIZATION\\\\u0000URgLrCxgvjHxtGJ9PgmckQ\\\\u0000\\",\\"aliases\\":[],\\"id\\":\\"URgLrCxgvjHxtGJ9PgmckQ\\",\\"name\\":\\"crystal-gems\\",\\"subtype\\":\\"ORGANIZATION\\"},\\"type\\":\\"CREATE_IDENTITY\\"},\\"ledgerTimestamp\\":2,\\"version\\":\\"1\\"},
+{\\"action\\":{\\"identity\\":{\\"address\\":\\"N\\\\u0000sourcecred\\\\u0000core\\\\u0000IDENTITY\\\\u0000USER\\\\u0000YVZhbGlkVXVpZEF0TGFzdA\\\\u0000\\",\\"aliases\\":[],\\"id\\":\\"YVZhbGlkVXVpZEF0TGFzdA\\",\\"name\\":\\"steven\\",\\"subtype\\":\\"USER\\"},\\"type\\":\\"CREATE_IDENTITY\\"},\\"ledgerTimestamp\\":0,\\"version\\":\\"1\\"},
+{\\"action\\":{\\"identity\\":{\\"address\\":\\"N\\\\u0000sourcecred\\\\u0000core\\\\u0000IDENTITY\\\\u0000ORGANIZATION\\\\u0000URgLrCxgvjHxtGJ9PgmckQ\\\\u0000\\",\\"aliases\\":[],\\"id\\":\\"URgLrCxgvjHxtGJ9PgmckQ\\",\\"name\\":\\"crystal-gems\\",\\"subtype\\":\\"ORGANIZATION\\"},\\"type\\":\\"CREATE_IDENTITY\\"},\\"ledgerTimestamp\\":1,\\"version\\":\\"1\\"},
 {\\"action\\":{\\"alias\\":\\"N\\\\u0000a1\\\\u0000\\",\\"identityId\\":\\"YVZhbGlkVXVpZEF0TGFzdA\\",\\"type\\":\\"ADD_ALIAS\\"},\\"ledgerTimestamp\\":3,\\"version\\":\\"1\\"},
 {\\"action\\":{\\"identityId\\":\\"YVZhbGlkVXVpZEF0TGFzdA\\",\\"type\\":\\"TOGGLE_ACTIVATION\\"},\\"ledgerTimestamp\\":4,\\"version\\":\\"1\\"},
 {\\"action\\":{\\"identityId\\":\\"URgLrCxgvjHxtGJ9PgmckQ\\",\\"type\\":\\"TOGGLE_ACTIVATION\\"},\\"ledgerTimestamp\\":4,\\"version\\":\\"1\\"},


### PR DESCRIPTION
Previously: ledger testing often used the real date, or truly random
UUIDs, and only fixed them when required by the tests

Now: Ledger always uses deterministic fake timestamps and fake UUIDs,
although it still allows setting them explicitly when needed.

Enables: A refactor to give ledger events UUIDs, without running into a
ton of associated mess.

Test plan: Unit tests pass, just a test change.