### PR TITLE
Setup Github Action to auto-publish to NPM

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -24,6 +24,8 @@ jobs:
 
       - name: Test
         run: yarn test --full --ci
+        env:
+          SOURCECRED_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       # Uses the version defined by the tag created in the Release
       # and pushes a commit that updates the version in package.json

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,38 @@
+name: Publish Release
+on:
+  # Publish when a new release is created on GitHub
+  release:
+    types: [published]
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v1
+        with:
+          node-version: 12
+          registry-url: 'https://registry.npmjs.org'
+
+      - uses: actions/cache@v2
+        with:
+          path: '**/node_modules'
+          key: nodeModules-${{ runner.os }}-${{ hashFiles('**/yarn.lock') }}
+
+      - name: Install packages
+        run: yarn --frozen-lockfile
+
+      - name: Test
+        run: yarn test --ci
+
+      # Uses the version defined by the tag created in the Release
+      # and pushes a commit that updates the version in package.json
+      - name: Publish to NPM
+        run: |
+          git config --global user.name $GITHUB_ACTOR
+          git config --global user.email ${GITHUB_ACTOR}@users.noreply.github.com
+          yarn publish --new-version ${GITHUB_REF#"refs/tags/"} --no-git-tag-version
+          git push
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -37,4 +37,4 @@ jobs:
       - name: Push to master
         uses: ad-m/github-push-action@master
         with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
+          github_token: ${{ secrets.CREDBOT_TOKEN }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -29,7 +29,12 @@ jobs:
           git config --global user.name $GITHUB_ACTOR
           git config --global user.email ${GITHUB_ACTOR}@users.noreply.github.com
           yarn publish --new-version ${GITHUB_REF#"refs/tags/"} --no-git-tag-version
-          git push
+          git add package.json
+          git commit -m "Release v${GITHUB_REF#"refs/tags/"}"
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
+      - name: Push to master
+        uses: ad-m/github-push-action@master
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -23,7 +23,7 @@ jobs:
         run: yarn --frozen-lockfile
 
       - name: Test
-        run: yarn test --ci
+        run: yarn test --full --ci
 
       # Uses the version defined by the tag created in the Release
       # and pushes a commit that updates the version in package.json

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -14,11 +14,6 @@ jobs:
           node-version: 12
           registry-url: 'https://registry.npmjs.org'
 
-      - uses: actions/cache@v2
-        with:
-          path: '**/node_modules'
-          key: nodeModules-${{ runner.os }}-${{ hashFiles('**/yarn.lock') }}
-
       - name: Install packages
         run: yarn --frozen-lockfile
 

--- a/package.json
+++ b/package.json
@@ -112,7 +112,7 @@
     "build": "run-p build:* && cp -r ./build ./bin/site-template && chmod +x ./bin/sourcecred.js",
     "build:frontend": "NODE_ENV=production webpack --config config/webpack.config.web.js",
     "build:backend": "NODE_ENV=development webpack --config config/webpack.config.backend.js",
-    "api": "webpack --config config/webpack.config.api.js",
+    "build:api": "NODE_ENV=production webpack --config config/webpack.config.api.js",
     "test": "node ./config/test.js",
     "createLedger": "babel-node ./scripts/createLedgerFromLegacyProject.js",
     "unit": "BABEL_ENV=test NODE_ENV=test jest --env=jsdom",

--- a/package.json
+++ b/package.json
@@ -120,7 +120,8 @@
     "sharness-full": "make -sC ./sharness prove PROVE_OPTS=-vf TEST_OPTS='-v --chain-lint --long'",
     "coverage": "yarn run unit --coverage",
     "flow": "flow",
-    "lint": "eslint src config --max-warnings 0"
+    "lint": "eslint src config --max-warnings 0",
+    "prepublishOnly": "yarn build"
   },
   "license": "(MIT OR Apache-2.0)",
   "jest": {

--- a/package.json
+++ b/package.json
@@ -160,7 +160,9 @@
     ]
   },
   "files": [
-    "/bin"
+    "/bin",
+    "/dist"
   ],
+  "main": "dist/api.js",
   "bin": "./bin/sourcecred.js"
 }


### PR DESCRIPTION
This sets up a Github Action that triggers every time a new release is created in GH. It runs tests, builds, updates the
package.json version to the one defined by the tag in the Release, then publishes to NPM.

This makes the process of creating a release super simple and only one step: Publish a release with the desired version
in Github.

Note: For this action to work, an [NPM_TOKEN](https://docs.npmjs.com/creating-and-viewing-authentication-tokens) will need to be added to the repo secrets. 

**Test Plan:** Create a new Release in the Github UI with a tag that is one version higher than the current version in package.json. Ensure this workflow is triggered and that the new version is released to NPM and the package.json version is updated as well on master.