### PR TITLE
Add experimental-discord createIdentities

### DIFF
--- a/src/plugins/experimental-discord/createGraph.js
+++ b/src/plugins/experimental-discord/createGraph.js
@@ -39,7 +39,7 @@ export function userAddress(userId: Model.Snowflake): NodeAddressT {
   return NodeAddress.append(memberNodeType.prefix, "user", userId);
 }
 
-function memberAddress(member: Model.GuildMember): NodeAddressT {
+export function memberAddress(member: Model.GuildMember): NodeAddressT {
   return NodeAddress.append(
     memberNodeType.prefix,
     member.user.bot ? "bot" : "user",

--- a/src/plugins/experimental-discord/createIdentities.js
+++ b/src/plugins/experimental-discord/createIdentities.js
@@ -1,0 +1,32 @@
+// @flow
+
+import {escape} from "entities";
+import {SqliteMirrorRepository} from "./mirrorRepository";
+import * as Model from "./models";
+import {memberAddress} from "./createGraph";
+import {type IdentityProposal} from "../../ledger/identityProposal";
+import {coerce, nameFromString} from "../../ledger/identity/name";
+
+export function _createIdentity(member: Model.GuildMember): IdentityProposal {
+  let name = member.nick !== null ? member.nick : member.user.username;
+  // Discord allows very long names. Let's ensure the length is reasonable.
+  name = name.slice(0, 39);
+  const description = `discord/${escape(name)}#${member.user.discriminator}`;
+  const alias = {
+    description,
+    address: memberAddress(member),
+  };
+  const type = member.user.bot ? "BOT" : "USER";
+  return {
+    pluginName: nameFromString("github"),
+    name: coerce(name),
+    type,
+    alias,
+  };
+}
+
+export function createIdentities(
+  repo: SqliteMirrorRepository
+): $ReadOnlyArray<IdentityProposal> {
+  return repo.members().map((m) => _createIdentity(m));
+}


### PR DESCRIPTION
This adds identity creation to the Discord plugin, using the system
added in #2128. In keeping with the rest of the plugin, it's untested.
However, when we integrate it, it will be easy to tell if it's broken
and to fix it if there are issues.

Test plan: Untested.