### PR TITLE
identity: restrict name length

### DIFF
--- a/src/ledger/identity/name.js
+++ b/src/ledger/identity/name.js
@@ -14,6 +14,9 @@ import * as C from "../../util/combo";
 export opaque type Name: string = string;
 const NAME_PATTERN = /^[A-Za-z0-9-]+$/;
 
+// Based on GitHub's requirements.
+const MAXIMUM_NAME_LENGTH = 39;
+
 /**
  * Parse a Name from a string.
  *
@@ -23,6 +26,9 @@ export function nameFromString(name: string): Name {
   if (!name.match(NAME_PATTERN)) {
     throw new Error(`invalid name: ${name}`);
   }
+  if (name.length > MAXIMUM_NAME_LENGTH) {
+    throw new Error(`name too long: ${name}`);
+  }
   return name;
 }
 
@@ -30,6 +36,9 @@ const COERCE_PATTERN = /[^A-Za-z0-9-]/g;
 /**
  * Attempt to coerce a string into a valid name, by replacing invalid
  * characters like `_` or `#` with hyphens.
+ *
+ * This can still error, if given a very long string or the empty string, it
+ * will fail rather than try to change the name length.
  */
 export function coerce(name: string): Name {
   const coerced = name.replace(COERCE_PATTERN, "-");

--- a/src/ledger/identity/name.test.js
+++ b/src/ledger/identity/name.test.js
@@ -4,13 +4,17 @@ import {nameFromString, coerce} from "./name";
 
 describe("ledger/identity/name", () => {
   describe("nameFromString", () => {
-    it("fails on invalid names", () => {
+    it("fails on very long names", () => {
+      const bad = "1234567890123456789012345678901234567890";
+      expect(() => nameFromString(bad)).toThrowError("too long");
+    });
+    it("fails on names with invalid characters", () => {
       const bad = [
         "With Space",
         "With.Period",
         "A/Slash",
-        "",
         "with_underscore",
+        "",
         "@name",
       ];
       for (const b of bad) {
@@ -37,6 +41,12 @@ describe("ledger/identity/name", () => {
     it("replaces invalid characters with dashes", () => {
       expect(coerce("My Special Name")).toEqual("My-Special-Name");
       expect(coerce("A!@#$%^Z")).toEqual("A------Z");
+    });
+    it("still fails on names with invalid length", () => {
+      const t1 = () => coerce("");
+      expect(t1).toThrowError("invalid name");
+      const t2 = () => coerce("1234567890123456789012345678901234567890");
+      expect(t2).toThrowError("too long");
     });
   });
 });


### PR DESCRIPTION
Borrowing from GitHub, we restrict identity name length to at most 39
characters.

Test plan: Unit tests added. `yarn test`.