### PR TITLE
Account Overview: make table fixed height

### DIFF
--- a/src/ui/components/AccountOverview.js
+++ b/src/ui/components/AccountOverview.js
@@ -12,13 +12,23 @@ import {type Account} from "../../ledger/ledger";
 import {type CurrencyDetails} from "../../api/currencyConfig";
 import * as G from "../../ledger/grain";
 import {useLedger} from "../utils/LedgerContext";
+import {makeStyles} from "@material-ui/core/styles";
 
 type OverviewProps = {|+currency: CurrencyDetails|};
+
+const useStyles = makeStyles(() => {
+  return {
+    container: {
+      maxHeight: "40em",
+    },
+  };
+});
 
 export const AccountOverview = ({
   currency: {suffix: currencySuffix},
 }: OverviewProps) => {
   const {ledger} = useLedger();
+  const classes = useStyles();
 
   const accounts = ledger.accounts();
 
@@ -31,8 +41,8 @@ export const AccountOverview = ({
 
   const sortedAccounts = accounts.slice().sort(comparator);
   return (
-    <TableContainer component={Paper}>
-      <Table>
+    <TableContainer component={Paper} className={classes.container}>
+      <Table stickyHeader>
         <TableHead>
           <TableRow>
             <TableCell>Username</TableCell>

--- a/yarn.lock
+++ b/yarn.lock
@@ -166,7 +166,7 @@
   dependencies:
     "@babel/types" "^7.11.0"
 
-"@babel/helper-module-imports@^7.10.4", "@babel/helper-module-imports@^7.8.3":
+"@babel/helper-module-imports@^7.10.4":
   version "7.10.4"
   resolved "https://registry.yarnpkg.com/@babel/helper-module-imports/-/helper-module-imports-7.10.4.tgz#4c5c54be04bd31670a7382797d75b9fa2e5b5620"
   integrity sha512-nEQJHqYavI217oD9+s5MUBzk6x1IlvoS9WTPfgG43CbMEeStE0v+r+TucWdx8KFGowPGvyOkDT9+7DHedIDnVw==
@@ -997,7 +997,7 @@
     globals "^11.1.0"
     lodash "^4.17.19"
 
-"@babel/types@^7.0.0", "@babel/types@^7.10.4", "@babel/types@^7.10.5", "@babel/types@^7.11.0", "@babel/types@^7.11.5", "@babel/types@^7.3.0", "@babel/types@^7.3.3", "@babel/types@^7.4.4", "@babel/types@^7.7.0", "@babel/types@^7.8.3", "@babel/types@^7.9.0", "@babel/types@^7.9.5":
+"@babel/types@^7.0.0", "@babel/types@^7.10.4", "@babel/types@^7.10.5", "@babel/types@^7.11.0", "@babel/types@^7.11.5", "@babel/types@^7.3.0", "@babel/types@^7.3.3", "@babel/types@^7.4.4", "@babel/types@^7.7.0":
   version "7.11.5"
   resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.11.5.tgz#d9de577d01252d77c6800cee039ee64faf75662d"
   integrity sha512-bvM7Qz6eKnJVFIn+1LPtjlBFPVN5jNDc1XmN15vWe7Q3DPBufWWsLiIvUu7xW87uTG6QoggpIDnUgLQvPheU+Q==
@@ -7118,7 +7118,7 @@ lodash.throttle@^4.1.1:
   resolved "https://registry.yarnpkg.com/lodash.throttle/-/lodash.throttle-4.1.1.tgz#c23e91b710242ac70c37f1e1cda9274cc39bf2f4"
   integrity sha1-wj6RtxAkKscMN/HhzaknTMOb8vQ=
 
-"lodash@>=3.5 <5", lodash@^4.0.0, lodash@^4.15.0, lodash@^4.17.11, lodash@^4.17.13, lodash@^4.17.14, lodash@^4.17.15, lodash@^4.17.19, lodash@^4.17.5, lodash@~4.17.4, lodash@~4.17.5:
+"lodash@>=3.5 <5", lodash@^4.0.0, lodash@^4.15.0, lodash@^4.17.11, lodash@^4.17.14, lodash@^4.17.15, lodash@^4.17.19, lodash@^4.17.5, lodash@~4.17.4, lodash@~4.17.5:
   version "4.17.20"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.20.tgz#b44a9b6297bcb698f1c51a3545a2b3b368d59c52"
   integrity sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==


### PR DESCRIPTION
This refactors the Account Overview page so that we now set a max height
(40 ems) on the table, and the user can scroll within the table to find
more entries. This is cleaner than simply having the table spill over
infinitely.

We might want to choose a more principled size than 40 ems (e.g. a % of
view) but I couldn't get that to work and I figured this minimal change
is still an improvement. I'd also like for us to set up scrollbar styles
that are more in line with our dark theme.

I set the `stickyHeader` property so that the header will always be visible at the top.

Test plan: Load with an instance which has many accounts (i.e. not the
test instance) and observe the nice scrolling behavior. Remember that
you can run `yarn start --instance PATH_TO_INSTANCE`.