### PR TITLE
jsonLog: update documentation about serialized form

### DIFF
--- a/src/util/jsonLog.js
+++ b/src/util/jsonLog.js
@@ -4,20 +4,22 @@ import stringify from "json-stable-stringify";
 import * as C from "./combo";
 
 /**
- * JsonLog tracks and serializes append-only logs of JSON objects.
+ * JsonLog tracks and serializes append-only logs of JSON values.
  *
  * At its heart, it's basically a simple wrapper around an array, which
  * enforces the rule that items may be appended to it, but never removed.
  *
- * It also provides serialization logic. We store the log as a JSON object
- * with custom formatting, so that each entry appears on its own line in the
- * output JSON file.
+ * It also provides serialization logic. We store the log as a
+ * newline-delimited stream of JSON values, with a one-to-one correspondence
+ * between POSIX lines and elements in the sequence. That is, the serialized
+ * form of an element will never contain an embedded newline, and there are no
+ * empty lines. JSON streams can be easily inspected and manipulatedwith tools
+ * like `jq` as well as standard Unix filters, and can be stored and
+ * transmitted efficiently in Git repositories thanks to packfiles and delta
+ * compression.
  *
- * This way the log can be stored efficiently in Git repositories, thanks to
- * Git packfiles.
- *
- * The JsonLog is always parsed using a Combo.Parser, which ensures type safety
- * at runtime.
+ * Elements of a `JsonLog` are always parsed using a Combo.Parser, which
+ * ensures type safety at runtime.
  */
 export class JsonLog<T: C.JsonObject> {
   +_items: T[];
@@ -38,8 +40,8 @@ export class JsonLog<T: C.JsonObject> {
   }
 
   toString(): string {
-    const stringifiedItems = this._items.map((x) => stringify(x) + "\n");
-    return stringifiedItems.join("");
+    const lines = this._items.map((x) => stringify(x) + "\n");
+    return lines.join("");
   }
 
   static fromString(log: string, parser: C.Parser<T>): JsonLog<T> {


### PR DESCRIPTION
Summary:
Follow-up to #2075, updating the documentation and fixing a couple
inaccuracies (e.g., it stores arbitrary JSON values, not just objects).

wchargin-branch: jsonlog-ndjson-docs
