### PR TITLE
Add a system for identity proposals

### DIFF
--- a/src/ledger/identity/index.js
+++ b/src/ledger/identity/index.js
@@ -10,6 +10,7 @@ export {
 } from "./identity";
 
 export type {IdentityType} from "./identityType";
+export {parser as identityTypeParser} from "./identityType";
 
 export type {Name} from "./name";
 export {nameFromString, parser as nameParser} from "./name";

--- a/src/ledger/identityProposal.js
+++ b/src/ledger/identityProposal.js
@@ -1,0 +1,98 @@
+// @flow
+
+import stringify from "json-stable-stringify";
+import * as C from "../util/combo";
+import {Ledger} from "./ledger";
+import {
+  type Name,
+  nameFromString,
+  nameParser,
+  type Alias,
+  aliasParser,
+  type IdentityType,
+  identityTypeParser,
+} from "./identity";
+
+/**
+ * An IdentityProposal allows a plugin to report a participant identity,
+ * for inclusion in the ledger.
+ *
+ * The proposal has an `alias`, which includes a node address for the identity.
+ * If some account already has that address, then the proposal may be ignored.
+ *
+ * If no account has that address, then the proposal will be added as a new
+ * identity in the ledger.
+ *
+ * The proposal has a proposed name for the identity, and a name for the
+ * plugin. The plugin name will be used as a discriminator if there's already a
+ * different identity with that name.
+ *
+ * If the name and discriminator combo is taken, then a further numeric
+ * discriminator will be added.
+ *
+ * When the identity is created, it will have its own identity address, per
+ * usual, and then the alias will be added. We give the plugin control over the
+ * full alias because aliases include helpful descriptions which are shown in
+ * the UI, and the plugin should choose an appropriate description.
+ */
+export type IdentityProposal = {|
+  +name: Name,
+  +pluginName: Name,
+  +alias: Alias,
+  +type: IdentityType,
+|};
+
+export const parser: C.Parser<IdentityProposal> = C.object({
+  name: nameParser,
+  pluginName: nameParser,
+  alias: aliasParser,
+  type: identityTypeParser,
+});
+
+/**
+ * Given a Ledger and an IdentityProposal, ensure that some Ledger account
+ * exists for the proposed identity.
+ *
+ * If there is already an account matching the node address of the proposal's
+ * alias, then the ledger is unchanged.
+ *
+ * Otherwise, a new account will be created per the semantics of the
+ * IdentityProposal type.
+ */
+export function ensureIdentityExists(
+  ledger: Ledger,
+  proposal: IdentityProposal
+) {
+  if (ledger.accountByAddress(proposal.alias.address) != null) {
+    // there is already some account that includes this address; do nothing
+    return;
+  }
+  const name = _chooseIdentityName(proposal, (n) => ledger.nameAvailable(n));
+  const id = ledger.createIdentity(proposal.type, name);
+  ledger.addAlias(id, proposal.alias);
+}
+
+const MAX_NUMERIC_DISCRIMINATOR = 100;
+export function _chooseIdentityName(
+  proposal: IdentityProposal,
+  checkAvailability: (Name) => boolean
+): Name {
+  if (checkAvailability(proposal.name)) {
+    return proposal.name;
+  }
+  const withPluginDiscriminator = nameFromString(
+    proposal.name + "-" + proposal.pluginName
+  );
+  if (checkAvailability(withPluginDiscriminator)) {
+    return withPluginDiscriminator;
+  }
+  for (let i = 1; i < MAX_NUMERIC_DISCRIMINATOR; i++) {
+    const withNumericDiscriminator = nameFromString(
+      withPluginDiscriminator + "-" + i
+    );
+    if (checkAvailability(withNumericDiscriminator)) {
+      return withNumericDiscriminator;
+    }
+  }
+  throw new Error(`unable to find an identity name for ${stringify(proposal)}`);
+}

