### PR TITLE
taskReporter: report milliseconds for tasks under 10s

### DIFF
--- a/src/util/taskReporter.js
+++ b/src/util/taskReporter.js
@@ -157,7 +157,7 @@ export function formatTimeElapsed(elapsed: MsSinceEpoch): string {
   if (elapsed < 0) {
     throw new Error("nonegative time expected");
   }
-  if (elapsed < 1000) {
+  if (elapsed < 10 * 1000) {
     return `${elapsed}ms`;
   }
   const seconds = Math.round(elapsed / 1000);

--- a/src/util/taskReporter.test.js
+++ b/src/util/taskReporter.test.js
@@ -20,8 +20,12 @@ describe("util/taskReporter", () => {
     tc("50ms", 50);
     tc("999ms", 999);
     const secs = 1000;
-    tc("1s", 1 * secs + 400);
-    tc("2s", 1 * secs + 600);
+    tc("1000ms", 1 * secs);
+    tc("1001ms", 1 * secs + 1);
+    tc("9999ms", 9 * secs + 999);
+    tc("10s", 10 * secs);
+    tc("10s", 10 * secs + 400);
+    tc("11s", 10 * secs + 600);
     tc("59s", 59 * secs);
     const mins = secs * 60;
     tc("1m 3s", mins + 3 * secs);


### PR DESCRIPTION
Summary:
In particular, since we round to the nearest second, tasks around 1.5s
have large variance when rounded to either 1 or 2 seconds.

Paired with @decentralion.

Test Plan:
Running `sourcecred credrank` now reports ~1661ms for creating a Markov
process graph on my machine.

wchargin-branch: taskreporter-ms-under10
