### PR TITLE
Strip the "v" in front of tag versions

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -28,9 +28,9 @@ jobs:
         run: |
           git config --global user.name $GITHUB_ACTOR
           git config --global user.email ${GITHUB_ACTOR}@users.noreply.github.com
-          yarn publish --new-version ${GITHUB_REF#"refs/tags/"} --no-git-tag-version
+          yarn publish --new-version ${GITHUB_REF#"refs/tags/v"} --no-git-tag-version
           git add package.json
-          git commit -m "Release v${GITHUB_REF#"refs/tags/"}"
+          git commit -m "Release ${GITHUB_REF#"refs/tags/"}"
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 


### PR DESCRIPTION
It's best practice to prepend version tags on GitHub with "v", but that is not valid syntax for
publishing on NPM.

Test Plan: Create a new release with tag v1.2.3 and ensure package is published with version 1.2.3