### PR TITLE
add isDirEmpty to disk utils

### DIFF
--- a/src/util/disk.js
+++ b/src/util/disk.js
@@ -96,3 +96,13 @@ export async function loadFileWithDefault(
     }
   }
 }
+
+/**
+ * Check if a directory is empty
+ *
+ * Will error if a path that resolves to anything other
+ * than a directory is provided
+ */
+export function isDirEmpty(dirPath: string): boolean {
+  return fs.readdirSync(dirPath).length === 0;
+}

--- a/src/util/disk.test.js
+++ b/src/util/disk.test.js
@@ -5,6 +5,7 @@ import {
   loadJsonWithDefault,
   loadJson,
   mkdirx,
+  isDirEmpty,
 } from "./disk";
 import tmp from "tmp";
 import fs from "fs-extra";
@@ -121,6 +122,29 @@ describe("util/disk", () => {
       expect(() => mkdirx(path)).toThrowError(
         "ENOENT: no such file or directory"
       );
+    });
+  });
+
+  describe("isDirEmpty", () => {
+    it("errors if path is not a directory", () => {
+      const f = tmp.fileSync();
+      let thunk = () => isDirEmpty(f.name);
+      expect(thunk).toThrow(/^ENOTDIR/);
+      const badName = tmp.tmpNameSync();
+      thunk = () => isDirEmpty(badName);
+      expect(thunk).toThrow(/^ENOENT/);
+    });
+
+    it("returns true if directory is empty", () => {
+      const dir = tmp.dirSync();
+      expect(isDirEmpty(dir.name)).toBe(true);
+    });
+    it("returns false if directory is not empty", () => {
+      const dir = tmp.dirSync();
+      fs.writeFileSync(pathJoin(dir.name, "temp.txt"), "");
+      expect(isDirEmpty(dir.name)).toBe(false);
+      // cleanup: tmpDirs won't auto-delete if not empty
+      fs.emptyDirSync(dir.name);
     });
   });
 });

--- a/src/util/disk.test.js
+++ b/src/util/disk.test.js
@@ -141,6 +141,10 @@ describe("util/disk", () => {
     });
     it("returns false if directory is not empty", () => {
       const dir = tmp.dirSync();
+      fs.mkdirSync(pathJoin(dir.name, "childDir"));
+      expect(isDirEmpty(dir.name)).toBe(false);
+      fs.writeFileSync(pathJoin(dir.name, ".temphidden.txt"), "");
+      expect(isDirEmpty(dir.name)).toBe(false);
       fs.writeFileSync(pathJoin(dir.name, "temp.txt"), "");
       expect(isDirEmpty(dir.name)).toBe(false);
       // cleanup: tmpDirs won't auto-delete if not empty


### PR DESCRIPTION
this helper is pretty self explanatory.

I thought about adding a check
for files with a specific extension as well, so we can scan for file
types without knowing the exact name or format and ignore potentially
unrelated files, but I wasn't sure how usefuly that would be.

test plan: unit tests are included