### PR TITLE
Usability tweaks for SpecialGrainDistribution

### DIFF
--- a/src/ui/components/SpecialGrainDistribution.js
+++ b/src/ui/components/SpecialGrainDistribution.js
@@ -44,7 +44,7 @@ export const SpecialGrainDistribution = ({ledger, setLedger}: Props) => {
       const nextLedger = ledger.distributeGrain(distribution);
       setLedger(nextLedger);
       setAmount(fromInteger(0));
-      setMemo("");
+      setRecipient(null);
     }
   };
 
@@ -95,7 +95,13 @@ export const SpecialGrainDistribution = ({ledger, setLedger}: Props) => {
             type="number"
             name="timestamp"
             value={credTimestamp}
-            onChange={(e) => setCredTimestamp(e.currentTarget.value)}
+            onChange={(e) => {
+              const newTimestamp = +e.currentTarget.value;
+              if (!Number.isFinite(newTimestamp)) {
+                throw new Error(`invalid timestamp: ${e.currentTarget.value}`);
+              }
+              setCredTimestamp(newTimestamp);
+            }}
           />
         </p>
         <input


### PR DESCRIPTION
This commit implements some usability improvements for
SpecialGrainDistribution.

- We ensure that manually-entered CredTimestamps are converted to
numbers, and error if the number is invalid.
- We reset the recipient on transfer, since there's no need to
distribute to the same person twice in a row.
- We keep the memo unchanged, since we may often want to re-use the memo
(e.g. "legacy earnings for July").

Test plan: Live usage while porting Maker's instance.