### PR TITLE
Implement TaskManager

### DIFF
--- a/src/util/taskManager.js
+++ b/src/util/taskManager.js
@@ -7,8 +7,10 @@ import {
   SilentTaskReporter,
 } from "./taskReporter";
 
+type TaskNodeId = string;
+type RootedTaskId = TaskNodeId[];
 type TaskNode = {|
-  id: TaskId,
+  reporter: TaskReporter,
   children: Map<TaskId, TaskNode>,
 |};
 
@@ -18,114 +20,117 @@ type TaskNode = {|
  * It utilizes TaskReporters internally for logging, and allows them to
  * maintain their own task state for internal use. The primary concern of
  * the manager is creating and enforcing task scopes via a tree structure.
- * When a plugin task needs to be terminated in the load command, it is important
- * that all child tasks also are terminated in case a restart of the task is
- * necessary. A well-behaved plugin should terminate all tasks it spawns on its own,
- * but in the case of a cache error or other unexpected error, this class makes it
- * possible to quickly find and terminate all child tasks.
+ *
+ * Motivation
+ * When a plugin task needs to be terminated in the load command, it is
+ * important that all child tasks also are terminated in case a restart of the
+ * task is necessary. A well-behaved plugin should terminate all tasks it
+ * spawns on its own, but in the case of a cache error or other unexpected
+ * error, this class makes it possible to quickly find and safely terminate all
+ * child tasks.
+ *
+ * Scopes
+ * A plugin can safely manage its own subset of tasks through the use of
+ * TaskManager.prototype.createScope. An existing TaskId can be passed in to
+ * create new TaskManager instance that has the plugin task as root, allowing
+ * the plugin context to manage its own tasks without the possiblity of
+ * terminating any out-of-scope tasks, or its own root process.
  */
-
 export class TaskManager {
   _taskRoot: TaskNode;
-  reporter: TaskReporter;
 
-  constructor(reporter: ?TaskReporter, rootNode: ?TaskNode) {
-    this._taskRoot = rootNode || {
-      id: "",
-      children: new Map(),
-    };
-    this.reporter = reporter || new SilentTaskReporter();
+  constructor(rootNode: ?TaskNode) {
+    this._taskRoot = rootNode || createNode();
   }
 
-  start(taskId: TaskId) {
-    if (this.findTask(taskId)) {
-      throw new Error(`task ${taskId} already registered`);
+  start(id: TaskId) {
+    const rootId = fromTaskId(id);
+    if (this.findTask(rootId)) {
+      throw new Error(`Task ${id} already registered`);
     }
-    this._createTask(taskId);
+    this._createTask(rootId);
     return this;
   }
 
-  finish(taskId: TaskId) {
-    this._findandFinishTask(taskId);
+  finish(id: TaskId) {
+    const rootId = fromTaskId(id);
+    if (!this.findTask(rootId)) {
+      throw new Error(`Task ${id} not registered`);
+    }
+    this._findandFinishTask(rootId);
     return this;
   }
 
-  _createTask(taskId: TaskId, startRoot: TaskNode = this._taskRoot) {
-    const newTask = {
-      id: taskId,
-      children: new Map(),
-    };
-    const parent = this._findTaskParent(taskId, startRoot);
-    parent.children.set(taskId, newTask);
-    this.reporter.start(taskId);
+  createScope(id: TaskId): TaskManager {
+    const rootId = fromTaskId(id);
+    const contextRoot = this.findTask(rootId);
+    if (!contextRoot) {
+      throw new Error(`task ${id} not registered`);
+    }
+    return new TaskManager(contextRoot);
   }
 
-  _findandFinishTask(
-    taskId: TaskId,
-    node: TaskNode = this._taskRoot,
-    parent: ?TaskNode
-  ) {
-    if (node.id === taskId) {
-      if (!parent) {
-        throw new Error("Cannot kill root task");
-      }
-      parent.children.delete(taskId);
-      this._finishTask(node);
+  findTask(rootId: RootedTaskId, node: TaskNode = this._taskRoot): ?TaskNode {
+    // don't want to modify the Id passed into findTask here
+    // so we create and operate on a duplicate
+    const idCopy = [...rootId];
+    if (!rootId.length) return node;
+    const id = idCopy.shift();
+    const child = node.children.get(id);
+    if (child) {
+      return this.findTask(idCopy, child);
+    }
+  }
+
+  _createTask(rootId: RootedTaskId, node: TaskNode = this._taskRoot) {
+    if (rootId.length === 0) return;
+    const id = rootId.shift();
+    let currentTask = node.children.get(id);
+    if (!currentTask) {
+      const newTask = createNode(new ScopedTaskReporter(node.reporter, id));
+      node.children.set(id, newTask);
+      node.reporter.start(id);
+
+      currentTask = newTask;
+    }
+    this._createTask(rootId, currentTask);
+  }
+
+  _findandFinishTask(rootId: RootedTaskId, node: TaskNode = this._taskRoot) {
+    const id = rootId.shift();
+    const currentTask = node.children.get(id);
+    if (rootId.length === 0) {
+      this._finishTask(id, node);
+
       return;
     }
-    let taskMightExist = false;
-    for (const child of node.children.values()) {
-      if (taskId.startsWith(child.id)) {
-        taskMightExist = true;
-        this._findandFinishTask(taskId, child, node);
-      }
-    }
-    if (!taskMightExist) {
-      throw new Error(`Task ${taskId} not registered`);
-    }
+    this._findandFinishTask(rootId, currentTask);
   }
 
-  _finishTask(task: TaskNode) {
-    this._finishChildren(task);
-    task.children.delete(task.id);
-    this.reporter.finish(task.id);
+  _finishTask(idToKill: TaskNodeId, parent: TaskNode) {
+    const tasktoKill = parent.children.get(idToKill);
+    // Keep Flow Happy
+    if (tasktoKill) {
+      this._finishChildren(tasktoKill);
+      parent.children.delete(idToKill);
+      parent.reporter.finish(idToKill);
+    }
   }
 
   _finishChildren(task: TaskNode) {
-    const children = Array.from(task.children.values());
-    for (const child of children) {
-      this._finishTask(child);
+    const children = Array.from(task.children.keys());
+    for (const id of children) {
+      this._finishTask(id, task);
     }
   }
+}
 
-  findTask(taskId: TaskId, node: TaskNode = this._taskRoot): ?TaskNode {
-    if (node.id === taskId) {
-      return node;
-    }
-    for (const child of node.children.values()) {
-      if (taskId.startsWith(child.id)) {
-        return this.findTask(taskId, child);
-      }
-    }
-  }
+export function createNode(
+  reporter: TaskReporter = new SilentTaskReporter()
+): TaskNode {
+  return {reporter, children: new Map()};
+}
 
-  createScope(taskId: TaskId): TaskManager {
-    const contextRoot = this.findTask(taskId);
-    if (!contextRoot) {
-      throw new Error(`task ${taskId} does not exist`);
-    }
-    return new TaskManager(
-      new ScopedTaskReporter(this.reporter, taskId),
-      contextRoot
-    );
-  }
-
-  _findTaskParent(taskId: TaskId, node: TaskNode = this._taskRoot): TaskNode {
-    for (const child of node.children.values()) {
-      if (taskId.startsWith(child.id)) {
-        return this._findTaskParent(taskId, child);
-      }
-    }
-    return node;
-  }
+function fromTaskId(id: TaskId): RootedTaskId {
+  return id.split(": ");
 }

--- a/src/util/taskManager.js
+++ b/src/util/taskManager.js
@@ -19,20 +19,18 @@ export type TaskNode = {|
  * maintain their own task state for internal use. The primary concern of
  * the manager is creating and enforcing task scopes via a tree structure.
  *
- * Motivation
- * When a plugin task needs to be terminated in the load command, it is
- * important that all child tasks also are terminated in case a restart of the
- * task is necessary. A well-behaved plugin should terminate all tasks it
- * spawns on its own, but in the case of a cache error or other unexpected
- * error, this class makes it possible to quickly find and safely terminate all
- * child tasks.
- *
  * Scopes
- * A plugin can safely manage its own subset of tasks through the use of
- * TaskManager.prototype.createScope. An existing TaskId can be passed in to
- * create new TaskManager instance that has the plugin task as root, allowing
- * the plugin context to manage its own tasks without the possiblity of
- * terminating any out-of-scope tasks, or its own root process.
+ * A parent task can safely manage its own subset of tasks through the use of
+ * scopes. TaskManager.prototype.start returns a new new TaskManager instance
+ * that is rooted on the newly created task. For this reason, TaskManager does not
+ * implement the TaskReporter interface.
+ *
+ * Motivation
+ * When a task needs to be terminated, it is important that all its child tasks
+ * also finish, especially the in the case of a restart. A well-behaved task should
+ * terminate all tasks it spawns within its own context, but in the case of an
+ * unexpected error, this class makes it possible to quickly find and safely terminate
+ * all child tasks.
  */
 export class TaskManager {
   _taskRoot: TaskNode;

--- a/src/util/taskManager.js
+++ b/src/util/taskManager.js
@@ -44,7 +44,7 @@ export class TaskManager {
   }
 
   finish(id: TaskId): this {
-    this._finishTask(id, this);
+    this._finishTask(id);
     return this;
   }
 
@@ -59,20 +59,19 @@ export class TaskManager {
     return newTask;
   }
 
-  _finishTask(idToKill: TaskId, parent: TaskManager) {
-    const tasktoKill = parent._findTask(idToKill);
+  _finishTask(idToKill: TaskId) {
+    const tasktoKill = this._findTask(idToKill);
     if (!tasktoKill) {
       throw new Error(`Task ${idToKill} not registered`);
     }
-    this._finishChildren(tasktoKill);
-    parent._children.delete(idToKill);
-    parent._reporter.finish(idToKill);
+    tasktoKill._finishChildren();
+    this._children.delete(idToKill);
+    this._reporter.finish(idToKill);
   }
 
-  _finishChildren(task: TaskManager) {
-    const children = Array.from(task._children.keys());
-    for (const id of children) {
-      this._finishTask(id, task);
+  _finishChildren() {
+    for (const id of this._children.keys()) {
+      this._finishTask(id);
     }
   }
 }

--- a/src/util/taskManager.js
+++ b/src/util/taskManager.js
@@ -1,0 +1,158 @@
+// @flow
+
+import {
+  type TaskId,
+  type TaskReporter,
+  ScopedTaskReporter,
+} from "./taskReporter";
+
+type TaskNode = {|
+  id: TaskId,
+  children: Map<TaskId, TaskNode>,
+|};
+
+/**
+ * TaskManager organizes and maintains a hierarchy of active tasks
+ *
+ * It utilizes TaskReporters internally for logging, and allows them to
+ * maintain their own task state for internal use. The primary concern of
+ * the manager is creating and enforcing task scopes via a tree structure.
+ * When a plugin task needs to be terminated in the load command, it is important
+ * that all child tasks also are terminated in case a restart of the task is
+ * necessary. A well-behaved plugin should terminate all tasks it spawns on its own,
+ * but in the case of a cache error or other unexpected error, this class makes it
+ * possible to quickly find and terminate all child tasks.
+ */
+
+export class TaskManager {
+  _activeTaskRoot: TaskNode;
+  reporter: TaskReporter;
+
+  constructor(reporter: TaskReporter) {
+    this.reporter = reporter;
+    this._activeTaskRoot = {
+      id: "",
+      children: new Map(),
+    };
+  }
+
+  start(taskId: TaskId) {
+    if (this.findTask(taskId)) {
+      throw new Error(`task ${taskId} already registered`);
+    }
+    this._createTask(taskId);
+    return this;
+  }
+
+  finish(taskId: TaskId) {
+    this._findandFinishTask(taskId);
+    return this;
+  }
+
+  _createTask(taskId: TaskId, startRoot: TaskNode = this._activeTaskRoot) {
+    const newTask = {
+      id: taskId,
+      children: new Map(),
+    };
+    const parent = this._findTaskParent(taskId, startRoot);
+    parent.children.set(taskId, newTask);
+    this.reporter.start(taskId);
+  }
+
+  _findandFinishTask(
+    taskId: TaskId,
+    node: TaskNode = this._activeTaskRoot,
+    parent: ?TaskNode
+  ) {
+    if (node.id === taskId) {
+      if (!parent) {
+        throw new Error("Cannot kill root task");
+      }
+      parent.children.delete(taskId);
+      this._finishTask(node);
+      return;
+    }
+    let taskMightExist = false;
+    for (const child of node.children.values()) {
+      if (taskId.startsWith(child.id)) {
+        taskMightExist = true;
+        this._findandFinishTask(taskId, child, node);
+      }
+    }
+    if (!taskMightExist) {
+      throw new Error(`Task ${taskId} not registered`);
+    }
+  }
+
+  _finishTask(task: TaskNode) {
+    this._finishChildren(task);
+    task.children.delete(task.id);
+    this.reporter.finish(task.id);
+  }
+
+  _finishChildren(task: TaskNode) {
+    const children = Array.from(task.children.values());
+    for (const child of children) {
+      this._finishTask(child);
+    }
+  }
+
+  findTask(taskId: TaskId, node: TaskNode = this._activeTaskRoot): ?TaskNode {
+    if (node.id === taskId) {
+      return node;
+    }
+    for (const child of node.children.values()) {
+      if (taskId.startsWith(child.id)) {
+        return this.findTask(taskId, child);
+      }
+    }
+  }
+
+  createScope(taskId: TaskId): ScopedTaskManager {
+    const contextRoot = this.findTask(taskId);
+    if (!contextRoot) {
+      throw new Error(`task ${taskId} does not exist`);
+    }
+    return new ScopedTaskManager(this, contextRoot);
+  }
+
+  _findTaskParent(
+    taskId: TaskId,
+    node: TaskNode = this._activeTaskRoot
+  ): TaskNode {
+    for (const child of node.children.values()) {
+      if (taskId.startsWith(child.id)) {
+        return this._findTaskParent(taskId, child);
+      }
+    }
+    return node;
+  }
+}
+
+export class ScopedTaskManager {
+  _mgr: TaskManager;
+  _subRoot: TaskNode;
+  reporter: ScopedTaskReporter;
+
+  constructor(parentManager: TaskManager, scopedRoot: TaskNode) {
+    this._subRoot = scopedRoot;
+    this._mgr = parentManager;
+  }
+
+  start(taskId: TaskId) {
+    const fullId = this._scoped(taskId);
+    if (this._mgr.findTask(fullId)) {
+      throw new Error(`task ${fullId} already registered`);
+    }
+    this._mgr._createTask(fullId, this._subRoot);
+  }
+
+  finish(taskId: TaskId) {
+    const fullId = this._scoped(taskId);
+    this._mgr._findandFinishTask(fullId, this._subRoot);
+  }
+
+  _scoped(taskId: TaskId): TaskId {
+    return `${this._subRoot.id}: ${taskId}`;
+  }
+}

--- a/src/util/taskManager.test.js
+++ b/src/util/taskManager.test.js
@@ -1,6 +1,6 @@
 // @flow
 
-import {TaskManager, createNode as createTaskNode} from "./taskManager";
+import {TaskManager} from "./taskManager";
 
 import {SilentTaskReporter} from "./taskReporter";
 
@@ -10,11 +10,10 @@ describe("util/taskManager", () => {
     reporter: SilentTaskReporter;
     constructor() {
       this.reporter = new SilentTaskReporter();
-      this.taskManager = new TaskManager(createTaskNode(this.reporter));
+      this.taskManager = new TaskManager(this.reporter);
     }
-    start(task: string) {
-      this.taskManager.start(task);
-      return this;
+    start(task: string): TaskManager {
+      return this.taskManager.start(task);
     }
     finish(task: string) {
       this.taskManager.finish(task);
@@ -26,19 +25,26 @@ describe("util/taskManager", () => {
     expect(fail).toThrowError("Task foo not registered");
   });
   it("errors when starting a a task twice", () => {
-    const fail = () => new TestCase().start("foo").start("foo");
+    const testCase = new TestCase();
+    testCase.start("foo");
+    const fail = () => testCase.start("foo");
     expect(fail).toThrow("Task foo already registered");
   });
   it("errors when finishing a task twice", () => {
-    const fail = () => new TestCase().start("foo").finish("foo").finish("foo");
+    const testCase = new TestCase();
+    testCase.start("foo");
+    testCase.finish("foo");
+    const fail = () => testCase.finish("foo");
     expect(fail).toThrow("Task foo not registered");
   });
   it("works when a parent task is started with a child and finishes, terminating both tasks", () => {
-    const testCase = new TestCase().start("foo");
+    const testCase = new TestCase();
+    const fooScope = testCase.start("foo");
     expect(testCase.reporter.entries()).toEqual([
       {"taskId": "foo", "type": "START"},
     ]);
-    testCase.start("foo: test").finish("foo");
+    fooScope.start("test");
+    testCase.finish("foo");
     expect(testCase.reporter.entries()).toEqual([
       {"taskId": "foo", "type": "START"},
       {"taskId": "foo: test", "type": "START"},
@@ -47,58 +53,38 @@ describe("util/taskManager", () => {
     ]);
   });
   it("works when a child task starts and finishes", () => {
-    const testCase = new TestCase().start("foo");
+    const testCase = new TestCase();
+    const fooScope = testCase.start("foo");
     expect(testCase.reporter.entries()).toEqual([
       {"taskId": "foo", "type": "START"},
     ]);
-    testCase.start("foo: test").finish("foo: test");
+    fooScope.start("test");
+    fooScope.finish("test");
     expect(testCase.reporter.entries()).toEqual([
       {"taskId": "foo", "type": "START"},
       {"taskId": "foo: test", "type": "START"},
       {"taskId": "foo: test", "type": "FINISH"},
     ]);
   });
-  describe("task creation order", () => {
-    const case0 = new TestCase().start("fo").start("fo: foo");
-    const case1 = new TestCase().start("foo").start("foo: fo: f");
-    it("cannot start duplicate tasks beyond root level", () => {
-      const fails = [
-        {task: "fo: foo", err: () => case0.start("fo: foo")},
-        {task: "foo: fo", err: () => case1.start("foo: fo")},
-      ];
-      fails.forEach(({task, err}) => {
-        expect(err).toThrow(`Task ${task} already registered`);
-      });
-    });
-    it("can finish tasks in below the root level", () => {
-      case0.finish("fo");
-      case1.finish("foo: fo").finish("foo");
-      expect(case0.taskManager._taskRoot.children).toEqual(new Map());
-      expect(case1.taskManager._taskRoot.children).toEqual(new Map());
-    });
-  });
 
   describe("Scoped TaskManager", () => {
     it("cannot create scope on nonexistent task", () => {});
     it("cannot terminate tasks outside of scope", () => {
       const testCase = new TestCase();
-      testCase.start("ctx1");
+      const scoped = testCase.start("ctx1");
       testCase.start("ct");
-      const scoped = testCase.taskManager.createScope("ctx1");
       const fail = () => scoped.finish("ct");
       expect(fail).toThrow("Task ct not registered");
     });
     it("cannot terminate scope root", () => {
       const testCase = new TestCase();
-      testCase.start("ctx1");
-      const scoped = testCase.taskManager.createScope("ctx1");
+      const scoped = testCase.start("ctx1");
       const fail = () => scoped.finish("");
       expect(fail).toThrow("Task  not registered");
     });
     it("can create and and finish tasks", () => {
       const testCase = new TestCase();
-      testCase.start("ctx1");
-      const scoped = testCase.taskManager.createScope("ctx1");
+      const scoped = testCase.start("ctx1");
       scoped.start("test");
       expect(testCase.reporter.entries()).toEqual([
         {

--- a/src/util/taskManager.test.js
+++ b/src/util/taskManager.test.js
@@ -76,8 +76,8 @@ describe("util/taskManager", () => {
     const case0 = new TestCase().start("fo").start("foo");
     const case1 = new TestCase().start("foo").start("fo");
     it("creates new branches when a potential parent is added after children", () => {
-      expect(case0.taskManager._activeTaskRoot).not.toEqual(
-        case1.taskManager._activeTaskRoot
+      expect(case0.taskManager._taskRoot).not.toEqual(
+        case1.taskManager._taskRoot
       );
     });
     it("cannot start duplicate tasks when tree diverges", () => {
@@ -89,8 +89,8 @@ describe("util/taskManager", () => {
     it("can finish tasks in divergent trees", () => {
       case0.finish("fo");
       case1.finish("fo").finish("foo");
-      expect(case0.taskManager._activeTaskRoot.children).toEqual(new Map());
-      expect(case1.taskManager._activeTaskRoot.children).toEqual(new Map());
+      expect(case0.taskManager._taskRoot.children).toEqual(new Map());
+      expect(case1.taskManager._taskRoot.children).toEqual(new Map());
     });
   });
 
@@ -101,14 +101,14 @@ describe("util/taskManager", () => {
       testCase.start("ct");
       const scoped = testCase.taskManager.createScope("ctx1");
       const fail = () => scoped.finish("ct");
-      expect(fail).toThrow("Task ctx1: ct not registered");
+      expect(fail).toThrow("Task ct not registered");
     });
     it("cannot terminate scope root", () => {
       const testCase = new TestCase();
       testCase.start("ctx1");
       const scoped = testCase.taskManager.createScope("ctx1");
       const fail = () => scoped.finish("");
-      expect(fail).toThrow("Task ctx1:  not registered");
+      expect(fail).toThrow("Task  not registered");
     });
     it("can create and and finish tasks", () => {
       const testCase = new TestCase();

--- a/src/util/taskManager.test.js
+++ b/src/util/taskManager.test.js
@@ -68,7 +68,6 @@ describe("util/taskManager", () => {
   });
 
   describe("Scoped TaskManager", () => {
-    it("cannot create scope on nonexistent task", () => {});
     it("cannot terminate tasks outside of scope", () => {
       const testCase = new TestCase();
       const scoped = testCase.start("ctx1");

--- a/src/util/taskManager.test.js
+++ b/src/util/taskManager.test.js
@@ -1,0 +1,145 @@
+// @flow
+
+import {TaskManager} from "./taskManager";
+
+import {SilentTaskReporter} from "./taskReporter";
+
+describe("util/taskManager", () => {
+  class TestCase {
+    taskManager: TaskManager;
+    reporter: SilentTaskReporter;
+    constructor() {
+      this.reporter = new SilentTaskReporter();
+      this.taskManager = new TaskManager(this.reporter);
+    }
+    start(task: string) {
+      this.taskManager.start(task);
+      return this;
+    }
+    finish(task: string) {
+      this.taskManager.finish(task);
+      return this;
+    }
+  }
+  it("errors when finishing an unregistered task", () => {
+    const fail = () => new TestCase().finish("foo");
+    expect(fail).toThrowError("Task foo not registered");
+  });
+  it("errors when starting a a task twice", () => {
+    const fail = () => new TestCase().start("foo").start("foo");
+    expect(fail).toThrow("task foo already registered");
+  });
+  it("errors when finishing a task twice", () => {
+    const fail = () => new TestCase().start("foo").finish("foo").finish("foo");
+    expect(fail).toThrow("Task foo not registered");
+  });
+  it("works for a task that immediately finishes", () => {
+    const {reporter} = new TestCase().start("foo").finish("foo");
+    //expect(reporter.entries()).toEqual(["derp"]);
+    expect(reporter.entries()).toEqual([
+      {
+        "taskId": "foo",
+        "type": "START",
+      },
+      {
+        "taskId": "foo",
+        "type": "FINISH",
+      },
+    ]);
+  });
+  it("works when a parent task is started with a child and finishes, terminating both tasks", () => {
+    const testCase = new TestCase().start("foo");
+    expect(testCase.reporter.entries()).toEqual([
+      {"taskId": "foo", "type": "START"},
+    ]);
+    testCase.start("foo: test").finish("foo");
+    expect(testCase.reporter.entries()).toEqual([
+      {"taskId": "foo", "type": "START"},
+      {"taskId": "foo: test", "type": "START"},
+      {"taskId": "foo: test", "type": "FINISH"},
+      {"taskId": "foo", "type": "FINISH"},
+    ]);
+  });
+  it("works when a child task starts and finishes", () => {
+    const testCase = new TestCase().start("foo");
+    expect(testCase.reporter.entries()).toEqual([
+      {"taskId": "foo", "type": "START"},
+    ]);
+    testCase.start("foo: test").finish("foo: test");
+    expect(testCase.reporter.entries()).toEqual([
+      {"taskId": "foo", "type": "START"},
+      {"taskId": "foo: test", "type": "START"},
+      {"taskId": "foo: test", "type": "FINISH"},
+    ]);
+  });
+  describe("task creation order", () => {
+    const case0 = new TestCase().start("fo").start("foo");
+    const case1 = new TestCase().start("foo").start("fo");
+    it("creates new branches when a potential parent is added after children", () => {
+      expect(case0.taskManager._activeTaskRoot).not.toEqual(
+        case1.taskManager._activeTaskRoot
+      );
+    });
+    it("cannot start duplicate tasks when tree diverges", () => {
+      const fails = [() => case0.start("foo"), () => case1.start("foo")];
+      fails.forEach((fail) => {
+        expect(fail).toThrow("task foo already registered");
+      });
+    });
+    it("can finish tasks in divergent trees", () => {
+      case0.finish("fo");
+      case1.finish("fo").finish("foo");
+      expect(case0.taskManager._activeTaskRoot.children).toEqual(new Map());
+      expect(case1.taskManager._activeTaskRoot.children).toEqual(new Map());
+    });
+  });
+
+  describe("ScopedTaskManager", () => {
+    it("cannot terminate tasks outside of scope", () => {
+      const testCase = new TestCase();
+      testCase.start("ctx1");
+      testCase.start("ct");
+      const scoped = testCase.taskManager.createScope("ctx1");
+      const fail = () => scoped.finish("ct");
+      expect(fail).toThrow("Task ctx1: ct not registered");
+    });
+    it("cannot terminate scope root", () => {
+      const testCase = new TestCase();
+      testCase.start("ctx1");
+      const scoped = testCase.taskManager.createScope("ctx1");
+      const fail = () => scoped.finish("");
+      expect(fail).toThrow("Task ctx1:  not registered");
+    });
+    it("can create and and finish tasks", () => {
+      const testCase = new TestCase();
+      testCase.start("ctx1");
+      const scoped = testCase.taskManager.createScope("ctx1");
+      scoped.start("test");
+      expect(testCase.reporter.entries()).toEqual([
+        {
+          "taskId": "ctx1",
+          "type": "START",
+        },
+        {
+          "taskId": "ctx1: test",
+          "type": "START",
+        },
+      ]);
+      scoped.finish("test");
+      expect(testCase.reporter.entries()).toEqual([
+        {
+          "taskId": "ctx1",
+          "type": "START",
+        },
+        {
+          "taskId": "ctx1: test",
+          "type": "START",
+        },
+        {
+          "taskId": "ctx1: test",
+          "type": "FINISH",
+        },
+      ]);
+    });
+  });
+});

--- a/src/util/taskReporter.js
+++ b/src/util/taskReporter.js
@@ -2,7 +2,7 @@
 
 const chalk = require("chalk");
 
-type TaskId = string;
+export type TaskId = string;
 
 type MsSinceEpoch = number;
 type ConsoleLog = (string) => void;


### PR DESCRIPTION
TaskManager organizes and maintains a hierarchy of active tasks

It utilizes TaskReporters internally for logging, and allows them to
maintain their own task state for internal use. The primary concern of
the manager is creating and enforcing task scopes via a tree structure.
When a plugin task needs to be terminated in the load CLI command, it is important
that all child tasks also are terminated in case a restart of the task is
necessary. A well-behaved plugin should terminate all tasks it spawns on its own,
but in the case of a cache error or other unexpected error, this class makes it
possible to quickly find and terminate all child tasks.

paired with: @decentralion 
paired with: @wchargin 

test plan: unit tests are provided