### PR TITLE
Use the typesafe numerics

### DIFF
--- a/src/analysis/credResult.test.js
+++ b/src/analysis/credResult.test.js
@@ -3,6 +3,7 @@
 import stringify from "json-stable-stringify";
 import {Graph, NodeAddress, EdgeAddress} from "../core/graph";
 import * as Weights from "../core/weights";
+import * as N from "../util/numerics";
 import type {NodeType, EdgeType} from "./types";
 import type {PluginDeclaration} from "./pluginDeclaration";
 import {defaultParams} from "./timeline/params";
@@ -15,14 +16,17 @@ describe("analysis/credResult", () => {
         name: "node",
         pluralName: "nodes",
         prefix: NodeAddress.fromParts(["node"]),
-        defaultWeight: 2,
+        defaultWeight: N.finiteNonnegative(2),
         description: "a type",
       };
       const edgeType: EdgeType = {
         forwardName: "points",
         backwardName: "is pointed to",
         prefix: EdgeAddress.fromParts(["edge"]),
-        defaultWeight: {forwards: 2, backwards: 3},
+        defaultWeight: {
+          forwards: N.finiteNonnegative(2),
+          backwards: N.finiteNonnegative(3),
+        },
         description: "a type",
       };
       const declaration: PluginDeclaration = {

--- a/src/analysis/credView.test.js
+++ b/src/analysis/credView.test.js
@@ -10,6 +10,7 @@ import {
 import {defaultParams} from "./timeline/params";
 import {compute} from "./credResult";
 import {CredView} from "./credView";
+import * as N from "../util/numerics";
 
 describe("analysis/credView", () => {
   async function example() {
@@ -18,28 +19,34 @@ describe("analysis/credView", () => {
       name: "foo",
       pluralName: "foos",
       prefix: NodeAddress.fromParts(["foo"]),
-      defaultWeight: 2,
+      defaultWeight: N.finiteNonnegative(2),
       description: "foo type",
     };
     const userType: NodeType = {
       name: "user",
       pluralName: "users",
       prefix: NodeAddress.fromParts(["user"]),
-      defaultWeight: 0,
+      defaultWeight: N.finiteNonnegative(0),
       description: "user type",
     };
     const flowType: EdgeType = {
       forwardName: "flows to",
       backwardName: "is flowed to by",
       prefix: EdgeAddress.fromParts(["flow"]),
-      defaultWeight: {forwards: 2, backwards: 3},
+      defaultWeight: {
+        forwards: N.finiteNonnegative(2),
+        backwards: N.finiteNonnegative(3),
+      },
       description: "flow type",
     };
     const streamType: EdgeType = {
       forwardName: "streams to",
       backwardName: "is stramed to by",
       prefix: EdgeAddress.fromParts(["stream"]),
-      defaultWeight: {forwards: 1, backwards: 0},
+      defaultWeight: {
+        forwards: N.finiteNonnegative(1),
+        backwards: N.finiteNonnegative(0),
+      },
       description: "stream type",
     };
     const declaration: PluginDeclaration = {

--- a/src/analysis/nodeScore.js
+++ b/src/analysis/nodeScore.js
@@ -2,14 +2,16 @@
 
 import {NodeAddress, type NodeAddressT} from "../core/graph";
 import type {NodeDistribution} from "../core/algorithm/nodeDistribution";
+import * as N from "../util/numerics";
 
 export type NodeScore = Map<NodeAddressT, number>;
 
 /* Normalize scores so that the maximum score has a fixed value */
 export function scoreByMaximumProbability(
   pi: NodeDistribution,
-  maxScore: number
+  maxScore: N.FiniteNonnegative
 ): NodeScore {
+  // Redundant with type signature, left in to make a safer refactor PR.
   if (maxScore <= 0) {
     throw new Error("Invalid argument: maxScore must be >= 0");
   }
@@ -31,7 +33,7 @@ export function scoreByMaximumProbability(
 /* Normalize scores so that a group of nodes have a fixed total score */
 export function scoreByConstantTotal(
   pi: NodeDistribution,
-  totalScore: number,
+  totalScore: N.FiniteNonnegative,
   nodeFilter: NodeAddressT /* Normalizes based on nodes matching this prefix */
 ): NodeScore {
   if (totalScore <= 0) {

--- a/src/analysis/nodeScore.test.js
+++ b/src/analysis/nodeScore.test.js
@@ -2,6 +2,7 @@
 
 import {NodeAddress} from "../core/graph";
 import {scoreByMaximumProbability, scoreByConstantTotal} from "./nodeScore";
+import * as N from "../util/numerics";
 
 describe("analysis/nodeScore", () => {
   const foo = NodeAddress.fromParts(["foo"]);
@@ -14,7 +15,10 @@ describe("analysis/nodeScore", () => {
       distribution.set(foo, 0.5);
       distribution.set(bar, 0.3);
       distribution.set(zod, 0.2);
-      const result = scoreByMaximumProbability(distribution, 100);
+      const result = scoreByMaximumProbability(
+        distribution,
+        N.finiteNonnegative(100)
+      );
       expect(result.get(foo)).toEqual(100);
       expect(result.get(bar)).toEqual(60);
       expect(result.get(zod)).toEqual(40);
@@ -24,7 +28,10 @@ describe("analysis/nodeScore", () => {
       distribution.set(foo, 0.5);
       distribution.set(bar, 0.3);
       distribution.set(zod, 0.2);
-      const result = scoreByMaximumProbability(distribution, 1000);
+      const result = scoreByMaximumProbability(
+        distribution,
+        N.finiteNonnegative(1000)
+      );
       expect(result.get(foo)).toEqual(1000);
       expect(result.get(bar)).toEqual(600);
       expect(result.get(zod)).toEqual(400);
@@ -32,19 +39,24 @@ describe("analysis/nodeScore", () => {
     it("handles a case with only a single node", () => {
       const distribution = new Map();
       distribution.set(foo, 1.0);
-      const result = scoreByMaximumProbability(distribution, 1000);
+      const result = scoreByMaximumProbability(
+        distribution,
+        N.finiteNonnegative(1000)
+      );
       expect(result.get(foo)).toEqual(1000);
     });
     it("errors if maxScore <= 0", () => {
       const distribution = new Map();
       distribution.set(foo, 1.0);
-      const result = () => scoreByMaximumProbability(distribution, 0);
+      const result = () =>
+        scoreByMaximumProbability(distribution, N.finiteNonnegative(0));
       expect(result).toThrowError("Invalid argument");
     });
     it("throws an error rather than divide by 0", () => {
       const distribution = new Map();
       distribution.set(foo, 0.0);
-      const result = () => scoreByMaximumProbability(distribution, 1000);
+      const result = () =>
+        scoreByMaximumProbability(distribution, N.finiteNonnegative(1000));
       expect(result).toThrowError("Invariant violation");
     });
   });
@@ -54,7 +66,11 @@ describe("analysis/nodeScore", () => {
       distribution.set(foo, 0.5);
       distribution.set(bar, 0.3);
       distribution.set(zod, 0.2);
-      const result = scoreByConstantTotal(distribution, 100, NodeAddress.empty);
+      const result = scoreByConstantTotal(
+        distribution,
+        N.finiteNonnegative(100),
+        NodeAddress.empty
+      );
       expect(result.get(foo)).toEqual(50);
       expect(result.get(bar)).toEqual(30);
       expect(result.get(zod)).toEqual(20);
@@ -66,7 +82,7 @@ describe("analysis/nodeScore", () => {
       distribution.set(zod, 0.2);
       const result = scoreByConstantTotal(
         distribution,
-        1000,
+        N.finiteNonnegative(1000),
         NodeAddress.empty
       );
       expect(result.get(foo)).toEqual(500);
@@ -79,7 +95,11 @@ describe("analysis/nodeScore", () => {
       distribution.set(foobar, 0.5);
       distribution.set(bar, 0.3);
       distribution.set(zod, 0.2);
-      const result = scoreByConstantTotal(distribution, 1000, foo);
+      const result = scoreByConstantTotal(
+        distribution,
+        N.finiteNonnegative(1000),
+        foo
+      );
       expect(result.get(foo)).toEqual(500);
       expect(result.get(foobar)).toEqual(500);
       expect(result.get(bar)).toEqual(300);
@@ -90,7 +110,7 @@ describe("analysis/nodeScore", () => {
       distribution.set(foo, 1.0);
       const result = scoreByConstantTotal(
         distribution,
-        1000,
+        N.finiteNonnegative(1000),
         NodeAddress.empty
       );
       expect(result.get(foo)).toEqual(1000);
@@ -98,13 +118,15 @@ describe("analysis/nodeScore", () => {
     it("errors if maxScore <= 0", () => {
       const distribution = new Map();
       distribution.set(foo, 1.0);
-      const result = () => scoreByConstantTotal(distribution, 0, foo);
+      const result = () =>
+        scoreByConstantTotal(distribution, N.finiteNonnegative(0), foo);
       expect(result).toThrowError("Invalid argument");
     });
     it("throws an error rather than divide by 0", () => {
       const distribution = new Map();
       distribution.set(foo, 1.0);
-      const result = () => scoreByConstantTotal(distribution, 1000, bar);
+      const result = () =>
+        scoreByConstantTotal(distribution, N.finiteNonnegative(1000), bar);
       expect(result).toThrowError(
         "Tried to normalize based on nodes with no score"
       );

--- a/src/analysis/pagerank.js
+++ b/src/analysis/pagerank.js
@@ -20,16 +20,17 @@ import {
   type PagerankOptions as CorePagerankOptions,
 } from "../core/algorithm/markovChain";
 import {uniformDistribution} from "../core/algorithm/distribution";
+import * as N from "../util/numerics";
 
 export type {NodeDistribution} from "../core/algorithm/nodeDistribution";
 export type {PagerankNodeDecomposition} from "./pagerankNodeDecomposition";
 export type FullPagerankOptions = {|
-  +selfLoopWeight: number,
+  +selfLoopWeight: N.FiniteNonnegative,
   +verbose: boolean,
-  +convergenceThreshold: number,
-  +maxIterations: number,
+  +convergenceThreshold: N.FiniteNonnegative,
+  +maxIterations: N.NonnegativeInteger,
   // Scores will be normalized so that scores sum to totalScore
-  +totalScore: number,
+  +totalScore: N.FiniteNonnegative,
   // Only nodes matching this prefix will count for normalization
   +totalScoreNodePrefix: NodeAddressT,
 |};
@@ -38,9 +39,9 @@ export type PagerankOptions = $Shape<FullPagerankOptions>;
 export type {EdgeWeight} from "../core/algorithm/graphToMarkovChain";
 export type EdgeEvaluator = (Edge) => EdgeWeight;
 
-export const DEFAULT_SYNTHETIC_LOOP_WEIGHT = 1e-3;
-export const DEFAULT_MAX_ITERATIONS = 255;
-export const DEFAULT_CONVERGENCE_THRESHOLD = 1e-7;
+export const DEFAULT_SYNTHETIC_LOOP_WEIGHT = N.finiteNonnegative(1e-3);
+export const DEFAULT_MAX_ITERATIONS = N.nonnegativeInteger(255);
+export const DEFAULT_CONVERGENCE_THRESHOLD = N.finiteNonnegative(1e-7);
 
 function defaultOptions(): PagerankOptions {
   return {
@@ -48,7 +49,7 @@ function defaultOptions(): PagerankOptions {
     selfLoopWeight: DEFAULT_SYNTHETIC_LOOP_WEIGHT,
     convergenceThreshold: DEFAULT_CONVERGENCE_THRESHOLD,
     maxIterations: DEFAULT_MAX_ITERATIONS,
-    totalScore: 1000,
+    totalScore: N.finiteNonnegative(1000),
     totalScoreNodePrefix: NodeAddress.empty,
   };
 }
@@ -70,7 +71,7 @@ export async function pagerank(
   const osmc = createOrderedSparseMarkovChain(connections);
   const params: PagerankParams = {
     chain: osmc.chain,
-    alpha: 0,
+    alpha: N.proportion(0),
     pi0: uniformDistribution(osmc.chain.length),
     seed: uniformDistribution(osmc.chain.length),
   };
@@ -78,7 +79,7 @@ export async function pagerank(
     verbose: fullOptions.verbose,
     convergenceThreshold: fullOptions.convergenceThreshold,
     maxIterations: fullOptions.maxIterations,
-    yieldAfterMs: 30,
+    yieldAfterMs: N.finiteNonnegative(30),
   };
   const distributionResult = await findStationaryDistribution(
     params,

--- a/src/analysis/pagerankNodeDecomposition.test.js
+++ b/src/analysis/pagerankNodeDecomposition.test.js
@@ -16,6 +16,7 @@ import {
   type PagerankNodeDecomposition,
 } from "./pagerankNodeDecomposition";
 import * as MapUtil from "../util/map";
+import * as N from "../util/numerics";
 
 import {advancedGraph, node, edge} from "../core/graphTestUtil";
 
@@ -137,15 +138,15 @@ describe("analysis/pagerankNodeDecomposition", () => {
       const osmc = createOrderedSparseMarkovChain(connections);
       const params: PagerankParams = {
         chain: osmc.chain,
-        alpha: 0,
+        alpha: N.proportion(0),
         seed: uniformDistribution(osmc.chain.length),
         pi0: uniformDistribution(osmc.chain.length),
       };
       const distributionResult = await findStationaryDistribution(params, {
         verbose: false,
-        convergenceThreshold: 1e-6,
-        maxIterations: 255,
-        yieldAfterMs: 1,
+        convergenceThreshold: N.finiteNonnegative(1e-6),
+        maxIterations: N.nonnegativeInteger(255),
+        yieldAfterMs: N.finiteNonnegative(1),
       });
       const pr = distributionToNodeDistribution(
         osmc.nodeOrder,
@@ -163,15 +164,15 @@ describe("analysis/pagerankNodeDecomposition", () => {
       const osmc = createOrderedSparseMarkovChain(connections);
       const params: PagerankParams = {
         chain: osmc.chain,
-        alpha: 0,
+        alpha: N.proportion(0),
         seed: uniformDistribution(osmc.chain.length),
         pi0: uniformDistribution(osmc.chain.length),
       };
       const distributionResult = await findStationaryDistribution(params, {
         verbose: false,
-        convergenceThreshold: 1e-6,
-        maxIterations: 255,
-        yieldAfterMs: 1,
+        convergenceThreshold: N.finiteNonnegative(1e-6),
+        maxIterations: N.nonnegativeInteger(255),
+        yieldAfterMs: N.finiteNonnegative(1),
       });
       const pr = distributionToNodeDistribution(
         osmc.nodeOrder,

--- a/src/analysis/pluginDeclaration.test.js
+++ b/src/analysis/pluginDeclaration.test.js
@@ -11,20 +11,24 @@ import {
   fromJSON,
 } from "./pluginDeclaration";
 import * as Weights from "../core/weights";
+import * as N from "../util/numerics";
 
 describe("analysis/pluginDeclaration", () => {
   const nodeType: NodeType = deepFreeze({
     name: "node",
     pluralName: "nodes",
     prefix: NodeAddress.fromParts(["node"]),
-    defaultWeight: 2,
+    defaultWeight: N.finiteNonnegative(2),
     description: "a type",
   });
   const edgeType: EdgeType = deepFreeze({
     forwardName: "points",
     backwardName: "is pointed to",
     prefix: EdgeAddress.fromParts(["edge"]),
-    defaultWeight: {forwards: 2, backwards: 3},
+    defaultWeight: {
+      forwards: N.finiteNonnegative(2),
+      backwards: N.finiteNonnegative(3),
+    },
     description: "a type",
   });
   const emptyDeclaration: PluginDeclaration = deepFreeze({

--- a/src/analysis/timeline/params.js
+++ b/src/analysis/timeline/params.js
@@ -1,6 +1,7 @@
 // @flow
 
 import * as C from "../../util/combo";
+import * as N from "../../util/numerics";
 
 /**
  * Parameters for computing TimelineCred
@@ -11,18 +12,18 @@ export type TimelineCredParameters = {|
   // Determines how quickly cred returns to the PageRank seed vector. If alpha
   // is high, then cred will tend to "stick" to nodes that are seeded, e.g.
   // issues and pull requests. Alpha should be between 0 and 1.
-  +alpha: number,
+  +alpha: N.Proportion,
   // Determines how quickly cred decays. The decay is 1, then cred never
   // decays, and old nodes and edges will retain full weight forever. (This
   // would result in cred that is highly biased towards old contributions, as
   // they would continue earning cred in every timeslice, forever.) If the
   // decay is 0, then weights go to zero the first week after their node/edge
   // was created. Should be between 0 and 1.
-  +intervalDecay: number,
+  +intervalDecay: N.Proportion,
 |};
 
-export const DEFAULT_ALPHA = 0.2;
-export const DEFAULT_INTERVAL_DECAY = 0.5;
+export const DEFAULT_ALPHA = N.proportion(0.2);
+export const DEFAULT_INTERVAL_DECAY = N.proportion(0.5);
 
 export type TimelineCredParametersJSON = {|
   +alpha: number,
@@ -42,14 +43,14 @@ export function paramsFromJSON(
   p: TimelineCredParametersJSON
 ): TimelineCredParameters {
   return {
-    alpha: p.alpha,
-    intervalDecay: p.intervalDecay,
+    alpha: N.proportion(p.alpha),
+    intervalDecay: N.proportion(p.intervalDecay),
   };
 }
 
 const partialParser: C.Parser<$Shape<TimelineCredParameters>> = C.shape({
-  alpha: C.number,
-  intervalDecay: C.number,
+  alpha: N.proportionParser,
+  intervalDecay: N.proportionParser,
 });
 
 export const parser: C.Parser<TimelineCredParameters> = C.fmap(

--- a/src/analysis/timeline/params.test.js
+++ b/src/analysis/timeline/params.test.js
@@ -10,12 +10,13 @@ import {
   DEFAULT_INTERVAL_DECAY,
   parser,
 } from "./params";
+import * as N from "../../util/numerics";
 
 describe("analysis/timeline/params", () => {
   it("JSON round trip", () => {
     const p: TimelineCredParameters = {
-      alpha: 0.1337,
-      intervalDecay: 0.31337,
+      alpha: N.proportion(0.1337),
+      intervalDecay: N.proportion(0.31337),
     };
     const j = paramsToJSON(p);
     const p_ = paramsFromJSON(j);
@@ -36,12 +37,12 @@ describe("analysis/timeline/params", () => {
       expect(params).toEqual(defaultParams());
     });
     it("accepts an alpha override", () => {
-      const params = partialParams({alpha: 0.99});
+      const params = partialParams({alpha: N.proportion(0.99)});
       expect(params.alpha).toEqual(0.99);
       expect(params.intervalDecay).toEqual(DEFAULT_INTERVAL_DECAY);
     });
     it("accepts intervalDecay override", () => {
-      const params = partialParams({intervalDecay: 0.1});
+      const params = partialParams({intervalDecay: N.proportion(0.1)});
       expect(params.alpha).toEqual(DEFAULT_ALPHA);
       expect(params.intervalDecay).toEqual(0.1);
     });
@@ -49,7 +50,10 @@ describe("analysis/timeline/params", () => {
 
   describe("parser", () => {
     it("works on a full object", () => {
-      const params: TimelineCredParameters = {alpha: 0.34, intervalDecay: 0.1};
+      const params: TimelineCredParameters = {
+        alpha: N.proportion(0.34),
+        intervalDecay: N.proportion(0.1),
+      };
       expect(parser.parseOrThrow(params)).toEqual(params);
     });
     it("works on a partial object", () => {

--- a/src/analysis/timeline/timelineCred.test.js
+++ b/src/analysis/timeline/timelineCred.test.js
@@ -10,13 +10,14 @@ import {TimelineCred} from "./timelineCred";
 import {defaultParams} from "./params";
 import {type PluginDeclaration} from "../pluginDeclaration";
 import {type NodeType} from "../types";
+import * as N from "../../util/numerics";
 
 describe("src/analysis/timeline/timelineCred", () => {
   const userType: NodeType = {
     name: "user",
     pluralName: "users",
     prefix: NodeAddress.fromParts(["user"]),
-    defaultWeight: 0,
+    defaultWeight: N.finiteNonnegative(0),
     description: "a user",
   };
   const userPrefix = userType.prefix;
@@ -24,7 +25,7 @@ describe("src/analysis/timeline/timelineCred", () => {
     name: "foo",
     pluralName: "foos",
     prefix: NodeAddress.fromParts(["foo"]),
-    defaultWeight: 0,
+    defaultWeight: N.finiteNonnegative(0),
     description: "a foo",
   };
   const fooPrefix = fooType.prefix;

--- a/src/analysis/types.js
+++ b/src/analysis/types.js
@@ -1,7 +1,7 @@
 // @flow
 
 import {type NodeAddressT, type EdgeAddressT} from "../core/graph";
-import {type EdgeWeight} from "../core/weights";
+import {type EdgeWeight, type NodeWeight} from "../core/weights";
 
 /**
  * This module defines `NodeType`s and `EdgeType`s, both of which are
@@ -66,7 +66,7 @@ export type NodeType = {|
   // The default weight to assign to nodes of this type. We use `1` to mean "of
   // normal importance", and the weights scale linearly from there (i.e. 2
   // means twice as important).
-  +defaultWeight: number,
+  +defaultWeight: NodeWeight,
   // The `description` property should be a human-readable string that makes
   // it clear to a user what each NodeType does
   +description: string,

--- a/src/analysis/weightsToEdgeEvaluator.test.js
+++ b/src/analysis/weightsToEdgeEvaluator.test.js
@@ -4,6 +4,7 @@ import {NodeAddress, EdgeAddress} from "../core/graph";
 import {type Weights as WeightsT} from "../core/weights";
 import * as Weights from "../core/weights";
 import {weightsToEdgeEvaluator} from "./weightsToEdgeEvaluator";
+import * as N from "../util/numerics";
 
 describe("analysis/weightsToEdgeEvaluator", () => {
   const src = NodeAddress.fromParts(["src"]);
@@ -26,29 +27,44 @@ describe("analysis/weightsToEdgeEvaluator", () => {
 
   it("matches all prefixes of the nodes in scope", () => {
     const weights = Weights.empty();
-    weights.nodeWeights.set(NodeAddress.empty, 99);
-    expect(evaluateEdge(weights)).toEqual({forwards: 99, backwards: 99});
+    weights.nodeWeights.set(NodeAddress.empty, N.finiteNonnegative(99));
+    expect(evaluateEdge(weights)).toEqual({
+      forwards: N.finiteNonnegative(99),
+      backwards: N.finiteNonnegative(99),
+    });
   });
 
   it("an explicit weight on a prefix overrides the type weight", () => {
     const weights = Weights.empty();
-    weights.nodeWeights.set(src, 1);
-    expect(evaluateEdge(weights)).toEqual({forwards: 1, backwards: 1});
+    weights.nodeWeights.set(src, N.finiteNonnegative(1));
+    expect(evaluateEdge(weights)).toEqual({
+      forwards: N.finiteNonnegative(1),
+      backwards: N.finiteNonnegative(1),
+    });
   });
 
   it("uses 1 as a default weight for unmatched nodes and edges", () => {
     const evaluator = weightsToEdgeEvaluator(Weights.empty());
-    expect(evaluator(edge)).toEqual({forwards: 1, backwards: 1});
+    expect(evaluator(edge)).toEqual({
+      forwards: N.finiteNonnegative(1),
+      backwards: N.finiteNonnegative(1),
+    });
   });
 
   it("ignores extra weights if they do not apply", () => {
     const withoutExtraWeights = evaluateEdge(Weights.empty());
     const extraWeights = Weights.empty();
-    extraWeights.nodeWeights.set(NodeAddress.fromParts(["foo"]), 99);
-    extraWeights.nodeWeights.set(NodeAddress.fromParts(["foo"]), 99);
+    extraWeights.nodeWeights.set(
+      NodeAddress.fromParts(["foo"]),
+      N.finiteNonnegative(99)
+    );
+    extraWeights.nodeWeights.set(
+      NodeAddress.fromParts(["foo"]),
+      N.finiteNonnegative(99)
+    );
     extraWeights.edgeWeights.set(EdgeAddress.fromParts(["foo"]), {
-      forwards: 14,
-      backwards: 19,
+      forwards: N.finiteNonnegative(14),
+      backwards: N.finiteNonnegative(19),
     });
     const withExtraWeights = evaluateEdge(extraWeights);
     expect(withoutExtraWeights).toEqual(withExtraWeights);

--- a/src/api/grainConfig.js
+++ b/src/api/grainConfig.js
@@ -4,17 +4,18 @@ import {type DistributionPolicy} from "../ledger/applyDistributions";
 import * as G from "../ledger/grain";
 import * as C from "../util/combo";
 import * as NullUtil from "../util/null";
+import * as N from "../util/numerics";
 
 export type GrainConfig = {|
-  +immediatePerWeek: number,
-  +balancedPerWeek: number,
+  +immediatePerWeek: N.NonnegativeInteger,
+  +balancedPerWeek: N.NonnegativeInteger,
   +maxSimultaneousDistributions?: number,
 |};
 
 export const parser: C.Parser<GrainConfig> = C.object(
   {
-    immediatePerWeek: C.number,
-    balancedPerWeek: C.number,
+    immediatePerWeek: N.nonnegativeIntegerParser,
+    balancedPerWeek: N.nonnegativeIntegerParser,
   },
   {
     maxSimultaneousDistributions: C.number,
@@ -22,16 +23,6 @@ export const parser: C.Parser<GrainConfig> = C.object(
 );
 
 export function toDistributionPolicy(x: GrainConfig): DistributionPolicy {
-  if (!isNonnegativeInteger(x.immediatePerWeek)) {
-    throw new Error(
-      `immediate budget must be nonnegative integer, got ${x.immediatePerWeek}`
-    );
-  }
-  if (!isNonnegativeInteger(x.balancedPerWeek)) {
-    throw new Error(
-      `balanced budget must be nonnegative integer, got ${x.balancedPerWeek}`
-    );
-  }
   const allocationPolicies = [];
   if (x.immediatePerWeek > 0) {
     allocationPolicies.push({
@@ -50,8 +41,4 @@ export function toDistributionPolicy(x: GrainConfig): DistributionPolicy {
     Infinity
   );
   return {allocationPolicies, maxSimultaneousDistributions};
-}
-
-function isNonnegativeInteger(x: number): boolean {
-  return x >= 0 && isFinite(x) && Math.floor(x) === x;
 }

--- a/src/core/algorithm/markovChain.js
+++ b/src/core/algorithm/markovChain.js
@@ -1,6 +1,8 @@
 // @flow
 
 import {computeDelta, type Distribution} from "./distribution";
+import * as N from "../../util/numerics";
+
 /**
  * The data inputs to running PageRank.
  *
@@ -19,7 +21,7 @@ export type PagerankParams = {|
   // The probability of teleporting back to the seed vector.
   // If alpha=0, then the seed vector is irrelevant.
   // If alpha=1, then it trivially converges to the seed vector.
-  +alpha: number,
+  +alpha: N.Proportion,
 |};
 
 /**
@@ -32,12 +34,12 @@ export type PagerankOptions = {|
   // A distribution is considered stationary if the action of the Markov
   // chain on the distribution does not change any component by more than
   // `convergenceThreshold` in absolute value.
-  +convergenceThreshold: number,
+  +convergenceThreshold: N.FiniteNonnegative,
   // We will run maxIterations markov chain steps at most.
-  +maxIterations: number,
+  +maxIterations: N.NonnegativeInteger,
   // To prevent locking the rest of the application, PageRank will yield control
   // after this many miliseconds, allowing UI updates, etc.
-  +yieldAfterMs: number,
+  +yieldAfterMs: N.FiniteNonnegative,
 |};
 
 export type StationaryDistributionResult = {|

--- a/src/core/algorithm/markovChain.test.js
+++ b/src/core/algorithm/markovChain.test.js
@@ -13,6 +13,7 @@ import {
   type StationaryDistributionResult,
   type PagerankParams,
 } from "./markovChain";
+import * as N from "../../util/numerics";
 
 describe("core/algorithm/markovChain", () => {
   /** A distribution that is 1 at the chosen index, and 0 elsewhere.*/
@@ -197,10 +198,10 @@ describe("core/algorithm/markovChain", () => {
     }
 
     const standardOptions = () => ({
-      maxIterations: 255,
-      convergenceThreshold: 1e-7,
+      maxIterations: N.nonnegativeInteger(255),
+      convergenceThreshold: N.finiteNonnegative(1e-7),
       verbose: false,
-      yieldAfterMs: 1,
+      yieldAfterMs: N.finiteNonnegative(1),
     });
 
     it("finds an all-accumulating stationary distribution", async () => {
@@ -211,7 +212,7 @@ describe("core/algorithm/markovChain", () => {
       ]);
       const params: PagerankParams = {
         chain,
-        alpha: 0,
+        alpha: N.proportion(0),
         seed: uniformDistribution(chain.length),
         pi0: uniformDistribution(chain.length),
       };
@@ -244,7 +245,7 @@ describe("core/algorithm/markovChain", () => {
       const chain = satelliteChain();
       const params: PagerankParams = {
         chain,
-        alpha: 0,
+        alpha: N.proportion(0),
         seed: uniformDistribution(chain.length),
         pi0: uniformDistribution(chain.length),
       };
@@ -263,7 +264,7 @@ describe("core/algorithm/markovChain", () => {
 
     it("finds the same stationary distribution regardless of initialDistribution", async () => {
       const chain = satelliteChain();
-      const alpha = 0.1;
+      const alpha = N.proportion(0.1);
       const seed = uniformDistribution(chain.length);
       const initialDistribution1 = singleIndexDistribution(chain.length, 0);
       const params1 = {chain, alpha, seed, pi0: initialDistribution1};
@@ -285,7 +286,7 @@ describe("core/algorithm/markovChain", () => {
 
     it("finds a non-degenerate stationary distribution with seed and non-zero alpha", async () => {
       const chain = satelliteChain();
-      const alpha = 0.1;
+      const alpha = N.proportion(0.1);
       const seed = singleIndexDistribution(chain.length, 0);
       const pi0 = uniformDistribution(chain.length);
       const result = await findStationaryDistribution(
@@ -309,7 +310,7 @@ describe("core/algorithm/markovChain", () => {
 
     it("converges immediately when initialDistribution equals the stationary distribution", async () => {
       const chain = satelliteChain();
-      const alpha = 0.1;
+      const alpha = N.proportion(0.1);
       const seed = singleIndexDistribution(chain.length, 0);
       // determine the expected stationary distribtution via Linear algebra
       // from python3:
@@ -355,7 +356,7 @@ describe("core/algorithm/markovChain", () => {
       ]);
       const params: PagerankParams = {
         chain,
-        alpha: 0,
+        alpha: N.proportion(0),
         seed: uniformDistribution(chain.length),
         pi0: uniformDistribution(chain.length),
       };
@@ -379,13 +380,13 @@ describe("core/algorithm/markovChain", () => {
       ]);
       const params: PagerankParams = {
         chain,
-        alpha: 0,
+        alpha: N.proportion(0),
         seed: uniformDistribution(chain.length),
         pi0: uniformDistribution(chain.length),
       };
       const result = await findStationaryDistribution(params, {
         ...standardOptions(),
-        maxIterations: 0,
+        maxIterations: N.nonnegativeInteger(0),
       });
       const expected = new Float64Array([0.5, 0.5]);
       expect(result.pi).toEqual(expected);
@@ -397,7 +398,7 @@ describe("core/algorithm/markovChain", () => {
         [0.75, 0.25],
         [0.5, 0.5],
       ]);
-      const alpha = 0.1;
+      const alpha = N.proportion(0.1);
       const seed1 = singleIndexDistribution(chain.length, 0);
       const seed2 = singleIndexDistribution(chain.length, 1);
       const seedUniform = uniformDistribution(chain.length);
@@ -452,7 +453,7 @@ describe("core/algorithm/markovChain", () => {
         [0.75, 0.25],
         [0.5, 0.5],
       ]);
-      const alpha = 0;
+      const alpha = N.proportion(0);
       const seed1 = singleIndexDistribution(chain.length, 0);
       const seed2 = singleIndexDistribution(chain.length, 1);
       const pi0 = uniformDistribution(chain.length);
@@ -483,7 +484,7 @@ describe("core/algorithm/markovChain", () => {
         [0.75, 0.25],
         [0.5, 0.5],
       ]);
-      const alpha = 1;
+      const alpha = N.proportion(1);
       const seed = singleIndexDistribution(chain.length, 0);
       const pi0 = uniformDistribution(chain.length);
 
@@ -499,7 +500,7 @@ describe("core/algorithm/markovChain", () => {
         [0.75, 0.25],
         [0.5, 0.5],
       ]);
-      const alpha = 0.2;
+      const alpha = N.proportion(0.2);
       const seed = singleIndexDistribution(chain.length, 0);
       const pi0 = uniformDistribution(chain.length);
       const result = await findStationaryDistribution(

--- a/src/core/algorithm/nodeDistribution.js
+++ b/src/core/algorithm/nodeDistribution.js
@@ -5,6 +5,7 @@ import {type Distribution, uniformDistribution} from "./distribution";
 
 export type Probability = number;
 export type NodeDistribution = Map<NodeAddressT, Probability>;
+import type {NodeWeight} from "../weights";
 
 export function distributionToNodeDistribution(
   nodeOrder: $ReadOnlyArray<NodeAddressT>,
@@ -35,10 +36,12 @@ export function distributionToNodeDistribution(
  */
 export function weightedDistribution(
   nodeOrder: $ReadOnlyArray<NodeAddressT>,
-  weights: Map<NodeAddressT, number>
+  weights: Map<NodeAddressT, NodeWeight>
 ): Distribution {
   let totalWeight = 0;
   for (const [address, weight] of weights.entries()) {
+    // This check is redundant with the type signature, and could be removed.
+    // (Left it in out of conserativism, and for a simpler refactor PR.)
     if (weight < 0 || !isFinite(weight)) {
       throw new Error(
         `Invalid weight ${weight} associated with address ${NodeAddress.toString(

--- a/src/core/algorithm/nodeDistribution.test.js
+++ b/src/core/algorithm/nodeDistribution.test.js
@@ -5,6 +5,7 @@ import {
   weightedDistribution,
   distributionToNodeDistribution,
 } from "./nodeDistribution";
+import * as N from "../../util/numerics";
 
 describe("core/algorithm/nodeDistribution", () => {
   const n1 = NodeAddress.fromParts(["n1"]);
@@ -31,25 +32,31 @@ describe("core/algorithm/nodeDistribution", () => {
       );
     });
     it("gives a uniform distribution for a map with 0 weight", () => {
-      const map = new Map().set(a, 0);
+      const map = new Map().set(a, N.finiteNonnegative(0));
       expect(weightedDistribution(order(), map)).toEqual(
         new Float64Array([0.25, 0.25, 0.25, 0.25])
       );
     });
     it("can put all weight on one node", () => {
-      const map = new Map().set(b, 0.1);
+      const map = new Map().set(b, N.finiteNonnegative(0.1));
       expect(weightedDistribution(order(), map)).toEqual(
         new Float64Array([0, 1, 0, 0])
       );
     });
     it("can split weight unequally", () => {
-      const map = new Map().set(b, 1).set(c, 3);
+      const map = new Map()
+        .set(b, N.finiteNonnegative(1))
+        .set(c, N.finiteNonnegative(3));
       expect(weightedDistribution(order(), map)).toEqual(
         new Float64Array([0, 0.25, 0.75, 0])
       );
     });
     it("can create a uniform distribution if all weights are equal", () => {
-      const map = new Map().set(a, 1).set(b, 1).set(c, 1).set(d, 1);
+      const map = new Map()
+        .set(a, N.finiteNonnegative(1))
+        .set(b, N.finiteNonnegative(1))
+        .set(c, N.finiteNonnegative(1))
+        .set(d, N.finiteNonnegative(1));
       expect(weightedDistribution(order(), map)).toEqual(
         new Float64Array([0.25, 0.25, 0.25, 0.25])
       );
@@ -57,25 +64,28 @@ describe("core/algorithm/nodeDistribution", () => {
     describe("errors if", () => {
       it("has a weighted node that is not in the order", () => {
         const z = NodeAddress.fromParts(["z"]);
-        const map = new Map().set(z, 1);
+        const map = new Map().set(z, N.finiteNonnegative(1));
         expect(() => weightedDistribution(order(), map)).toThrowError(
           "weights included nodes not present in the nodeOrder"
         );
       });
       it("has a node with negative weight", () => {
         const map = new Map().set(a, -1);
+        // $FlowExpectedError
         expect(() => weightedDistribution(order(), map)).toThrowError(
           "Invalid weight -1"
         );
       });
       it("has a node with NaN weight", () => {
         const map = new Map().set(a, NaN);
+        // $FlowExpectedError
         expect(() => weightedDistribution(order(), map)).toThrowError(
           "Invalid weight NaN"
         );
       });
       it("has a node with infinite weight", () => {
         const map = new Map().set(a, Infinity);
+        // $FlowExpectedError
         expect(() => weightedDistribution(order(), map)).toThrowError(
           "Invalid weight Infinity"
         );

--- a/src/core/algorithm/weightEvaluator.test.js
+++ b/src/core/algorithm/weightEvaluator.test.js
@@ -3,6 +3,7 @@
 import {NodeAddress, EdgeAddress} from "../graph";
 import {nodeWeightEvaluator, edgeWeightEvaluator} from "./weightEvaluator";
 import * as Weights from "../weights";
+import * as N from "../../util/numerics";
 
 describe("src/core/algorithm/weightEvaluator", () => {
   describe("nodeWeightEvaluator", () => {
@@ -17,8 +18,8 @@ describe("src/core/algorithm/weightEvaluator", () => {
     });
     it("composes matching weights multiplicatively", () => {
       const weights = Weights.empty();
-      weights.nodeWeights.set(foo, 2);
-      weights.nodeWeights.set(foobar, 3);
+      weights.nodeWeights.set(foo, N.finiteNonnegative(2));
+      weights.nodeWeights.set(foobar, N.finiteNonnegative(3));
       const evaluator = nodeWeightEvaluator(weights);
       expect(evaluator(empty)).toEqual(1);
       expect(evaluator(foo)).toEqual(2);
@@ -30,12 +31,21 @@ describe("src/core/algorithm/weightEvaluator", () => {
     const foobar = EdgeAddress.fromParts(["foo", "bar"]);
     it("gives default 1,1 weights if no matching type", () => {
       const evaluator = edgeWeightEvaluator(Weights.empty());
-      expect(evaluator(foo)).toEqual({forwards: 1, backwards: 1});
+      expect(evaluator(foo)).toEqual({
+        forwards: N.finiteNonnegative(1),
+        backwards: N.finiteNonnegative(1),
+      });
     });
     it("composes weights multiplicatively for all matching types", () => {
       const weights = Weights.empty();
-      weights.edgeWeights.set(foo, {forwards: 2, backwards: 3});
-      weights.edgeWeights.set(foobar, {forwards: 4, backwards: 5});
+      weights.edgeWeights.set(foo, {
+        forwards: N.finiteNonnegative(2),
+        backwards: N.finiteNonnegative(3),
+      });
+      weights.edgeWeights.set(foobar, {
+        forwards: N.finiteNonnegative(4),
+        backwards: N.finiteNonnegative(5),
+      });
       const evaluator = edgeWeightEvaluator(weights);
       expect(evaluator(foo)).toEqual({forwards: 2, backwards: 3});
       expect(evaluator(foobar)).toEqual({forwards: 8, backwards: 15});

--- a/src/core/weightedGraph.test.js
+++ b/src/core/weightedGraph.test.js
@@ -4,6 +4,7 @@ import * as Weights from "./weights";
 import {Graph, NodeAddress, EdgeAddress} from "./graph";
 import * as WeightedGraph from "./weightedGraph";
 import * as GraphTest from "./graphTestUtil";
+import * as N from "../util/numerics";
 
 describe("core/weightedGraph", () => {
   function expectEqual(wg1, wg2) {
@@ -33,7 +34,7 @@ describe("core/weightedGraph", () => {
       const node = GraphTest.node("foo");
       const graph = new Graph().addNode(node);
       const weights = Weights.empty();
-      weights.nodeWeights.set(node.address, 5);
+      weights.nodeWeights.set(node.address, N.finiteNonnegative(5));
       const wg = {graph, weights};
       const wgJSON = WeightedGraph.toJSON(wg);
       const wg_ = WeightedGraph.fromJSON(wgJSON);
@@ -49,9 +50,9 @@ describe("core/weightedGraph", () => {
       const g1 = new Graph().addNode(foo);
       const g2 = new Graph().addNode(bar);
       const w1 = Weights.empty();
-      w1.nodeWeights.set(foo.address, 1);
+      w1.nodeWeights.set(foo.address, N.finiteNonnegative(1));
       const w2 = Weights.empty();
-      w2.nodeWeights.set(bar.address, 2);
+      w2.nodeWeights.set(bar.address, N.finiteNonnegative(2));
       const wg1 = {graph: g1, weights: w1};
       const wg2 = {graph: g2, weights: w2};
       const g = Graph.merge([g1, g2]);
@@ -66,10 +67,16 @@ describe("core/weightedGraph", () => {
     const example = () => {
       const graph = new Graph().addNode(foo).addNode(bar);
       const weights = Weights.empty();
-      weights.nodeWeights.set(NodeAddress.empty, 0);
-      weights.nodeWeights.set(foo.address, 1);
-      weights.edgeWeights.set(foobar.address, {forwards: 2, backwards: 2});
-      weights.edgeWeights.set(EdgeAddress.empty, {forwards: 3, backwards: 3});
+      weights.nodeWeights.set(NodeAddress.empty, N.finiteNonnegative(0));
+      weights.nodeWeights.set(foo.address, N.finiteNonnegative(1));
+      weights.edgeWeights.set(foobar.address, {
+        forwards: N.finiteNonnegative(2),
+        backwards: N.finiteNonnegative(2),
+      });
+      weights.edgeWeights.set(EdgeAddress.empty, {
+        forwards: N.finiteNonnegative(3),
+        backwards: N.finiteNonnegative(3),
+      });
       return {graph, weights};
     };
     it("has no effect if the overrides are empty", () => {
@@ -79,18 +86,24 @@ describe("core/weightedGraph", () => {
     });
     it("takes weights from base and overrides, choosing overrides on conflicts", () => {
       const overrides = Weights.empty();
-      overrides.nodeWeights.set(foo.address, 101);
-      overrides.nodeWeights.set(bar.address, 102);
+      overrides.nodeWeights.set(foo.address, N.finiteNonnegative(101));
+      overrides.nodeWeights.set(bar.address, N.finiteNonnegative(102));
       overrides.edgeWeights.set(foobar.address, {
-        forwards: 103,
-        backwards: 103,
+        forwards: N.finiteNonnegative(103),
+        backwards: N.finiteNonnegative(103),
       });
       const expected = Weights.empty();
-      expected.nodeWeights.set(NodeAddress.empty, 0);
-      expected.nodeWeights.set(foo.address, 101);
-      expected.nodeWeights.set(bar.address, 102);
-      expected.edgeWeights.set(foobar.address, {forwards: 103, backwards: 103});
-      expected.edgeWeights.set(EdgeAddress.empty, {forwards: 3, backwards: 3});
+      expected.nodeWeights.set(NodeAddress.empty, N.finiteNonnegative(0));
+      expected.nodeWeights.set(foo.address, N.finiteNonnegative(101));
+      expected.nodeWeights.set(bar.address, N.finiteNonnegative(102));
+      expected.edgeWeights.set(foobar.address, {
+        forwards: N.finiteNonnegative(103),
+        backwards: N.finiteNonnegative(103),
+      });
+      expected.edgeWeights.set(EdgeAddress.empty, {
+        forwards: N.finiteNonnegative(3),
+        backwards: N.finiteNonnegative(3),
+      });
       const actual = WeightedGraph.overrideWeights(example(), overrides)
         .weights;
       expect(expected).toEqual(actual);

--- a/src/core/weights.js
+++ b/src/core/weights.js
@@ -2,6 +2,7 @@
 
 import * as MapUtil from "../util/map";
 import * as C from "../util/combo";
+import * as N from "../util/numerics";
 import {
   type NodeAddressT,
   type EdgeAddressT,
@@ -15,7 +16,7 @@ import {toCompat, type Compatible, compatibleParser} from "../util/compat";
  * Weight 1 is the default value and signifies normal importance.
  * Weights are linear, so 2 is twice as important as 1.
  */
-export type NodeWeight = number;
+export type NodeWeight = N.FiniteNonnegative;
 
 export type NodeOperator = (NodeWeight, NodeWeight) => NodeWeight;
 
@@ -25,7 +26,10 @@ export type NodeOperator = (NodeWeight, NodeWeight) => NodeWeight;
  * Weight 1 is the default value and signifies normal importance.
  * Weights are linear, so 2 is twice as important as 1.
  */
-export type EdgeWeight = {|+forwards: number, +backwards: number|};
+export type EdgeWeight = {|
+  +forwards: N.FiniteNonnegative,
+  +backwards: N.FiniteNonnegative,
+|};
 
 export type EdgeOperator = (EdgeWeight, EdgeWeight) => EdgeWeight;
 
@@ -142,9 +146,12 @@ function deserialize_0_2_0(weights: SerializedWeights_0_2_0): Weights {
 }
 
 const Parse_0_2_0: C.Parser<SerializedWeights_0_2_0> = (() => {
-  const parseEdgeWeight = C.object({forwards: C.number, backwards: C.number});
+  const parseEdgeWeight = C.object({
+    forwards: N.finiteNonnegativeParser,
+    backwards: N.finiteNonnegativeParser,
+  });
   return C.object({
-    nodeWeights: C.dict(C.number, NodeAddress.parser),
+    nodeWeights: C.dict(N.finiteNonnegativeParser, NodeAddress.parser),
     edgeWeights: C.dict(parseEdgeWeight, EdgeAddress.parser),
   });
 })();

--- a/src/ledger/identity.js
+++ b/src/ledger/identity.js
@@ -38,6 +38,7 @@ import {
 } from "../core/graph";
 import type {NodeType} from "../analysis/types";
 import type {PluginDeclaration} from "../analysis/pluginDeclaration";
+import * as N from "../util/numerics";
 
 /**
  * We validate identityNames using GitHub-esque rules.
@@ -154,28 +155,28 @@ export const identityParser: C.Parser<Identity> = C.object({
 const userNodeType: NodeType = {
   name: "user",
   pluralName: "users",
-  defaultWeight: 0,
+  defaultWeight: N.finiteNonnegative(0),
   description: "a canonical user identity",
   prefix: NodeAddress.append(IDENTITY_PREFIX, "USER"),
 };
 const projectNodeType: NodeType = {
   name: "project",
   pluralName: "projects",
-  defaultWeight: 0,
+  defaultWeight: N.finiteNonnegative(0),
   description: "a canonical project identity",
   prefix: NodeAddress.append(IDENTITY_PREFIX, "PROJECT"),
 };
 const organizationNodeType: NodeType = {
   name: "organization",
   pluralName: "organizations",
-  defaultWeight: 0,
+  defaultWeight: N.finiteNonnegative(0),
   description: "a canonical organization identity",
   prefix: NodeAddress.append(IDENTITY_PREFIX, "ORGANIZATION"),
 };
 const botNodeType: NodeType = {
   name: "bot",
   pluralName: "bots",
-  defaultWeight: 0,
+  defaultWeight: N.finiteNonnegative(0),
   description: "a canonical bot identity",
   prefix: NodeAddress.append(IDENTITY_PREFIX, "BOT"),
 };

--- a/src/plugins/demo/declaration.js
+++ b/src/plugins/demo/declaration.js
@@ -5,12 +5,13 @@ import deepFreeze from "deep-freeze";
 import {NodeAddress, EdgeAddress} from "../../core/graph";
 import type {PluginDeclaration} from "../../analysis/pluginDeclaration";
 import type {EdgeType, NodeType} from "../../analysis/types";
+import * as N from "../../util/numerics";
 
 export const inserterNodeType: NodeType = deepFreeze({
   name: "inserter",
   pluralName: "inserters",
   prefix: NodeAddress.fromParts(["factorio", "inserter"]),
-  defaultWeight: 1,
+  defaultWeight: N.finiteNonnegative(1),
   description: "Nodes for Factorio inserter objects in demo plugin",
 });
 
@@ -18,14 +19,17 @@ export const machineNodeType: NodeType = deepFreeze({
   name: "machine",
   pluralName: "machines",
   prefix: NodeAddress.fromParts(["factorio", "machine"]),
-  defaultWeight: 2,
+  defaultWeight: N.finiteNonnegative(2),
   description: "Nodes for Factorio machine objects in demo plugin",
 });
 
 export const assemblesEdgeType: EdgeType = deepFreeze({
   forwardName: "assembles",
   backwardName: "is assembled by",
-  defaultWeight: {forwards: 2, backwards: 2 ** -2},
+  defaultWeight: {
+    forwards: N.finiteNonnegative(2),
+    backwards: N.finiteNonnegative(2 ** -2),
+  },
   prefix: EdgeAddress.fromParts(["factorio", "assembles"]),
   description: "Connects assembly machines to products they assemble.",
 });
@@ -33,7 +37,10 @@ export const assemblesEdgeType: EdgeType = deepFreeze({
 export const transportsEdgeType: EdgeType = deepFreeze({
   forwardName: "transports",
   backwardName: "is transported by",
-  defaultWeight: {forwards: 2, backwards: 2 ** -1},
+  defaultWeight: {
+    forwards: N.finiteNonnegative(2),
+    backwards: N.finiteNonnegative(2 ** -1),
+  },
   prefix: EdgeAddress.fromParts(["factorio", "transports"]),
   description: "Connects transporter belts to objects they transport.",
 });

--- a/src/plugins/discourse/createGraph.js
+++ b/src/plugins/discourse/createGraph.js
@@ -13,6 +13,7 @@ import {
   linksToReferences,
 } from "./references";
 import * as NE from "./nodesAndEdges";
+import * as N from "../../util/numerics";
 
 export type GraphUser = {|
   +node: Node,
@@ -48,20 +49,22 @@ export type GraphData = {
 // TODO: Make this configurable.
 // For details on trust levels:
 // https://blog.discourse.org/2018/06/understanding-discourse-trust-levels/
-export const DEFAULT_TRUST_LEVEL_TO_WEIGHT = Object.freeze({
-  "0": 0,
+export const DEFAULT_TRUST_LEVEL_TO_WEIGHT: {
+  [string]: NodeWeight,
+} = Object.freeze({
+  "0": N.finiteNonnegative(0),
   // Trust level 1 indicates little engagement (doesn't even require any posts)
   // so I gave them a very small weight.
-  "1": 0.1,
+  "1": N.finiteNonnegative(0.1),
   // Trust level 2 in my mind indicates being a "full member" so it feels
   // like a good anchor for a standard weight of 1.
-  "2": 1,
+  "2": N.finiteNonnegative(1),
   // Trust level 3 requires that you are highly active and have earned lots of
   // likes, so feels trusted enough for some bonus minting.
-  "3": 1.25,
+  "3": N.finiteNonnegative(1.25),
   // Trust level 4 means you've been designated as high trust by the admins, so
   // we give a bigger bonus. Could make this even larger (2?)
-  "4": 1.5,
+  "4": N.finiteNonnegative(1.5),
 });
 
 export function weightForTrustLevel(trustLevel: ?number): NodeWeight {
@@ -71,7 +74,7 @@ export function weightForTrustLevel(trustLevel: ?number): NodeWeight {
     // This means they could have trust level 1. But to be conservative, we treat anyone
     // with a null trust level as if they have trust level 0.
     // Possibly this could come up with deleted users too.
-    return 0;
+    return N.finiteNonnegative(0);
   }
 
   const key = String(trustLevel);

--- a/src/plugins/discourse/createGraph.test.js
+++ b/src/plugins/discourse/createGraph.test.js
@@ -14,6 +14,7 @@ import {
   DEFAULT_TRUST_LEVEL_TO_WEIGHT,
 } from "./createGraph";
 import * as NE from "./nodesAndEdges";
+import * as N from "../../util/numerics";
 
 import {userAddress, postAddress, topicAddress} from "./address";
 
@@ -480,7 +481,7 @@ describe("plugins/discourse/createGraph", () => {
             createsLike: expect.anything(),
             likes: expect.anything(),
             node: NE.likeNode(url, like1, "[unknown post]"),
-            weight: DEFAULT_TRUST_LEVEL_TO_WEIGHT[4],
+            weight: DEFAULT_TRUST_LEVEL_TO_WEIGHT["4"],
           },
           {
             createsLike: expect.anything(),
@@ -503,7 +504,7 @@ describe("plugins/discourse/createGraph", () => {
         node: NE.likeNode(url, likeAction, "[unknown post]"),
         createsLike: NE.createsLikeEdge(url, likeAction),
         likes: NE.likesEdge(url, likeAction),
-        weight: 0.33,
+        weight: N.finiteNonnegative(0.33),
       };
       const data = {
         users: [],

--- a/src/plugins/discourse/declaration.js
+++ b/src/plugins/discourse/declaration.js
@@ -4,6 +4,7 @@ import deepFreeze from "deep-freeze";
 import type {PluginDeclaration} from "../../analysis/pluginDeclaration";
 import type {NodeType, EdgeType} from "../../analysis/types";
 import {NodeAddress, EdgeAddress} from "../../core/graph";
+import * as N from "../../util/numerics";
 
 export const nodePrefix = NodeAddress.fromParts(["sourcecred", "discourse"]);
 export const edgePrefix = EdgeAddress.fromParts(["sourcecred", "discourse"]);
@@ -12,7 +13,7 @@ export const topicNodeType: NodeType = deepFreeze({
   name: "Topic",
   pluralName: "Topics",
   prefix: NodeAddress.append(nodePrefix, "topic"),
-  defaultWeight: 0,
+  defaultWeight: N.finiteNonnegative(0),
   description:
     "A topic (or post-container) in a Discourse instance. Every topic has at least one post.",
 });
@@ -21,7 +22,7 @@ export const postNodeType: NodeType = deepFreeze({
   name: "Post",
   pluralName: "Posts",
   prefix: NodeAddress.append(nodePrefix, "post"),
-  defaultWeight: 0,
+  defaultWeight: N.finiteNonnegative(0),
   description: "A post in some topic in a Discourse instance.",
 });
 
@@ -29,7 +30,7 @@ export const userNodeType: NodeType = deepFreeze({
   name: "User",
   pluralName: "Users",
   prefix: NodeAddress.append(nodePrefix, "user"),
-  defaultWeight: 0,
+  defaultWeight: N.finiteNonnegative(0),
   description: "A user account on a particular Discourse instance.",
 });
 
@@ -37,7 +38,7 @@ export const likeNodeType: NodeType = deepFreeze({
   name: "Like",
   pluralName: "Likes",
   prefix: NodeAddress.append(nodePrefix, "like"),
-  defaultWeight: 4,
+  defaultWeight: N.finiteNonnegative(4),
   description: "A like by some user, directed at some post",
 });
 
@@ -45,7 +46,10 @@ export const topicContainsPostEdgeType: EdgeType = deepFreeze({
   forwardName: "contains post",
   backwardName: "is contained by topic",
   prefix: EdgeAddress.append(edgePrefix, "topicContainsPost"),
-  defaultWeight: {forwards: 0, backwards: 1 / 8},
+  defaultWeight: {
+    forwards: N.finiteNonnegative(0),
+    backwards: N.finiteNonnegative(1 / 8),
+  },
   description: "Connects a topic to the posts that it contains.",
 });
 
@@ -53,7 +57,10 @@ export const postRepliesEdgeType: EdgeType = deepFreeze({
   forwardName: "post is reply to",
   backwardName: "post replied to by",
   prefix: EdgeAddress.append(edgePrefix, "replyTo"),
-  defaultWeight: {forwards: 1 / 2, backwards: 0},
+  defaultWeight: {
+    forwards: N.finiteNonnegative(1 / 2),
+    backwards: N.finiteNonnegative(0),
+  },
   description: "Connects a post to the post that it is a reply to.",
 });
 
@@ -61,7 +68,10 @@ export const authorsTopicEdgeType: EdgeType = deepFreeze({
   forwardName: "authors topic",
   backwardName: "topic is authored by",
   prefix: EdgeAddress.append(edgePrefix, "authors", "topic"),
-  defaultWeight: {forwards: 0, backwards: 1},
+  defaultWeight: {
+    forwards: N.finiteNonnegative(0),
+    backwards: N.finiteNonnegative(1),
+  },
   description: "Connects an author to a topic they created.",
 });
 
@@ -69,7 +79,10 @@ export const authorsPostEdgeType: EdgeType = deepFreeze({
   forwardName: "authors post",
   backwardName: "post is authored by",
   prefix: EdgeAddress.append(edgePrefix, "authors", "post"),
-  defaultWeight: {forwards: 0, backwards: 1},
+  defaultWeight: {
+    forwards: N.finiteNonnegative(0),
+    backwards: N.finiteNonnegative(1),
+  },
   description: "Connects an author to a post they've created.",
 });
 
@@ -77,7 +90,10 @@ export const createsLikeEdgeType: EdgeType = deepFreeze({
   forwardName: "creates like",
   backwardName: "like created by",
   prefix: EdgeAddress.append(edgePrefix, "createsLike"),
-  defaultWeight: {forwards: 1, backwards: 0},
+  defaultWeight: {
+    forwards: N.finiteNonnegative(1),
+    backwards: N.finiteNonnegative(0),
+  },
   description: "Connects a Discourse user to a like that they created.",
 });
 
@@ -85,7 +101,10 @@ export const likesEdgeType: EdgeType = deepFreeze({
   forwardName: "likes",
   backwardName: "is liked by",
   prefix: EdgeAddress.append(edgePrefix, "likes"),
-  defaultWeight: {forwards: 1, backwards: 0},
+  defaultWeight: {
+    forwards: N.finiteNonnegative(1),
+    backwards: N.finiteNonnegative(0),
+  },
   description: "Connects a Discourse like to a post that was liked.",
 });
 
@@ -93,7 +112,10 @@ export const referencesPostEdgeType: EdgeType = deepFreeze({
   forwardName: "references post",
   backwardName: "post is referenced by",
   prefix: EdgeAddress.append(edgePrefix, "references", "post"),
-  defaultWeight: {forwards: 1 / 2, backwards: 0},
+  defaultWeight: {
+    forwards: N.finiteNonnegative(1 / 2),
+    backwards: N.finiteNonnegative(0),
+  },
   description: "Connects a Discourse post to another post it referenced.",
 });
 
@@ -101,7 +123,10 @@ export const referencesTopicEdgeType: EdgeType = deepFreeze({
   forwardName: "references topic",
   backwardName: "topic is referenced by",
   prefix: EdgeAddress.append(edgePrefix, "references", "topic"),
-  defaultWeight: {forwards: 1 / 2, backwards: 0},
+  defaultWeight: {
+    forwards: N.finiteNonnegative(1 / 2),
+    backwards: N.finiteNonnegative(0),
+  },
   description: "Connects a Discourse post to a topic it referenced.",
 });
 
@@ -109,7 +134,10 @@ export const referencesUserEdgeType: EdgeType = deepFreeze({
   forwardName: "mentions",
   backwardName: "is mentioned by",
   prefix: EdgeAddress.append(edgePrefix, "references", "user"),
-  defaultWeight: {forwards: 1 / 4, backwards: 0},
+  defaultWeight: {
+    forwards: N.finiteNonnegative(1 / 4),
+    backwards: N.finiteNonnegative(0),
+  },
   description: "Connects a Discourse post to a user it mentions",
 });
 

--- a/src/plugins/experimental-discord/config.js
+++ b/src/plugins/experimental-discord/config.js
@@ -3,6 +3,7 @@
 import * as Combo from "../../util/combo";
 import * as Model from "./models";
 import {type EmojiWeightMap} from "./createGraph";
+import * as N from "../../util/numerics";
 
 export type {BotToken as DiscordToken} from "./models";
 
@@ -28,6 +29,6 @@ export const parser: Combo.Parser<DiscordConfig> = (() => {
   const C = Combo;
   return C.object({
     guildId: C.string,
-    reactionWeights: C.dict(C.number),
+    reactionWeights: C.dict(N.finiteNonnegativeParser),
   });
 })();

--- a/src/plugins/experimental-discord/declaration.js
+++ b/src/plugins/experimental-discord/declaration.js
@@ -4,6 +4,7 @@ import deepFreeze from "deep-freeze";
 import type {PluginDeclaration} from "../../analysis/pluginDeclaration";
 import type {NodeType, EdgeType} from "../../analysis/types";
 import {NodeAddress, EdgeAddress} from "../../core/graph";
+import * as N from "../../util/numerics";
 
 export const nodePrefix = NodeAddress.fromParts(["sourcecred", "discord"]);
 export const edgePrefix = EdgeAddress.fromParts(["sourcecred", "discord"]);
@@ -12,7 +13,7 @@ export const memberNodeType: NodeType = deepFreeze({
   name: "Member",
   pluralName: "Members",
   prefix: NodeAddress.append(nodePrefix, "MEMBER"),
-  defaultWeight: 0,
+  defaultWeight: N.finiteNonnegative(0),
   description: "A member of the Discord server",
 });
 
@@ -20,7 +21,7 @@ export const messageNodeType: NodeType = deepFreeze({
   name: "Message",
   pluralName: "Messages",
   prefix: NodeAddress.append(nodePrefix, "MESSAGE"),
-  defaultWeight: 0,
+  defaultWeight: N.finiteNonnegative(0),
   description: "A Discord message, posted in a particular channel",
 });
 
@@ -28,7 +29,7 @@ export const reactionNodeType: NodeType = deepFreeze({
   name: "Reaction",
   pluralName: "Reactions",
   prefix: NodeAddress.append(nodePrefix, "REACTION"),
-  defaultWeight: 1,
+  defaultWeight: N.finiteNonnegative(1),
   description: "A reaction by some user, directed at some message",
 });
 
@@ -36,7 +37,10 @@ export const authorsMessageEdgeType: EdgeType = deepFreeze({
   forwardName: "authors message",
   backwardName: "message is authored by",
   prefix: EdgeAddress.append(edgePrefix, "AUTHORS", "MESSAGE"),
-  defaultWeight: {forwards: 1 / 4, backwards: 1},
+  defaultWeight: {
+    forwards: N.finiteNonnegative(1 / 4),
+    backwards: N.finiteNonnegative(1),
+  },
   description: "Connects an author to a message they've created.",
 });
 
@@ -44,7 +48,10 @@ export const addsReactionEdgeType: EdgeType = deepFreeze({
   forwardName: "adds reaction",
   backwardName: "reaction added by",
   prefix: EdgeAddress.append(edgePrefix, "ADDS_REACTION"),
-  defaultWeight: {forwards: 1, backwards: 1 / 16},
+  defaultWeight: {
+    forwards: N.finiteNonnegative(1),
+    backwards: N.finiteNonnegative(1 / 16),
+  },
   description: "Connects a member to a reaction that they added.",
 });
 
@@ -52,7 +59,10 @@ export const reactsToEdgeType: EdgeType = deepFreeze({
   forwardName: "reacts to",
   backwardName: "is reacted to by",
   prefix: EdgeAddress.append(edgePrefix, "REACTS_TO"),
-  defaultWeight: {forwards: 1, backwards: 1 / 16},
+  defaultWeight: {
+    forwards: N.finiteNonnegative(1),
+    backwards: N.finiteNonnegative(1 / 16),
+  },
   description: "Connects a reaction to a message that it reacts to.",
 });
 
@@ -60,7 +70,10 @@ export const mentionsEdgeType: EdgeType = deepFreeze({
   forwardName: "mentions",
   backwardName: "is mentioned by",
   prefix: EdgeAddress.append(edgePrefix, "MENTIONS"),
-  defaultWeight: {forwards: 1, backwards: 1 / 16},
+  defaultWeight: {
+    forwards: N.finiteNonnegative(1),
+    backwards: N.finiteNonnegative(1 / 16),
+  },
   description: "Connects a message to the member being mentioned.",
 });
 

--- a/src/plugins/git/declaration.js
+++ b/src/plugins/git/declaration.js
@@ -5,12 +5,13 @@ import type {PluginDeclaration} from "../../analysis/pluginDeclaration";
 import type {NodeType} from "../../analysis/types";
 import * as N from "./nodes";
 import * as E from "./edges";
+import * as Num from "../../util/numerics";
 
 const commitNodeType: NodeType = deepFreeze({
   name: "Commit",
   pluralName: "Commits",
   prefix: N.Prefix.commit,
-  defaultWeight: 2,
+  defaultWeight: Num.finiteNonnegative(2),
   description: "NodeType representing a git commit",
 });
 
@@ -18,7 +19,10 @@ const hasParentEdgeType = deepFreeze({
   forwardName: "has parent",
   backwardName: "is parent of",
   prefix: E.Prefix.hasParent,
-  defaultWeight: {forwards: 1, backwards: 1},
+  defaultWeight: {
+    forwards: Num.finiteNonnegative(1),
+    backwards: Num.finiteNonnegative(1),
+  },
   description: "Connects a Git commit to its parent commit(s).",
 });
 

--- a/src/plugins/github/createGraph.js
+++ b/src/plugins/github/createGraph.js
@@ -9,6 +9,7 @@ import * as N from "./nodes";
 import * as R from "./relationalView";
 import {createEdge} from "./edges";
 import {ReactionContent$Values as Reactions} from "./graphqlTypes";
+import * as Num from "../../util/numerics";
 
 export function createGraph(view: R.RelationalView): WeightedGraph {
   const creator = new GraphCreator();
@@ -53,7 +54,7 @@ class GraphCreator {
       } else {
         const addr = N.toRaw(pull.address());
         // Un-merged PRs do not mint cred.
-        this.weights.nodeWeights.set(addr, 0);
+        this.weights.nodeWeights.set(addr, Num.finiteNonnegative(0));
       }
     }
 

--- a/src/plugins/github/createGraph.test.js
+++ b/src/plugins/github/createGraph.test.js
@@ -4,6 +4,7 @@ import {exampleGraph, exampleRelationalView} from "./example/example";
 import {empty as emptyWeights} from "../../core/weights";
 import {createGraph} from "./createGraph";
 import * as N from "./nodes";
+import * as Num from "../../util/numerics";
 
 describe("plugins/github/createGraph", () => {
   it("example graph matches snapshot", () => {
@@ -26,7 +27,7 @@ describe("plugins/github/createGraph", () => {
     const expectedWeights = emptyWeights();
     for (const unmerged of unmergedPrs) {
       const addr = N.toRaw(unmerged.address());
-      expectedWeights.nodeWeights.set(addr, 0);
+      expectedWeights.nodeWeights.set(addr, Num.finiteNonnegative(0));
     }
     const {weights} = createGraph(view);
     expect(weights).toEqual(expectedWeights);

--- a/src/plugins/github/declaration.js
+++ b/src/plugins/github/declaration.js
@@ -5,12 +5,13 @@ import type {PluginDeclaration} from "../../analysis/pluginDeclaration";
 import * as N from "./nodes";
 import * as E from "./edges";
 import dedent from "../../util/dedent";
+import * as Num from "../../util/numerics";
 
 export const repoNodeType = deepFreeze({
   name: "Repository",
   pluralName: "Repositories",
   prefix: N.Prefix.repo,
-  defaultWeight: 0,
+  defaultWeight: Num.finiteNonnegative(0),
   description: "NodeType for a GitHub repository",
 });
 
@@ -18,7 +19,7 @@ const issueNodeType = deepFreeze({
   name: "Issue",
   pluralName: "Issues",
   prefix: N.Prefix.issue,
-  defaultWeight: 0,
+  defaultWeight: Num.finiteNonnegative(0),
   description: "NodeType for a GitHub issue",
 });
 
@@ -26,7 +27,7 @@ const pullNodeType = deepFreeze({
   name: "Pull request",
   pluralName: "Pull requests",
   prefix: N.Prefix.pull,
-  defaultWeight: 4,
+  defaultWeight: Num.finiteNonnegative(4),
   description: "NodeType for a GitHub pull request",
 });
 
@@ -34,7 +35,7 @@ const reviewNodeType = deepFreeze({
   name: "Pull request review",
   pluralName: "Pull request reviews",
   prefix: N.Prefix.review,
-  defaultWeight: 1,
+  defaultWeight: Num.finiteNonnegative(1),
   description: "NodeType for a GitHub code review",
 });
 
@@ -42,7 +43,7 @@ const commentNodeType = deepFreeze({
   name: "Comment",
   pluralName: "Comments",
   prefix: N.Prefix.comment,
-  defaultWeight: 0,
+  defaultWeight: Num.finiteNonnegative(0),
   description: "NodeType for a GitHub comment",
 });
 
@@ -50,7 +51,7 @@ const commitNodeType = deepFreeze({
   name: "Commit",
   pluralName: "Commits",
   prefix: N.Prefix.commit,
-  defaultWeight: 0,
+  defaultWeight: Num.finiteNonnegative(0),
   description:
     "Represents a particular Git commit on GitHub, i.e. scoped to a particular repository",
 });
@@ -59,7 +60,7 @@ export const userNodeType = deepFreeze({
   name: "User",
   pluralName: "Users",
   prefix: N.Prefix.user,
-  defaultWeight: 0,
+  defaultWeight: Num.finiteNonnegative(0),
   description: "NodeType for a GitHub user",
 });
 
@@ -67,7 +68,7 @@ const botNodeType = deepFreeze({
   name: "Bot",
   pluralName: "Bots",
   prefix: N.Prefix.bot,
-  defaultWeight: 0,
+  defaultWeight: Num.finiteNonnegative(0),
   description: "NodeType for a GitHub bot account",
 });
 
@@ -85,7 +86,10 @@ const nodeTypes = deepFreeze([
 const authorsEdgeType = deepFreeze({
   forwardName: "authors",
   backwardName: "is authored by",
-  defaultWeight: {forwards: 1 / 2, backwards: 1},
+  defaultWeight: {
+    forwards: Num.finiteNonnegative(1 / 2),
+    backwards: Num.finiteNonnegative(1),
+  },
   prefix: E.Prefix.authors,
   description: dedent`\
     Connects a GitHub account to a post that they authored.
@@ -97,7 +101,10 @@ const authorsEdgeType = deepFreeze({
 const hasParentEdgeType = deepFreeze({
   forwardName: "has parent",
   backwardName: "has child",
-  defaultWeight: {forwards: 1, backwards: 1 / 4},
+  defaultWeight: {
+    forwards: Num.finiteNonnegative(1),
+    backwards: Num.finiteNonnegative(1 / 4),
+  },
   prefix: E.Prefix.hasParent,
   description: dedent`\
     Connects a GitHub entity to its child entities.
@@ -110,7 +117,10 @@ const hasParentEdgeType = deepFreeze({
 const mergedAsEdgeType = deepFreeze({
   forwardName: "merges",
   backwardName: "is merged by",
-  defaultWeight: {forwards: 1 / 2, backwards: 1},
+  defaultWeight: {
+    forwards: Num.finiteNonnegative(1 / 2),
+    backwards: Num.finiteNonnegative(1),
+  },
   prefix: E.Prefix.mergedAs,
   description: dedent`\
     Connects a GitHub pull request to the Git commit that it merges.
@@ -120,7 +130,10 @@ const mergedAsEdgeType = deepFreeze({
 const referencesEdgeType = deepFreeze({
   forwardName: "references",
   backwardName: "is referenced by",
-  defaultWeight: {forwards: 1, backwards: 0},
+  defaultWeight: {
+    forwards: Num.finiteNonnegative(1),
+    backwards: Num.finiteNonnegative(0),
+  },
   prefix: E.Prefix.references,
   description: dedent`\
     Connects a GitHub post to an entity that it references.
@@ -134,7 +147,10 @@ const referencesEdgeType = deepFreeze({
 const reactsHeartEdgeType = deepFreeze({
   forwardName: "reacted ❤️ to",
   backwardName: "got ❤️ from",
-  defaultWeight: {forwards: 2, backwards: 0},
+  defaultWeight: {
+    forwards: Num.finiteNonnegative(2),
+    backwards: Num.finiteNonnegative(0),
+  },
   prefix: E.Prefix.reactsHeart,
   description: dedent`\
     Connects users to posts to which they gave a ❤️ reaction.
@@ -144,7 +160,10 @@ const reactsHeartEdgeType = deepFreeze({
 const reactsThumbsUpEdgeType = deepFreeze({
   forwardName: "reacted 👍 to",
   backwardName: "got 👍 from",
-  defaultWeight: {forwards: 1, backwards: 0},
+  defaultWeight: {
+    forwards: Num.finiteNonnegative(1),
+    backwards: Num.finiteNonnegative(0),
+  },
   prefix: E.Prefix.reactsThumbsUp,
   description: dedent`\
     Connects users to posts to which they gave a 👍 reaction.
@@ -154,7 +173,10 @@ const reactsThumbsUpEdgeType = deepFreeze({
 const reactsHoorayEdgeType = deepFreeze({
   forwardName: "reacted 🎉 to",
   backwardName: "got 🎉 from",
-  defaultWeight: {forwards: 4, backwards: 0},
+  defaultWeight: {
+    forwards: Num.finiteNonnegative(4),
+    backwards: Num.finiteNonnegative(0),
+  },
   prefix: E.Prefix.reactsHooray,
   description: dedent`\
     Connects users to posts to which they gave a 🎉 reaction.
@@ -164,7 +186,10 @@ const reactsHoorayEdgeType = deepFreeze({
 const reactsRocketEdgeType = deepFreeze({
   forwardName: "reacted 🚀 to",
   backwardName: "got 🚀 from",
-  defaultWeight: {forwards: 1, backwards: 0},
+  defaultWeight: {
+    forwards: Num.finiteNonnegative(1),
+    backwards: Num.finiteNonnegative(0),
+  },
   prefix: E.Prefix.reactsRocket,
   description: dedent`\
     Connects users to posts to which they gave a 🚀 reaction.
@@ -174,7 +199,10 @@ const reactsRocketEdgeType = deepFreeze({
 const correspondsToCommitEdgeType = deepFreeze({
   forwardName: "corresponds to Git commit",
   backwardName: "merged on GitHub as",
-  defaultWeight: {forwards: 1, backwards: 1},
+  defaultWeight: {
+    forwards: Num.finiteNonnegative(1),
+    backwards: Num.finiteNonnegative(1),
+  },
   prefix: E.Prefix.correspondsToCommit,
   description: dedent`\
     Connects a commit on GitHub to the corresponding raw Git commit.

--- a/src/plugins/initiatives/createGraph.test.js
+++ b/src/plugins/initiatives/createGraph.test.js
@@ -25,6 +25,7 @@ import {
   championsEdgeType,
   contributesToEntryEdgeType,
 } from "./declaration";
+import * as N from "../../util/numerics";
 
 const exampleEntry = (overrides: $Shape<NodeEntry>): NodeEntry => ({
   key: overrides.title ? _titleSlug(overrides.title) : "sample-title",
@@ -163,7 +164,10 @@ describe("plugins/initiatives/createGraph", () => {
         id: createId("TEST_INITIATIVE_WEIGHTS", "41"),
         title: "Weights set, not completed",
         completed: false,
-        weight: {incomplete: 222, complete: 333},
+        weight: {
+          incomplete: N.finiteNonnegative(222),
+          complete: N.finiteNonnegative(333),
+        },
       });
 
       // When
@@ -179,7 +183,10 @@ describe("plugins/initiatives/createGraph", () => {
         id: createId("TEST_INITIATIVE_WEIGHTS", "41"),
         title: "Weights set, completed",
         completed: true,
-        weight: {incomplete: 222, complete: 333},
+        weight: {
+          incomplete: N.finiteNonnegative(222),
+          complete: N.finiteNonnegative(333),
+        },
       });
 
       // When
@@ -222,10 +229,23 @@ describe("plugins/initiatives/createGraph", () => {
     it("should add node weights for initiatives with weights", () => {
       // Given
       const {repo, refs} = example();
-      repo.addInitiative({weight: {incomplete: 360, complete: 420}});
-      repo.addInitiative({weight: {incomplete: 42, complete: 69}});
       repo.addInitiative({
-        weight: {incomplete: 42, complete: 69},
+        weight: {
+          incomplete: N.finiteNonnegative(360),
+          complete: N.finiteNonnegative(420),
+        },
+      });
+      repo.addInitiative({
+        weight: {
+          incomplete: N.finiteNonnegative(42),
+          complete: N.finiteNonnegative(69),
+        },
+      });
+      repo.addInitiative({
+        weight: {
+          incomplete: N.finiteNonnegative(42),
+          complete: N.finiteNonnegative(69),
+        },
         completed: true,
       });
 
@@ -704,7 +724,10 @@ describe("plugins/initiatives/createGraph", () => {
             urls: [],
             entries: [
               exampleEntry({title: "Without weight", weight: null}),
-              exampleEntry({title: "With weight", weight: 360}),
+              exampleEntry({
+                title: "With weight",
+                weight: N.finiteNonnegative(360),
+              }),
             ],
           },
         });
@@ -743,7 +766,10 @@ describe("plugins/initiatives/createGraph", () => {
             urls: [],
             entries: [
               exampleEntry({title: "Without weight", weight: null}),
-              exampleEntry({title: "With weight", weight: 360}),
+              exampleEntry({
+                title: "With weight",
+                weight: N.finiteNonnegative(360),
+              }),
             ],
           },
         });
@@ -782,7 +808,10 @@ describe("plugins/initiatives/createGraph", () => {
             urls: [],
             entries: [
               exampleEntry({title: "Without weight", weight: null}),
-              exampleEntry({title: "With weight", weight: 360}),
+              exampleEntry({
+                title: "With weight",
+                weight: N.finiteNonnegative(360),
+              }),
             ],
           },
         });

--- a/src/plugins/initiatives/declaration.js
+++ b/src/plugins/initiatives/declaration.js
@@ -5,6 +5,7 @@ import type {PluginDeclaration} from "../../analysis/pluginDeclaration";
 import type {NodeType, EdgeType} from "../../analysis/types";
 import {NodeAddress, EdgeAddress} from "../../core/graph";
 import type {NodeEntryField} from "./nodeEntry";
+import * as N from "../../util/numerics";
 
 export const nodePrefix = NodeAddress.fromParts(["sourcecred", "initiatives"]);
 export const edgePrefix = EdgeAddress.fromParts(["sourcecred", "initiatives"]);
@@ -13,7 +14,7 @@ export const initiativeNodeType: NodeType = deepFreeze({
   name: "Initiative",
   pluralName: "Initiatives",
   prefix: NodeAddress.append(nodePrefix, "initiative"),
-  defaultWeight: 1,
+  defaultWeight: N.finiteNonnegative(1),
   description:
     "An initiative supernode, describing a scoped improvement to a project from proposal to completion.",
 });
@@ -29,7 +30,7 @@ function nodeEntryType(field: NodeEntryField): NodeType {
     name: `${displayField} Entry`,
     pluralName: `${displayField} Entries`,
     prefix: NodeAddress.append(nodePrefix, String(field)),
-    defaultWeight: 1,
+    defaultWeight: N.finiteNonnegative(1),
     description:
       `A ${displayField.toLowerCase()} entry node, to easily include` +
       `contributions when other plugins don't add it to the graph.`,
@@ -66,7 +67,10 @@ export const dependsOnEdgeType: EdgeType = deepFreeze({
   forwardName: "depends on",
   backwardName: "is a dependency for",
   prefix: EdgeAddress.append(edgePrefix, "dependsOn"),
-  defaultWeight: {forwards: 1, backwards: 1 / 16},
+  defaultWeight: {
+    forwards: N.finiteNonnegative(1),
+    backwards: N.finiteNonnegative(1 / 16),
+  },
   description: "Connects an initiative to it's dependencies.",
 });
 
@@ -82,7 +86,10 @@ export const referencesEdgeType: EdgeType = deepFreeze({
   forwardName: "references",
   backwardName: "is referenced for",
   prefix: EdgeAddress.append(edgePrefix, "references"),
-  defaultWeight: {forwards: 1 / 2, backwards: 1 / 16},
+  defaultWeight: {
+    forwards: N.finiteNonnegative(1 / 2),
+    backwards: N.finiteNonnegative(1 / 16),
+  },
   description: "Connects an initiative to it's references.",
 });
 
@@ -97,7 +104,10 @@ export const contributesToEdgeType: EdgeType = deepFreeze({
   forwardName: "contributes to",
   backwardName: "is contributed to by",
   prefix: EdgeAddress.append(edgePrefix, "contributesTo"),
-  defaultWeight: {forwards: 1, backwards: 1},
+  defaultWeight: {
+    forwards: N.finiteNonnegative(1),
+    backwards: N.finiteNonnegative(1),
+  },
   description: "Connects an initiative to it's contributions.",
 });
 
@@ -112,7 +122,10 @@ export const contributesToEntryEdgeType: EdgeType = deepFreeze({
   forwardName: "contributes to entry",
   backwardName: "entry is contributed to by",
   prefix: EdgeAddress.append(edgePrefix, "contributesToEntry"),
-  defaultWeight: {forwards: 1 / 16, backwards: 1},
+  defaultWeight: {
+    forwards: N.finiteNonnegative(1 / 16),
+    backwards: N.finiteNonnegative(1),
+  },
   description: "Connects a contributor to an entry node.",
 });
 
@@ -131,7 +144,10 @@ export const championsEdgeType: EdgeType = deepFreeze({
   forwardName: "champions",
   backwardName: "is championed by",
   prefix: EdgeAddress.append(edgePrefix, "champions"),
-  defaultWeight: {forwards: 1, backwards: 4},
+  defaultWeight: {
+    forwards: N.finiteNonnegative(1),
+    backwards: N.finiteNonnegative(4),
+  },
   description: "Connects an initiative to users who champion it.",
 });
 

--- a/src/plugins/initiatives/initiativeFile.test.js
+++ b/src/plugins/initiatives/initiativeFile.test.js
@@ -11,11 +11,15 @@ import {
   initiativeFileURL,
   initiativeFileId,
 } from "./initiativeFile";
+import * as N from "../../util/numerics";
 
 const exampleInitiativeFile = (): InitiativeFile => ({
   title: "Sample initiative",
   timestampIso: Timestamp.toISO(Date.parse("2020-01-08T22:01:57.766Z")),
-  weight: {incomplete: 360, complete: 420},
+  weight: {
+    incomplete: N.finiteNonnegative(360),
+    complete: N.finiteNonnegative(420),
+  },
   completed: false,
   champions: ["http://foo.bar/champ"],
   contributions: {

--- a/src/plugins/initiatives/initiativesDirectory.test.js
+++ b/src/plugins/initiatives/initiativesDirectory.test.js
@@ -19,11 +19,15 @@ import {
   _createReferenceMap,
 } from "./initiativesDirectory";
 import {type InitiativeFile} from "./initiativeFile";
+import * as N from "../../util/numerics";
 
 const exampleInitiativeFile = (): InitiativeFile => ({
   title: "Sample initiative",
   timestampIso: Timestamp.toISO(Date.parse("2020-01-08T22:01:57.766Z")),
-  weight: {incomplete: 360, complete: 420},
+  weight: {
+    incomplete: N.finiteNonnegative(360),
+    complete: N.finiteNonnegative(420),
+  },
   completed: false,
   champions: ["http://foo.bar/champ"],
   contributions: {

--- a/src/plugins/initiatives/nodeEntry.test.js
+++ b/src/plugins/initiatives/nodeEntry.test.js
@@ -11,6 +11,7 @@ import {
   normalizeNodeEntry,
   _titleSlug,
 } from "./nodeEntry";
+import * as N from "../../util/numerics";
 
 describe("plugins/initiatives/nodeEntry", () => {
   describe("addressForNodeEntry", () => {
@@ -73,13 +74,16 @@ describe("plugins/initiatives/nodeEntry", () => {
 
     it("should handle an entry with weights", () => {
       const timestampMs: TimestampMs = 123;
-      const entry: NodeEntryJson = {title: "Include weight", weight: 42};
+      const entry: NodeEntryJson = {
+        title: "Include weight",
+        weight: N.finiteNonnegative(42),
+      };
       const expected: NodeEntry = {
         title: "Include weight",
         key: "include-weight",
         contributors: [],
         timestampMs,
-        weight: 42,
+        weight: N.finiteNonnegative(42),
       };
       expect(normalizeNodeEntry(entry, timestampMs)).toEqual(expected);
     });

--- a/src/plugins/initiatives/parseInitiative.js
+++ b/src/plugins/initiatives/parseInitiative.js
@@ -9,6 +9,7 @@ import type {
 } from "./initiativeFile";
 import {_validateUrl} from "./initiativesDirectory";
 import {fromISO, toISO} from "../../util/timestamp";
+import * as N from "../../util/numerics";
 
 const URLParser = C.fmap(C.string, _validateUrl);
 
@@ -17,7 +18,10 @@ const TimestampParser = C.fmap(C.string, (t) => toISO(fromISO(t)));
 const CommonFields = {
   title: C.string,
   timestampIso: TimestampParser,
-  weight: C.object({incomplete: C.number, complete: C.number}),
+  weight: C.object({
+    incomplete: N.finiteNonnegativeParser,
+    complete: N.finiteNonnegativeParser,
+  }),
   completed: C.boolean,
 };
 
@@ -31,7 +35,7 @@ const NodeEntryParser = C.object(
   },
   {
     key: C.string,
-    weight: C.number,
+    weight: N.finiteNonnegativeParser,
   }
 );
 

--- a/src/ui/weights/EdgeTypeConfig.js
+++ b/src/ui/weights/EdgeTypeConfig.js
@@ -5,6 +5,7 @@ import {WeightSlider, type Props as WeightSliderProps} from "./WeightSlider";
 
 import type {EdgeType} from "../../analysis/types";
 import type {EdgeWeight} from "../../core/weights";
+import * as N from "../../util/numerics";
 
 export class EdgeTypeConfig extends React.Component<{
   +weight: EdgeWeight,
@@ -22,7 +23,10 @@ export class EdgeTypeConfig extends React.Component<{
           weight={forwards}
           description={description}
           onChange={(newForwards) => {
-            this.props.onChange({forwards: newForwards, backwards});
+            this.props.onChange({
+              forwards: N.finiteNonnegative(newForwards),
+              backwards,
+            });
           }}
         />
         <EdgeWeightSlider
@@ -32,7 +36,7 @@ export class EdgeTypeConfig extends React.Component<{
           onChange={(newBackwards) => {
             this.props.onChange({
               forwards,
-              backwards: newBackwards,
+              backwards: N.finiteNonnegative(newBackwards),
             });
           }}
         />

--- a/src/ui/weights/EdgeTypeConfig.test.js
+++ b/src/ui/weights/EdgeTypeConfig.test.js
@@ -6,6 +6,7 @@ import {shallow} from "enzyme";
 import {WeightSlider} from "./WeightSlider";
 import {EdgeTypeConfig, EdgeWeightSlider} from "./EdgeTypeConfig";
 import {assemblesEdgeType} from "../../plugins/demo/declaration";
+import * as N from "../../util/numerics";
 
 require("../../webutil/testUtil").configureEnzyme();
 
@@ -14,7 +15,10 @@ describe("ui/weights/EdgeTypeConfig", () => {
     function example() {
       const onChange = jest.fn();
       const type = assemblesEdgeType;
-      const weight = {forwards: 1, backwards: 0.5};
+      const weight = {
+        forwards: N.finiteNonnegative(1),
+        backwards: N.finiteNonnegative(0.5),
+      };
       const element = shallow(
         <EdgeTypeConfig onChange={onChange} type={type} weight={weight} />
       );

--- a/src/ui/weights/NodeTypeConfig.js
+++ b/src/ui/weights/NodeTypeConfig.js
@@ -4,6 +4,7 @@ import React from "react";
 import {WeightSlider} from "./WeightSlider";
 import type {NodeType} from "../../analysis/types";
 import type {NodeWeight} from "../../core/weights";
+import * as N from "../../util/numerics";
 
 export class NodeTypeConfig extends React.Component<{
   +weight: NodeWeight,
@@ -16,7 +17,7 @@ export class NodeTypeConfig extends React.Component<{
         name={this.props.type.name}
         weight={this.props.weight}
         description={this.props.type.description}
-        onChange={(weight) => this.props.onChange(weight)}
+        onChange={(weight) => this.props.onChange(N.finiteNonnegative(weight))}
       />
     );
   }

--- a/src/ui/weights/NodeTypeConfig.test.js
+++ b/src/ui/weights/NodeTypeConfig.test.js
@@ -6,6 +6,7 @@ import {shallow} from "enzyme";
 import {WeightSlider} from "./WeightSlider";
 import {NodeTypeConfig} from "./NodeTypeConfig";
 import {inserterNodeType} from "../../plugins/demo/declaration";
+import * as N from "../../util/numerics";
 
 require("../../webutil/testUtil").configureEnzyme();
 
@@ -14,7 +15,7 @@ describe("ui/weights/NodeTypeConfig", () => {
     function example() {
       const onChange = jest.fn();
       const type = inserterNodeType;
-      const weight = 0.125;
+      const weight = N.finiteNonnegative(0.125);
       const element = shallow(
         <NodeTypeConfig onChange={onChange} weight={weight} type={type} />
       );

--- a/src/ui/weights/WeightConfig.js
+++ b/src/ui/weights/WeightConfig.js
@@ -16,7 +16,7 @@ type Props = {|
   +nodeWeights: Map<NodeAddressT, NodeWeight>,
   // Map from EdgeType prefix to weight.
   +edgeWeights: Map<EdgeAddressT, EdgeWeight>,
-  +onNodeWeightChange: (NodeAddressT, number) => void,
+  +onNodeWeightChange: (NodeAddressT, NodeWeight) => void,
   +onEdgeWeightChange: (EdgeAddressT, EdgeWeight) => void,
 |};
 


### PR DESCRIPTION
This large commit refactors the codebase to use the new typesafe
numerics introduced in #2082. It "changes the world" rather than doing
isolated refactors, which I regret, but I was fairly deep in before I
realized how messy the commit would wind up being.

That said, this doesn't have much review burden because it consists
entirely of tightening up type declarations, and is extremely unlikely
to introduce regressions. I'm particularly pleased that we now require
that all node and edge weights are finite and non-negative, as this data
comes from plugins, and will now be validated when the plugin graph is
being parsed, which ensures fast and clear failures if a plugin produces
invalid weights.

Test plan: Refactor without runtime changes to code. `yarn test` passes.