### PR TITLE
disable ledger-modifiable views when site is statically served

### DIFF
--- a/config/paths.js
+++ b/config/paths.js
@@ -14,6 +14,7 @@ module.exports = {
   favicon: resolveApp("src/assets/logo/rasterized/logo_32.png"),
   appBuild: resolveApp("build"),
   appIndexJs: resolveApp("src/ui/index.js"),
+  serverInfoJson: resolveApp("src/ui/server-info.json"),
   appServerSideRenderingIndexJs: resolveApp("src/ui/server.js"),
   appPackageJson: resolveApp("package.json"),
   appSrc: resolveApp("src"),

--- a/config/webpack.config.web.js
+++ b/config/webpack.config.web.js
@@ -265,7 +265,10 @@ async function plugins(mode /*: "development" | "production" */) {
       paths: ["/"],
       locals: {},
     }),
-    new CopyPlugin([{from: paths.favicon, to: "favicon.png"}]),
+    new CopyPlugin([
+      {from: paths.favicon, to: "favicon.png"},
+      {from: paths.serverInfoJson, to: "static/server-info.json"},
+    ]),
     // Makes some environment variables available to the JS code, for example:
     // if (process.env.NODE_ENV === 'production') { ... }. See `./env.js`.
     // It is absolutely essential that NODE_ENV was set to production here.

--- a/config/webpack.config.web.js
+++ b/config/webpack.config.web.js
@@ -76,6 +76,14 @@ async function makeConfig(
         app.get(`/cache`, rejectCache);
         app.get(`/cache/*`, rejectCache);
 
+        // override static config to enable ledger updates
+        app.get("/static/server-info.json", (
+          _unused_req,
+          res /*: ExpressResponse */
+        ) => {
+          res.status(200).send({hasBackend: true});
+        });
+
         // It's important that we individually whitelist directories (and the
         // sourcecred.json file) rather than indiscriminately serving from
         // root, because there might be a "permanent" frontend installed in

--- a/config/webpack.config.web.js
+++ b/config/webpack.config.web.js
@@ -101,10 +101,6 @@ async function makeConfig(
           "/config/",
           express.static(path.join(developmentInstancePath, "config"))
         );
-        app.use(
-          "/data/",
-          express.static(path.join(developmentInstancePath, "data"))
-        );
 
         // configure the dev server to support writing the ledger to disk
         app.use(express.text());

--- a/src/cli/serve.js
+++ b/src/cli/serve.js
@@ -2,6 +2,7 @@
 
 import type {Command} from "./command";
 import {loadInstanceConfig} from "./common";
+import type {$Response as ExpressResponse} from "express";
 
 const fs = require("fs");
 const express = require("express");
@@ -21,6 +22,14 @@ const adminCommand: Command = async (args, std) => {
   }
 
   const server = express();
+
+  // override static config to enable ledger updates
+  server.get(
+    "/static/server-info.json",
+    (_unused_req, res: ExpressResponse) => {
+      res.status(200).send({hasBackend: true});
+    }
+  );
 
   // serve the static admin site and all subdirectories
   // also enables GETing data/ledger.json

--- a/src/ui/components/AdminApp.js
+++ b/src/ui/components/AdminApp.js
@@ -27,34 +27,40 @@ const theme = createMuiTheme({
   },
 });
 
