### PR TITLE
identity names: support capitalization

### DIFF
--- a/src/ledger/identity/name.js
+++ b/src/ledger/identity/name.js
@@ -4,10 +4,11 @@ import * as C from "../../util/combo";
 
 /**
  * A Name is an identity name which has the following properties:
- * - It consists of lowercase alphanumeric ASCII and of dashes, which
- *   makes it suitable for including in urls (so we can give each contributor
- *   a hardcoded URL showing their contributions, Cred, and Grain).
- * - It is unique within an instance.
+ * - It consists of alphanumeric ASCII and of dashes, which makes it suitable
+ *   for including in urls (so we can give each contributor a hardcoded URL
+ *   showing their contributions, Cred, and Grain).
+ * - It is unique within an instance. Also, no two identites may have names that both
+ *   have the same lowercase representation.
  * - It's chosen by (and changeable by) the owner of the identity.
  */
 export opaque type Name: string = string;
@@ -22,7 +23,7 @@ export function nameFromString(name: string): Name {
   if (!name.match(NAME_PATTERN)) {
     throw new Error(`invalid name: ${name}`);
   }
-  return name.toLowerCase();
+  return name;
 }
 
 export const parser: C.Parser<Name> = C.fmap(C.string, nameFromString);

--- a/src/ledger/identity/name.test.js
+++ b/src/ledger/identity/name.test.js
@@ -20,11 +20,11 @@ describe("ledger/identity/name", () => {
     it("succeeds on valid names", () => {
       const names = ["h", "hi-there", "ZaX99324cab"];
       for (const n of names) {
-        expect(nameFromString(n)).toEqual(n.toLowerCase());
+        expect(nameFromString(n)).toEqual(n);
       }
     });
-    it("lower-cases names", () => {
-      expect(nameFromString("FooBAR")).toEqual("foobar");
+    it("does not lower-case names", () => {
+      expect(nameFromString("FooBAR")).toEqual("FooBAR");
     });
   });
 });

--- a/src/ledger/ledger.js
+++ b/src/ledger/ledger.js
@@ -76,6 +76,7 @@ export type Account = $ReadOnly<MutableAccount>;
 export class Ledger {
   _ledgerEventLog: JsonLog<LedgerEvent>;
   _nameToId: Map<Name, IdentityId>;
+  _lowercaseNames: Set<string>;
   _aliasAddressToIdentity: Map<NodeAddressT, IdentityId>;
   _accounts: Map<IdentityId, MutableAccount>;
   _latestTimestamp: TimestampMs = -Infinity;
@@ -84,6 +85,7 @@ export class Ledger {
   constructor() {
     this._ledgerEventLog = new JsonLog();
     this._nameToId = new Map();
+    this._lowercaseNames = new Set();
     this._aliasAddressToIdentity = new Map();
     this._accounts = new Map();
   }
@@ -137,6 +139,11 @@ export class Ledger {
       // This identity already exists; return.
       throw new Error(`createIdentity: name already taken: ${identity.name}`);
     }
+    if (this._lowercaseNames.has(identity.name.toLowerCase())) {
+      throw new Error(
+        `createIdentity: already have same name with different capitalization: ${identity.name}`
+      );
+    }
     if (identity.aliases.length !== 0) {
       throw new Error(`createIdentity: new identities may not have aliases`);
     }
@@ -150,6 +157,7 @@ export class Ledger {
 
     // Mutations! Method must not fail after this comment.
     this._nameToId.set(identity.name, identity.id);
+    this._lowercaseNames.add(identity.name.toLowerCase());
     // Reserve this identity's own address
     this._aliasAddressToIdentity.set(identity.address, identity.id);
     // Every identity has a corresponding Account.
@@ -181,7 +189,8 @@ export class Ledger {
     }
     const account = this._mutableAccount(identityId);
     const existingIdentity = account.identity;
-    if (existingIdentity.name === newName) {
+    const existingName = existingIdentity.name;
+    if (existingName === newName) {
       // We error rather than silently succeed because we don't want the ledger
       // to get polluted with no-op records (no successful operations are
       // idempotent, since they do add to the ledger logs)
@@ -191,6 +200,15 @@ export class Ledger {
       // We already checked that the name is not owned by this identity,
       // so it is a conflict. Fail.
       throw new Error(`renameIdentity: conflict on name ${newName}`);
+    }
+    const lowerCased = newName.toLowerCase();
+    if (
+      this._lowercaseNames.has(lowerCased) &&
+      lowerCased !== existingName.toLowerCase()
+    ) {
+      throw new Error(
+        `renameIdentity: already have same name with different capitalization: ${newName}`
+      );
     }
     const updatedIdentity = {
       id: identityId,
@@ -203,6 +221,8 @@ export class Ledger {
     // Mutations! Method must not fail after this comment.
     this._nameToId.delete(existingIdentity.name);
     this._nameToId.set(newName, identityId);
+    this._lowercaseNames.delete(existingIdentity.name.toLowerCase());
+    this._lowercaseNames.add(newName.toLowerCase());
     account.identity = updatedIdentity;
   }
 


### PR DESCRIPTION
This changes the identity name module so that we allow names to
canonically include capitalization. To maintain safety, the ledger
ensures that no two names would have the same lowercase
representation--e.g. "Foo" and "foo" are both valid names, but no
instance may contain both at the same time.

This goes against the counsel of @wchargin, because it could create some
confusion, e.g. if we are ever writing output to the filesystem for each
user and need to worry about case sensitivity on the filesystem. But I
think it's a worthy tradeoff to allow users to have more self-expression
in their chosen names. (As an example, GitHub allows case-sensitive
names.)

Test plan: Unit tests updated. New unit tests added to the ledger to
ensure that createIdentity and renameIdentity error if two identities
would have the same name modulo capitalization, and renameIdentity tests
to ensure that its legal to rename an identity to a name that is the
same modulo capitalization.