--- a/src/ledger/identityProposal.test.js
+++ b/src/ledger/identityProposal.test.js
@@ -1,0 +1,111 @@
+// @flow
+
+import deepFreeze from "deep-freeze";
+import {NodeAddress} from "../core/graph";
+import {Ledger} from "./ledger";
+import {nameFromString} from "./identity";
+import {ensureIdentityExists, _chooseIdentityName} from "./identityProposal";
+
+describe("ledger/identityProposal", () => {
+  const alias = {description: "example", address: NodeAddress.empty};
+  const proposal = deepFreeze({
+    name: nameFromString("foo"),
+    pluginName: nameFromString("bar"),
+    alias,
+    type: "USER",
+  });
+  describe("ensureIdentityExists", () => {
+    it("doesn't mutate the ledger if the address is already taken", () => {
+      const ledger = new Ledger();
+      const address = NodeAddress.empty;
+      const id = ledger.createIdentity("USER", "foo");
+      ledger.addAlias(id, alias);
+      const log = ledger.eventLog();
+      const otherAlias = {description: "different description", address};
+      const proposal = {
+        name: nameFromString("foo"),
+        pluginName: nameFromString("bar"),
+        alias: otherAlias,
+        type: "USER",
+      };
+      ensureIdentityExists(ledger, proposal);
+      // Verify that the ledger didn't mutate.
+      expect(ledger.eventLog()).toEqual(log);
+    });
+    it("creates a new identity (with alias) if address isn't taken", () => {
+      const ledger = new Ledger();
+      ensureIdentityExists(ledger, proposal);
+      const account = ledger.accountByAddress(alias.address);
+      if (account == null) {
+        throw new Error("identity not created");
+      }
+      expect(account.identity.name).toEqual(proposal.name);
+      expect(account.identity.aliases).toEqual([alias]);
+    });
+    it("uses the discriminator logic from _chooseIdentityName if needed", () => {
+      const ledger = new Ledger();
+      ledger.createIdentity("USER", "foo");
+      ensureIdentityExists(ledger, proposal);
+      const account = ledger.accountByAddress(alias.address);
+      if (account == null) {
+        throw new Error("identity not created");
+      }
+      expect(account.identity.name).toEqual("foo-bar");
+      expect(account.identity.aliases).toEqual([alias]);
+    });
+    it("creates an identity with the correct type", () => {
+      for (const type of ["USER", "PROJECT", "ORGANIZATION", "BOT"]) {
+        const ledger = new Ledger();
+        const typedProposal = {
+          name: nameFromString("foo"),
+          pluginName: nameFromString("bar"),
+          alias,
+          type,
+        };
+        ensureIdentityExists(ledger, typedProposal);
+        const account = ledger.accountByAddress(alias.address);
+        if (account == null) {
+          throw new Error("identity not created");
+        }
+        expect(account.identity.subtype).toEqual(type);
+      }
+    });
+  });
+  describe("_chooseIdentityName", () => {
+    it("returns the default name if available", () => {
+      function checkAvailable() {
+        return true;
+      }
+      expect(_chooseIdentityName(proposal, checkAvailable)).toEqual("foo");
+    });
+    it("adds a plugin discriminator if needed", () => {
+      function checkAvailable(n) {
+        return n !== "foo";
+      }
+      expect(_chooseIdentityName(proposal, checkAvailable)).toEqual("foo-bar");
+    });
+    it("adds a further numeric discriminator if needed", () => {
+      function checkAvailable(n) {
+        return n !== "foo" && n !== "foo-bar";
+      }
+      expect(_chooseIdentityName(proposal, checkAvailable)).toEqual(
+        "foo-bar-1"
+      );
+    });
+    it("increments the numeric discriminator if needed", () => {
+      function checkAvailable(n) {
+        return n !== "foo" && n !== "foo-bar" && n !== "foo-bar-1";
+      }
+      expect(_chooseIdentityName(proposal, checkAvailable)).toEqual(
+        "foo-bar-2"
+      );
+    });
+    it("fails if it can't find any valid discriminator after many tries", () => {
+      function checkAvailable() {
+        return false;
+      }
+      const thunk = () => _chooseIdentityName(proposal, checkAvailable);
+      expect(thunk).toThrowError("unable to find an identity name");
+    });
+  });
+});

--- a/src/ledger/ledger.test.js
+++ b/src/ledger/ledger.test.js
@@ -1091,5 +1091,12 @@ describe("ledger/ledger", () => {
     it("serialized ledger snapshots as expected", () => {
       expect(richLedger().serialize()).toMatchSnapshot();
     });
+    it("eventLog is a separate copy from the ledger's underlying log", () => {
+      const ledger = new Ledger();
+      const log = ledger.eventLog();
+      ledger.createIdentity("USER", "foo");
+      // Ledger's own log mutated; retrieved log is static.
+      expect(log).not.toEqual(ledger.eventLog());
+    });
   });
 });


### PR DESCRIPTION
This commit adds the `identityProposal` module, which specifies how a
plugin may propose a new identity to be added to the Ledger. The
proposal includes a name, the name of the plugin (for
disambiguation), the type of identity that should be created, and
the initial alias the identity should own.

If some existing identity has an alias with that address already, then
no action will be taken. However, if there is no identity matching that
alias, then a new identity will be created, based on the name (and, if
necessary, pluginName) of the proposal.

This will allow the Ledger to be auto-populated with new identities as
provided by plugins, which will save instance adminstrators from the
very tedious task of making an identity for each user in the instance.
This will also have other downstream benefits, like letting us do away
with the plugin node types in favor of assuming that all user accounts
correspond to identities (and, thus, identity addresses).

This is a big step towards #2109.

Test plan: Unit tests included, as per usual.

Note: I considered putting the identity proposal logic into the ledger
directly, but I think it's cleaner to write it as a consumer of the
ledger APIs. Primarily because by forcing it to go through API
boundaries, it's easier to reason about the implementation, and doesn't
add any bloat to the Ledger module, which is already quite complex.