### PR TITLE
Prettify markdown files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Unreleased]
 
 <!-- Please add new entries just beneath this line. -->
+
 - Change default alpha from 0.05 to 0.20 (#1391)
 - Enable viewing and changing alpha in the explorer (#1390)
 - Enable combining different user identities together (#1385)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -71,6 +71,7 @@ number of commits only entails 3 additional steps of bisection, which is
 not a big deal. On the other hand, once the offending commit is
 identified, the cause is more apparent if the commit is tiny than if it
 is large.
+
 </details>
 
 ### Checks
@@ -78,44 +79,44 @@ is large.
 Each commit will need to pass all tests. Run `yarn test` or `npm test`
 to run them all. This will run:
 
-  - **Flow** (`yarn flow`). Your code must type-check with no errors or
-    warnings. Using `any`-casts is permitted, but should be truly a last
-    resort. You should put significant effort into avoiding every
-    `any`-cast.
+- **Flow** (`yarn flow`). Your code must type-check with no errors or
+  warnings. Using `any`-casts is permitted, but should be truly a last
+  resort. You should put significant effort into avoiding every
+  `any`-cast.
 
-  - **Unit tests** (`yarn unit`). You can also run `yarn unit --watch`
-    to automatically re-run tests when you change a relevant file.
+- **Unit tests** (`yarn unit`). You can also run `yarn unit --watch`
+  to automatically re-run tests when you change a relevant file.
 
-  - **Sharness** (`yarn sharness`). This runs shell-based tests, located
-    in the `sharness/` directory.
+- **Sharness** (`yarn sharness`). This runs shell-based tests, located
+  in the `sharness/` directory.
 
-  - **Prettier** (`check-pretty`). You can simply run `yarn prettify` to
-    reformat all files. It can be convenient to set up your editor to
-    run `yarn prettier --write CURRENT_FILENAME` whenever you save a
-    file.
+- **Prettier** (`check-pretty`). You can simply run `yarn prettify` to
+  reformat all files. It can be convenient to set up your editor to
+  run `yarn prettier --write CURRENT_FILENAME` whenever you save a
+  file.
 
-  - **Lint** (`yarn lint`). You’ll have to fix lint errors manually.
-    These are almost always unused imports or unused variables, and
-    sometimes catch logic errors before unit tests do. Feel free to
-    disable spurious lint errors on a per-line basis by inserting a
-    preceding line with `// eslint-disable-next-line LINT_RULE_NAME`.
+- **Lint** (`yarn lint`). You’ll have to fix lint errors manually.
+  These are almost always unused imports or unused variables, and
+  sometimes catch logic errors before unit tests do. Feel free to
+  disable spurious lint errors on a per-line basis by inserting a
+  preceding line with `// eslint-disable-next-line LINT_RULE_NAME`.
 
-  - **Backend applications build** (`yarn build:backend`). This makes
-    sure that the CLI still builds.
+- **Backend applications build** (`yarn build:backend`). This makes
+  sure that the CLI still builds.
 
-  - **Check for `@flow` pragmas** (`./scripts/ensure-flow.sh`). This
-    makes sure that every file includes a `// @flow` directive or an
-    explicit `// @no-flow` directive. The former is required for Flow to
-    consider a file. The latter has no effect, but we assert its
-    existence to make sure that we don’t simply forget to mark a file
-    for Flow. If this is failing, you probably added a new file and just
-    need to add `// @flow` to the top. Exceptional circumstances
-    excepted, all new files should have `// @flow`.
+- **Check for `@flow` pragmas** (`./scripts/ensure-flow.sh`). This
+  makes sure that every file includes a `// @flow` directive or an
+  explicit `// @no-flow` directive. The former is required for Flow to
+  consider a file. The latter has no effect, but we assert its
+  existence to make sure that we don’t simply forget to mark a file
+  for Flow. If this is failing, you probably added a new file and just
+  need to add `// @flow` to the top. Exceptional circumstances
+  excepted, all new files should have `// @flow`.
 
-  - **Check for stopships.** The sequence `STOPSHIP` (in any case) is
-    not allowed to appear in the codebase, except in Markdown files. You
-    can take advantage of this to insert a quick hack and make sure that
-    you remember to remove it later.
+- **Check for stopships.** The sequence `STOPSHIP` (in any case) is
+  not allowed to appear in the codebase, except in Markdown files. You
+  can take advantage of this to insert a quick hack and make sure that
+  you remember to remove it later.
 
 This is the same set of tests that is run on our CI system, CircleCI.
 
@@ -125,7 +126,7 @@ If your patch makes a change that would be visible or interesting to a
 user of SourceCred—for example, fixing a bug—please add a description of
 the change under the `[Unreleased]` heading of `CHANGELOG.md`. Your new
 change should be the first entry in the section. The format of your
-entry should be: ```<description of change> (#<PR number>)```.
+entry should be: `<description of change> (#<PR number>)`.
 
 ## When writing commit messages
 
@@ -138,11 +139,11 @@ summary should either be in sentence case (i.e., the first letter of the
 first word capitalized), or of the form “area: change description”. For
 instance, all of the following are examples of good summaries:
 
-  - Improve error messages when GitHub query fails
-  - Make deploy script wait for valid response
-  - Upgrade Flow to v0.76.0
-  - new-webpack: replace old scripts in `package.json`
-  - fetchGithubRepo: remove vestigial data field
+- Improve error messages when GitHub query fails
+- Make deploy script wait for valid response
+- Upgrade Flow to v0.76.0
+- new-webpack: replace old scripts in `package.json`
+- fetchGithubRepo: remove vestigial data field
 
 If you find that you can’t concisely explain your change in 50
 characters, move non-essential information into the body of the commit
@@ -159,6 +160,7 @@ this information. The particular style of the summary is chosen to be
 consistent with those commits emitted by Git itself: commands like
 `git-revert` and `git-merge` are of this form, so it’s a good standard
 to pick.
+
 </details>
 
 ### Description
@@ -180,6 +182,7 @@ the change was necessary. Documenting the motivation, alternate
 formulations, etc. is helpful both in the present (for reviewers) and in
 the future (for people using `git-blame` to try to understand how a
 piece of code came to be).
+
 </details>
 
 ### Test plan
@@ -206,6 +209,7 @@ plan is as simple as “standard unit tests suffice”, this indicates to
 observers that no additional testing is required. The test plan is
 useful for reviewers, and for anyone bisecting through the history or
 trying to learn more about the development or intention of a commit.
+
 </details>
 
 ### Wrapping
@@ -222,6 +226,7 @@ this amount of padding exists.
 
 (Yes, people really still use 80-character terminals. When each of your
 terminals has bounded width, you can display more of them on a screen!)
+
 </details>
 
 ### Example

--- a/README.md
+++ b/README.md
@@ -87,8 +87,8 @@ practices.
 You can check out the issues marked [contributions welcome], or ask in the
 Discord's #programming channel if anyone has something you can contribute to.
 
-[our Discord]: https://sourcecred.io/discord
-[Contributing Guidelines]: ./CONTRIBUTING.md
+[our discord]: https://sourcecred.io/discord
+[contributing guidelines]: ./CONTRIBUTING.md
 [contributions welcome]: https://github.com/sourcecred/sourcecred/issues?q=is%3Aopen+is%3Aissue+label%3Acontributions-welcome
 
 ## Getting Support
@@ -97,28 +97,29 @@ If you need help with SourceCred, try asking for help in the #tech-support chann
 on our Discord. You can also come to our weekly dev meeting, on Mondays at 12pm PT.
 (Check out the [SourceCred calendar].)
 
-[SourceCred calendar]: https://sourcecred.io/calendar
+[sourcecred calendar]: https://sourcecred.io/calendar
 
 ## Development Setup
 
 ### Dependencies
 
-  - Install [Node] (tested on v12.x.x and v10.x.x).
-  - Install [Yarn] (tested on v1.7.0).
-  - For macOS users: Ensure that your environment provides GNU
-    coreutils. [See this comment for details about what, how, and
-    why.][macos-gnu]
+- Install [Node] (tested on v12.x.x and v10.x.x).
+- Install [Yarn] (tested on v1.7.0).
+- For macOS users: Ensure that your environment provides GNU
+  coreutils. [See this comment for details about what, how, and
+  why.][macos-gnu]
 
-[Node]: https://nodejs.org/en/
-[Yarn]: https://yarnpkg.com/lang/en/
+[node]: https://nodejs.org/en/
+[yarn]: https://yarnpkg.com/lang/en/
 [macos-gnu]: https://github.com/sourcecred/sourcecred/issues/698#issuecomment-417202213
 
 If you want to work on the GitHub plugin, you should
 create a [GitHub API token]. No special permissions are required.
 
-[GitHub API token]: https://github.com/settings/tokens
+[github api token]: https://github.com/settings/tokens
 
 Then, set it in your environment:
+
 ```Bash
 export SOURCECRED_GITHUB_TOKEN=1234....asdf
 ```
@@ -152,6 +153,7 @@ cd $MY_SC_INSTANCE
 # Run the `sourcecred go` command, in your instance, using your modified code.
 scdev go
 ```
+
 ### Using a Modified Frontend
 
 If you've made changes to the SourceCred frontend, you can preview and test it using our builtin development server:
@@ -166,11 +168,11 @@ If you'd like to run it in your instance instead, start it via:
 
 SourceCred is dual-licensed under Apache 2.0 and MIT terms:
 
-  * Apache License, Version 2.0, ([LICENSE-APACHE](LICENSE-APACHE) or <https://www.apache.org/licenses/LICENSE-2.0>)
-  * MIT License ([LICENSE-MIT](LICENSE-MIT) or <https://opensource.org/licenses/MIT>)
+- Apache License, Version 2.0, ([LICENSE-APACHE](LICENSE-APACHE) or <https://www.apache.org/licenses/LICENSE-2.0>)
+- MIT License ([LICENSE-MIT](LICENSE-MIT) or <https://opensource.org/licenses/MIT>)
 
 ## Acknowledgements
 
 We’d like to thank [Protocol Labs] for funding and support of SourceCred.
 
-[Protocol Labs]: https://protocol.ai
+[protocol labs]: https://protocol.ai

--- a/package.json
+++ b/package.json
@@ -103,8 +103,8 @@
     ]
   },
   "scripts": {
-    "prettify": "prettier --write '**/*.js'",
-    "check-pretty": "prettier --list-different '**/*.js'",
+    "prettify": "prettier --write '**/*.{js,md}'",
+    "check-pretty": "prettier --list-different '**/*.{js,md}'",
     "start": "NODE_ENV=development webpack-dev-server --config config/webpack.config.web.js",
     "build": "run-p build:* && cp -r ./build ./bin/site-template && chmod +x ./bin/sourcecred.js",
     "build:frontend": "NODE_ENV=production webpack --config config/webpack.config.web.js",

--- a/src/plugins/demo/README.md
+++ b/src/plugins/demo/README.md
@@ -10,4 +10,4 @@ available.
 The plugin is loosely based on the wonderful video game [Factorio], which the
 SourceCred developers heartily recommend.
 
-[Factorio]: https://www.factorio.com/
+[factorio]: https://www.factorio.com/

--- a/src/plugins/discord/README.md
+++ b/src/plugins/discord/README.md
@@ -20,7 +20,6 @@ Discord app
 You can create both on the developer portal here:
 https://discordapp.com/developers/applications
 
-
 Permissions this bot will need:
 
 - `View Channels`
@@ -57,7 +56,6 @@ You can find some of those out by using the browser version of Discord and inspe
 
 Otherwise you can also use the API and query for it yourself with tools like Postman or CURL.
 
-
 With the bot invited and auth set up. Find out the Guild ID using:
 
 `GET https://discordapp.com/api/users/@me/guilds`
@@ -65,4 +63,3 @@ With the bot invited and auth set up. Find out the Guild ID using:
 Find your custom emoji using:
 
 `GET https://discordapp.com/api/guilds/{{discordGuildId}}/emojis`
-

--- a/src/plugins/experimental-discord/README.md
+++ b/src/plugins/experimental-discord/README.md
@@ -20,7 +20,6 @@ Discord app
 You can create both on the developer portal here:
 https://discordapp.com/developers/applications
 
-
 Permissions this bot will need:
 
 - `View Channels`
@@ -57,7 +56,6 @@ You can find some of those out by using the browser version of Discord and inspe
 
 Otherwise you can also use the API and query for it yourself with tools like Postman or CURL.
 
-
 With the bot invited and auth set up. Find out the Guild ID using:
 
 `GET https://discordapp.com/api/users/@me/guilds`
@@ -65,4 +63,3 @@ With the bot invited and auth set up. Find out the Guild ID using:
 Find your custom emoji using:
 
 `GET https://discordapp.com/api/guilds/{{discordGuildId}}/emojis`
-

--- a/src/plugins/github/README.md
+++ b/src/plugins/github/README.md
@@ -30,17 +30,19 @@ cred than a clean, elegant pull request (which merges with a minimum of fuss).
 
 We intend to improve the cred robustness of the GitHub plugin by
 adding better heuristics for assigning cred, e.g.:
+
 - Minting cred when PRs are merged, rather than when they are created.
 - Allowing custom labels that influence the cred minted to pulls.
 - Modifying cred minting based on metrics like the size of the pull request.
 
 We also intend to move cred minting away from raw activity and towards
 actions that require review, e.g.:
+
 - Minting cred when a pull request merges.
 - Minting cred when a release is created.
 - Minting cred when a feature is added (via the Initiatives Plugin).
 
-[GitHub]: https://github.com/
+[github]: https://github.com/
 
 ## Nodes
 
@@ -56,8 +58,7 @@ node has no timestamp, so setting a weight on the repository will have no
 effect (i.e. repos do not mint cred). This may change when we switch to
 [CredRank].
 
-[CredRank]: https://github.com/sourcecred/sourcecred/issues/1686
-
+[credrank]: https://github.com/sourcecred/sourcecred/issues/1686
 [sourcecred/sourcecred]: https://github.com/sourcecred/sourcecred
 
 - **Issue**:
@@ -82,7 +83,6 @@ that they created when merged.
 A review of a GitHub pull request, e.g. [this review]. Reviews are connected to
 their author(s), to entities they reference, to their comments, and to the pull
 they review. Note that review assignments are not currently tracked.
-
 
 [this review]: https://github.com/sourcecred/sourcecred/pull/91#pullrequestreview-105254836
 
@@ -134,7 +134,6 @@ Bots have the same connections as users.
 
 [bots.js]: https://github.com/sourcecred/sourcecred/blob/master/src/plugins/github/bots.js
 
-
 ## Edges
 
 - **Authors**:
@@ -160,7 +159,6 @@ hyphen or colon, so that the below are all valid "paired with" designators:
 > Paired With: @wchargin
 >
 > Paired-With: @wchargin
->
 
 - **References**:
 
@@ -186,20 +184,19 @@ reactions as nodes, so as to support reaction-minted cred, in the style of
 A has-parent edge connects a "child" node to its "parent" node. Here's a table
 summarizing these relationships:
 
-| Child | Parent |
-| --- | --- |
-| Issue | Repository |
-| Issue Comment | Issue |
-| Pull Request | Repository |
-| Pull Comment | Pull Request |
-| Pull Request Review | Pull Request |
+| Child                       | Parent              |
+| --------------------------- | ------------------- |
+| Issue                       | Repository          |
+| Issue Comment               | Issue               |
+| Pull Request                | Repository          |
+| Pull Comment                | Pull Request        |
+| Pull Request Review         | Pull Request        |
 | Pull Request Review Comment | Pull Request Review |
 
 - **Merged As**:
 
 A merged-as edge connects a pull request to the commit that it merged, assuming
 the pull request was merged.
-
 
 ## Implementation
 


### PR DESCRIPTION
I've updated `yarn prettify` and `yarn check-pretty` so that we now
prettify markdown files.

Test plan: Pretty trivial change. Running `yarn prettify` resulted in
the markdown changes included in this commit. Running `yarn
check-pretty` passes, as does `yarn test`. Note that `yarn check-pretty`
has been modified to also check markdown.