### PR TITLE
Split Identity into some submodules

### DIFF
--- a/src/ledger/identity.test.js
+++ b/src/ledger/identity.test.js
@@ -3,12 +3,7 @@
 import deepFreeze from "deep-freeze";
 import {fromString as uuidFromString} from "../util/uuid";
 import {NodeAddress} from "../core/graph";
-import {
-  loginFromString,
-  graphNode,
-  type Identity,
-  newIdentity,
-} from "./identity";
+import {graphNode, type Identity, newIdentity} from "./identity";
 
 describe("ledger/identity", () => {
   const example: Identity = deepFreeze(newIdentity("USER", "foo"));
@@ -52,29 +47,5 @@ describe("ledger/identity", () => {
     expect(node.description).toEqual(example.name);
     expect(node.address).toEqual(example.address);
     expect(node.timestampMs).toEqual(null);
-  });
-  describe("loginFromString", () => {
-    it("fails on invalid logins", () => {
-      const bad = [
-        "With Space",
-        "With.Period",
-        "A/Slash",
-        "",
-        "with_underscore",
-        "@name",
-      ];
-      for (const b of bad) {
-        expect(() => loginFromString(b)).toThrowError("invalid login");
-      }
-    });
-    it("succeeds on valid logins", () => {
-      const names = ["h", "hi-there", "ZaX99324cab"];
-      for (const n of names) {
-        expect(loginFromString(n)).toEqual(n.toLowerCase());
-      }
-    });
-    it("lower-cases logins", () => {
-      expect(loginFromString("FooBAR")).toEqual("foobar");
-    });
   });
 });

--- a/src/ledger/identity/alias.js
+++ b/src/ledger/identity/alias.js
@@ -1,0 +1,20 @@
+// @flow
+
+import {type NodeAddressT, NodeAddress} from "../../core/graph";
+import * as C from "../../util/combo";
+
+/**
+ * An Alias is basically another graph Node which resolves to this identity. We
+ * ignore the timestamp because it's generally not significant for users; we
+ * keep the address out of obvious necessity, and we keep the description so we
+ * can describe this alias in UIs (e.g. the ledger admin panel).
+ */
+export type Alias = {|
+  +description: string,
+  +address: NodeAddressT,
+|};
+
+export const parser: C.Parser<Alias> = C.object({
+  address: NodeAddress.parser,
+  description: C.string,
+});

--- a/src/ledger/identity/login.js
+++ b/src/ledger/identity/login.js
@@ -1,0 +1,28 @@
+// @flow
+
+import * as C from "../../util/combo";
+
+/**
+ * A Login is an identity name which has the following properties:
+ * - It consists of lowercase alphanumeric ASCII and of dashes, which
+ *   makes it suitable for including in urls (so we can give each contributor
+ *   a hardcoded URL showing their contributions, Cred, and Grain).
+ * - It is unique within an instance.
+ * - It's chosen by (and changeable by) the owner of the identity.
+ */
+export opaque type Login: string = string;
+const LOGIN_PATTERN = /^[A-Za-z0-9-]+$/;
+
+/**
+ * Parse a Login from a string.
+ *
+ * Throws an error if the Login is invalid.
+ */
+export function loginFromString(login: string): Login {
+  if (!login.match(LOGIN_PATTERN)) {
+    throw new Error(`invalid login: ${login}`);
+  }
+  return login.toLowerCase();
+}
+
+export const parser: C.Parser<Login> = C.fmap(C.string, loginFromString);

--- a/src/ledger/identity/login.test.js
+++ b/src/ledger/identity/login.test.js
@@ -1,0 +1,30 @@
+// @flow
+
+import {loginFromString} from "./login";
+
+describe("ledger/identity/login", () => {
+  describe("loginFromString", () => {
+    it("fails on invalid logins", () => {
+      const bad = [
+        "With Space",
+        "With.Period",
+        "A/Slash",
+        "",
+        "with_underscore",
+        "@name",
+      ];
+      for (const b of bad) {
+        expect(() => loginFromString(b)).toThrowError("invalid login");
+      }
+    });
+    it("succeeds on valid logins", () => {
+      const names = ["h", "hi-there", "ZaX99324cab"];
+      for (const n of names) {
+        expect(loginFromString(n)).toEqual(n.toLowerCase());
+      }
+    });
+    it("lower-cases logins", () => {
+      expect(loginFromString("FooBAR")).toEqual("foobar");
+    });
+  });
+});


### PR DESCRIPTION
This commit pulls the Login and Alias concepts out of the
`ledger/identity.js` file. The rationale is that as part of #2109 we
will need to make multiple versions of the Identity type (and, for
backcompat reasons, support all versions indefinitely). Therefore the
file needs to be split lest it become a huge mess. This is the first and
easiest bit to pull out.

For now, I'm re-exporting the types, functions, and parsers from the
same `identity.js` file, so we don't need to change any clients.

Test plan: Simple re-org, `yarn test` passes.