### PR TITLE
ledger: retrieve account by address

### DIFF
--- a/src/ledger/ledger.js
+++ b/src/ledger/ledger.js
@@ -131,6 +131,19 @@ export class Ledger {
   }
 
   /**
+   * Return the account matching a given NodeAddress, if one exists.
+   *
+   * Returns null if there is no account matching that address.
+   */
+  accountByAddress(address: NodeAddressT): Account | null {
+    const identityId = this._aliasAddressToIdentity.get(address);
+    if (identityId == null) {
+      return null;
+    }
+    return this.account(identityId);
+  }
+
+  /**
    * Create an account in the ledger.
    *
    * This will reserve the identity's name, and its innate address.

--- a/src/ledger/ledger.test.js
+++ b/src/ledger/ledger.test.js
@@ -642,6 +642,40 @@ describe("ledger/ledger", () => {
         active: false,
       });
     });
+
+    describe("accountByAddress", () => {
+      it("returns null if no account matches the address", () => {
+        const ledger = new Ledger();
+        expect(ledger.accountByAddress(NodeAddress.empty)).toBe(null);
+      });
+      it("retrieves an account by innate address", () => {
+        const ledger = ledgerWithIdentities();
+        const account = ledger.account(id1);
+        const address = account.identity.address;
+        expect(ledger.accountByAddress(address)).toEqual(account);
+      });
+      it("retrieves an account by alias address", () => {
+        const ledger = ledgerWithIdentities();
+        ledger.addAlias(id1, alias);
+        const account = ledger.account(id1);
+        const address = alias.address;
+        expect(ledger.accountByAddress(address)).toEqual(account);
+      });
+      it("after merge, retrieves an account by target's innate address", () => {
+        const ledger = ledgerWithIdentities();
+        const addr2 = ledger.account(id2).identity.address;
+        ledger.mergeIdentities({base: id1, target: id2});
+        const account = ledger.account(id1);
+        expect(ledger.accountByAddress(addr2)).toBe(account);
+      });
+      it("after merge, retrieves an account by target's alias address", () => {
+        const ledger = ledgerWithIdentities();
+        ledger.addAlias(id2, alias);
+        ledger.mergeIdentities({base: id1, target: id2});
+        const account = ledger.account(id1);
+        expect(ledger.accountByAddress(alias.address)).toBe(account);
+      });
+    });
   });
 
   describe("grain updates", () => {


### PR DESCRIPTION
This adds a method for getting an account given a node address, which
will be necessary for #2109 (so that we can see if we need to make an
identity for a given node address, or if some identity already exists).

Test plan: Unit tests added; `yarn test`