### PR TITLE
Add the v2 identity type

### DIFF
--- a/src/ledger/identity/description.js
+++ b/src/ledger/identity/description.js
@@ -1,0 +1,17 @@
+// @flow
+
+import * as C from "../../util/combo";
+
+import {type Login, parser as loginParser} from "./login";
+import {type IdentityType, parser as identityTypeParser} from "./identityType";
+
+export type IdentityDescription = {|
+  +login: Login,
+  +displayName: string,
+  +type: IdentityType,
+|};
+export const parser: C.Parser<IdentityDescription> = C.object({
+  login: loginParser,
+  displayName: C.string,
+  type: identityTypeParser,
+});

--- a/src/ledger/identity/v2.js
+++ b/src/ledger/identity/v2.js
@@ -1,0 +1,60 @@
+// @flow
+
+import {parser as uuidParser, random as randomUuid} from "../../util/uuid";
+import * as C from "../../util/combo";
+import {type Alias, parser as aliasParser} from "./alias";
+import {type IdentityId} from "./id";
+import {
+  type IdentityDescription,
+  parser as descriptionParser,
+} from "./description";
+import {
+  NodeAddress,
+  type NodeAddressT,
+  type Node as GraphNode,
+  type NodeContraction,
+} from "../../core/graph";
+import {IDENTITY_PREFIX} from "./declaration";
+
+export type Identity = {|
+  +id: IdentityId,
+  +aliases: $ReadOnlyArray<Alias>,
+  +description: IdentityDescription,
+|};
+export const parser: C.Parser<Identity> = C.object({
+  id: uuidParser,
+  aliases: C.array(aliasParser),
+  description: descriptionParser,
+});
+
+export function newIdentity(
+  description: IdentityDescription,
+  initialAliases: $ReadOnlyArray<Alias>
+) {
+  return parser.parseOrThrow({
+    id: randomUuid(),
+    aliases: initialAliases,
+    description,
+  });
+}
+
+export function identityAddress(identity: Identity): NodeAddressT {
+  return NodeAddress.append(IDENTITY_PREFIX, identity.id);
+}
+
+export function graphNode(identity: Identity): GraphNode {
+  return {
+    address: identityAddress(identity),
+    description: identity.description.displayName,
+    timestampMs: null,
+  };
+}
+
+export function contractions(
+  identities: $ReadOnlyArray<Identity>
+): $ReadOnlyArray<NodeContraction> {
+  return identities.map((i) => ({
+    replacement: graphNode(i),
+    old: i.aliases.map((a) => a.address),
+  }));
+}

--- a/src/ledger/identity/v2.test.js
+++ b/src/ledger/identity/v2.test.js
@@ -1,0 +1,64 @@
+// @flow
+
+import deepFreeze from "deep-freeze";
+import {NodeAddress} from "../../core/graph";
+import {loginFromString} from "./login";
+import {type IdentityDescription} from "./description";
+import {type Alias} from "./alias";
+import {newIdentity, parser, graphNode, identityAddress} from "./v2";
+import {parser as uuidParser} from "../../util/uuid";
+import {IDENTITY_PREFIX} from "./declaration";
+
+describe("ledger/identity/v2", () => {
+  const description: IdentityDescription = deepFreeze({
+    login: loginFromString("user"),
+    type: "USER",
+    displayName: "A User",
+  });
+  const aliases: $ReadOnlyArray<Alias> = deepFreeze([
+    {address: NodeAddress.empty, description: "alias"},
+  ]);
+  const identity = deepFreeze(newIdentity(description, aliases));
+  describe("newIdentity", () => {
+    it("uses included description and aliases, and provides a uuid", () => {
+      expect(identity.aliases).toEqual(aliases);
+      expect(identity.description).toEqual(description);
+      // Proof that we have a valid id
+      uuidParser.parseOrThrow(identity.id);
+      parser.parseOrThrow(identity);
+    });
+    it("errors if there's an invalid description", () => {
+      const description = {
+        login: loginFromString("user"),
+        type: "BAR",
+        displayName: "A User",
+      };
+      const aliases = [{address: NodeAddress.empty, description: "alias"}];
+      // $FlowExpectedError
+      const thunk = () => newIdentity(description, aliases);
+      expect(thunk).toThrowError("description");
+    });
+    it("errors if there's an invalid alias", () => {
+      const description = {
+        login: loginFromString("user"),
+        type: "USER",
+        displayName: "A User",
+      };
+      const aliases = [{address: "nope", description: "alias"}];
+      // $FlowExpectedError
+      const thunk = () => newIdentity(description, aliases);
+      expect(thunk).toThrowError("aliases");
+    });
+  });
+  it("identityAddress works", () => {
+    expect(identityAddress(identity)).toEqual(
+      NodeAddress.append(IDENTITY_PREFIX, identity.id)
+    );
+  });
+  it("graphNode works", () => {
+    const node = graphNode(identity);
+    expect(node.description).toEqual(identity.description.displayName);
+    expect(node.address).toEqual(identityAddress(identity));
+    expect(node.timestampMs).toEqual(null);
+  });
+});


### PR DESCRIPTION
This adds a new version of the Identity type. Key differences:
- All the state which may be freely changed by the owner of the identity
is grouped into an `IdentityDescription`. This will allow clean events
to update this state, as suggested by @hammadj in [a review].
- The identity no longer has an included address--it will instead be
implicit. This removes a class of desync bugs.
- We now support giving the identity some initial aliases rather than
always starting with empty aliases.

Part of #2109.

[a review]: https://github.com/sourcecred/sourcecred/pull/2080#pullrequestreview-463906325

Test plan: `yarn test` passes.