### PR TITLE
Deduplicate `findUserbyUsername` and `findUsername`

### DIFF
--- a/src/plugins/discourse/createGraph.test.js
+++ b/src/plugins/discourse/createGraph.test.js
@@ -82,8 +82,13 @@ describe("plugins/discourse/createGraph", () => {
         maxTopicId: this._topics.reduce((max, t) => Math.max(t.id, max), 0),
       };
     }
-    findUsername() {
-      throw new Error("Method findUsername should be unused by createGraph");
+    findUser(username: string) {
+      for (const user of this.users()) {
+        if (user.username === username) {
+          return user;
+        }
+      }
+      return null;
     }
     topicById() {
       throw new Error("Method topicById should be unused by createGraph");
@@ -468,10 +473,13 @@ describe("plugins/discourse/createGraph", () => {
         maxIds() {
           throw new Error("Unused");
         }
-        findUsername() {
-          throw new Error(
-            "Method findUsername should be unused by createGraph"
-          );
+        findUser(username: string) {
+          for (const user of this.users()) {
+            if (user.username === username) {
+              return user;
+            }
+          }
+          return null;
         }
         topicById() {
           throw new Error("Method topicById should be unused by createGraph");

--- a/src/plugins/discourse/mirrorRepository.js
+++ b/src/plugins/discourse/mirrorRepository.js
@@ -49,11 +49,11 @@ export interface ReadRepository {
   likes(): $ReadOnlyArray<LikeAction>;
 
   /**
-   * Gets the username of a user, if it exists.
+   * Gets the user with a given name, if they exist.
    *
    * Note: input username is case-insensitive.
    */
-  findUsername(username: string): ?string;
+  findUser(username: string): ?User;
 
   /**
    * Gets a Topic by ID.
@@ -386,7 +386,7 @@ export class SqliteMirrorRepository
       }));
   }
 
-  findUserbyUsername(username: string): ?User {
+  findUser(username: string): ?User {
     const user = this._db
       .prepare(
         dedent`\
@@ -396,20 +396,10 @@ export class SqliteMirrorRepository
         `
       )
       .get({username});
+    if (user == null) {
+      return null;
+    }
     return {username: user.username, trustLevel: user.trust_level};
-  }
-
-  findUsername(username: string): ?string {
-    return this._db
-      .prepare(
-        dedent`\
-          SELECT username
-          FROM users
-          WHERE username = :username COLLATE NOCASE
-        `
-      )
-      .pluck()
-      .get({username});
   }
 
   likes(): $ReadOnlyArray<LikeAction> {

--- a/src/plugins/discourse/mirrorRepository.test.js
+++ b/src/plugins/discourse/mirrorRepository.test.js
@@ -26,7 +26,7 @@ describe("plugins/discourse/mirrorRepository", () => {
     expect(fs.readFileSync(filename).toJSON()).toEqual(data);
   });
 
-  it("findUsername does a case-insensitive query", () => {
+  it("findUser does a case-insensitive query", () => {
     // Given
     const db = new Database(":memory:");
     const url = "http://example.com";
@@ -34,13 +34,13 @@ describe("plugins/discourse/mirrorRepository", () => {
     const repository = new SqliteMirrorRepository(db, url);
 
     // When
-    repository.addOrReplaceUser({username, trustLevel: 3});
-    const result1 = repository.findUsername("pascalfan1988");
-    const result2 = repository.findUsername(username);
+    const user = {username, trustLevel: 3};
+    repository.addOrReplaceUser(user);
 
     // Then
-    expect(result1).toEqual(username);
-    expect(result2).toEqual(username);
+    expect(repository.findUser(username.toLowerCase())).toEqual(user);
+    expect(repository.findUser(username)).toEqual(user);
+    expect(repository.findUser("nonexistent")).toEqual(null);
   });
 
   it("bumpedMsForTopic finds an existing topic's bumpedMs", () => {
@@ -324,7 +324,7 @@ describe("plugins/discourse/mirrorRepository", () => {
     // When
     repository.addTopic(topic);
     repository.addPost(p1);
-    const postingUser = repository.findUserbyUsername("crunkle");
+    const postingUser = repository.findUser("crunkle");
 
     // Then
     expect(postingUser).toEqual({username: "crunkle", trustLevel: 3});
@@ -364,7 +364,7 @@ describe("plugins/discourse/mirrorRepository", () => {
     repository.addPost(p1);
     repository.addLike(l1);
     const likes = repository.likes();
-    const likingUser = repository.findUserbyUsername("crunkle");
+    const likingUser = repository.findUser("crunkle");
 
     // Then
     expect(likes).toEqual([l1]);
@@ -415,7 +415,7 @@ describe("plugins/discourse/mirrorRepository", () => {
     repository.addPost(p1);
     repository.addPost(p2);
     repository.addLike(l1);
-    const likingUser = repository.findUserbyUsername("crunkle");
+    const likingUser = repository.findUser("crunkle");
 
     // Then
     expect(likingUser).toEqual({username: "crunkle", trustLevel: 2});

--- a/src/plugins/discourse/referenceDetector.js
+++ b/src/plugins/discourse/referenceDetector.js
@@ -47,9 +47,9 @@ export class DiscourseReferenceDetector implements ReferenceDetector {
       case "USER": {
         // Look up the username to validate it exists, and make sure we use
         // the result. As this should correct our capitalization. See #1479.
-        const username = this.data.findUsername(reference.username);
-        if (username) {
-          return userAddress(reference.serverUrl, username);
+        const user = this.data.findUser(reference.username);
+        if (user) {
+          return userAddress(reference.serverUrl, user.username);
         }
         break;
       }


### PR DESCRIPTION
The Mirror repository had a public method, `findUsername`, which didn't
return the User but just the user's name, and a private method,
`findUserbyUsername`, which gave the full user. Obviously, given the
user, it's trivial to find the username. So I deduplicated this method
and we now export a method `findUser` which can be used in both cases.

Test plan: `yarn test` suffices.