### PR TITLE
add dependenciesMintPolicy

### DIFF
--- a/src/core/dependenciesMintPolicy.js
+++ b/src/core/dependenciesMintPolicy.js
@@ -1,0 +1,133 @@
+// @flow
+
+/**
+ * This module adds a core type for specifying "Dependency Mint" policies.
+ * The Dependency Minting system is how we intend to allow projects to
+ * flow Cred to their dependencies; e.g. it is how a user of SourceCred may
+ * flow Cred to SourceCred itself. We want to make this easily configured at
+ * the whole-project level, so that e.g. we can make projects flow ~5% of their
+ * Cred to SourceCred by default.
+ *
+ * It's not obvious how to embed this information directly into the Contribution
+ * Graph in a way that's elegant and computationally efficient. E.g. we could add
+ * an edge from every individual contribution to each dependency, but that
+ * greatly increases the size and max degree of the Graph, which is
+ * undesirable. After some discussion and consideration of alternatives,
+ * @decentralion and @wchargin decided it would be cleanest to handle this
+ * outside of the normal Graph abstraction. Thus, the Dependency Mint Policy was
+ * born. These policies specify that after normal, Graph-based Cred computation is
+ * finished, some nodes will recieve "extra" Cred minting which is proportional
+ * to the total pre-dependencies Cred.
+ *
+ * The total amount of Cred that may be minted is unbounded; for example, if
+ * the dependencies have a total weight of 0.2, then the total Cred will be
+ * 120% of the base Cred, but if the dependencies had a total weight of 1, then
+ * the total Cred would be double the base Cred. This was a deliberate design
+ * decision so that dependency minting would feel "non-rival", i.e. there is
+ * not a fixed budget of dependency cred that must be split between the
+ * dependencies. In many cases, it may be very reasonable for the total Cred
+ * flowing to a project's dependencies to be larger than the total Cred flowing
+ * directly to the project's contributors; consider that the total amount of
+ * time/effort invested in building all the dependencies may be orders of
+ * magnitude larger than investment in the project itself.
+ *
+ * In the future, we may develop more elegant approaches that integrate
+ * dependencies more naturally into the contribution graph itself, in which
+ * case we could phase out this system. But for now, it seems like a
+ * sufficiently useful and flexible abstraction to merit inclusion in core/.
+ *
+ * Note that there's nothing in the implementation or data types that imply
+ * that this is only used for dependencies; one could imagine using it for
+ * other purposes, e.g. minting extra Cred for moderators of a forum, or for
+ * maintainers of a project. However, we have a prior that all contributors to
+ * a project should be paid via CredRank and the graph-based system, rather
+ * than "out-of-band" fiat/configuration like the mint policies in this module.
+ * Thus, we're naming it the dependencyMintPolicy to communicate that
+ * intention.
+ */
+import {type NodeAddressT, NodeAddress} from "./graph";
+import {type TimestampMs} from "../util/timestamp";
+
+export type DependencyMintPolicy = {|
+  // The node address that will receieve the extra minted Cred
+  +address: NodeAddressT,
+  // Information on how the minted Cred varies in time.
+  +periods: $ReadOnlyArray<DependencyMintPeriod>,
+|};
+
+export type DependencyMintPeriod = {|
+  // What proportion of the project's raw Cred should be minted to this
+  // dependency during this period. For example, if the weight is 0.05, and the
+  // project has a pre-dependencies total Cred of 1000 in a given interval,
+  // then this dependench will receive an additional 50 Cred.
+  +weight: number,
+  // Timestamp or number because we allow -Infinity as the first "timestamp"
+  // Within any policy, the period timestamps must be in sorted order, or else
+  // an error will be thrown.
+  +startTimeMs: TimestampMs | number,
+|};
+
+/**
+ * The ProcessedMintPolicy is a DependencyMintPolicy which has
+ * been transformed so that it matches the abstractions available when
+ * we're doing raw cred computation: instead of an address, we track an index
+ * into the canonical node order, and rather than arbitrary client-provided
+ * periods, we compute the weight for each Interval.
+ */
+export type ProcessedMintPolicy = {|
+  +nodeIndex: number,
+  +intervalWeights: $ReadOnlyArray<number>,
+|};
+
+export function processMintPolicy(
+  policy: DependencyMintPolicy,
+  nodeOrder: $ReadOnlyArray<NodeAddressT>,
+  intervalStarts: $ReadOnlyArray<TimestampMs>
+): ProcessedMintPolicy {
+  const {address, periods} = policy;
+  const nodeIndex = nodeOrder.indexOf(address);
+  if (nodeIndex === -1) {
+    throw new Error(
+      `address not in nodeOrder: ${NodeAddress.toString(address)}`
+    );
+  }
+  const intervalWeights = _alignPeriodsToIntervals(periods, intervalStarts);
+  return {nodeIndex, intervalWeights};
+}
+
+export function _alignPeriodsToIntervals(
+  periods: $ReadOnlyArray<DependencyMintPeriod>,
+  intervalStarts: $ReadOnlyArray<TimestampMs>
+): $ReadOnlyArray<number> {
+  if (periods.length === 0) {
+    return intervalStarts.map(() => 0);
+  }
+  // Validate the periods to make sure they are in order and the weights
+  // are finite and non-negative
+  let currentStartTimeMs = periods[0].startTimeMs;
+  for (const {startTimeMs, weight} of periods) {
+    if (currentStartTimeMs > startTimeMs) {
+      throw new Error(
+        `mint periods out of order: ${currentStartTimeMs} > ${startTimeMs}`
+      );
+    }
+    currentStartTimeMs = startTimeMs;
+    if (weight < 0 || !Number.isFinite(weight)) {
+      throw new Error(`invalid mint weight: ${weight}`);
+    }
+  }
+  let currentPeriodIndex = -1;
+  let currentWeight = 0;
+  // We always return the weight of the latest period whose startTimeMs was
+  // less than or equal to the interval's start.
+  return intervalStarts.map((s) => {
+    while (
+      currentPeriodIndex < periods.length - 1 &&
+      periods[currentPeriodIndex + 1].startTimeMs <= s
+    ) {
+      currentPeriodIndex++;
+      currentWeight = periods[currentPeriodIndex].weight;
+    }
+    return currentWeight;
+  });
+}

