### PR TITLE
CredView/Explorer: support dependency minted cred

### DIFF
--- a/src/analysis/credView.js
+++ b/src/analysis/credView.js
@@ -77,7 +77,17 @@ export type SyntheticLoopFlow = {|
   +flow: number,
 |};
 
-export type Flow = EdgeFlow | MintFlow | ReturnFlow | SyntheticLoopFlow;
+export type DependencyMintFlow = {|
+  +type: "DEPENDENCY_MINT",
+  +flow: number,
+|};
+
+export type Flow =
+  | EdgeFlow
+  | MintFlow
+  | ReturnFlow
+  | SyntheticLoopFlow
+  | DependencyMintFlow;
 
 export type EdgesOptions = {|
   // An edge address prefix. Only show edges whose addresses match this prefix.
@@ -232,9 +242,17 @@ export class CredView {
     }
     const {alpha} = this.params();
     const flows: Flow[] = [];
-    const {seedFlow, syntheticLoopFlow, cred} = credNode.credSummary;
+    const {
+      seedFlow,
+      syntheticLoopFlow,
+      cred,
+      dependencyMintedCred,
+    } = credNode.credSummary;
     if (syntheticLoopFlow > 0) {
       flows.push({type: "SYNTHETIC_LOOP", flow: syntheticLoopFlow});
+    }
+    if (dependencyMintedCred > 0) {
+      flows.push({type: "DEPENDENCY_MINT", flow: dependencyMintedCred});
     }
     if (direction === Direction.IN) {
       if (seedFlow > 0) {

--- a/src/ui/components/Explorer.js
+++ b/src/ui/components/Explorer.js
@@ -390,6 +390,8 @@ function FlowRow(view: CredView, f: Flow, total: number, depth: number) {
         return "Mint from Seed";
       case "SYNTHETIC_LOOP":
         return "Synthetic self-loop";
+      case "DEPENDENCY_MINT":
+        return "Dependency Minted Cred";
       default:
         throw new Error((f.type: empty));
     }


### PR DESCRIPTION
Simple change to the CredView and Explorer so that they will show
dependency minted cred properly.

Part of #1941.

Test plan:
Very little logic here, if the integration is broken I'll see it on a
future commit when I actually tie in this logic.