### PR TITLE
Creditor Nodes: initial implementation

### DIFF
--- a/src/plugins/creditor/credNodeStore.js
+++ b/src/plugins/creditor/credNodeStore.js
@@ -1,0 +1,100 @@
+// @flow
+
+import {type CreditorNode, type NodeUuid, type NodeTagId} from "./creditorNode";
+import {JsonLog} from "../../util/jsonLog";
+
+export type NodeEntry = {|type: "NODE", entry: CreditorNode|};
+export type NodeDetails = {title: string, id: NodeUuid};
+type NodesFile = JsonLog<NodeEntry>;
+
+export function toNodeEntry(entry: CreditorNode): NodeEntry {
+  return {type: "NODE", entry};
+}
+
+export function fromNodeEntry({entry}: NodeEntry): [NodeUuid, CreditorNode] {
+  return [entry.id, entry];
+}
+
+export function getDetails({id, title}: CreditorNode): NodeDetails {
+  return {id, title};
+}
+
+/**
+ * CredNodeStore is the static, in-memory representation of creditor nodes
+ *
+ * This class is used to accept and validate frontend inputs, and export them in
+ * serialized format utilizing the jsonLog functionality when saving to a file.
+ * Nodes in this class are still modifiable, of course, and jsonLogging is utilized
+ * because it outputs a gitdiff-friendly format
+ *
+ * Nodes in the the cred node store are not deletable at this time. In lieu of deleting nodes,
+ * their weights (`mint` values) can simply be set to zero
+ */
+export default class CredNodeStore {
+  +_nodes: Map<NodeUuid, CreditorNode>;
+
+  constructor(fromDisk: NodesFile | void) {
+    if (!fromDisk) {
+      this._nodes = new Map();
+    } else {
+      const nodeKVArray = Array.from(fromDisk.values()).map(fromNodeEntry);
+      this._nodes = new Map(nodeKVArray);
+    }
+  }
+
+  serialize(): string {
+    const log = new JsonLog();
+    const sortedEntries = Array.from(this.values()).sort(
+      ({createdAt: a}, {createdAt: b}) => a - b
+    );
+    return log.append(sortedEntries.map(toNodeEntry)).toString();
+  }
+
+  set(node: CreditorNode): CredNodeStore {
+    const {
+      id,
+      tags,
+      title,
+      description,
+      graphTimestamp,
+      createdAt,
+      parent,
+    } = node;
+    if (!id) {
+      throw new Error("Creditor Node UUID required");
+    }
+    if (!Array.isArray(tags)) throw new Error("`tags` must be an array");
+    if (!(title || description))
+      throw new Error("`title` and `description` are required in Cred Nodes");
+    if (!(graphTimestamp || createdAt))
+      throw new Error(
+        "`createdAt` and `graphTimestamp` values must be non-zero"
+      );
+    if (parent && !this._nodes.has(parent))
+      throw new Error("cannot add node with nonexistent parent");
+    this._nodes.set(node.id, node);
+    return this;
+  }
+
+  get(id: NodeUuid): ?CreditorNode {
+    return this._nodes.get(id);
+  }
+
+  values(): Iterator<CreditorNode> {
+    return this._nodes.values();
+  }
+
+  referencingTag(id: NodeTagId): NodeDetails[] {
+    return Array.from(this._nodes.values())
+      .filter(({tags}) => tags.includes(id))
+      .map(getDetails);
+  }
+
+  getParent(child: NodeUuid): ?CreditorNode {
+    const childNode = this._nodes.get(child);
+    if (!childNode)
+      throw new Error(`cred node with Id ${child} does not exist`);
+    if (!childNode.parent) return null;
+    return this._nodes.get(childNode.parent);
+  }
+}

