### PR TITLE
credrank: use identities as scoring nodes

### DIFF
--- a/src/core/markovProcessGraph.js
+++ b/src/core/markovProcessGraph.js
@@ -72,6 +72,7 @@ import * as NullUtil from "../util/null";
 import * as MapUtil from "../util/map";
 import type {TimestampMs} from "../util/timestamp";
 import {type SparseMarkovChain} from "./algorithm/markovChain";
+import {IDENTITY_PREFIX} from "../ledger/identity/identity";
 
 export type TransitionProbability = number;
 
@@ -347,7 +348,10 @@ export class MarkovProcessGraph {
         const name = NodeAddress.toString(node.address);
         throw new Error(`Bad node weight for ${name}: ${weight}`);
       }
-      if (NodeAddress.hasPrefix(node.address, CORE_NODE_PREFIX)) {
+      if (
+        NodeAddress.hasPrefix(node.address, CORE_NODE_PREFIX) &&
+        !NodeAddress.hasPrefix(node.address, IDENTITY_PREFIX)
+      ) {
         throw new Error(
           "Unexpected core node in underlying graph: " +
             NodeAddress.toString(node.address)
@@ -550,7 +554,10 @@ export class MarkovProcessGraph {
         NodeAddress.hasPrefix(node.address, EPOCH_ACCUMULATOR_PREFIX)
       ) {
         type = EPOCH_ACCUMULATOR_RADIATION;
-      } else if (NodeAddress.hasPrefix(node.address, CORE_NODE_PREFIX)) {
+      } else if (
+        NodeAddress.hasPrefix(node.address, CORE_NODE_PREFIX) &&
+        !NodeAddress.hasPrefix(node.address, IDENTITY_PREFIX)
+      ) {
         throw new Error(
           "invariant violation: unknown core node: " +
             NodeAddress.toString(node.address)


### PR DESCRIPTION
Summary:
This patch builds on #2280, and defines the set of scoring nodes to be
exactly those identities known to the ledger. The CLI code is yoinked
from `score.js`.

Test Plan:
Running CredRank on SourceCred’s own cred, as configured at:
<https://github.com/sourcecred/cred>

…and swiss-army-knifing a bit with `jq(1)`:

```
$ <output/credResult.json jq '
    . as $root | .[1].credData.nodeSummaries as $ns
    | $ns | keys | map({k: ., v: $ns[.]})
    | sort_by(-.v.cred)
    | .[:10]
    | map(
        {
            who: $root[1].weightedGraph[1].graphJSON[1].nodes[.k].description,
            cred: .v.cred,
        }
        | {(.who): .cred}
    )
    | add
'
```

…we see data that closely matches the [live cred instance][live]:

```
{
  "decentralion": 22946.889743358242,
  "[sourcecred/sourcecred](https://github.com/sourcecred/sourcecred)": 13593.889942342785,
  "wchargin": 11005.05826894236,
  "beanow": 5842.940309531616,
  "lbstrobbe": 4080.3695547690318,
  "s-ben": 4025.0487034512935,
  "hammad": 3127.664458806897,
  "burrrata": 1698.7993086795168,
  "mzargham": 1220.660754468257,
  "bex": 1069.149977323768
}
```

The numbers shouldn’t be expected to match exactly, because the
algorithms are different (CredRank vs. timeline cred). What’s salient
here is that the shape is “approximately right” and that the identity
nodes are correctly making it into the graph.

[live]: https://cred.sourcecred.io/

wchargin-branch: credrank-identity-scoring-nodes
