### PR TITLE
Make match alias robust and performant

### DIFF
--- a/src/ui/components/AliasSelector.js
+++ b/src/ui/components/AliasSelector.js
@@ -1,13 +1,15 @@
 // @flow
-
 import React, {useState, useEffect} from "react";
-import {useCombobox} from "downshift";
 import {Ledger} from "../../ledger/ledger";
 import {type Alias, type IdentityId} from "../../ledger/identity";
 import {CredView} from "../../analysis/credView";
 import {type NodeAddressT} from "../../core/graph";
 import Markdown from "react-markdown";
 import removeMd from "remove-markdown";
+
+import {makeStyles} from "@material-ui/core/styles";
+import {List, ListItem, TextField} from "@material-ui/core";
+import {Autocomplete} from "@material-ui/lab";
 
 type Props = {|
   +selectedIdentityId: IdentityId,
@@ -16,17 +18,26 @@ type Props = {|
   +setLedger: (Ledger) => void,
 |};
 
+const useStyles = makeStyles({
+  aliasesHeader: {marginBottom: 0},
+  /* This are temporary and will be fixed on next branch!
+    Only here to get this Autocomplete to be useable
+    before redoing the ledger admin components */
+  temporaryAutocompleteStyling: {width: "20%", border: "1px solid black"},
+  temporaryInputStyles: {color: "black"},
+});
+
 export function AliasSelector({
   selectedIdentityId,
   ledger,
   setLedger,
   credView,
 }: Props) {
+  const classes = useStyles();
   const selectedAccount = ledger.account(selectedIdentityId);
   if (selectedAccount == null) {
     throw new Error("Selected identity not present in ledger");
   }
-  const selectedIdentity = selectedAccount.identity;
   const [inputValue, setInputValue] = useState("");
 
   const claimedAddresses: Set<NodeAddressT> = new Set();
@@ -45,110 +56,66 @@ export function AliasSelector({
     }))
     .filter(({address}) => !claimedAddresses.has(address));
 
-  function filteredAliasesMatchingString(input: string): Alias[] {
-    return potentialAliases.filter(({description}) =>
-      removeMd(description).toLowerCase().startsWith(input.toLowerCase())
+  const filteredAliasesMatchingString = (input: string): Alias[] =>
+    potentialAliases.filter(({description}) =>
+      removeMd(description).toLowerCase().includes(input.toLowerCase())
     );
-  }
 
   const [inputItems, setInputItems] = useState(
     filteredAliasesMatchingString("")
   );
 
-  const setAliasSearch = (input: string = "") => {
+  const setAliasSearch = (input: string = "") =>
     setInputItems(filteredAliasesMatchingString(input));
-  };
 
-  useEffect(() => {
-    setAliasSearch();
-  }, [selectedAccount.identity.aliases]);
+  useEffect(() => setAliasSearch(), [selectedAccount.identity.aliases]);
 
-  const {
-    isOpen,
-    getToggleButtonProps,
-    getMenuProps,
-    getInputProps,
-    getComboboxProps,
-    highlightedIndex,
-    getItemProps,
-    selectItem,
-  } = useCombobox({
-    inputValue,
-    items: inputItems,
-    onStateChange: ({inputValue, type, selectedItem}) => {
-      switch (type) {
-        case useCombobox.stateChangeTypes.InputChange:
-          setInputValue(inputValue);
-          setAliasSearch(inputValue);
-          break;
-        case useCombobox.stateChangeTypes.InputKeyDownEnter:
-        case useCombobox.stateChangeTypes.ItemClick:
-        case useCombobox.stateChangeTypes.InputBlur:
-          if (selectedItem) {
-            setLedger(ledger.addAlias(selectedIdentityId, selectedItem));
-            setInputValue("");
-            selectItem(null);
-          }
-          break;
-        default:
-          break;
-      }
-    },
-  });
   return (
-    <div>
-      <label>
-        <h2>Aliases:</h2>
-      </label>
-      <div>
-        {selectedIdentity.aliases.map((alias, index) => (
-          <span key={`selected-item-${index}`}>
-            <Markdown
-              renderers={{paragraph: "span"}}
-              source={alias.description}
-            />
-            <br />
-          </span>
-        ))}
-        <div style={comboboxStyles} {...getComboboxProps()}>
-          <input {...getInputProps()} />
-          <button {...getToggleButtonProps()} aria-label={"toggle menu"}>
-            &#8595;
-          </button>
-        </div>
-      </div>
-      <ul {...getMenuProps()} style={menuMultipleStyles}>
-        {isOpen &&
-          inputItems.map((alias, index) => (
-            <li
-              style={
-                highlightedIndex === index ? {backgroundColor: "#bde4ff"} : {}
-              }
-              key={`${alias.address}${index}`}
-              {...getItemProps({alias, index})}
-            >
+    <>
+      <h3 className={classes.aliasesHeader}>Aliases:</h3>
+      {selectedAccount.identity.aliases.length > 0 && (
+        <List dense>
+          {selectedAccount.identity.aliases.map((alias, index) => (
+            <ListItem key={`selected-item-${index}`}>
               <Markdown
-                renderers={{link: "span", paragraph: "span"}}
+                renderers={{paragraph: "span"}}
                 source={alias.description}
               />
-            </li>
+            </ListItem>
           ))}
-      </ul>
-    </div>
+        </List>
+      )}
+      <Autocomplete
+        onInputChange={(_, value, reason) => {
+          if (reason === "input") {
+            setAliasSearch(value);
+            setInputValue(value);
+          }
+        }}
+        onChange={(_, selectedItem, reason) => {
+          if (reason === "select-option") {
+            setLedger(ledger.addAlias(selectedIdentityId, selectedItem));
+            setAliasSearch("");
+            setInputValue("");
+          }
+        }}
+        className={classes.temporaryAutocompleteStyling}
+        freeSolo
+        disableClearable
+        options={inputItems}
+        getOptionLabel={({description}) => description || ""}
+        inputValue={inputValue}
+        renderInput={(params) => (
+          <TextField
+            {...params}
+            placeholder="Alias"
+            InputProps={{
+              ...params.InputProps,
+              className: classes.temporaryInputStyles,
+            }}
+          />
+        )}
+      />
+    </>
   );
 }
-
-const comboboxStyles = {display: "inline-block", marginLeft: "5px"};
-
-const menuMultipleStyles = {
-  maxHeight: "180px",
-  overflowY: "auto",
-  width: "135px",
-  margin: 0,
-  borderTop: 0,
-  background: "white",
-  position: "absolute",
-  zIndex: 1000,
-  listStyle: "none",
-  padding: 0,
-};


### PR DESCRIPTION
This branch is for issue: https://github.com/sourcecred/sourcecred/issues/2084

Switch to  more performant material-ui over combobox
Use includes rather than startsWith for alias search.
Test plan: test performance on maker instance.
Also test matching via UI

It's not beautiful, but it's honest work:
![Screenshot from 2020-08-10 23-52-03](https://user-images.githubusercontent.com/7257527/89855502-9b7b8f00-db64-11ea-8f4f-90b2eef90fe4.png)

I am going to branch off of this to do a full material-ui overhaul, and fix page styling. So don't worry, it won't look like this for long.