### PR TITLE
update selectedItems control memo to use new aliases

### DIFF
--- a/src/ui/components/AliasSelector.js
+++ b/src/ui/components/AliasSelector.js
@@ -1,6 +1,6 @@
 // @flow
 
-import React, {useState, useMemo} from "react";
+import React, {useState} from "react";
 import {useCombobox} from "downshift";
 import {Ledger} from "../../ledger/ledger";
 import {type Identity, type Alias} from "../../ledger/identity";
@@ -56,10 +56,6 @@ export function AliasSelector({
     setInputItems(filteredAliasesMatchingString(input));
   };
 
-  useMemo(() => {
-    setAliasSearch();
-  }, [currentIdentity && currentIdentity.aliases]);
-
   const {
     isOpen,
     getToggleButtonProps,
@@ -86,6 +82,7 @@ export function AliasSelector({
             setCurrentIdentity(ledger.account(currentIdentity.id).identity);
             setInputValue("");
             selectItem(null);
+            setAliasSearch();
             claimedAddresses.add(selectedItem.address);
           }
 

--- a/src/ui/components/AliasSelector.js
+++ b/src/ui/components/AliasSelector.js
@@ -25,7 +25,6 @@ export function AliasSelector({
 }: Props) {
   const [inputValue, setInputValue] = useState("");
   const {
-    getSelectedItemProps,
     getDropdownProps,
     addSelectedItem,
     removeSelectedItem,
@@ -122,10 +121,7 @@ export function AliasSelector({
       </label>
       <div>
         {selectedItems.map((selectedItem, index) => (
-          <span
-            key={`selected-item-${index}`}
-            {...getSelectedItemProps({selectedItem, index})}
-          >
+          <span key={`selected-item-${index}`}>
             <Markdown
               renderers={{paragraph: "span"}}
               source={selectedItem.description}

--- a/src/ui/components/AliasSelector.js
+++ b/src/ui/components/AliasSelector.js
@@ -1,6 +1,6 @@
 // @flow
 
-import React, {useState} from "react";
+import React, {useState, useEffect} from "react";
 import {useCombobox} from "downshift";
 import {Ledger} from "../../ledger/ledger";
 import {type Alias, type IdentityId} from "../../ledger/identity";
@@ -59,6 +59,10 @@ export function AliasSelector({
     setInputItems(filteredAliasesMatchingString(input));
   };
 
+  useEffect(() => {
+    setAliasSearch();
+  }, [selectedAccount.identity.aliases]);
+
   const {
     isOpen,
     getToggleButtonProps,
@@ -84,7 +88,6 @@ export function AliasSelector({
             setLedger(ledger.addAlias(selectedIdentityId, selectedItem));
             setInputValue("");
             selectItem(null);
-            setAliasSearch();
           }
           break;
         default:

--- a/src/ui/components/AliasSelector.js
+++ b/src/ui/components/AliasSelector.js
@@ -1,7 +1,7 @@
 // @flow
 
 import React, {useState, useMemo} from "react";
-import {useCombobox, useMultipleSelection} from "downshift";
+import {useCombobox} from "downshift";
 import {Ledger} from "../../ledger/ledger";
 import {type Identity, type Alias} from "../../ledger/identity";
 import {CredView} from "../../analysis/credView";
@@ -25,25 +25,6 @@ export function AliasSelector({
   credView,
 }: Props) {
   const [inputValue, setInputValue] = useState("");
-  const {
-    getDropdownProps,
-    addSelectedItem,
-    removeSelectedItem,
-    selectedItems,
-  } = useMultipleSelection({
-    initialSelectedItems: [],
-  });
-
-  // this memo is utilized to repopulate the selected Items
-  // list each time the user is changed in the interface
-  useMemo(() => {
-    selectedItems.forEach((alias: Alias) => {
-      removeSelectedItem(alias);
-    });
-    if (currentIdentity) {
-      currentIdentity.aliases.forEach((alias) => addSelectedItem(alias));
-    }
-  }, [currentIdentity && currentIdentity.id]);
 
   const claimedAddresses: Set<NodeAddressT> = new Set();
   for (const {identity} of ledger.accounts()) {
@@ -104,7 +85,6 @@ export function AliasSelector({
             setLedger(ledger.addAlias(currentIdentity.id, selectedItem));
             setCurrentIdentity(ledger.account(currentIdentity.id).identity);
             setInputValue("");
-            addSelectedItem(selectedItem);
             selectItem(null);
             claimedAddresses.add(selectedItem.address);
           }
@@ -131,9 +111,7 @@ export function AliasSelector({
           </span>
         ))}
         <div style={comboboxStyles} {...getComboboxProps()}>
-          <input
-            {...getInputProps(getDropdownProps({preventKeyAction: isOpen}))}
-          />
+          <input {...getInputProps()} />
           <button {...getToggleButtonProps()} aria-label={"toggle menu"}>
             &#8595;
           </button>

--- a/src/ui/components/AliasSelector.js
+++ b/src/ui/components/AliasSelector.js
@@ -7,6 +7,7 @@ import {type Identity, type Alias} from "../../ledger/identity";
 import {CredView} from "../../analysis/credView";
 import {type NodeAddressT} from "../../core/graph";
 import Markdown from "react-markdown";
+import removeMd from "remove-markdown";
 
 type Props = {|
   +currentIdentity: Identity | null,
@@ -62,7 +63,7 @@ export function AliasSelector({
 
   function filteredAliasesMatchingString(input: string): Alias[] {
     return potentialAliases.filter(({description}) =>
-      description.toLowerCase().startsWith(input.toLowerCase())
+      removeMd(description).toLowerCase().startsWith(input.toLowerCase())
     );
   }
 

--- a/src/ui/components/AliasSelector.js
+++ b/src/ui/components/AliasSelector.js
@@ -28,7 +28,7 @@ export function AliasSelector({
     getSelectedItemProps,
     getDropdownProps,
     addSelectedItem,
-    //removeSelectedItem, will be utilzed again when #2059 is merged
+    removeSelectedItem,
     selectedItems,
   } = useMultipleSelection({
     initialSelectedItems: [],
@@ -37,9 +37,12 @@ export function AliasSelector({
   // this memo is utilized to repopulate the selected Items
   // list each time the user is changed in the interface
   useMemo(() => {
-    // This memo will be reimplemented once the
-    // alias primitives (#2059) are merged into this
-    // branch or master
+    selectedItems.forEach((alias: Alias) => {
+      removeSelectedItem(alias);
+    });
+    if (currentIdentity) {
+      currentIdentity.aliases.forEach((alias) => addSelectedItem(alias));
+    }
   }, [currentIdentity && currentIdentity.id]);
 
   const claimedAddresses: Set<NodeAddressT> = new Set();

--- a/src/ui/components/AliasSelector.js
+++ b/src/ui/components/AliasSelector.js
@@ -125,7 +125,7 @@ export function AliasSelector({
               {...getItemProps({item, index})}
             >
               <Markdown
-                renderers={{paragraph: "span"}}
+                renderers={{link: "span", paragraph: "span"}}
                 source={item.description}
               />
             </li>

--- a/src/ui/components/AliasSelector.js
+++ b/src/ui/components/AliasSelector.js
@@ -10,7 +10,7 @@ import Markdown from "react-markdown";
 import removeMd from "remove-markdown";
 
 type Props = {|
-  +currentIdentity: Identity | null,
+  +currentIdentity: Identity,
   +ledger: Ledger,
   +credView: CredView,
   +setLedger: (Ledger) => void,
@@ -100,7 +100,7 @@ export function AliasSelector({
         case useCombobox.stateChangeTypes.InputKeyDownEnter:
         case useCombobox.stateChangeTypes.ItemClick:
         case useCombobox.stateChangeTypes.InputBlur:
-          if (selectedItem && currentIdentity) {
+          if (selectedItem) {
             setLedger(ledger.addAlias(currentIdentity.id, selectedItem));
             setCurrentIdentity(ledger.account(currentIdentity.id).identity);
             setInputValue("");
@@ -116,12 +116,12 @@ export function AliasSelector({
     },
   });
   return (
-    <div style={{visibility: currentIdentity ? "visible" : "hidden"}}>
+    <div>
       <label>
         <h2>Aliases:</h2>
       </label>
       <div>
-        {selectedItems.map((selectedItem, index) => (
+        {currentIdentity.aliases.map((selectedItem, index) => (
           <span key={`selected-item-${index}`}>
             <Markdown
               renderers={{paragraph: "span"}}

--- a/src/ui/components/LedgerAdmin.js
+++ b/src/ui/components/LedgerAdmin.js
@@ -92,47 +92,46 @@ export const LedgerAdmin = ({credView, ledger, setLedger}: Props) => {
           type="submit"
           value={currentIdentity ? "update username" : "create identity"}
         />
-        <br />
-        <input
-          type="button"
-          value="save ledger to disk"
-          onClick={() => {
-            fetch("data/ledger.json", {
-              headers: {
-                Accept: "text/plain",
-                "Content-Type": "text/plain",
-              },
-              method: "POST",
-              body: ledger.serialize(),
-            });
-          }}
-        />
-        {currentIdentity && (
-          <>
-            <br />
-            <input
-              type="button"
-              value="New identity"
-              onClick={() => setActiveIdentity(currentIdentity)}
-            />
-            <br />
-            <input
-              type="checkbox"
-              id="active"
-              name="active"
-              checked={checkboxSelected}
-              onChange={() => toggleIdentityActivation(currentIdentity)}
-            />
-            <label htmlFor="active">Account is active</label>
-            <AliasSelector
-              selectedIdentityId={currentIdentity.id}
-              ledger={ledger}
-              setLedger={setLedger}
-              credView={credView}
-            />
-          </>
-        )}
       </form>
+      <input
+        type="button"
+        value="save ledger to disk"
+        onClick={() => {
+          fetch("data/ledger.json", {
+            headers: {
+              Accept: "text/plain",
+              "Content-Type": "text/plain",
+            },
+            method: "POST",
+            body: ledger.serialize(),
+          });
+        }}
+      />
+      {currentIdentity && (
+        <>
+          <br />
+          <input
+            type="button"
+            value="New identity"
+            onClick={() => setActiveIdentity(currentIdentity)}
+          />
+          <br />
+          <input
+            type="checkbox"
+            id="active"
+            name="active"
+            checked={checkboxSelected}
+            onChange={() => toggleIdentityActivation(currentIdentity)}
+          />
+          <label htmlFor="active">Account is active</label>
+          <AliasSelector
+            selectedIdentityId={currentIdentity.id}
+            ledger={ledger}
+            setLedger={setLedger}
+            credView={credView}
+          />
+        </>
+      )}
     </div>
   );
 

--- a/src/ui/components/LedgerAdmin.js
+++ b/src/ui/components/LedgerAdmin.js
@@ -124,19 +124,16 @@ export const LedgerAdmin = ({credView, ledger, setLedger}: Props) => {
               onChange={() => toggleIdentityActivation(currentIdentity)}
             />
             <label htmlFor="active">Account is active</label>
+            <AliasSelector
+              currentIdentity={currentIdentity}
+              ledger={ledger}
+              setLedger={setLedger}
+              setCurrentIdentity={setCurrentIdentity}
+              credView={credView}
+            />
           </>
         )}
       </form>
-      <div>
-        {/* Warning: don't conditionally render AliasSelector because it contains react hooks*/}
-        <AliasSelector
-          currentIdentity={currentIdentity}
-          ledger={ledger}
-          setLedger={setLedger}
-          setCurrentIdentity={setCurrentIdentity}
-          credView={credView}
-        />
-      </div>
     </div>
   );
 

--- a/src/ui/components/LedgerAdmin.js
+++ b/src/ui/components/LedgerAdmin.js
@@ -125,10 +125,9 @@ export const LedgerAdmin = ({credView, ledger, setLedger}: Props) => {
             />
             <label htmlFor="active">Account is active</label>
             <AliasSelector
-              currentIdentity={currentIdentity}
+              selectedIdentityId={currentIdentity.id}
               ledger={ledger}
               setLedger={setLedger}
-              setCurrentIdentity={setCurrentIdentity}
               credView={credView}
             />
           </>


### PR DESCRIPTION
Now that the aliases property on ledger identities includes the
description in addition to the address, we can render it in the selected
items array. This memo activates on any renders where the
currentIdentity Id changes, and removes all selected aliases from the
array that is rendered. If another identity is selected, the new aliases
are added to the array.

test plan: recalculate the graph and cred before testing, then ensure
that:
- existing aliases now render out their pre-added aliases
- selected aliases rerender with the selected identity's alias upon
selected a new identity