--- a/src/core/dependenciesMintPolicy.js
+++ b/src/core/dependenciesMintPolicy.js
@@ -51,7 +51,7 @@ import {type TimestampMs} from "../util/timestamp";
 export type DependencyMintPolicy = {|
   // The node address that will receieve the extra minted Cred
   +address: NodeAddressT,
-  // Information on how the minted Cred varies in time.
+  // Information on how the Cred minting weight varies in time.
   +periods: $ReadOnlyArray<DependencyMintPeriod>,
 |};
 
@@ -59,7 +59,7 @@ export type DependencyMintPeriod = {|
   // What proportion of the project's raw Cred should be minted to this
   // dependency during this period. For example, if the weight is 0.05, and the
   // project has a pre-dependencies total Cred of 1000 in a given interval,
-  // then this dependench will receive an additional 50 Cred.
+  // then this dependency will receive an additional 50 Cred.
   +weight: number,
   // Timestamp or number because we allow -Infinity as the first "timestamp"
   // Within any policy, the period timestamps must be in sorted order, or else
@@ -68,13 +68,13 @@ export type DependencyMintPeriod = {|
 |};
 
 /**
- * The ProcessedMintPolicy is a DependencyMintPolicy which has
+ * The ProcessedDependencyMintPolicy is a DependencyMintPolicy which has
  * been transformed so that it matches the abstractions available when
  * we're doing raw cred computation: instead of an address, we track an index
  * into the canonical node order, and rather than arbitrary client-provided
  * periods, we compute the weight for each Interval.
  */
-export type ProcessedMintPolicy = {|
+export type ProcessedDependencyMintPolicy = {|
   +nodeIndex: number,
   +intervalWeights: $ReadOnlyArray<number>,
 |};
@@ -83,7 +83,7 @@ export function processMintPolicy(
   policy: DependencyMintPolicy,
   nodeOrder: $ReadOnlyArray<NodeAddressT>,
   intervalStarts: $ReadOnlyArray<TimestampMs>
-): ProcessedMintPolicy {
+): ProcessedDependencyMintPolicy {
   const {address, periods} = policy;
   const nodeIndex = nodeOrder.indexOf(address);
   if (nodeIndex === -1) {

--- a/src/core/dependenciesMintPolicy.test.js
+++ b/src/core/dependenciesMintPolicy.test.js
@@ -1,0 +1,93 @@
+// @flow
+
+import deepFreeze from "deep-freeze";
+import {NodeAddress} from "./graph";
+import {
+  _alignPeriodsToIntervals,
+  processMintPolicy,
+} from "./dependenciesMintPolicy";
+
+describe("core/dependenciesMintPolicy", () => {
+  describe("_alignPeriodsToIntervals", () => {
+    it("handles a case with no periods and no intervals", () => {
+      expect(_alignPeriodsToIntervals([], [])).toEqual([]);
+    });
+    it("handles a case with no periods and intervals", () => {
+      expect(_alignPeriodsToIntervals([], [1, 2])).toEqual([0, 0]);
+    });
+    it("handles a case with a single period that spans all time", () => {
+      const period = {startTimeMs: -Infinity, weight: 0.5};
+      expect(_alignPeriodsToIntervals([period], [1, 2])).toEqual([0.5, 0.5]);
+    });
+    it("handles a case with a single period that starts midway", () => {
+      const period = {startTimeMs: 1, weight: 0.5};
+      expect(_alignPeriodsToIntervals([period], [0, 1, 2])).toEqual([
+        0,
+        0.5,
+        0.5,
+      ]);
+    });
+    it("handles a case with a multiple periods", () => {
+      const period1 = {startTimeMs: 10, weight: 0.5};
+      const period2 = {startTimeMs: 20, weight: 0.1};
+      expect(
+        _alignPeriodsToIntervals([period1, period2], [0, 5, 10, 15, 20, 25])
+      ).toEqual([0, 0, 0.5, 0.5, 0.1, 0.1]);
+    });
+    it("ignores a period if the next period has the same startTime", () => {
+      const period1 = {startTimeMs: 1, weight: 0.5};
+      const period2 = {startTimeMs: 1, weight: 0.1};
+      expect(_alignPeriodsToIntervals([period1, period2], [0, 1, 2])).toEqual([
+        0,
+        0.1,
+        0.1,
+      ]);
+    });
+    it("ignores all periods if they all start in the future", () => {
+      const period1 = {startTimeMs: 10, weight: 0.5};
+      const period2 = {startTimeMs: 15, weight: 0.1};
+      expect(_alignPeriodsToIntervals([period1, period2], [0, 1, 2])).toEqual([
+        0,
+        0,
+        0,
+      ]);
+    });
+    it("errors if periods are out-of-rder", () => {
+      const period1 = {startTimeMs: 10, weight: 0.5};
+      const period2 = {startTimeMs: 15, weight: 0.1};
+      const thunk = () =>
+        _alignPeriodsToIntervals([period2, period1], [0, 1, 2]);
+      expect(thunk).toThrowError("mint periods out of order: 15 > 10");
+    });
+    it("errors if any mint weights are invalid", () => {
+      const bads = [-1, NaN, Infinity, -Infinity];
+      for (const b of bads) {
+        const period = {startTimeMs: 10, weight: b};
+        const thunk = () => _alignPeriodsToIntervals([period], [0, 1, 2]);
+        expect(thunk).toThrowError("invalid mint weight");
+      }
+    });
+  });
+
+  describe("processMintPolicy", () => {
+    const n1 = NodeAddress.fromParts(["1"]);
+    const n2 = NodeAddress.fromParts(["2"]);
+    const n3 = NodeAddress.fromParts(["3"]);
+    const nx = NodeAddress.fromParts(["x"]);
+    const nodeOrder = deepFreeze([n1, n2, n3]);
+    const intervals = deepFreeze([1, 2, 3, 4]);
+    const periods = [deepFreeze({startTimeMs: 2, weight: 0.5})];
+    it("converts the address and periods correctly", () => {
+      const policy = {address: n2, periods};
+      const intervalWeights = _alignPeriodsToIntervals(periods, intervals);
+      const actual = processMintPolicy(policy, nodeOrder, intervals);
+      const expected = {nodeIndex: 1, intervalWeights};
+      expect(actual).toEqual(expected);
+    });
+    it("errors if the node address isn't in the ordering", () => {
+      const policy = {address: nx, periods};
+      const thunk = () => processMintPolicy(policy, nodeOrder, intervals);
+      expect(thunk).toThrowError("address not in nodeOrder");
+    });
+  });
+});

--- a/src/core/dependenciesMintPolicy.test.js
+++ b/src/core/dependenciesMintPolicy.test.js
@@ -34,6 +34,21 @@ describe("core/dependenciesMintPolicy", () => {
         _alignPeriodsToIntervals([period1, period2], [0, 5, 10, 15, 20, 25])
       ).toEqual([0, 0, 0.5, 0.5, 0.1, 0.1]);
     });
+    it("handles a case where the period starts in-between intervals", () => {
+      const period1 = {startTimeMs: 15, weight: 0.5};
+      expect(_alignPeriodsToIntervals([period1], [0, 10, 20])).toEqual([
+        0,
+        0,
+        0.5,
+      ]);
+    });
+    it("handles a case where there are multiple periods within one interval", () => {
+      const period1 = {startTimeMs: 15, weight: 0.5};
+      const period2 = {startTimeMs: 16, weight: 0.1};
+      expect(
+        _alignPeriodsToIntervals([period1, period2], [0, 10, 20])
+      ).toEqual([0, 0, 0.1]);
+    });
     it("ignores a period if the next period has the same startTime", () => {
       const period1 = {startTimeMs: 1, weight: 0.5};
       const period2 = {startTimeMs: 1, weight: 0.1};


### PR DESCRIPTION
From the module docstring:

This module adds a core type for specifying "Dependency Mint" policies.
The Dependency Minting system is how we intend to allow projects to
flow Cred to their dependencies; e.g. it is how a user of SourceCred may
flow Cred to SourceCred itself. We want to make this easily configured at
the whole-project level, so that e.g. we can make projects flow ~5% of their
Cred to SourceCred by default.

It's not obvious how to embed this information directly into the Contribution
Graph in a way that's elegant and computationally efficient. E.g. we could add
an edge from every individual contribution to each dependency, but that
greatly increases the size and max degree of the Graph, which is
undesirable. After some discussion and consideration of alternatives,
@decentralion and @wchargin decided it would be cleanest to handle this
outside of the normal Graph abstraction. Thus, the Dependency Mint Policy was
born. These policies specify that after normal, Graph-based Cred computation is
finished, some nodes will recieve "extra" Cred minting which is proportional
to the total pre-dependencies Cred.

The total amount of Cred that may be minted is unbounded; for example, if
the dependencies have a total weight of 0.2, then the total Cred will be
120% of the base Cred, but if the dependencies had a total weight of 1, then
the total Cred would be double the base Cred. This was a deliberate design
decision so that dependency minting would feel "non-rival", i.e. there is
not a fixed budget of dependency cred that must be split between the
dependencies. In many cases, it may be very reasonable for the total Cred
flowing to a project's dependencies to be larger than the total Cred flowing
directly to the project's contributors; consider that the total amount of
time/effort invested in building all the dependencies may be orders of
magnitude larger than investment in the project itself.

In the future, we may develop more elegant approaches that integrate
dependencies more naturally into the contribution graph itself, in which
case we could phase out this system. But for now, it seems like a
sufficiently useful and flexible abstraction to merit inclusion in core/.

Note that there's nothing in the implementation or data types that imply
that this is only used for dependencies; one could imagine using it for
other purposes, e.g. minting extra Cred for moderators of a forum, or for
maintainers of a project. However, we have a prior that all contributors to
a project should be paid via CredRank and the graph-based system, rather
than "out-of-band" fiat/configuration like the mint policies in this module.
Thus, we're naming it the dependencyMintPolicy to communicate that
intention.

Test plan: Unit tests included, run `yarn test`.

Progress on #1941.