### PR TITLE
credView: retrieve intervals and intervalIndices

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "lodash.clonedeep": "^4.5.0",
     "lodash.isequal": "^4.5.0",
     "lodash.sortby": "^4.7.0",
+    "lodash.sortedindex": "^4.1.0",
     "object-assign": "^4.1.1",
     "pako": "^1.0.11",
     "promise": "^8.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6642,6 +6642,11 @@ lodash.sortby@^4.7.0:
   resolved "https://registry.yarnpkg.com/lodash.sortby/-/lodash.sortby-4.7.0.tgz#edd14c824e2cc9c1e0b0a1b42bb5210516a42438"
   integrity sha1-7dFMgk4sycHgsKG0K7UhBRakJDg=
 
+lodash.sortedindex@^4.1.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/lodash.sortedindex/-/lodash.sortedindex-4.1.0.tgz#3f6417ee20e8b22416ab005bfa16344a0446b448"
+  integrity sha1-P2QX7iDosiQWqwBb+hY0SgRGtEg=
+
 lodash.throttle@^4.1.1:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/lodash.throttle/-/lodash.throttle-4.1.1.tgz#c23e91b710242ac70c37f1e1cda9274cc39bf2f4"


### PR DESCRIPTION
This makes three changes to the CredView API:

- We can now retrieve intervals directly from the CredView via
`view.intervalEnds()`.
- Nodes now have an `intervalIndex`, which finds the interval for which
that node's timestamp is included, assuming the timestamp is non-null
- Edges now have an `intervalIndex`, as with nodes (but never null)

This makes it a lot easier to do queries like finding the total cred by
interval or finding the top contributions in a given interval.

Test plan: Unit tests added. `yarn test`