### PR TITLE
Stop depending on userTypes

### DIFF
--- a/src/analysis/__snapshots__/credResult.test.js.snap
+++ b/src/analysis/__snapshots__/credResult.test.js.snap
@@ -94,7 +94,7 @@ exports[`analysis/credResult to/fro JSON to/froJSON snapshots as expected 1`] = 
               \\"description\\": \\"a type\\",
               \\"name\\": \\"node\\",
               \\"pluralName\\": \\"nodes\\",
-              \\"prefix\\": \\"N\\\\u0000node\\\\u0000\\"
+              \\"prefix\\": \\"N\\\\u0000sourcecred\\\\u0000core\\\\u0000IDENTITY\\\\u0000\\"
             }
           ],
           \\"userTypes\\": [
@@ -103,7 +103,7 @@ exports[`analysis/credResult to/fro JSON to/froJSON snapshots as expected 1`] = 
               \\"description\\": \\"a type\\",
               \\"name\\": \\"node\\",
               \\"pluralName\\": \\"nodes\\",
-              \\"prefix\\": \\"N\\\\u0000node\\\\u0000\\"
+              \\"prefix\\": \\"N\\\\u0000sourcecred\\\\u0000core\\\\u0000IDENTITY\\\\u0000\\"
             }
           ]
         }
@@ -137,11 +137,15 @@ exports[`analysis/credResult to/fro JSON to/froJSON snapshots as expected 1`] = 
             ],
             \\"sortedNodeAddresses\\": [
               [
-                \\"node\\",
+                \\"sourcecred\\",
+                \\"core\\",
+                \\"IDENTITY\\",
                 \\"1\\"
               ],
               [
-                \\"node\\",
+                \\"sourcecred\\",
+                \\"core\\",
+                \\"IDENTITY\\",
                 \\"2\\"
               ]
             ]

--- a/src/analysis/credResult.js
+++ b/src/analysis/credResult.js
@@ -32,6 +32,7 @@ import {
   type DependencyMintPolicy,
   processMintPolicy,
 } from "../core/dependenciesMintPolicy";
+import {IDENTITY_PREFIX} from "../ledger/identity";
 
 /**
  * Comprehensive cred output data, including the graph, the scores, the params, and the plugins.
@@ -57,8 +58,7 @@ export async function compute(
 ): Promise<CredResult> {
   const {graph} = wg;
   const nodeOrder = Array.from(graph.nodes()).map((x) => x.address);
-  const userTypes = [].concat(...plugins.map((x) => x.userTypes));
-  const scorePrefixes = userTypes.map((x) => x.prefix);
+  const scorePrefixes = [IDENTITY_PREFIX];
   const distribution = await timelinePagerank(
     wg,
     params.intervalDecay,
@@ -93,15 +93,12 @@ export function compressByThreshold(
 
 export function stripOverTimeDataForNonUsers(x: CredResult): CredResult {
   const {params, plugins, weightedGraph, credData, dependencyPolicies} = x;
-  const userPrefixes = []
-    .concat(...plugins.map((x) => x.userTypes))
-    .map((x) => x.prefix);
   const nodeOrder = Array.from(weightedGraph.graph.nodes()).map(
     (x) => x.address
   );
   const inclusionIndices = new Set();
   nodeOrder.forEach((a, i) => {
-    if (userPrefixes.some((p) => NodeAddress.hasPrefix(a, p))) {
+    if (NodeAddress.hasPrefix(a, IDENTITY_PREFIX)) {
       inclusionIndices.add(i);
     }
   });

--- a/src/analysis/credResult.test.js
+++ b/src/analysis/credResult.test.js
@@ -7,6 +7,7 @@ import type {NodeType, EdgeType} from "./types";
 import type {PluginDeclaration} from "./pluginDeclaration";
 import {defaultParams} from "./timeline/params";
 import {compute, toJSON, fromJSON} from "./credResult";
+import {IDENTITY_PREFIX} from "../ledger/identity";
 
 describe("analysis/credResult", () => {
   describe("to/fro JSON", () => {
@@ -14,7 +15,7 @@ describe("analysis/credResult", () => {
       const nodeType: NodeType = {
         name: "node",
         pluralName: "nodes",
-        prefix: NodeAddress.fromParts(["node"]),
+        prefix: IDENTITY_PREFIX,
         defaultWeight: 2,
         description: "a type",
       };
@@ -36,12 +37,12 @@ describe("analysis/credResult", () => {
 
       const graph = new Graph()
         .addNode({
-          address: NodeAddress.fromParts(["node", "1"]),
+          address: NodeAddress.append(IDENTITY_PREFIX, "1"),
           description: "n1",
           timestampMs: 100000,
         })
         .addNode({
-          address: NodeAddress.fromParts(["node", "2"]),
+          address: NodeAddress.append(IDENTITY_PREFIX, "2"),
           description: "n2",
           timestampMs: 110000,
         });

--- a/src/analysis/credView.js
+++ b/src/analysis/credView.js
@@ -6,6 +6,7 @@ import {type CredResult, compute} from "./credResult";
 import {type TimelineCredParameters} from "./timeline/params";
 import {type PluginDeclarations} from "./pluginDeclaration";
 import {type NodeType, type EdgeType} from "./types";
+import {IDENTITY_PREFIX} from "../ledger/identity";
 
 import {get as nullGet} from "../util/null";
 import type {TimestampMs} from "../util/timestamp";
@@ -201,13 +202,7 @@ export class CredView {
     return graphNodes.map((x) => this._promoteNode(x));
   }
   userNodes(): $ReadOnlyArray<CredNode> {
-    const userPrefixes = []
-      .concat(...this.plugins().map((x) => x.userTypes))
-      .map((x) => x.prefix);
-    const nodes = this.nodes();
-    return nodes.filter((n) =>
-      userPrefixes.some((p) => NodeAddress.hasPrefix(n.address, p))
-    );
+    return this.nodes({prefix: IDENTITY_PREFIX});
   }
 
   _promoteEdge(e: GraphEdge): CredEdge {

--- a/src/analysis/pluginDeclaration.js
+++ b/src/analysis/pluginDeclaration.js
@@ -17,12 +17,8 @@ export type PluginDeclaration = {|
   +nodeTypes: $ReadOnlyArray<NodeType>,
   +edgeTypes: $ReadOnlyArray<EdgeType>,
   // Which node types represent user identities.
-  // Important for computing score and for display in the frontend.
-  // It's expected that the userTypes will also be included in the array of
-  // nodeTypes.
-  // It's expected that every userType will have a default weight of 0, as
-  // users should not mint cred. UIs and interfaces should disallow changing
-  // user type weights.
+  // This is vestigial, as now all users are automatically made into Identities.
+  // It will be removed in the future.
   +userTypes: $ReadOnlyArray<NodeType>,
 |};
 

--- a/src/ledger/identity/index.js
+++ b/src/ledger/identity/index.js
@@ -18,4 +18,4 @@ export {nameFromString, parser as nameParser} from "./name";
 export type {Alias} from "./alias";
 export {parser as aliasParser} from "./alias";
 
-export {declaration} from "./declaration";
+export {declaration, IDENTITY_PREFIX} from "./declaration";


### PR DESCRIPTION
Now that all users are made into identities (cf #2134), we can hardcode
in the IDENTITY_PREFIX rather than depending on plugins to enumerate all
the user types.

I updated the credResult test case to make all of the nodes
psuedo-identity nodes, to maintain test consistency.

Test plan: `yarn test --full` passes, which means snapshots for the
example instance are unchanged, which means we're still running cred
calculation with the right set of users.