### PR TITLE
Add no-load flag to go CLI command

### DIFF
--- a/src/cli/go.js
+++ b/src/cli/go.js
@@ -11,22 +11,24 @@ function die(std, message) {
   return 1;
 }
 
-const noLoadArg = "--no-load";
+const NO_LOAD_ARG = "--no-load";
 
 const goCommand: Command = async (args, std) => {
+  let noLoad = false;
+  if (args.length === 1 && args[0] === NO_LOAD_ARG) {
+    noLoad = true;
+  } else if (args.length !== 0) {
+    return die(std, "usage: sourcecred go [--no-load]");
+  }
+
   const commandSequence = [
     {name: "load", command: load},
     {name: "graph", command: graph},
     {name: "score", command: score},
   ];
 
-  if (args.length === 1 && args[0] === noLoadArg) {
-    commandSequence.shift();
-  } else if (args.length !== 0) {
-    return die(std, "usage: sourcecred go [--no-load]");
-  }
-
   for (const {name, command} of commandSequence) {
+    if (name === "load" && noLoad) continue;
     const ret = await command([], std);
     if (ret !== 0) {
       return die(std, `go: failed on command ${name}`);

--- a/src/cli/go.js
+++ b/src/cli/go.js
@@ -11,15 +11,21 @@ function die(std, message) {
   return 1;
 }
 
+const noLoadArg = "--no-load";
+
 const goCommand: Command = async (args, std) => {
-  if (args.length !== 0) {
-    return die(std, "usage: sourcecred go");
-  }
   const commandSequence = [
     {name: "load", command: load},
     {name: "graph", command: graph},
     {name: "score", command: score},
   ];
+
+  if (args.length === 1 && args[0] === noLoadArg) {
+    commandSequence.shift();
+  } else if (args.length !== 0) {
+    return die(std, "usage: sourcecred go [--no-load]");
+  }
+
   for (const {name, command} of commandSequence) {
     const ret = await command([], std);
     if (ret !== 0) {


### PR DESCRIPTION
Now the load step can be skipped if desired, without using lower-level
commands.

test plan: `path/to/local/build/of/sourcecred.js go` to ensure no regressions,  
`... go --no-load`, and
`path/to/local/build/of/sourcecred.js go --bad-flag` to ensure extraneous
arguments cause the command to throw