--- a/src/plugins/creditor/credNodeStore.test.js
+++ b/src/plugins/creditor/credNodeStore.test.js
@@ -1,0 +1,124 @@
+// @flow
+
+import {type CreditorNode} from "./creditorNode";
+import Store, {getDetails, toNodeEntry} from "./credNodeStore";
+import {random as randomUuid} from "../../util/uuid";
+
+describe("plugins/creditor/credNodeStore", () => {
+  const tagId1 = randomUuid();
+  const tagId2 = randomUuid();
+  const baseNode: CreditorNode = {
+    id: randomUuid(),
+    tags: [tagId1, tagId2],
+    title: "Implementing credNodes",
+    description: "creating credNodes for use in the creditor",
+    graphTimestamp: new Date("1/1/2000").getTime(),
+    createdAt: new Date("12/1/2000").getTime(),
+    mint: 0,
+    parent: null,
+  };
+
+  const childNode: CreditorNode = {
+    id: randomUuid(),
+    tags: [tagId2],
+    title: "Creating credNode type",
+    description: "specifying credNodes to test the store",
+    graphTimestamp: new Date("1/1/2000").getTime(),
+    createdAt: new Date("11/1/2000").getTime(),
+    mint: 20,
+    parent: baseNode.id,
+  };
+
+  describe("adding nodes to store", () => {
+    it("requires nodes to have expected members", () => {
+      const store = new Store();
+      const thunk = (badNode: Object) => () => store.set(badNode);
+
+      const badNodes = [
+        [{}, "Creditor Node UUID required"],
+        [{id: randomUuid()}, "`tags` must be an array"],
+        [
+          {id: randomUuid(), tags: []},
+          "`title` and `description` are required in Cred Nodes",
+        ],
+        [
+          {
+            id: randomUuid(),
+            tags: [],
+            title: "bad Node",
+            description: "badDescription",
+            createdAt: 0,
+            graphTimestamp: 0,
+          },
+          "`createdAt` and `graphTimestamp` values must be non-zero",
+        ],
+      ];
+      badNodes.forEach(([node, errorMsg]) =>
+        expect(thunk(node)).toThrowError(errorMsg)
+      );
+    });
+    it("can set and get valid nodes", () => {
+      const store = new Store();
+      const nextStore = store.set(baseNode);
+      expect(nextStore).toEqual(store);
+      const returnedBase = store.get(baseNode.id);
+      expect(returnedBase).toEqual(baseNode);
+    });
+    it("returns null for nonexistent nodes", () => {
+      const store = new Store();
+      const badId = randomUuid();
+      const result = store.get(badId);
+      expect(result).toBeEmpty;
+    });
+  });
+  describe("node interactions", () => {
+    const store = new Store();
+    describe("child-parent relationships", () => {
+      it("cannot add node with nonexistent parent", () => {
+        expect(() => store.set(childNode)).toThrowError(
+          "cannot add node with nonexistent parent"
+        );
+      });
+      it("can add child after parent", () => {
+        store.set(baseNode);
+        store.set(childNode);
+      });
+      it("can access parent from child ID", () => {
+        const returnedNode = store.getParent(childNode.id);
+        expect(returnedNode).toEqual(baseNode);
+      });
+      it("returns null when getting nonexistent parent", () => {
+        const result = store.getParent(baseNode.id);
+        expect(result).toBeEmpty;
+      });
+    });
+    describe("tag references", () => {
+      it("returns NodeDetails when querying nodes by tag IDs", () => {
+        const baseDetails = getDetails(baseNode);
+        const childDetails = getDetails(childNode);
+        expect(store.referencingTag(tagId1)).toEqual([baseDetails]);
+        expect(store.referencingTag(tagId2)).toEqual([
+          baseDetails,
+          childDetails,
+        ]);
+      });
+      it("returns an empty array when unused tag is queried", () => {
+        expect(store.referencingTag(randomUuid())).toEqual([]);
+      });
+    });
+  });
+  describe("exports", () => {
+    const store = new Store().set(baseNode).set(childNode);
+    it("returns an iterable on the values method call", () => {
+      expect(Array.from(store.values())).toEqual([baseNode, childNode]);
+    });
+    it("returns nodes sorted on `createdAt` in ascending order when serialized", () => {
+      //TODO replace jsonParse with comboParser
+      expect(JSON.parse(store.serialize())).toEqual([
+        toNodeEntry(childNode),
+        toNodeEntry(baseNode),
+      ]);
+    });
+  });
+  it.todo("test non-empty constructor");
+});

