### PR TITLE
Simplify site output

### DIFF
--- a/src/cli/admin.js
+++ b/src/cli/admin.js
@@ -24,7 +24,7 @@ const adminCommand: Command = async (args, std) => {
 
   // serve the static admin site and all subdirectories
   // also enables GETing data/ledger.json
-  server.use(express.static("."));
+  server.use(express.static("./site"));
 
   // middleware that parses text request bodies for us
   server.use(express.text());


### PR DESCRIPTION
This commit modifies the site command so it no longer "hoists" its
index.html, favicon, and so forth up to the root. Instead, all site data
is inside the site directory, and it symlinks in `sourcecred.json`, and
the `data/`, `config/` and `output/` directories. This generates much
less pollution, and is conducive to having the entire site in a
gitignored directory or in its own side branch.

Note that if you do want to move it to a side branch, you'll need to
either copy the symlink targets explicitly, or dereference the symlinks.

Test plan: I ran the new site command inside a real cred instance. It
produced a working site directroy, as verified by running the admin
command.