### PR TITLE
add cache-clearing step in load cli command

### DIFF
--- a/src/cli/load.js
+++ b/src/cli/load.js
@@ -5,10 +5,27 @@ import type {Command} from "./command";
 import {loadInstanceConfig, pluginDirectoryContext} from "./common";
 import {LoggingTaskReporter} from "../util/taskReporter";
 import * as pluginId from "../api/pluginId";
+import {Plugin, PluginDirectoryContext} from "../api/plugin";
+import {isDirEmpty} from "../util/disk";
+import fs from "fs-extra";
 
 function die(std, message) {
   std.err("fatal: " + message);
   return 1;
+}
+
+type PluginLoadContext = {|
+  +plugin: Plugin,
+  +dirContext: PluginDirectoryContext,
+  +taskReporter: LoggingTaskReporter,
+  +task: string,
+|};
+
+function loadPlugin(ctx: PluginLoadContext) {
+  const {plugin, dirContext, taskReporter, task} = ctx;
+  return plugin
+    .load(dirContext, taskReporter)
+    .then(() => taskReporter.finish(task));
 }
 
 const loadCommand: Command = async (args, std) => {
@@ -34,14 +51,28 @@ const loadCommand: Command = async (args, std) => {
   taskReporter.start("load");
   const failedPlugins = [];
   const loadPromises = [];
+  const cacheEmpty = new Map<pluginId.PluginId, boolean>();
   for (const name of pluginsToLoad) {
     const plugin = NullUtil.get(config.bundledPlugins.get(name));
     const task = `loading ${name}`;
     taskReporter.start(task);
     const dirContext = pluginDirectoryContext(baseDir, name);
-    const promise = plugin
-      .load(dirContext, taskReporter)
-      .then(() => taskReporter.finish(task))
+    cacheEmpty.set(name, isDirEmpty(dirContext.cacheDirectory()));
+    const pluginCtx: PluginLoadContext = {
+      plugin,
+      dirContext,
+      taskReporter,
+      task,
+    };
+    const promise = loadPlugin(pluginCtx)
+      .catch((e) => {
+        if (!cacheEmpty.get(name)) {
+          // clear the cache and try again
+          fs.emptyDirSync(dirContext.cacheDirectory());
+          return loadPlugin(pluginCtx);
+        }
+        throw e;
+      })
       .catch((e) => {
         console.error(e);
         failedPlugins.push(name);

--- a/src/cli/load.js
+++ b/src/cli/load.js
@@ -16,7 +16,12 @@ function die(std, message) {
 
 function warn(std, task: string, message: string) {
   const label = chalk.bgYellow.bold.white(" WARN ");
-  std.out(`${label} ${task}: ${message}`);
+  std.err(`${label} ${task}: ${message}`);
+}
+
+function fail(std, task: string, message: string = "") {
+  const label = chalk.bgRed.bold.white(" FAIL ");
+  std.err(`${label} ${task}${message ? `: ${message}` : ""}`);
 }
 
 const loadCommand: Command = async (args, std) => {
@@ -38,7 +43,7 @@ const loadCommand: Command = async (args, std) => {
       }
     }
   }
-  const taskReporter = new LoggingTaskReporter();
+  const taskReporter = new LoggingTaskReporter(std.out);
   taskReporter.start("load");
   const failedPlugins = [];
   const loadPromises = [];
@@ -57,7 +62,7 @@ const loadCommand: Command = async (args, std) => {
 
     const endChildRunners = () => {
       const prefixRegex = new RegExp("^" + name);
-      // create static array of taskIds from active map
+      // create static array of taskIds from activeTasks map
       Array.from(taskReporter.activeTasks.keys())
         .filter((taskId) => prefixRegex.test(taskId))
         .forEach((taskId: string) => {
@@ -87,7 +92,7 @@ const loadCommand: Command = async (args, std) => {
         throw e;
       })
       .catch((e) => {
-        console.error(e);
+        fail(std, name, e);
         failedPlugins.push(name);
       });
     loadPromises.push(loadWithPossibleRetry);


### PR DESCRIPTION
This is a relatively naive implementation of a cache clearing retry for
the load command. It works as follows:
1. check all plugins to be loaded for an existing cache db and save the
state to a Map
2. For each plugin if the load fails for any reason and a cache exists,
  the cache is deleted and the load is retried. Otherwise the load fails
  as before.
3. If the single retry fails, the load will fail.

Some alternative implementations were considered but decided against for
the following reasons:
- the CLI context has no knowledge of the db file name composition
semantics, so naively checking the cache dir was implemented in favor of
looking for a specific file
- It's difficult to catalog all reasons the cache may be
invalidated across plugins, so this implementation does not parse the
error type in order to determine whether a retry is the proper next step

test plan:
1. run `path/to/sourcred.js load` to set up an initital cache
2. perform an action that would cause a sqlite db error or a
graphql error using the master cli load command
3. run `path/to/sourcred.js load` again to verify the error does not
occur. Instead, the cache db should be deleted and recreated