### PR TITLE
Show more rows in the Explorer

### DIFF
--- a/src/ui/components/Explorer.js
+++ b/src/ui/components/Explorer.js
@@ -223,7 +223,7 @@ export class Explorer extends React.Component<ExplorerProps, ExplorerState> {
             </tr>
           </thead>
           <tbody>
-            {sortedNodes.slice(0, 40).map((node) => (
+            {sortedNodes.slice(0, 200).map((node) => (
               <NodeRow
                 depth={0}
                 key={node.address}


### PR DESCRIPTION
Currently, we only display 40 rows in the Explorer. This means only the
top 40 users by Cred can see their scores, which sucks.

We should build proper pagination... but for now lets show 200 rows by
default rather than 40. This way 5 times more people get to see their
Cred score.

Test plan: Manual inspection of the frontend.