### PR TITLE
Ledger: support changing identity subtypes

### DIFF
--- a/src/ledger/__snapshots__/ledger.test.js.snap
+++ b/src/ledger/__snapshots__/ledger.test.js.snap
@@ -9,5 +9,6 @@ exports[`ledger/ledger state reconstruction serialized ledger snapshots as expec
 {\\"action\\":{\\"distribution\\":{\\"allocations\\":[{\\"id\\":\\"yYNur0NEEkh7fMaUn6n9QQ\\",\\"policy\\":{\\"budget\\":\\"100\\",\\"policyType\\":\\"IMMEDIATE\\"},\\"receipts\\":[{\\"amount\\":\\"50\\",\\"id\\":\\"YVZhbGlkVXVpZEF0TGFzdA\\"},{\\"amount\\":\\"50\\",\\"id\\":\\"URgLrCxgvjHxtGJ9PgmckQ\\"}]}],\\"credTimestamp\\":1,\\"id\\":\\"f9xPz9YGH0PuBpPAg2824Q\\"},\\"type\\":\\"DISTRIBUTE_GRAIN\\"},\\"ledgerTimestamp\\":4,\\"uuid\\":\\"000000000000000000005A\\",\\"version\\":\\"1\\"}
 {\\"action\\":{\\"amount\\":\\"10\\",\\"from\\":\\"YVZhbGlkVXVpZEF0TGFzdA\\",\\"memo\\":null,\\"to\\":\\"URgLrCxgvjHxtGJ9PgmckQ\\",\\"type\\":\\"TRANSFER_GRAIN\\"},\\"ledgerTimestamp\\":5,\\"uuid\\":\\"000000000000000000006A\\",\\"version\\":\\"1\\"}
 {\\"action\\":{\\"base\\":\\"YVZhbGlkVXVpZEF0TGFzdA\\",\\"target\\":\\"URgLrCxgvjHxtGJ9PgmckQ\\",\\"type\\":\\"MERGE_IDENTITIES\\"},\\"ledgerTimestamp\\":6,\\"uuid\\":\\"000000000000000000007A\\",\\"version\\":\\"1\\"}
+{\\"action\\":{\\"identityId\\":\\"YVZhbGlkVXVpZEF0TGFzdA\\",\\"newType\\":\\"PROJECT\\",\\"type\\":\\"CHANGE_IDENTITY_TYPE\\"},\\"ledgerTimestamp\\":7,\\"uuid\\":\\"000000000000000000008A\\",\\"version\\":\\"1\\"}
 "
 `;

--- a/src/ledger/ledger.js
+++ b/src/ledger/ledger.js
@@ -19,6 +19,7 @@ import {
   type Identity,
   newIdentity,
   identityParser,
+  identityTypeParser,
 } from "./identity";
 import {type NodeAddressT, NodeAddress} from "../core/graph";
 import {type TimestampMs} from "../util/timestamp";
@@ -168,8 +169,8 @@ export class Ledger {
    *
    * Will fail if the name is not valid, or already taken.
    */
-  createIdentity(subtype: IdentityType, name: string): IdentityId {
-    const identity = newIdentity(subtype, name);
+  createIdentity(type: IdentityType, name: string): IdentityId {
+    const identity = newIdentity(type, name);
     const action = {
       type: "CREATE_IDENTITY",
       identity,
@@ -534,6 +535,46 @@ export class Ledger {
     toAccount.balance = G.add(toAccount.balance, amount);
   }
 
+  changeIdentityType(identityId: IdentityId, newType: IdentityType): Ledger {
+    this._createAndProcessEvent({
+      type: "CHANGE_IDENTITY_TYPE",
+      newType,
+      identityId,
+    });
+    return this;
+  }
+  _changeIdentityType({identityId, newType}: ChangeIdentityType) {
+    const parseResult = identityTypeParser.parse(newType);
+    if (!parseResult.ok) {
+      throw new Error(`changeIdentityType: invalid type ${newType}`);
+    }
+    if (!this._accounts.has(identityId)) {
+      throw new Error(
+        `changeIdentityType: no identity matches id ${identityId}`
+      );
+    }
+    const account = this._mutableAccount(identityId);
+    const existingIdentity = account.identity;
+    if (existingIdentity.subtype === newType) {
+      // We error rather than silently succeed because we don't want the ledger
+      // to get polluted with no-op records (no successful operations are
+      // idempotent, since they do add to the ledger logs)
+      throw new Error(
+        `changeIdentityType: identity already has type ${newType}`
+      );
+    }
+    const updatedIdentity = {
+      id: identityId,
+      name: existingIdentity.name,
+      subtype: newType,
+      address: existingIdentity.address,
+      aliases: existingIdentity.aliases,
+    };
+
+    // Mutations! Method must not fail after this comment.
+    account.identity = updatedIdentity;
+  }
+
   /**
    * Retrieve the log of all actions in the Ledger's history.
    *
@@ -604,6 +645,9 @@ export class Ledger {
       case "TRANSFER_GRAIN":
         this._transferGrain(action);
         break;
+      case "CHANGE_IDENTITY_TYPE":
+        this._changeIdentityType(action);
+        break;
       // istanbul ignore next: unreachable per Flow
       default:
         throw new Error(`Unknown type: ${(action.type: empty)}`);
@@ -664,7 +708,8 @@ type Action =
   | MergeIdentities
   | ToggleActivation
   | DistributeGrain
-  | TransferGrain;
+  | TransferGrain
+  | ChangeIdentityType;
 
 type CreateIdentity = {|
   +type: "CREATE_IDENTITY",
@@ -684,6 +729,17 @@ const renameIdentityParser: C.Parser<RenameIdentity> = C.object({
   type: C.exactly(["RENAME_IDENTITY"]),
   identityId: uuid.parser,
   newName: nameParser,
+});
+
+type ChangeIdentityType = {|
+  +type: "CHANGE_IDENTITY_TYPE",
+  +identityId: IdentityId,
+  +newType: IdentityType,
+|};
+const changeIdentityTypeParser = C.object({
+  type: C.exactly(["CHANGE_IDENTITY_TYPE"]),
+  identityId: uuid.parser,
+  newType: identityTypeParser,
 });
 
 type AddAlias = {|
@@ -744,6 +800,7 @@ const transferGrainParser: C.Parser<TransferGrain> = C.object({
 const actionParser: C.Parser<Action> = C.orElse([
   createIdentityParser,
   renameIdentityParser,
+  changeIdentityTypeParser,
   addAliasParser,
   mergeIdentitiesParser,
   toggleActivationParser,

--- a/src/ledger/ledger.test.js
+++ b/src/ledger/ledger.test.js
@@ -273,6 +273,73 @@ describe("ledger/ledger", () => {
       });
     });
 
+    describe("changeIdentityType", () => {
+      it("works", () => {
+        const ledger = new Ledger();
+        setFakeDate(0);
+        const id = ledger.createIdentity("USER", "foo");
+        const initialIdentity = ledger.account(id).identity;
+        setFakeDate(1);
+        ledger.changeIdentityType(id, "PROJECT");
+        const identity = ledger.account(id).identity;
+
+        expect(identity).toEqual({
+          id,
+          name: "foo",
+          subtype: "PROJECT",
+          address: initialIdentity.address,
+          aliases: [],
+        });
+
+        expect(ledger.eventLog()).toEqual([
+          {
+            ledgerTimestamp: 0,
+            uuid: expect.anything(),
+            version: "1",
+            action: {
+              type: "CREATE_IDENTITY",
+              identity: initialIdentity,
+            },
+          },
+          {
+            ledgerTimestamp: 1,
+            uuid: expect.anything(),
+            version: "1",
+            action: {
+              type: "CHANGE_IDENTITY_TYPE",
+              newType: "PROJECT",
+              identityId: id,
+            },
+          },
+        ]);
+      });
+      it("fails if the identity already has that type", () => {
+        const ledger = new Ledger();
+        const id = ledger.createIdentity("USER", "foo");
+        const thunk = () => ledger.changeIdentityType(id, "USER");
+        failsWithoutMutation(
+          ledger,
+          thunk,
+          "changeIdentityType: identity already has type USER"
+        );
+      });
+      it("fails on nonexistent identity id", () => {
+        const ledger = new Ledger();
+        failsWithoutMutation(
+          ledger,
+          (l) => l.changeIdentityType(uuid.random(), "USER"),
+          "changeIdentityType: no identity matches id"
+        );
+      });
+      it("fails on invalid type", () => {
+        const ledger = new Ledger();
+        const fooId = ledger.createIdentity("USER", "foo");
+        // $FlowExpectedError
+        const thunk = () => ledger.changeIdentityType(fooId, "ENTITY");
+        failsWithoutMutation(ledger, thunk, "invalid type ENTITY");
+      });
+    });
+
     describe("addAlias", () => {
       it("works", () => {
         const ledger = new Ledger();
@@ -1112,6 +1179,8 @@ describe("ledger/ledger", () => {
 
       setFakeDate(6);
       ledger.mergeIdentities({base: id1, target: id2});
+      setFakeDate(7);
+      ledger.changeIdentityType(id1, "PROJECT");
       return ledger;
     }
     it("fromEventLog with an empty action log results in an empty ledger", () => {

--- a/src/ledger/ledger.test.js
+++ b/src/ledger/ledger.test.js
@@ -274,7 +274,7 @@ describe("ledger/ledger", () => {
     });
 
     describe("changeIdentityType", () => {
-      it("works", () => {
+      it("changes a USER identity type into a PROJECT identity type", () => {
         const ledger = new Ledger();
         setFakeDate(0);
         const id = ledger.createIdentity("USER", "foo");


### PR DESCRIPTION
We support a few different identity subtypes (USER, PROJECT,
ORGANIZATION, BOT, etc). Right now these subtypes aren't really used,
but we'll likely use them in UI filtering in the future.

We'll need to support changing these, much like we do identity names.
This commit adds a new CHANGE_IDENTITY_SUBTYPE action and tests support
for it.

Test plan: Unit tests updated; `yarn test` passes.