### PR TITLE
bugfix: remove resource menu link generator

### DIFF
--- a/src/ui/components/AdminApp.js
+++ b/src/ui/components/AdminApp.js
@@ -27,8 +27,8 @@ const theme = createMuiTheme({
   },
 });
 
-const AppLayout = (loadResult: LoadSuccess) => (props) => (
-  <Layout {...props} appBar={AppBar} menu={withRouter(Menu(loadResult))} />
+const AppLayout = (props) => (
+  <Layout {...props} appBar={AppBar} menu={withRouter(Menu)} />
 );
 
 const customRoutes = (
@@ -96,7 +96,7 @@ const AdminInner = ({loadResult: loadSuccess}: AdminInnerProps) => {
   const history = useHistory();
   return (
     <Admin
-      layout={AppLayout(loadSuccess)}
+      layout={AppLayout}
       theme={theme}
       dataProvider={dataProvider}
       history={history}

--- a/src/ui/components/Menu.js
+++ b/src/ui/components/Menu.js
@@ -1,8 +1,7 @@
 // @flow
 import React from "react";
-import {createElement} from "react";
 import {useSelector} from "react-redux";
-import {MenuItemLink, getResources} from "react-admin";
+import {MenuItemLink} from "react-admin";
 import {type LoadSuccess} from "../load";
 import TrendingUpIcon from "@material-ui/icons/TrendingUp";
 import DefaultIcon from "@material-ui/icons/ViewList";
@@ -12,7 +11,6 @@ type menuProps = {|onMenuClick: Function|};
 
 const Menu = ({bundledPlugins}: LoadSuccess) => ({onMenuClick}: menuProps) => {
   const open = useSelector((state) => state.admin.ui.sidebarOpen);
-  const resources = useSelector(getResources);
   return (
     <>
       <MenuItemLink
@@ -22,24 +20,6 @@ const Menu = ({bundledPlugins}: LoadSuccess) => ({onMenuClick}: menuProps) => {
         onClick={onMenuClick}
         sidebarIsOpen={open}
       />
-
-      {bundledPlugins.includes("sourcecred/initiatives") &&
-        resources.map((resource) => {
-          return (
-            <MenuItemLink
-              key={resource.name}
-              to={`/${resource.name}`}
-              primaryText={
-                (resource.options && resource.options.label) || resource.name
-              }
-              leftIcon={
-                resource.icon ? createElement(resource.icon) : <DefaultIcon />
-              }
-              onClick={onMenuClick}
-              sidebarIsOpen={open}
-            />
-          );
-        })}
       <MenuItemLink
         to="/grain"
         primaryText="Grain Accounts"

--- a/src/ui/components/Menu.js
+++ b/src/ui/components/Menu.js
@@ -2,14 +2,13 @@
 import React from "react";
 import {useSelector} from "react-redux";
 import {MenuItemLink} from "react-admin";
-import {type LoadSuccess} from "../load";
 import TrendingUpIcon from "@material-ui/icons/TrendingUp";
 import DefaultIcon from "@material-ui/icons/ViewList";
 import TransformIcon from "@material-ui/icons/Transform";
 
 type menuProps = {|onMenuClick: Function|};
 
-const Menu = ({bundledPlugins}: LoadSuccess) => ({onMenuClick}: menuProps) => {
+const Menu = ({onMenuClick}: menuProps) => {
   const open = useSelector((state) => state.admin.ui.sidebarOpen);
   return (
     <>


### PR DESCRIPTION
Currently we are not using react admin resources for any interfaces, so
this logic is unnecessary. Originally, it'd render a react admin
initiatives interface but since it hasn't been merged, this logic only
renders the dummy resource we don't actually want to show

test plan: any instances with the `sourcecred/initiatives` plugin
enabled should _not_ show the dummy resource in the left menu.