### PR TITLE
Fix small errors from cache-clearing step changes

### DIFF
--- a/src/cli/load.js
+++ b/src/cli/load.js
@@ -61,20 +61,24 @@ const loadCommand: Command = async (args, std) => {
         .then(() => taskReporter.finish(task));
 
     const endChildRunners = () => {
-      const prefixRegex = new RegExp("^" + name);
       // create static array of taskIds from activeTasks map
       Array.from(taskReporter.activeTasks.keys())
-        .filter((taskId) => prefixRegex.test(taskId))
+        .filter((taskId) => taskId.startsWith(name))
         .forEach((taskId: string) => {
-          console.log("[debug] killing: ", taskId);
           taskReporter.finish(taskId);
-          warn(std, taskId, "Retrying");
+          warn(std, taskId, "Parent task restarting. Retrying");
         });
     };
 
     const restartParentRunner = (error: string) => {
       taskReporter.finish(task);
-      warn(std, task, `${error}; clearing cache`);
+      warn(
+        std,
+        task,
+        `Error updating cache. clearing cache and restarting.
+        This is the error from the plugin:\n
+        ${error}`
+      );
       taskReporter.start(task);
     };
 


### PR DESCRIPTION
- remove debug logs
- add detail to warning logs
- change regex to use startsWith instead

test plan: `yarn load`
`sqlite3 ./cache/sourcecred/github/*.db "UPDATE meta SET config = 'bad'"`
`yarn load`