### PR TITLE
Remove whatwg-fetch dependency

### DIFF
--- a/config/polyfills.js
+++ b/config/polyfills.js
@@ -7,9 +7,6 @@ if (typeof Promise === "undefined") {
   window.Promise = require("promise/lib/es6-extensions.js");
 }
 
-// fetch() polyfill for making API calls.
-require("whatwg-fetch");
-
 // Object.assign() is commonly used with React.
 // It will use the native implementation if it's present and isn't buggy.
 Object.assign = require("object-assign");

--- a/package.json
+++ b/package.json
@@ -52,8 +52,7 @@
     "retry": "^0.12.0",
     "rimraf": "^3.0.2",
     "svg-react-loader": "^0.4.6",
-    "tmp": "0.0.33",
-    "whatwg-fetch": "^3.4.0"
+    "tmp": "0.0.33"
   },
   "devDependencies": {
     "@babel/core": "^7.8.7",
@@ -101,7 +100,6 @@
       "history",
       "react-dev-utils",
       "react-router",
-      "whatwg-fetch",
       "tmp"
     ]
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -11026,7 +11026,7 @@ whatwg-fetch@3.0.0:
   resolved "https://registry.yarnpkg.com/whatwg-fetch/-/whatwg-fetch-3.0.0.tgz#fc804e458cc460009b1a2b966bc8817d2578aefb"
   integrity sha512-9GSJUgz1D4MfyKU7KRqwOjXCXTqWdFNvEr7eUBYchQiVc744mqK/MzXPNR2WsPkmkOa4ywfg8C2n8h+13Bey1Q==
 
-whatwg-fetch@>=0.10.0, whatwg-fetch@^3.4.0:
+whatwg-fetch@>=0.10.0:
   version "3.4.0"
   resolved "https://registry.yarnpkg.com/whatwg-fetch/-/whatwg-fetch-3.4.0.tgz#e11de14f4878f773fbebcde8871b2c0699af8b30"
   integrity sha512-rsum2ulz2iuZH08mJkT0Yi6JnKhwdw4oeyMjokgxd+mmqYSd9cPpOQf01TIWgjxG/U4+QR+AwKq6lSbXVxkyoQ==


### PR DESCRIPTION
whatwg-fetch was needed when all pages in the static website were
rendered server-side. Because we're making all API calls inside react
admin, the fetch command is never exposed server-side, so this polyfill
is no longer needed

Additionally,  whatwg-fetch@v3+ doesn't seem to work
well with Server-side rendering without a patch at least.
this will fix build issues from #2185 

test plan:
1. Run `yarn build` to ensure no errors
2. Run `yarn start` and ensure no load errors