### PR TITLE
credrank: enumerate scoring addresses explicitly

### DIFF
--- a/src/cli/credrank.js
+++ b/src/cli/credrank.js
@@ -5,6 +5,7 @@ import stringify from "json-stable-stringify";
 import {join as pathJoin} from "path";
 
 import {credrank} from "../core/algorithm/credrank";
+import {NodeAddress, type Graph, type NodeAddressT} from "../core/graph";
 import {LoggingTaskReporter} from "../util/taskReporter";
 import {MarkovProcessGraph} from "../core/markovProcessGraph";
 import type {Command} from "./command";
@@ -55,8 +56,9 @@ const credrankCommand: Command = async (args, std) => {
   taskReporter.start("create Markov process graph");
   // TODO: Support loading transition probability params from config.
   const fibrationOptions = {
-    what: [].concat(
-      ...declarations.map((d) => d.userTypes.map((t) => t.prefix))
+    scoringAddresses: findScoringAddresses(
+      wg.graph,
+      [].concat(...declarations.map((d) => d.userTypes.map((t) => t.prefix)))
     ),
     beta: DEFAULT_BETA,
     gammaForward: DEFAULT_GAMMA_FORWARD,
@@ -80,5 +82,19 @@ const credrankCommand: Command = async (args, std) => {
 
   return 0;
 };
+
+/** Find addresses of all nodes matching any of the scoring prefixes. */
+function findScoringAddresses(
+  graph: Graph,
+  scoringPrefixes: $ReadOnlyArray<NodeAddressT>
+): Set<NodeAddressT> {
+  const result = new Set();
+  for (const {address} of graph.nodes()) {
+    if (scoringPrefixes.some((p) => NodeAddress.hasPrefix(address, p))) {
+      result.add(address);
+    }
+  }
+  return result;
+}
 
 export default credrankCommand;

--- a/src/core/markovProcessGraph.js
+++ b/src/core/markovProcessGraph.js
@@ -61,7 +61,6 @@ import {
   NodeAddress,
   type EdgeAddressT,
   EdgeAddress,
-  type Graph,
 } from "./graph";
 import {type WeightedGraph as WeightedGraphT} from "./weightedGraph";
 import {

--- a/src/core/markovProcessGraph.js
+++ b/src/core/markovProcessGraph.js
@@ -229,10 +229,8 @@ const CONTRIBUTION_RADIATION = EdgeAddress.fromParts([
 const SEED_MINT = EdgeAddress.fromParts(["sourcecred", "core", "SEED_MINT"]);
 
 export type FibrationOptions = {|
-  // List of node prefixes for temporal fibration. A node with address
-  // `a` will be fibrated if `NodeAddress.hasPrefix(a, prefix)` for some
-  // element `prefix` of `what`.
-  +what: $ReadOnlyArray<NodeAddressT>,
+  // Set of node addresses for temporal fibration.
+  +scoringAddresses: Set<NodeAddressT>,
   // Transition probability for payout edges from epoch nodes to their
   // owners.
   +beta: TransitionProbability,
@@ -275,7 +273,7 @@ export class MarkovProcessGraph {
   ) {
     const _nodes = new Map();
     const _edges = new Map();
-    const _scoringAddresses = _findScoringAddresses(wg.graph, fibration.what);
+    const _scoringAddresses = new Set(fibration.scoringAddresses);
 
     // _nodeOutMasses[a] = sum(e.pr for e in edges if e.src == a)
     // Used for computing remainder-to-seed edges.
@@ -683,18 +681,4 @@ export class MarkovProcessGraph {
       new Set(data.scoringAddresses)
     );
   }
-}
-
-/** Find addresses of all nodes matching any of the scoring prefixes. */
-function _findScoringAddresses(
-  graph: Graph,
-  scoringPrefixes: $ReadOnlyArray<NodeAddressT>
-): Set<NodeAddressT> {
-  const result = new Set();
-  for (const {address} of graph.nodes()) {
-    if (scoringPrefixes.some((p) => NodeAddress.hasPrefix(address, p))) {
-      result.add(address);
-    }
-  }
-  return result;
 }


### PR DESCRIPTION
Summary:
Prior to this change, the Markov process graph took a list of node
address prefixes to determine the scoring addresses. It now takes a set
of scoring addresses directly. This is more flexible, since it enables
specifying as scoring nodes a proper subset of the nodes of a given
type.

Test Plan:
Running `sourcecred credrank` on the SourceCred cred instance outputs an
identical `output/credGraph.json` before and after this change.

wchargin-branch: credrank-enumerate-scoring-nodes
