### PR TITLE
Discourse mirror repository: add postById

### DIFF
--- a/src/plugins/discourse/createGraph.test.js
+++ b/src/plugins/discourse/createGraph.test.js
@@ -88,6 +88,14 @@ describe("plugins/discourse/createGraph", () => {
     topicById() {
       throw new Error("Method topicById should be unused by createGraph");
     }
+    postById(id: PostId): ?Post {
+      for (const p of this._posts) {
+        if (p.id === id) {
+          return p;
+        }
+      }
+      return null;
+    }
   }
 
   function example() {
@@ -467,6 +475,9 @@ describe("plugins/discourse/createGraph", () => {
         }
         topicById() {
           throw new Error("Method topicById should be unused by createGraph");
+        }
+        postById() {
+          return null;
         }
       }
       const url = "https://example.com";

--- a/src/plugins/discourse/mirrorRepository.js
+++ b/src/plugins/discourse/mirrorRepository.js
@@ -59,6 +59,11 @@ export interface ReadRepository {
    * Gets a Topic by ID.
    */
   topicById(id: TopicId): ?Topic;
+
+  /**
+   * Gets a Post by ID.
+   */
+  postById(id: PostId): ?Post;
 }
 
 export type SyncHeads = {|
@@ -335,6 +340,40 @@ export class SqliteMirrorRepository
         replyToPostIndex: x.reply_to_post_index,
         cooked: x.cooked,
       }));
+  }
+
+  postById(id: PostId): ?Post {
+    const res = this._db
+      .prepare(
+        dedent`\
+        SELECT
+          id,
+          timestamp_ms,
+          author_username,
+          topic_id,
+          trust_level,
+          index_within_topic,
+          reply_to_post_index,
+          cooked
+        FROM posts
+        WHERE id = :id`
+      )
+      .get({id});
+
+    if (!res) {
+      return null;
+    }
+
+    return {
+      id: res.id,
+      timestampMs: res.timestamp_ms,
+      authorUsername: res.author_username,
+      topicId: res.topic_id,
+      trustLevel: res.trust_level,
+      indexWithinTopic: res.index_within_topic,
+      replyToPostIndex: res.reply_to_post_index,
+      cooked: res.cooked,
+    };
   }
 
   users(): $ReadOnlyArray<User> {

--- a/src/plugins/discourse/mirrorRepository.test.js
+++ b/src/plugins/discourse/mirrorRepository.test.js
@@ -261,6 +261,40 @@ describe("plugins/discourse/mirrorRepository", () => {
     // Then
     expect(actualT1).toEqual(topic1);
     expect(actualT2).toEqual(topic2);
+    expect(repository.topicById(1337)).toEqual(null);
+  });
+
+  it("topicById gets the matching topics", () => {
+    // Given
+    const db = new Database(":memory:");
+    const url = "http://example.com";
+    const repository = new SqliteMirrorRepository(db, url);
+    const topic: Topic = {
+      id: 123,
+      categoryId: 42,
+      title: "Sample topic 1",
+      timestampMs: 456789,
+      bumpedMs: 456999,
+      authorUsername: "credbot",
+    };
+    const post: Post = {
+      id: 100,
+      topicId: 123,
+      indexWithinTopic: 0,
+      replyToPostIndex: null,
+      timestampMs: 456789,
+      authorUsername: "credbot",
+      cooked: "<p>Valid post</p>",
+      trustLevel: 3,
+    };
+
+    // When
+    repository.addTopic(topic);
+    repository.addPost(post);
+
+    // Then
+    expect(repository.postById(post.id)).toEqual(post);
+    expect(repository.postById(1337)).toEqual(null);
   });
 
   it("on addPost, user trustLevel is equal to post trustLevel", () => {


### PR DESCRIPTION
It's a straightforward extension for the module contract (it already
allows getting topic by id) and will be useful for solving #1896.

Test plan: Added some unit tests. (Also, the implementation is trivial.)