### PR TITLE
Fix "Payload too large" error when saving Ledger to disk from UI

### DIFF
--- a/config/webpack.config.web.js
+++ b/config/webpack.config.web.js
@@ -103,7 +103,7 @@ async function makeConfig(
         );
 
         // configure the dev server to support writing the ledger to disk
-        app.use(express.text());
+        app.use(express.text({limit: "50mb"}));
         const ledgerPath = path.join(
           developmentInstancePath,
           "data/ledger.json"

--- a/src/cli/serve.js
+++ b/src/cli/serve.js
@@ -36,7 +36,7 @@ const adminCommand: Command = async (args, std) => {
   server.use(express.static("./site"));
 
   // middleware that parses text request bodies for us
-  server.use(express.text());
+  server.use(express.text({limit: "50mb"}));
   // write posted ledger.json files to disk
   server.post("/data/ledger.json", (req, res) => {
     try {


### PR DESCRIPTION
The default limit for request bodies in express is 10kb, which was too low for ledger files that had a decent amount of data.
This updates the limit to 50mb for both the `sourcecred serve` command and when using the webpack dev server with `yarn start`.

Test Plan: Load a large ledger into the admin UI, make some changes, click "Save ledger to disk", and ensure the ledger saves
to disk without any errors.