### PR TITLE
Add `coerce` to try to generate identity names

### DIFF
--- a/src/ledger/identity/name.js
+++ b/src/ledger/identity/name.js
@@ -26,4 +26,14 @@ export function nameFromString(name: string): Name {
   return name;
 }
 
+const COERCE_PATTERN = /[^A-Za-z0-9-]/g;
+/**
+ * Attempt to coerce a string into a valid name, by replacing invalid
+ * characters like `_` or `#` with hyphens.
+ */
+export function coerce(name: string): Name {
+  const coerced = name.replace(COERCE_PATTERN, "-");
+  return nameFromString(coerced);
+}
+
 export const parser: C.Parser<Name> = C.fmap(C.string, nameFromString);

--- a/src/ledger/identity/name.test.js
+++ b/src/ledger/identity/name.test.js
@@ -1,6 +1,6 @@
 // @flow
 
-import {nameFromString} from "./name";
+import {nameFromString, coerce} from "./name";
 
 describe("ledger/identity/name", () => {
   describe("nameFromString", () => {
@@ -25,6 +25,18 @@ describe("ledger/identity/name", () => {
     });
     it("does not lower-case names", () => {
       expect(nameFromString("FooBAR")).toEqual("FooBAR");
+    });
+  });
+
+  describe("coerce", () => {
+    it("does not change valid names", () => {
+      const names = ["hi", "Foo-123-Bar", "X"];
+      const coerced = names.map(coerce);
+      expect(names).toEqual(coerced);
+    });
+    it("replaces invalid characters with dashes", () => {
+      expect(coerce("My Special Name")).toEqual("My-Special-Name");
+      expect(coerce("A!@#$%^Z")).toEqual("A------Z");
     });
   });
 });


### PR DESCRIPTION
This adds a method called `coerce` which tries to force an input to be a
valid identity name by replacing special characters with dashes. This
will be useful for automatically generating identity names from
plugin-specific identifiers for #2109.

Test plan: `yarn test`