### PR TITLE
bugfix: remove root slash from sourcecred.json fetch

### DIFF
--- a/src/ui/load.js
+++ b/src/ui/load.js
@@ -16,7 +16,7 @@ export type LoadFailure = {|+type: "FAILURE", +error: any|};
 export async function load(): Promise<LoadResult> {
   const queries = [
     fetch("output/credResult.json"),
-    fetch("/sourcecred.json"),
+    fetch("sourcecred.json"),
     fetch("data/ledger.json"),
   ];
   const responses = await Promise.all(queries);


### PR DESCRIPTION
This slash indicates the file is located at the site's root, as opposed
to the current route's location, and therefore causes load failures when 
the static website isn't loaded from the site's root.

fixes #2093

test plan:
1. build these changes in this repo: `yarn build`
2. navigate to a local test instance and run
`$ route/to/local/sourcecred.js site`
3. navigate to the parent directory: `$ cd ..`
4. run `$ python2 -m SimpleHTTPServer 6060`
5. browse to http://localhost:6060/\<test-instance\> and
observe everything load