### PR TITLE
lint: disable `no-inner-declarations`

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -36,6 +36,7 @@ module.exports = {
       },
     ],
     "no-constant-condition": ["warn", {checkLoops: false}],
+    "no-inner-decalartions": ["off"],
     "no-use-before-define": ["off"],
     "no-useless-constructor": ["off"],
     "no-case-declarations": ["off"],

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -36,7 +36,7 @@ module.exports = {
       },
     ],
     "no-constant-condition": ["warn", {checkLoops: false}],
-    "no-inner-decalartions": ["off"],
+    "no-inner-declarations": ["off"],
     "no-use-before-define": ["off"],
     "no-useless-constructor": ["off"],
     "no-case-declarations": ["off"],


### PR DESCRIPTION
Summary:
As described in the [`no-inner-declarations` docs][1], this rule is
obsolete in ES6. Problematic behavior is encountered when declaring a
function inside a `for`-loop whose iteratee is bound with `var`, but not
when it’s bound with `let` or `const`.

[1]: https://eslint.org/docs/rules/no-inner-declarations#when-not-to-use-it-81

Test Plan:

```javascript
const varFuns = [];
for (var i = 0; i < 5; i++) {
  varFuns.push(() => i);
}
const letFuns = [];
for (let i = 0; i < 5; i++) {
  letFuns.push(() => i);
}
console.log(varFuns[2]()); // prints 5 (confusing)
console.log(letFuns[2]()); // prints 2 (expected)
```

wchargin-branch: yes-inner-declarations
