### PR TITLE
disable esModules in css-loader

### DIFF
--- a/config/webpack.config.web.js
+++ b/config/webpack.config.web.js
@@ -218,6 +218,9 @@ async function makeConfig(
             {
               test: /\.css$/,
               loader: "css-loader", // TODO(@wchargin): add csso-loader
+              options: {
+                esModule: false,
+              },
             },
             {
               test: /\.svg$/,


### PR DESCRIPTION
css-loader v4 has a breaking change that enables esModules for imports
by default. setting the config to false returns behavior to what we were
using in v3

This impacts our current build because the `require` here: https://github.com/sourcecred/sourcecred/blob/0dfeca47da0c2a566647309bb5e3720584de9f3a/src/ui/server.js#L42

is imported as a module without this added config to set `esModule: false`


test plan: `yarn && yarn start` and inspect the index.html file to ensure the
index.css body styling is correctly loaded under the <script> tag