### PR TITLE
dependenciesMintPolicy: take intervals not starts

### DIFF
--- a/src/core/dependenciesMintPolicy.js
+++ b/src/core/dependenciesMintPolicy.js
@@ -47,6 +47,7 @@
  */
 import {type NodeAddressT, NodeAddress} from "./graph";
 import {type TimestampMs} from "../util/timestamp";
+import {type Interval} from "./interval";
 
 export type DependencyMintPolicy = {|
   // The node address that will receieve the extra minted Cred
@@ -82,7 +83,7 @@ export type ProcessedDependencyMintPolicy = {|
 export function processMintPolicy(
   policy: DependencyMintPolicy,
   nodeOrder: $ReadOnlyArray<NodeAddressT>,
-  intervalStarts: $ReadOnlyArray<TimestampMs>
+  intervals: $ReadOnlyArray<Interval>
 ): ProcessedDependencyMintPolicy {
   const {address, periods} = policy;
   const nodeIndex = nodeOrder.indexOf(address);
@@ -91,6 +92,7 @@ export function processMintPolicy(
       `address not in nodeOrder: ${NodeAddress.toString(address)}`
     );
   }
+  const intervalStarts = intervals.map((i) => i.startTimeMs);
   const intervalWeights = _alignPeriodsToIntervals(periods, intervalStarts);
   return {nodeIndex, intervalWeights};
 }

--- a/src/core/dependenciesMintPolicy.test.js
+++ b/src/core/dependenciesMintPolicy.test.js
@@ -90,11 +90,17 @@ describe("core/dependenciesMintPolicy", () => {
     const n3 = NodeAddress.fromParts(["3"]);
     const nx = NodeAddress.fromParts(["x"]);
     const nodeOrder = deepFreeze([n1, n2, n3]);
-    const intervals = deepFreeze([1, 2, 3, 4]);
+    const intervals = deepFreeze([
+      {startTimeMs: 1, endTimeMs: 2},
+      {startTimeMs: 2, endTimeMs: 3},
+      {startTimeMs: 3, endTimeMs: 4},
+      {startTimeMs: 4, endTimeMs: 5},
+    ]);
     const periods = [deepFreeze({startTimeMs: 2, weight: 0.5})];
     it("converts the address and periods correctly", () => {
       const policy = {address: n2, periods};
-      const intervalWeights = _alignPeriodsToIntervals(periods, intervals);
+      const intervalStarts = intervals.map((i) => i.startTimeMs);
+      const intervalWeights = _alignPeriodsToIntervals(periods, intervalStarts);
       const actual = processMintPolicy(policy, nodeOrder, intervals);
       const expected = {nodeIndex: 1, intervalWeights};
       expect(actual).toEqual(expected);


### PR DESCRIPTION
the `processMintPolicy` method used to take interval start times. This
had the potential to cause confusing bugs because elsewhere we
canonically use interval end times. To avoid conclusion, I've updated
the method to take full `Interval` types instead, and to pluck the start
time within module scope.

Test plan: Simple refactor; `yarn test` passes.