### PR TITLE
Log SourceCred version on load

### DIFF
--- a/src/ui/index.js
+++ b/src/ui/index.js
@@ -3,11 +3,14 @@ import React from "react";
 import ReactDOM from "react-dom";
 import {HashRouter} from "react-router-dom";
 import App from "./components/AdminApp";
+import {VERSION_SHORT} from "../core/version";
 
 const target = document.getElementById("root");
 if (target == null) {
   throw new Error("Unable to find root element!");
 }
+
+console.log(`SourceCred version: ${VERSION_SHORT}`);
 
 ReactDOM.hydrate(
   <HashRouter>


### PR DESCRIPTION
This commit prints the SourceCred version into the console on frontend
load. This will be useful to help provide tech support for users, since
we'll be able to find what version of SourceCred they'll be using.

Test plan: Run `yarn start`, and check the console.