### PR TITLE
Identity: rename "IdentityName" type to "Login"

### DIFF
--- a/scripts/createLedgerFromLegacyProject.js
+++ b/scripts/createLedgerFromLegacyProject.js
@@ -6,7 +6,7 @@ import * as C from "../src/util/combo";
 import {Ledger} from "../src/ledger/ledger";
 import type {NodeAddressT} from "../src/core/graph";
 import {resolveAlias} from "../src/cli/alias";
-import {identityNameFromString} from "../src/ledger/identity";
+import {loginFromString} from "../src/ledger/identity";
 
 const URL_PATTERN = /https?:\/\/(www\.)?[-a-zA-Z0-9@:%._+~#=]{1,256}\.[a-zA-Z0-9()]{1,6}\b([-a-zA-Z0-9()@:%_+.~#?&//=]*)/;
 

--- a/src/ledger/identity.test.js
+++ b/src/ledger/identity.test.js
@@ -4,7 +4,7 @@ import deepFreeze from "deep-freeze";
 import {fromString as uuidFromString} from "../util/uuid";
 import {NodeAddress} from "../core/graph";
 import {
-  identityNameFromString,
+  loginFromString,
   graphNode,
   type Identity,
   newIdentity,
@@ -39,7 +39,7 @@ describe("ledger/identity", () => {
     });
     it("errors on invalid names", () => {
       const fail = () => newIdentity("USER", "bad string");
-      expect(fail).toThrowError("invalid identityName");
+      expect(fail).toThrowError("invalid login");
     });
     it("errors on invalid subtype", () => {
       // $FlowExpectedError
@@ -53,8 +53,8 @@ describe("ledger/identity", () => {
     expect(node.address).toEqual(example.address);
     expect(node.timestampMs).toEqual(null);
   });
-  describe("identityNameFromString", () => {
-    it("fails on invalid identityNames", () => {
+  describe("loginFromString", () => {
+    it("fails on invalid logins", () => {
       const bad = [
         "With Space",
         "With.Period",
@@ -64,19 +64,17 @@ describe("ledger/identity", () => {
         "@name",
       ];
       for (const b of bad) {
-        expect(() => identityNameFromString(b)).toThrowError(
-          "invalid identityName"
-        );
+        expect(() => loginFromString(b)).toThrowError("invalid login");
       }
     });
-    it("succeeds on valid identityNames", () => {
+    it("succeeds on valid logins", () => {
       const names = ["h", "hi-there", "ZaX99324cab"];
       for (const n of names) {
-        expect(identityNameFromString(n)).toEqual(n.toLowerCase());
+        expect(loginFromString(n)).toEqual(n.toLowerCase());
       }
     });
-    it("lower-cases identityNames", () => {
-      expect(identityNameFromString("FooBAR")).toEqual("foobar");
+    it("lower-cases logins", () => {
+      expect(loginFromString("FooBAR")).toEqual("foobar");
     });
   });
 });

--- a/src/ledger/ledger.test.js
+++ b/src/ledger/ledger.test.js
@@ -113,16 +113,16 @@ describe("ledger/ledger", () => {
           },
         ]);
       });
-      it("throws an error if the identityName is invalid", () => {
+      it("throws an error if the login is invalid", () => {
         const ledger = new Ledger();
         const thunk = () => ledger.createIdentity("USER", "foo bar");
-        failsWithoutMutation(ledger, thunk, "invalid identityName");
+        failsWithoutMutation(ledger, thunk, "invalid login");
       });
-      it("throws an error if the identityName is taken", () => {
+      it("throws an error if the login is taken", () => {
         const ledger = new Ledger();
         ledger.createIdentity("USER", "foo");
         const thunk = () => ledger.createIdentity("USER", "foo");
-        failsWithoutMutation(ledger, thunk, "identityName already taken");
+        failsWithoutMutation(ledger, thunk, "login already taken");
       });
       it("throws an error given an identity with aliases", () => {
         const ledger = new Ledger();
@@ -195,7 +195,7 @@ describe("ledger/ledger", () => {
           "renameIdentity: no identity matches id"
         );
       });
-      it("fails on identityName conflict", () => {
+      it("fails on login conflict", () => {
         const ledger = new Ledger();
         const fooId = ledger.createIdentity("USER", "foo");
         ledger.createIdentity("USER", "bar");
@@ -203,14 +203,14 @@ describe("ledger/ledger", () => {
         failsWithoutMutation(
           ledger,
           thunk,
-          "renameIdentity: conflict on identityName bar"
+          "renameIdentity: conflict on login bar"
         );
       });
-      it("fails on invalid identityName", () => {
+      it("fails on invalid login", () => {
         const ledger = new Ledger();
         const fooId = ledger.createIdentity("USER", "foo");
         const thunk = () => ledger.renameIdentity(fooId, "foo bar");
-        failsWithoutMutation(ledger, thunk, "invalid identityName");
+        failsWithoutMutation(ledger, thunk, "invalid login");
       });
     });
 


### PR DESCRIPTION
I'm planning to re-organize the Identity module so that we separate the
concept of a "login" (short, url-sanitized string) from a "displayName".

To do so, I'm going to refactor the Identity type to separate the
user-chosen data from the automatically maintained data. But first, as a
prelude cleanup, I rename the IdentityName type to Login in this commit.

Test plan: Existing unit test coverage suffices.

Part of #2109.