### PR TITLE
Add parsers for TimestampMs and TimestampISO

### DIFF
--- a/src/util/timestamp.js
+++ b/src/util/timestamp.js
@@ -1,5 +1,7 @@
 // @flow
 
+import * as C from "./combo";
+
 /**
  * We have a convention of using TimestampMs as our default representation.
  * However TimestampISO has the benefit of being human readable / writable,
@@ -22,7 +24,7 @@ export opaque type TimestampISO: string = string;
  * than a forced refactor across the codebase.
  */
 export function toISO(timestampLike: TimestampMs | number): TimestampISO {
-  const timestampMs: TimestampMs = validate(timestampLike);
+  const timestampMs: TimestampMs = validateTimestampMs(timestampLike);
   return new Date(timestampMs).toISOString();
 }
 
@@ -52,7 +54,7 @@ export function fromISO(timestampISO: TimestampISO | string): TimestampMs {
  * This checks that the number is a finite integer, which avoids some potential
  * numbers that are not valid timestamps.
  */
-export function validate(timestampMs: number): TimestampMs {
+export function validateTimestampMs(timestampMs: number): TimestampMs {
   const asNumber = Number(timestampMs);
   if (
     timestampMs === null ||
@@ -66,3 +68,18 @@ export function validate(timestampMs: number): TimestampMs {
   }
   return new Date(asNumber).valueOf();
 }
+
+export function validateTimestampISO(timestampISO: string): TimestampISO {
+  // Verify that it can be converted without throwing an error
+  fromISO(timestampISO);
+  return timestampISO;
+}
+
+export const timestampMsParser: C.Parser<TimestampMs> = C.fmap(
+  C.number,
+  validateTimestampMs
+);
+export const timestampISOParser: C.Parser<TimestampISO> = C.fmap(
+  C.string,
+  validateTimestampISO
+);

--- a/src/util/timestamp.test.js
+++ b/src/util/timestamp.test.js
@@ -1,7 +1,12 @@
 // @flow
 
 import type {TimestampMs, TimestampISO} from "./timestamp";
-import {fromISO, toISO, validate} from "./timestamp";
+import {
+  fromISO,
+  toISO,
+  validateTimestampMs,
+  validateTimestampISO,
+} from "./timestamp";
 
 /**
  * Helper function to write readable "toThrow" tests. This intentionally
@@ -33,14 +38,14 @@ describe("util/timestamp", () => {
   describe("roundtrips", () => {
     it("should handle number roundtrips", () => {
       const origin: number = fullExample.ms;
-      expect(validate(origin)).toBe(origin);
+      expect(validateTimestampMs(origin)).toBe(origin);
       expect(fromISO(toISO(origin))).toBe(origin);
-      expect(validate(fromISO(toISO(origin)))).toBe(origin);
+      expect(validateTimestampMs(fromISO(toISO(origin)))).toBe(origin);
     });
     it("should handle ISO roundtrips", () => {
       const origin: TimestampISO = fullExample.ISO;
       expect(toISO(fromISO(origin))).toBe(origin);
-      expect(toISO(validate(fromISO(origin)))).toBe(origin);
+      expect(toISO(validateTimestampMs(fromISO(origin)))).toBe(origin);
     });
   });
 
@@ -96,34 +101,61 @@ describe("util/timestamp", () => {
     });
   });
 
-  describe("validate", () => {
+  describe("validateTimestampMs", () => {
     it("should throw on null", () => {
-      given(null).expect(validate).toThrow(TypeError);
+      given(null).expect(validateTimestampMs).toThrow(TypeError);
     });
     it("should throw on undefined", () => {
-      given(undefined).expect(validate).toThrow(TypeError);
+      given(undefined).expect(validateTimestampMs).toThrow(TypeError);
     });
     it("should throw on NaN", () => {
-      given(NaN).expect(validate).toThrow(TypeError);
+      given(NaN).expect(validateTimestampMs).toThrow(TypeError);
     });
     it("should throw on Infinity", () => {
-      given(Infinity).expect(validate).toThrow(TypeError);
+      given(Infinity).expect(validateTimestampMs).toThrow(TypeError);
     });
     it("should throw on floating point numbers", () => {
       given(1 / 3)
-        .expect(validate)
+        .expect(validateTimestampMs)
         .toThrow(TypeError);
     });
     it("should handle 0 correctly", () => {
-      expect(validate(0)).toBe(0);
+      expect(validateTimestampMs(0)).toBe(0);
     });
     it("should handle Date.now correctly", () => {
       const now = Date.now();
-      expect(validate(now)).toBe(now);
+      expect(validateTimestampMs(now)).toBe(now);
     });
     it("should handle examples correctly", () => {
-      expect(validate(fullExample.ms)).toBe(fullExample.ms);
-      expect(validate(partialExample.ms)).toBe(partialExample.ms);
+      expect(validateTimestampMs(fullExample.ms)).toBe(fullExample.ms);
+      expect(validateTimestampMs(partialExample.ms)).toBe(partialExample.ms);
+    });
+  });
+
+  describe("validateTimestampISO", () => {
+    it("should throw on null", () => {
+      given(null).expect(validateTimestampISO).toThrow(TypeError);
+    });
+    it("should throw on undefined", () => {
+      given(undefined).expect(validateTimestampISO).toThrow(TypeError);
+    });
+    it("should throw on numbers", () => {
+      given(123).expect(validateTimestampISO).toThrow(TypeError);
+    });
+    it("should handle examples correctly", () => {
+      // No errors thrown.
+      validateTimestampISO(fullExample.ISO);
+      validateTimestampISO(partialExample.ISO);
+    });
+    it("should throw on invalid formatting", () => {
+      given("04/31/2016 12:46pm")
+        .expect(validateTimestampISO)
+        .toThrow(RangeError);
+    });
+    it("should throw on illegal date", () => {
+      given("2000-02-32T00:00:00.000Z")
+        .expect(validateTimestampISO)
+        .toThrow(RangeError);
     });
   });
 });


### PR DESCRIPTION
This commit adds parsers to the timestamp module. To accomplish this, I
wrote a new `validateTimestampISO` function, which simply checks whether
the timestamp can be converted without error, and renamed `validate` to
`validateTimestampMs` for disambiguation.

Test plan: Added tests for the `validateTimestampISO` method, although I
think it's not really necessary. Didn't test the parsers because their
implementations are trivially correct.