### PR TITLE
Fix white-on-white text in alpha subpanel

### DIFF
--- a/src/ui/components/Explorer/Explorer.js
+++ b/src/ui/components/Explorer/Explorer.js
@@ -256,7 +256,7 @@ export class Explorer extends React.Component<ExplorerProps, ExplorerState> {
           {analyzeButton}
         </Grid>
         {showWeightConfig && (
-          <div style={{marginTop: 10}}>
+          <div style={{color: "black", marginTop: 10}}>
             <span>Upload/Download weights:</span>
             {weightFileManager}
             <span>α</span>


### PR DESCRIPTION
Summary:
Credit to @decentralion for noticing this while QA testing.

Test Plan:
Note that both the “α” label and value are now visible, as is the
“upload/download” text:

![Screenshot of the alpha slider in the weights explorer][ss]

[ss]: https://user-images.githubusercontent.com/4317806/93006209-438eca00-f50e-11ea-9a8d-e314c6b2e882.png

For a more general test, hit Ctrl-A to select all text (giving it a
colored background) and note that no white-on-colored text appears.

wchargin-branch: fix-invisible-alpha
