### PR TITLE
Add site CLI call inside serve command

### DIFF
--- a/src/cli/serve.js
+++ b/src/cli/serve.js
@@ -1,8 +1,10 @@
 // @flow
 
+import type {$Response as ExpressResponse} from "express";
+
 import type {Command} from "./command";
 import {loadInstanceConfig} from "./common";
-import type {$Response as ExpressResponse} from "express";
+import site from "./site";
 
 const fs = require("fs");
 const express = require("express");
@@ -13,6 +15,10 @@ function die(std, message) {
 }
 
 const adminCommand: Command = async (args, std) => {
+  const returnVal = await site([], std);
+  if (returnVal !== 0) {
+    return die(std, `site: SourceCred site instance failed to update`);
+  }
   const basedir = process.cwd();
   // check to ensure service is running within an instance directory
   await loadInstanceConfig(basedir);

--- a/src/cli/serve.js
+++ b/src/cli/serve.js
@@ -4,7 +4,7 @@ import type {$Response as ExpressResponse} from "express";
 
 import type {Command} from "./command";
 import {loadInstanceConfig} from "./common";
-import site from "./site";
+import siteCommand from "./site";
 
 const fs = require("fs");
 const express = require("express");
@@ -14,8 +14,8 @@ function die(std, message) {
   return 1;
 }
 
-const adminCommand: Command = async (args, std) => {
-  const returnVal = await site([], std);
+const serveCommand: Command = async (args, std) => {
+  const returnVal = await siteCommand([], std);
   if (returnVal !== 0) {
     return die(std, `site: SourceCred site instance failed to update`);
   }
@@ -59,4 +59,4 @@ const adminCommand: Command = async (args, std) => {
   return 0;
 };
 
-export default adminCommand;
+export default serveCommand;


### PR DESCRIPTION
small quality-of-life improvement to make local administration easier

test plan: `yarn serve` on an instance with stale site build