### PR TITLE
ledger: allow checking if a name is available

### DIFF
--- a/src/ledger/ledger.js
+++ b/src/ledger/ledger.js
@@ -116,6 +116,21 @@ export class Ledger {
   }
 
   /**
+   * Return whether the IdentityName in question is available.
+   *
+   * For convenience in test code (and consistency with createIdentity and renameIdentity),
+   * the name is provided as a string. If the string is not a valid name, an error will be
+   * thrown.
+   */
+  nameAvailable(name: string): boolean {
+    // Error if the name is not valid.
+    nameFromString(name);
+    // We don't need to explicitly test the name itself, since if a name
+    // is reserved, its lowercased version is also reserved.
+    return !this._lowercaseNames.has(name.toLowerCase());
+  }
+
+  /**
    * Create an account in the ledger.
    *
    * This will reserve the identity's name, and its innate address.


### PR DESCRIPTION
This will be useful for auto-choosing free identity names for #2109.

Test plan: Unit tests added. `yarn test`.