### PR TITLE
Fix issue in calculating Grain distributions

### DIFF
--- a/src/cli/grain.js
+++ b/src/cli/grain.js
@@ -42,7 +42,8 @@ const grainCommand: Command = async (args, std) => {
   const distributions = applyDistributions(
     distributionPolicy,
     credView,
-    ledger
+    ledger,
+    +Date.now()
   );
 
   let totalDistributed = G.ZERO;

--- a/src/ledger/applyDistributions.js
+++ b/src/ledger/applyDistributions.js
@@ -41,12 +41,14 @@ export type DistributionPolicy = {|
 export function applyDistributions(
   policy: DistributionPolicy,
   view: CredView,
-  ledger: Ledger
+  ledger: Ledger,
+  currentTimestamp: TimestampMs
 ): $ReadOnlyArray<Distribution> {
   const credIntervals = view.intervals();
   const distributionIntervals = _chooseDistributionIntervals(
     credIntervals,
     ledger.lastDistributionTimestamp(),
+    currentTimestamp,
     policy.maxSimultaneousDistributions
   );
   return distributionIntervals.map((interval) => {
@@ -66,10 +68,13 @@ export function applyDistributions(
 export function _chooseDistributionIntervals(
   credIntervals: $ReadOnlyArray<Interval>,
   lastDistributionTimestamp: TimestampMs,
+  currentTimestamp: TimestampMs,
   maxSimultaneousDistributions: number
 ): $ReadOnlyArray<Interval> {
   // Slice off the final interval--we may assume that it is not yet finished.
-  const completeIntervals = credIntervals.slice(0, credIntervals.length - 1);
+  const completeIntervals = credIntervals.filter(
+    (x) => x.endTimeMs <= currentTimestamp
+  );
   const undistributedIntervals = completeIntervals.filter(
     (i) => i.endTimeMs > lastDistributionTimestamp
   );

--- a/src/ledger/applyDistributions.test.js
+++ b/src/ledger/applyDistributions.test.js
@@ -20,6 +20,7 @@ describe("ledger/applyDistributions", () => {
         _chooseDistributionIntervals(
           credIntervals,
           lastDistributionTimestamp,
+          299,
           maxSimultaneousDistributions
         )
       ).toEqual(expected);
@@ -37,6 +38,7 @@ describe("ledger/applyDistributions", () => {
         _chooseDistributionIntervals(
           credIntervals,
           lastDistributionTimestamp,
+          299,
           maxSimultaneousDistributions
         )
       ).toEqual(expected);
@@ -54,6 +56,7 @@ describe("ledger/applyDistributions", () => {
         _chooseDistributionIntervals(
           credIntervals,
           lastDistributionTimestamp,
+          299,
           maxSimultaneousDistributions
         )
       ).toEqual(expected);
@@ -71,6 +74,25 @@ describe("ledger/applyDistributions", () => {
         _chooseDistributionIntervals(
           credIntervals,
           lastDistributionTimestamp,
+          299,
+          maxSimultaneousDistributions
+        )
+      ).toEqual(expected);
+    });
+    it("handles the case where the latest interval is complete", () => {
+      const credIntervals = [
+        {startTimeMs: 0, endTimeMs: 100},
+        {startTimeMs: 100, endTimeMs: 200},
+        {startTimeMs: 200, endTimeMs: 300},
+      ];
+      const lastDistributionTimestamp = -Infinity;
+      const maxSimultaneousDistributions = 1;
+      const expected = [{startTimeMs: 200, endTimeMs: 300}];
+      expect(
+        _chooseDistributionIntervals(
+          credIntervals,
+          lastDistributionTimestamp,
+          300,
           maxSimultaneousDistributions
         )
       ).toEqual(expected);


### PR DESCRIPTION
This commit fixes #2239. See the bug for context. Honestly, the API for
the Grain command is really wonky and should probably be changed more,
but for now I'll settle for just fixing the bug.

Test plan: There's a unit test added for the case where the latest
interval is complete.