--- a/src/plugins/creditor/creditorNode.js
+++ b/src/plugins/creditor/creditorNode.js
@@ -1,0 +1,28 @@
+// @flow
+
+import {type TimestampMs} from "../../util/timestamp";
+import {type Uuid} from "../../util/uuid";
+
+export type NodeTagId = Uuid;
+
+export type NodeTag = {|
+  id: NodeTagId,
+  mint: number, // additive semantics
+  name: string,
+|};
+
+export type NodeUuid = Uuid;
+
+export type CreditorNode = {|
+  +id: NodeUuid,
+  +tags: $ReadOnlyArray<NodeTagId>,
+  +title: string,
+  +description: string,
+  +graphTimestamp: TimestampMs,
+  +createdAt: TimestampMs,
+  +mint: number,
+  +parent: NodeUuid | null,
+|};
+
+//TODO graph node mint value = sum of node and all applied tags
+//TODO graph edge weight value = product of edge and all applied tags

--- a/src/plugins/creditor/declaration.js
+++ b/src/plugins/creditor/declaration.js
@@ -1,0 +1,49 @@
+// @flow
+
+import deepFreeze from "deep-freeze";
+import type {PluginDeclaration} from "../../analysis/pluginDeclaration";
+import type {NodeType, EdgeType} from "../../analysis/types";
+import {NodeAddress, EdgeAddress} from "../../core/graph";
+
+export const nodePrefix = NodeAddress.fromParts(["sourcecred", "creditor"]);
+export const edgePrefix = EdgeAddress.fromParts(["sourcecred", "creditor"]);
+
+export const CreditorEntryType: NodeType = deepFreeze({
+  name: "CredNode",
+  pluralName: "CredNodes",
+  prefix: NodeAddress.append(nodePrefix, "credNode"),
+  defaultWeight: 0,
+  description:
+    "An creditor node, describing a scoped improvement to a project from proposal to completion. \
+    Creditor nodes can be nested  arbitrarily (but non-circularly) to represent complet projects and scopes",
+});
+
+/*
+  Note on the forward and backward naming convention.
+  It follows the core/graph.js documentation to use
+  a <subject> <verb> <object> format to figure out
+  the directionality.
+*/
+
+/**
+ * A contributor (src) CONTRIBUTES TO (verb) an Creditor node (dst).
+ * Forward: a contributor towards the entry node has a small endorsement of that
+ * contribution.
+ * Backward: flows the value of the contribution to the contributors.
+ */
+export const CreditorEdgeType: EdgeType = deepFreeze({
+  forwardName: "contributes to entry",
+  backwardName: "entry is contributed to by",
+  prefix: EdgeAddress.append(edgePrefix, "contributesToEntry"),
+  defaultWeight: {forwards: 1 / 16, backwards: 1},
+  description: "Connects a contributor to an entry node.",
+});
+
+export const declaration: PluginDeclaration = deepFreeze({
+  name: "Creditor",
+  nodePrefix,
+  edgePrefix,
+  nodeTypes: [CreditorEntryType],
+  edgeTypes: [CreditorEdgeType],
+  userTypes: [],
+});


### PR DESCRIPTION
Creditor nodes are utilized to store user-created cred minting actions.
The cannot be deleted, but they are modifiable. In memory they are
stored in the CredNodeStore, which enforces their structure and
heirarchical relationships with other nodes.

Like Initiatives, Creditor nodes are saved to disk in the instance repo.
Unlike Initiatives, they are not meant to be user-modifiable in this
state, but are rather meant to be updated via a web frontend. Diffing
changes is facilitated through use of jsonLog, which outputs each node
on a separate line.

test-plan: unit tests are provided for all methods in the CredNodeStore