-const AppLayout = (props) => (
-  <Layout {...props} appBar={AppBar} menu={withRouter(Menu)} />
+const AppLayout = (hasBackend: Boolean) => (props) => (
+  <Layout {...props} appBar={AppBar} menu={withRouter(Menu(hasBackend))} />
 );
 
 const customRoutes = (
   credView: CredView,
+  hasBackend: Boolean,
   ledger: Ledger,
   setLedger: (Ledger) => void
-) => [
-  <Route key="explorer" exact path="/explorer">
-    <Explorer initialView={credView} />
-  </Route>,
-  <Route key="root" exact path="/">
-    <Redirect to="/explorer" />
-  </Route>,
-  <Route key="grain" exact path="/grain">
-    <GrainAccountOverview credView={credView} ledger={ledger} />
-  </Route>,
-  <Route key="admin" exact path="/admin">
-    <LedgerAdmin credView={credView} ledger={ledger} setLedger={setLedger} />
-  </Route>,
-  <Route key="transfer" exact path="/transfer">
-    <TransferGrain ledger={ledger} setLedger={setLedger} />
-  </Route>,
-  <Route key="special-distribution" exact path="/special-distribution">
-    <SpecialGrainDistribution ledger={ledger} setLedger={setLedger} />
-  </Route>,
-];
+) => {
+  const routes = [
+    <Route key="explorer" exact path="/explorer">
+      <Explorer initialView={credView} />
+    </Route>,
+    <Route key="root" exact path="/">
+      <Redirect to="/explorer" />
+    </Route>,
+    <Route key="grain" exact path="/grain">
+      <GrainAccountOverview credView={credView} ledger={ledger} />
+    </Route>,
+  ];
+  const backendRoutes = [
+    <Route key="admin" exact path="/admin">
+      <LedgerAdmin credView={credView} ledger={ledger} setLedger={setLedger} />
+    </Route>,
+    <Route key="transfer" exact path="/transfer">
+      <TransferGrain ledger={ledger} setLedger={setLedger} />
+    </Route>,
+    <Route key="special-distribution" exact path="/special-distribution">
+      <SpecialGrainDistribution ledger={ledger} setLedger={setLedger} />
+    </Route>,
+  ];
+  return routes.concat(hasBackend ? backendRoutes : []);
+};
 
 const AdminApp = () => {
   const [loadResult, setLoadResult] = React.useState<LoadResult | null>(null);
@@ -96,11 +102,16 @@ const AdminInner = ({loadResult: loadSuccess}: AdminInnerProps) => {
   const history = useHistory();
   return (
     <Admin
-      layout={AppLayout}
+      layout={AppLayout(loadSuccess.hasBackend)}
       theme={theme}
       dataProvider={dataProvider}
       history={history}
-      customRoutes={customRoutes(loadSuccess.credView, ledger, setLedger)}
+      customRoutes={customRoutes(
+        loadSuccess.credView,
+        loadSuccess.hasBackend,
+        ledger,
+        setLedger
+      )}
     >
       {/*
           This dummy resource is required to get react

--- a/src/ui/components/Menu.js
+++ b/src/ui/components/Menu.js
@@ -8,7 +8,7 @@ import TransformIcon from "@material-ui/icons/Transform";
 
 type menuProps = {|onMenuClick: Function|};
 
-const Menu = ({onMenuClick}: menuProps) => {
+const Menu = (hasBackend: Boolean) => ({onMenuClick}: menuProps) => {
   const open = useSelector((state) => state.admin.ui.sidebarOpen);
   return (
     <>
@@ -26,20 +26,24 @@ const Menu = ({onMenuClick}: menuProps) => {
         onClick={onMenuClick}
         sidebarIsOpen={open}
       />
-      <MenuItemLink
-        to="/admin"
-        primaryText="Ledger Admin"
-        leftIcon={<DefaultIcon />}
-        onClick={onMenuClick}
-        sidebarIsOpen={open}
-      />
-      <MenuItemLink
-        to="/transfer"
-        primaryText="Transfer Grain"
-        leftIcon={<TransformIcon />}
-        onClick={onMenuClick}
-        sidebarIsOpen={open}
-      />
+      {hasBackend && (
+        <>
+          <MenuItemLink
+            to="/admin"
+            primaryText="Ledger Admin"
+            leftIcon={<DefaultIcon />}
+            onClick={onMenuClick}
+            sidebarIsOpen={open}
+          />
+          <MenuItemLink
+            to="/transfer"
+            primaryText="Transfer Grain"
+            leftIcon={<TransformIcon />}
+            onClick={onMenuClick}
+            sidebarIsOpen={open}
+          />
+        </>
+      )}
     </>
   );
 };

--- a/src/ui/load.js
+++ b/src/ui/load.js
@@ -10,6 +10,7 @@ export type LoadSuccess = {|
   +credView: CredView,
   +ledger: Ledger,
   +bundledPlugins: $ReadOnlyArray<pluginId.PluginId>,
+  +hasBackend: Boolean,
 |};
 export type LoadFailure = {|+type: "FAILURE", +error: any|};
 
@@ -18,6 +19,7 @@ export async function load(): Promise<LoadResult> {
     fetch("output/credResult.json"),
     fetch("sourcecred.json"),
     fetch("data/ledger.json"),
+    fetch("static/server-info.json"),
   ];
   const responses = await Promise.all(queries);
 
@@ -34,7 +36,8 @@ export async function load(): Promise<LoadResult> {
     const {bundledPlugins} = await responses[1].json();
     const rawLedger = await responses[2].text();
     const ledger = Ledger.parse(rawLedger);
-    return {type: "SUCCESS", credView, bundledPlugins, ledger};
+    const {hasBackend} = await responses[3].json();
+    return {type: "SUCCESS", credView, bundledPlugins, ledger, hasBackend};
   } catch (e) {
     console.error(e);
     return {type: "FAILURE", error: e};

--- a/src/ui/server-info.json
+++ b/src/ui/server-info.json
@@ -1,0 +1,1 @@
+{"hasBackend": false}


### PR DESCRIPTION
server-info.json will be consumed by the frontend to determine whether or not to show ledger-modifiable views. When an instance is served statically, the ledger cannot be updated. However, when a local node service is used, either via the instance's `yarn serve` or the core repo's `yarn start`, the ledger can be modified and posted back to the file
system.

test plan: each individual commit includes a test plan to ensure each part of this change was implemented correctly. A test plan for the whole branch will just demonstrate behavior as it exists now in the master branch development environment. 

resolves #2113