### PR TITLE
Revert change to special distribution policy type

### DIFF
--- a/src/ledger/grainAllocation.js
+++ b/src/ledger/grainAllocation.js
@@ -59,7 +59,7 @@ export type SpecialPolicy = {|
   +policyType: Special,
   +budget: G.Grain,
   +memo: string,
-  +recipientId: IdentityId,
+  +recipient: IdentityId,
 |};
 
 export type GrainReceipt = {|
@@ -255,13 +255,11 @@ function specialReceipts(
   identities: ProcessedIdentities
 ): $ReadOnlyArray<GrainReceipt> {
   for (const {id} of identities) {
-    if (id === policy.recipientId) {
+    if (id === policy.recipient) {
       return [{id, amount: policy.budget}];
     }
   }
-  throw new Error(
-    `no active grain account for identity: ${policy.recipientId}`
-  );
+  throw new Error(`no active grain account for identity: ${policy.recipient}`);
 }
 
 const regularPolicyParser: P.Parser<RegularPolicy> = P.object({
@@ -273,7 +271,7 @@ const specialPolicyParser: P.Parser<SpecialPolicy> = P.object({
   policyType: P.exactly(["SPECIAL"]),
   budget: G.parser,
   memo: P.string,
-  recipientId: uuidParser,
+  recipient: uuidParser,
 });
 
 export const allocationPolicyParser: P.Parser<AllocationPolicy> = P.orElse([

--- a/src/ledger/grainAllocation.test.js
+++ b/src/ledger/grainAllocation.test.js
@@ -153,7 +153,7 @@ describe("src/ledger/grainAllocation", () => {
           policyType: "SPECIAL",
           budget: ng(100),
           memo: "something",
-          recipientId: i1.id,
+          recipient: i1.id,
         };
         const allocation = computeAllocation(policy, [i1]);
         const expectedReceipts = [{id: i1.id, amount: ng(100)}];
@@ -171,7 +171,7 @@ describe("src/ledger/grainAllocation", () => {
           policyType: "SPECIAL",
           budget: ng(100),
           memo: "something",
-          recipientId: id,
+          recipient: id,
         };
         const thunk = () => computeAllocation(policy, [other]);
         expect(thunk).toThrowError("no active grain account for identity");

--- a/src/ui/components/SpecialDistribution.js
+++ b/src/ui/components/SpecialDistribution.js
@@ -69,7 +69,7 @@ export const SpecialDistribution = ({
         policyType: "SPECIAL",
         budget: fromFloatString(amount),
         memo,
-        recipientId: recipient.identity.id,
+        recipient: recipient.identity.id,
       };
       const allocation = computeAllocation(policy, [
         {cred: [1], paid: ZERO, id: recipient.identity.id},


### PR DESCRIPTION
PR #2165 renamed the "recipient" field in the special policy to
"recipientId". This is a reasonable change in isolation, but it actually
breaks existing ledgers because they already have serialized policies.
It wasn't caught in tests because the ledger snapshot tests do not
exhaustively include every policy type.

We should find a way to catch issues like this in CI. Maybe we could
enumerate every data type that is part of the serialized API, and then
have a test suite that must contain a snapshot of every serialized API
data type? Not sure. But for now, I'm just going to fix this by
reverting the field rename.

Test plan: After rebuilding with this patch, we can again load the
official SourceCred instance.