### PR TITLE
Fix inability for credbot to push to master in Release workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -8,7 +8,10 @@ jobs:
   publish:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@master
+        with:
+          persist-credentials: false # allows usage of custom access token with admin permissions
+          fetch-depth: 0 # fetches all commits / tags. Otherwise, it fails to push refs to dest branch
       - uses: actions/setup-node@v1
         with:
           node-version: 12
@@ -20,14 +23,14 @@ jobs:
       - name: Test
         run: yarn test --full --ci
         env:
-          SOURCECRED_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          SOURCECRED_GITHUB_TOKEN: ${{ secrets.SOURCECRED_GITHUB_TOKEN }}
 
       # Uses the version defined by the tag created in the Release
       # and pushes a commit that updates the version in package.json
       - name: Publish to NPM
         run: |
-          git config --global user.name $GITHUB_ACTOR
-          git config --global user.email ${GITHUB_ACTOR}@users.noreply.github.com
+          git config --global user.name 'credbot'
+          git config --global user.email credbot@users.noreply.github.com
           yarn publish --new-version ${GITHUB_REF#"refs/tags/v"} --no-git-tag-version
           git add package.json
           git commit -m "Release ${GITHUB_REF#"refs/tags/"}"


### PR DESCRIPTION
Updated the workflow to fetch all history for commits which is required for the refs to properly be pushed into
 master according to the docs of the push action (https://github.com/ad-m/github-push-action). Also disables
 persist-credentials which prevents the auto-generated GITHUB_TOKEN for actions from being used.

Verified successful run on a fork with same repo security settings (https://github.com/hammadj/sourcecred/runs/1098839653?check_suite_focus=true)

Test Plan: Create a release and ensure the action runs successfully and updates master branch with new version.