### PR TITLE
Discord: actually no spam

### DIFF
--- a/src/plugins/experimental-discord/createGraph.js
+++ b/src/plugins/experimental-discord/createGraph.js
@@ -248,10 +248,7 @@ export function createGraph(
       if (hasEdges) {
         const author = memberMap.get(message.authorId);
         if (!author) {
-          console.warn(
-            `Message author not loaded ${message.authorId}, maybe a Deleted User?\n` +
-              `${messageUrl(guild, channel.id, message.id)}`
-          );
+          // Probably this user left the server.
           continue;
         }
         wg.graph.addNode(memberNode(author));


### PR DESCRIPTION
This is a fixup for #2057, which turned out to not remove all the
sources of spam.

Test plan: Now there truly is no spam. I really tested it this time.