### PR TITLE
github: add createIdentities

### DIFF
--- a/src/plugins/github/createIdentities.js
+++ b/src/plugins/github/createIdentities.js
@@ -1,0 +1,40 @@
+// @flow
+
+import {type IdentityProposal} from "../../ledger/identityProposal";
+import {coerce, nameFromString} from "../../ledger/identity/name";
+import {RelationalView, Userlike} from "./relationalView";
+import {toRaw} from "./nodes";
+
+export function _createIdentity(u: Userlike): IdentityProposal {
+  const alias = {
+    description: u.description(),
+    address: toRaw(u.address()),
+  };
+  function chooseType(u: Userlike) {
+    const subtype = u.address().subtype;
+    // TODO: We should let it infer ORGANIZATION or PROJECT types too,
+    // but at present we'll let the maintainer set this directly in the UI.
+    switch (subtype) {
+      case "USER": {
+        return "USER";
+      }
+      case "BOT": {
+        return "BOT";
+      }
+      default:
+        throw new Error(`unknown userlike subtype: ${(subtype: empty)}`);
+    }
+  }
+  return {
+    pluginName: nameFromString("github"),
+    name: coerce(u.login()),
+    type: chooseType(u),
+    alias,
+  };
+}
+
+export function createIdentities(
+  rv: RelationalView
+): $ReadOnlyArray<IdentityProposal> {
+  return Array.from(rv.userlikes()).map(_createIdentity);
+}

--- a/src/plugins/github/createIdentities.test.js
+++ b/src/plugins/github/createIdentities.test.js
@@ -1,0 +1,50 @@
+// @flow
+
+import {exampleEntities, exampleRelationalView} from "./example/example";
+import {toRaw, type UserlikeAddress} from "./nodes";
+import {_createIdentity, createIdentities} from "./createIdentities";
+
+describe("plugins/github/createIdentities", () => {
+  describe("_createIdentity", () => {
+    it("sets the fields correctly in a simple case", () => {
+      const {userlike} = exampleEntities();
+      const expectedAlias = {
+        description: userlike.description(),
+        address: toRaw(userlike.address()),
+      };
+      expect(_createIdentity(userlike)).toEqual({
+        type: "USER",
+        pluginName: "github",
+        name: userlike.login(),
+        alias: expectedAlias,
+      });
+    });
+    it("coerces the name if needed", () => {
+      const {userlike} = exampleEntities();
+      // $FlowExpectedError
+      userlike.login = () => "coerce?me";
+      const identity = _createIdentity(userlike);
+      expect(identity.name).toEqual("coerce-me");
+    });
+    it("sets the type to BOT for bots", () => {
+      const {userlike} = exampleEntities();
+      const address = userlike.address();
+      const fakeAddress: UserlikeAddress = {
+        ...address,
+        subtype: "BOT",
+      };
+      // $FlowExpectedError
+      userlike.address = () => fakeAddress;
+      const identity = _createIdentity(userlike);
+      expect(identity.type).toEqual("BOT");
+    });
+  });
+  describe("createIdentities", () => {
+    it("maps over the users in the RelationalView", () => {
+      const rv = exampleRelationalView();
+      const expected = Array.from(rv.userlikes()).map(_createIdentity);
+      const actual = createIdentities(rv);
+      expect(expected).toEqual(actual);
+    });
+  });
+});


### PR DESCRIPTION
This adds a method for the GitHub plugin to create identities, per
the identity proposal system added in #2128.

Test plan: Unit tests. `yarn test`.