### PR TITLE
Add a hidden panel for special distributions

### DIFF
--- a/src/ui/components/AdminApp.js
+++ b/src/ui/components/AdminApp.js
@@ -12,6 +12,7 @@ import {CredView} from "../../analysis/credView";
 import {Ledger} from "../../ledger/ledger";
 import {GrainAccountOverview} from "./GrainAccountOverview";
 import {TransferGrain} from "./TransferGrain";
+import {SpecialGrainDistribution} from "./SpecialGrainDistribution";
 import {load, type LoadResult, type LoadSuccess} from "../load";
 import {withRouter} from "react-router-dom";
 import AppBar from "./AppBar";
@@ -49,6 +50,9 @@ const customRoutes = (
   </Route>,
   <Route key="transfer" exact path="/transfer">
     <TransferGrain ledger={ledger} setLedger={setLedger} />
+  </Route>,
+  <Route key="special-distribution" exact path="/special-distribution">
+    <SpecialGrainDistribution ledger={ledger} setLedger={setLedger} />
   </Route>,
 ];
 

--- a/src/ui/components/SpecialGrainDistribution.js
+++ b/src/ui/components/SpecialGrainDistribution.js
@@ -1,0 +1,124 @@
+// @flow
+
+import React, {useState} from "react";
+import {div, fromInteger, fromFloatString, ZERO} from "../../ledger/grain";
+import {type IdentityId} from "../../ledger/identity";
+import {Ledger, type Account} from "../../ledger/ledger";
+import AccountDropdown from "./AccountSelector";
+import {computeAllocation} from "../../ledger/grainAllocation";
+import * as uuid from "../../util/uuid";
+import type {TimestampMs} from "../../util/timestamp";
+
+export type Props = {|
+  +ledger: Ledger,
+  +setLedger: (Ledger) => void,
+|};
+
+export const SpecialGrainDistribution = ({ledger, setLedger}: Props) => {
+  const [credTimestamp, setCredTimestamp] = useState<TimestampMs>(+Date.now());
+  const [recipient, setRecipient] = useState<IdentityId | null>(null);
+  const [amount, setAmount] = useState<string>("0");
+  const [memo, setMemo] = useState<string>("");
+
+  const setRecipientFromAccount = (acct: Account) => {
+    setRecipient(acct.identity.id);
+  };
+
+  const submitDistribution = (e) => {
+    e.preventDefault();
+    if (recipient != null && amount !== ZERO) {
+      const policy = {
+        policyType: "SPECIAL",
+        budget: fromFloatString(amount),
+        memo,
+        recipient,
+      };
+      const allocation = computeAllocation(policy, [
+        {cred: [1], paid: ZERO, id: recipient},
+      ]);
+      const distribution = {
+        id: uuid.random(),
+        credTimestamp,
+        allocations: [allocation],
+      };
+      const nextLedger = ledger.distributeGrain(distribution);
+      setLedger(nextLedger);
+      setAmount(fromInteger(0));
+      setMemo("");
+    }
+  };
+
+  return (
+    <div
+      style={{
+        width: "80%",
+        margin: "0 auto",
+        background: "white",
+        padding: "0 5em 5em",
+      }}
+    >
+      <h1>Legacy Grain Distribution Tool</h1>
+      <p>
+        This is a temporary migration tool for making special Grain payments. It
+        is intended to port legacy ledger balances.
+      </p>
+      <form onSubmit={(e) => submitDistribution(e)}>
+        <label>Recipient</label>
+        <AccountDropdown
+          ledger={ledger}
+          setCurrentIdentity={setRecipientFromAccount}
+        />
+        <p>
+          <label htmlFor="amount">Amount</label> <br />
+          <input
+            type="number"
+            name="amount"
+            min="0"
+            step="any"
+            required
+            value={amount}
+            onChange={(e) => setAmount(e.currentTarget.value)}
+          />
+        </p>
+        <p>
+          <label htmlFor="memo">Memo</label> <br />
+          <input
+            type="text"
+            name="memo"
+            value={memo}
+            onChange={(e) => setMemo(e.currentTarget.value)}
+          />
+        </p>
+        <p>
+          <label htmlFor="timestamp">Timestamp</label> <br />
+          <input
+            type="number"
+            name="timestamp"
+            value={credTimestamp}
+            onChange={(e) => setCredTimestamp(e.currentTarget.value)}
+          />
+        </p>
+        <input
+          disabled={recipient == null}
+          type="submit"
+          value="distribute special grain"
+        />
+        <br />
+        <input
+          type="button"
+          value="save ledger to disk"
+          onClick={() => {
+            fetch("data/ledger.json", {
+              headers: {
+                Accept: "text/plain",
+                "Content-Type": "text/plain",
+              },
+              method: "POST",
+              body: ledger.serialize(),
+            });
+          }}
+        />
+      </form>
+    </div>
+  );
+};


### PR DESCRIPTION
For porting our legacy Grain balances, we're issuing "special" one-time
distributions for past Grain balances. This commit adds the ability to
do so via a hidden frontend UI. It's only accessible by manually
navigating to `/#/special-distributions`. After we've migrated existing
projects, we'll remove this UI.

Test plan: I used it to generate some fake distributions in our test
instance.

This builds on #2052. The implementation is mostly copied from #2035.