### PR TITLE
Replace BigInt with big-integer for Safari support

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "base-64": "^0.1.0",
     "base64url": "^3.0.1",
     "better-sqlite3": "^7.0.0",
+    "big-integer": "^1.6.48",
     "bottleneck": "^2.19.5",
     "chalk": "^4.0.0",
     "commonmark": "^0.29.1",
@@ -155,6 +156,8 @@
       "mjs"
     ]
   },
-  "files": ["/bin"],
+  "files": [
+    "/bin"
+  ],
   "bin": "./bin/sourcecred.js"
 }

--- a/src/ledger/grain.test.js
+++ b/src/ledger/grain.test.js
@@ -96,7 +96,7 @@ describe("src/ledger/grain", () => {
     });
     it("fromString errors on invalid Grain values", () => {
       expect(() => G.fromString("123.4")).toThrowError(
-        "Cannot convert 123.4 to a BigInt"
+        "Invalid integer: 123.4"
       );
     });
   });

--- a/yarn.lock
+++ b/yarn.lock
@@ -2180,6 +2180,11 @@ better-sqlite3@^7.0.0:
     prebuild-install "^5.3.3"
     tar "4.4.10"
 
+big-integer@^1.6.48:
+  version "1.6.48"
+  resolved "https://registry.yarnpkg.com/big-integer/-/big-integer-1.6.48.tgz#8fd88bd1632cba4a1c8c3e3d7159f08bb95b4b9e"
+  integrity sha512-j51egjPa7/i+RdiRuJbPdJ2FIUYYPhvYLjzoYbcMMm62ooO6F94fETG4MTs46zPAF9Brs04OajboA/qTGuz78w==
+
 big.js@^3.1.3:
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/big.js/-/big.js-3.2.0.tgz#a5fc298b81b9e0dca2e458824784b65c52ba588e"


### PR DESCRIPTION
This commit swaps out the implementation of our Grain module so that it
uses the big-integer library rather than native BigInts, because BigInts
are not yet supported on Safari. This makes SourceCred usable on iOS and
Safari immediately.

Since we were using native BigInts for computation but not as an at-rest
representation, this is a really easy swap. Actually, the big-integer
library has a `toString` which sensibly just returns the string
implementation, so we could swap to using big integers at rest, and our
serialization/parsing logic would still work, which was what motivated
the string representation to begin with (see #1938 for context, and
also #1936 for a different appraoch considered). However, that would be
a more involved change as it would require re-writing tests. For now,
let's just make the simple fix and start supporting safari.

Test plan: The change is entirely internal to the grain module, which is
well tested; CI passing gives good confidence that this change landed
cleanly. Also, I ran `yarn start` and now Safari can properly load the
instance instead of getting stuck on a loading screen.