### PR TITLE
GrainAccountOverview: sort by paid, not balance

### DIFF
--- a/src/ui/components/GrainAccountOverview.js
+++ b/src/ui/components/GrainAccountOverview.js
@@ -23,7 +23,7 @@ export const GrainAccountOverview = (props: Props) => {
     if (a.balance === b.balance) {
       return 0;
     }
-    return G.gt(a.balance, b.balance) ? -1 : 1;
+    return G.gt(a.paid, b.paid) ? -1 : 1;
   }
 
   const sortedAccounts = accounts.slice().sort(comparator);


### PR DESCRIPTION
This changes the GrainAccountOverview so it sorts by lifetime paid, not
by current balance. It's a suggestion from @wchargin which I agree
with... makes the ordering more stable and better reflect overall
engagement/reward from the project, rather than the current state of how
much they've cashed out.

Test plan: `yarn start` and inspect results