### PR TITLE
Add a module for typesafe numerics

### DIFF
--- a/src/util/numerics.js
+++ b/src/util/numerics.js
@@ -1,0 +1,70 @@
+// @flow
+
+import * as C from "./combo";
+
+/**
+ * A library for making type-level assertions about numeric properties;
+ * e.g. that a number is finite, or finite and non-negative, or an integer.
+ *
+ * We should avoid having these methods in numeric hot loops by doing "unsafe"
+ * operations in the hot loop, and then validating on exiting the loop.
+ *
+ * Nonetheless, we avoid unnecessary function calls for performance reasons (i.e.
+ * the validator functions avoid calling each other).
+ */
+
+// A number guaranteed to not be NaN, Infinity, or -Infinity
+export opaque type Finite: number = number;
+export function finite(n: number): Finite {
+  if (!isFinite(n)) {
+    throw new Error(`expected finite, got: ${n}`);
+  }
+  return n;
+}
+export const finiteParser: C.Parser<Finite> = C.fmap(C.number, finite);
+
+export opaque type FiniteNonnegative: number = number;
+export function finiteNonnegative(n: number): FiniteNonnegative {
+  if (n < 0 || !isFinite(n)) {
+    throw new Error(`expected finite nonnegative, got: ${n}`);
+  }
+  return n;
+}
+export const finiteNonnegativeParser: C.Parser<FiniteNonnegative> = C.fmap(
+  C.number,
+  finiteNonnegative
+);
+
+export opaque type Integer: number = number;
+export function integer(n: number): Integer {
+  if (!isFinite(n) || n !== Math.floor(n)) {
+    throw new Error(`expected integer, got: ${n}`);
+  }
+  return n;
+}
+export const integerParser: C.Parser<Integer> = C.fmap(C.number, integer);
+
+export opaque type NonnegativeInteger: number = number;
+export function nonnegativeInteger(n: number): NonnegativeInteger {
+  if (!isFinite(n) || n !== Math.floor(n) || n < 0) {
+    throw new Error(`expected nonnegative integer, got: ${n}`);
+  }
+  return n;
+}
+export const nonnegativeIntegerParser: C.Parser<NonnegativeInteger> = C.fmap(
+  C.number,
+  nonnegativeInteger
+);
+
+// A number guaranteed to be in the range [0, 1]
+export opaque type Proportion: number = number;
+export function proportion(n: number): Proportion {
+  if (!isFinite(n) || n < 0 || n > 1) {
+    throw new Error(`expected proportion in [0, 1], got: ${n}`);
+  }
+  return n;
+}
+export const proportionParser: C.Parser<Proportion> = C.fmap(
+  C.number,
+  proportion
+);

--- a/src/util/numerics.test.js
+++ b/src/util/numerics.test.js
@@ -1,0 +1,95 @@
+// @flow
+
+import * as N from "./numerics";
+
+describe("util/numerics", () => {
+  describe("finite", () => {
+    it("allows finite numbers", () => {
+      for (const f of [-1.2, 0, 999]) {
+        expect(N.finite(f)).toEqual(f);
+        expect(N.finiteParser.parseOrThrow(f)).toEqual(f);
+      }
+    });
+    it("disallows non-finite numbers", () => {
+      for (const f of [NaN, Infinity, -Infinity]) {
+        expect(() => N.finite(f)).toThrow("expected finite, got:");
+        expect(() => N.finiteParser.parseOrThrow(f)).toThrow(
+          "expected finite, got:"
+        );
+      }
+    });
+  });
+  describe("finiteNonnegative", () => {
+    it("allows finite nonnegative numbers", () => {
+      for (const f of [0, 0.12, 999]) {
+        expect(N.finite(f)).toEqual(f);
+        expect(N.finiteParser.parseOrThrow(f)).toEqual(f);
+      }
+    });
+    it("disallows non-finite or negative numbers", () => {
+      for (const f of [NaN, Infinity, -Infinity, -3, -0.12]) {
+        expect(() => N.finiteNonnegative(f)).toThrow(
+          "expected finite nonnegative, got:"
+        );
+        expect(() => N.finiteNonnegativeParser.parseOrThrow(f)).toThrow(
+          "expected finite nonnegative, got:"
+        );
+      }
+    });
+  });
+
+  describe("integer", () => {
+    it("allows integers", () => {
+      for (const f of [-12, 0, 13]) {
+        expect(N.integer(f)).toEqual(f);
+        expect(N.integerParser.parseOrThrow(f)).toEqual(f);
+      }
+    });
+    it("disallows non-integers", () => {
+      for (const f of [NaN, Infinity, -Infinity, -1.23, 14.91]) {
+        expect(() => N.integer(f)).toThrow("expected integer, got:");
+        expect(() => N.integerParser.parseOrThrow(f)).toThrow(
+          "expected integer, got:"
+        );
+      }
+    });
+  });
+
+  describe("nonnegativeInteger", () => {
+    it("allows nonnegative integers", () => {
+      for (const f of [0, 13]) {
+        expect(N.nonnegativeInteger(f)).toEqual(f);
+        expect(N.nonnegativeIntegerParser.parseOrThrow(f)).toEqual(f);
+      }
+    });
+    it("disallows non-integers or negative integers", () => {
+      for (const f of [NaN, Infinity, -Infinity, -13, -1.23, 14.91]) {
+        expect(() => N.nonnegativeInteger(f)).toThrow(
+          "expected nonnegative integer, got:"
+        );
+        expect(() => N.nonnegativeIntegerParser.parseOrThrow(f)).toThrow(
+          "expected nonnegative integer, got:"
+        );
+      }
+    });
+  });
+
+  describe("proportion", () => {
+    it("allows finite numbers in [0, 1]", () => {
+      for (const f of [0, 0.3, 1]) {
+        expect(N.proportion(f)).toEqual(f);
+        expect(N.proportionParser.parseOrThrow(f)).toEqual(f);
+      }
+    });
+    it("disallows numbers outside [0, 1]", () => {
+      for (const f of [NaN, Infinity, -Infinity, -13, -1.23, 1.01]) {
+        expect(() => N.proportion(f)).toThrow(
+          "expected proportion in [0, 1], got:"
+        );
+        expect(() => N.proportionParser.parseOrThrow(f)).toThrow(
+          "expected proportion in [0, 1], got:"
+        );
+      }
+    });
+  });
+});


### PR DESCRIPTION
This commit adds the `util/numerics` module which exposes typesafe
numeric sub-types, such as Finite, FiniteNonnegative, Integer,
NonnegativeInteger, and Proportion. These types all have an associated
parsing method, and a parser.

Test plan: See included unit tests, a followon PR will refactor the
codebase to use these types.