### PR TITLE
Remove nodes/edges debug info

### DIFF
--- a/src/ui/components/Explorer.js
+++ b/src/ui/components/Explorer.js
@@ -204,8 +204,6 @@ export class Explorer extends React.Component<ExplorerProps, ExplorerState> {
           padding: "0 5em 5em",
         }}
       >
-        <h1>Nodes: {view.nodes().length}</h1>
-        <h1>Edges: {view.edges().length}</h1>
         {this.renderConfigurationRow()}
         {recalculating ? <h1>Recalculating...</h1> : ""}
         <table


### PR DESCRIPTION
The explorer currently shows the # of nodes and edges at the top of the
screen. This was included as a vestigial development artifact, it's
basically a "console.log" to verify the data pipeline is working. We can
now remove it.

Test plan: UI doesn't show this debug info at the top.