### PR TITLE
frontend shares ledger state

### DIFF
--- a/src/ui/components/AdminApp.js
+++ b/src/ui/components/AdminApp.js
@@ -87,7 +87,7 @@ const AdminApp = () => {
  * initial one. We may want to handle CredViews the same way, since the
  * explorer can re-calculate it.
  */
-const AdminInner = ({loadResult: loadSuccess}) => {
+const AdminInner = ({loadResult: loadSuccess}: AdminInnerProps) => {
   const [ledger, setLedger] = React.useState<Ledger>(loadSuccess.ledger);
   const history = useHistory();
   return (
@@ -106,5 +106,9 @@ const AdminInner = ({loadResult: loadSuccess}) => {
     </Admin>
   );
 };
+
+type AdminInnerProps = {|
+  +loadResult: LoadSuccess,
+|};
 
 export default AdminApp;

--- a/src/ui/components/AdminApp.js
+++ b/src/ui/components/AdminApp.js
@@ -8,6 +8,8 @@ import pink from "@material-ui/core/colors/pink";
 import fakeDataProvider from "ra-data-fakerest";
 import {Explorer} from "./Explorer";
 import {LedgerAdmin} from "./LedgerAdmin";
+import {CredView} from "../../analysis/credView";
+import {Ledger} from "../../ledger/ledger";
 import {GrainAccountOverview} from "./GrainAccountOverview";
 import {TransferGrain} from "./TransferGrain";
 import {load, type LoadResult, type LoadSuccess} from "../load";
@@ -28,27 +30,25 @@ const AppLayout = (loadResult: LoadSuccess) => (props) => (
   <Layout {...props} appBar={AppBar} menu={withRouter(Menu(loadResult))} />
 );
 
-const customRoutes = (loadResult: LoadSuccess) => [
+const customRoutes = (
+  credView: CredView,
+  ledger: Ledger,
+  setLedger: (Ledger) => void
+) => [
   <Route key="explorer" exact path="/explorer">
-    <Explorer initialView={loadResult.credView} />
+    <Explorer initialView={credView} />
   </Route>,
   <Route key="root" exact path="/">
     <Redirect to="/explorer" />
   </Route>,
   <Route key="grain" exact path="/grain">
-    <GrainAccountOverview
-      credView={loadResult.credView}
-      ledger={loadResult.ledger}
-    />
+    <GrainAccountOverview credView={credView} ledger={ledger} />
   </Route>,
   <Route key="admin" exact path="/admin">
-    <LedgerAdmin
-      credView={loadResult.credView}
-      initialLedger={loadResult.ledger}
-    />
+    <LedgerAdmin credView={credView} ledger={ledger} setLedger={setLedger} />
   </Route>,
   <Route key="transfer" exact path="/transfer">
-    <TransferGrain initialLedger={loadResult.ledger} />
+    <TransferGrain ledger={ledger} setLedger={setLedger} />
   </Route>,
 ];
 
@@ -76,24 +76,35 @@ const AdminApp = () => {
         </div>
       );
     case "SUCCESS":
-      return (
-        <Admin
-          layout={AppLayout(loadResult)}
-          theme={theme}
-          dataProvider={dataProvider}
-          history={history}
-          customRoutes={customRoutes(loadResult)}
-        >
-          {/*
-          This dummy resource is required to get react
-          admin working beyond the hello world screen
-        */}
-          <Resource name="dummyResource" />
-        </Admin>
-      );
+      return AdminInner(loadResult);
     default:
       throw new Error((loadResult.type: empty));
   }
+};
+
+/**
+ * AdminInner keeps track of the Ledger state so that if one component
+ * changes the ledger, the others use the updated ledger instead of the
+ * initial one. We may want to handle CredViews the same way, since the
+ * explorer can re-calculate it.
+ */
+const AdminInner = (loadSuccess: LoadSuccess) => {
+  const [ledger, setLedger] = React.useState<Ledger>(loadSuccess.ledger);
+  return (
+    <Admin
+      layout={AppLayout(loadSuccess)}
+      theme={theme}
+      dataProvider={dataProvider}
+      history={history}
+      customRoutes={customRoutes(loadSuccess.credView, ledger, setLedger)}
+    >
+      {/*
+          This dummy resource is required to get react
+          admin working beyond the hello world screen
+        */}
+      <Resource name="dummyResource" />
+    </Admin>
+  );
 };
 
 export default AdminApp;

--- a/src/ui/components/AdminApp.js
+++ b/src/ui/components/AdminApp.js
@@ -57,7 +57,6 @@ const AdminApp = () => {
   React.useEffect(() => {
     load().then(setLoadResult);
   }, []);
-  const history = useHistory();
 
   if (!loadResult) {
     return (
@@ -76,7 +75,7 @@ const AdminApp = () => {
         </div>
       );
     case "SUCCESS":
-      return AdminInner(loadResult);
+      return <AdminInner loadResult={loadResult} />;
     default:
       throw new Error((loadResult.type: empty));
   }
@@ -88,8 +87,9 @@ const AdminApp = () => {
  * initial one. We may want to handle CredViews the same way, since the
  * explorer can re-calculate it.
  */
-const AdminInner = (loadSuccess: LoadSuccess) => {
+const AdminInner = ({loadResult: loadSuccess}) => {
   const [ledger, setLedger] = React.useState<Ledger>(loadSuccess.ledger);
+  const history = useHistory();
   return (
     <Admin
       layout={AppLayout(loadSuccess)}

--- a/src/ui/components/LedgerAdmin.js
+++ b/src/ui/components/LedgerAdmin.js
@@ -8,11 +8,11 @@ import {AliasSelector} from "./AliasSelector";
 
 export type Props = {|
   +credView: CredView,
-  +initialLedger: Ledger,
+  +ledger: Ledger,
+  +setLedger: (Ledger) => void,
 |};
 
-export const LedgerAdmin = ({credView, initialLedger}: Props) => {
-  const [ledger, setLedger] = useState<Ledger>(initialLedger);
+export const LedgerAdmin = ({credView, ledger, setLedger}: Props) => {
   const [nextIdentityName, setIdentityName] = useState<string>("");
   const [currentIdentity, setCurrentIdentity] = useState<Identity | null>(null);
   const [promptString, setPromptString] = useState<string>("Add Identity:");

--- a/src/ui/components/TransferGrain.js
+++ b/src/ui/components/TransferGrain.js
@@ -14,11 +14,11 @@ import {Ledger, type Account} from "../../ledger/ledger";
 import AccountDropdown from "./AccountSelector";
 
 export type Props = {|
-  +initialLedger: Ledger,
+  +ledger: Ledger,
+  +setLedger: (Ledger) => void,
 |};
 
-export const TransferGrain = ({initialLedger}: Props) => {
-  const [ledger, setLedger] = useState<Ledger>(initialLedger);
+export const TransferGrain = ({ledger, setLedger}: Props) => {
   const [sourceIdentity, setSourceIdentity] = useState<Identity | null>(null);
   const [destIdentity, setDestIdentity] = useState<Identity | null>(null);
   const [amount, setAmount] = useState<string>("0");


### PR DESCRIPTION
Currently, if one frontend component changes the ledger state, that
doesn't propagate over to the other components, e.g. if you make a new
identity in the admin, then switch to the transfer view, you can't
transfer to the new identity. This commit fixes this by adding a shared
ledger state across all of the admin components.

Test plan: Make a new identity, activate it, and switch to the transfers
pane and transfer to the new identity.

Paired with @topocount 