### PR TITLE
Ledger: validate distributions

### DIFF
--- a/src/ledger/ledger.js
+++ b/src/ledger/ledger.js
@@ -327,6 +327,10 @@ export class Ledger {
     return this;
   }
   _distributeGrain({distribution}: DistributeGrain) {
+    const parseResult = distributionParser.parse(distribution);
+    if (!parseResult.ok) {
+      throw new Error(`invalid distribution: ${parseResult.err}`);
+    }
     for (const {receipts} of distribution.allocations) {
       for (const {id, amount} of receipts) {
         if (!this._accounts.has(id)) {

--- a/src/ledger/ledger.test.js
+++ b/src/ledger/ledger.test.js
@@ -587,6 +587,19 @@ describe("ledger/ledger", () => {
         });
         expect(l.lastDistributionTimestamp()).toEqual(102);
       });
+      it("fails if the distribution doesn't parse", () => {
+        const ledger = new Ledger();
+        const distribution = {
+          // Error: should be number
+          credTimestamp: "1",
+          allocations: [],
+          id: uuid.random(),
+        };
+        setFakeDate(2);
+        // $FlowExpectedError
+        const thunk = () => ledger.distributeGrain(distribution);
+        expect(thunk).toThrowError("invalid distribution");
+      });
     });
 
     describe("transferGrain", () => {


### PR DESCRIPTION
Previously, the ledger did not validate distributions. This meant the
ledger could recieve a bad distribution at runtime, write it to disk,
and then be unable to load from disk (because on load, it tried to parse
the invalid distribution). As of this commit, the ledger checks that the
distribution is parseable before adding it to the event log.

Test plan: Unit tests included.