### PR TITLE
Set default period if it doesn't exist in dependenciesConfig

### DIFF
--- a/sharness/__snapshots__/test-instance/config/dependencies.json
+++ b/sharness/__snapshots__/test-instance/config/dependencies.json
@@ -1,6 +1,7 @@
 [
     {
         "autoActivateOnIdentityCreation": true,
+        "autoInjectStartingPeriodWeight": 0.05,
         "id": "2zWwkGHnBGXmEcYneeWAzw",
         "name": "SourceCred",
         "periods": [{"startTime": "2019-01-01", "weight": 0.05}]

--- a/src/api/dependenciesConfig.js
+++ b/src/api/dependenciesConfig.js
@@ -90,7 +90,7 @@ export type DependencyConfig = {|
   +autoActivateOnIdentityCreation?: boolean,
 
   // If this is set, then a default time period will be injected in the
-  // dependency config with the weight set to this value (e.g. 0.05 = 5% of total cred).
+  // dependency config with the weight set to this value (e.g. 0.05 = 5% additional cred minted).
   // (Mostly included so we can have SourceCred receiving cred by default)
   // Does not inject a starting period if unset.
   +autoInjectStartingPeriodWeight?: number,
@@ -107,8 +107,7 @@ export const mintPeriodParser: C.Parser<MintPeriod> = C.object({
 });
 
 function checkWeightValid(x: number): number {
-  if (x > 1 || x < 0)
-    throw new Error(`must be a number between 0 and 1, got ${x}`);
+  if (x < 0) throw new Error(`must be a non-negative number, got ${x}`);
   return x;
 }
 
@@ -149,7 +148,6 @@ export function ensureIdentityExists(
       }
       const weight = dep.autoInjectStartingPeriodWeight;
       if (weight != null && !dep.periods.length) {
-        // Set default start period to one week from adding the dependency
         return {
           ...dep,
           id,

--- a/src/api/dependenciesConfig.js
+++ b/src/api/dependenciesConfig.js
@@ -48,6 +48,7 @@ import {
   type TimestampISO,
   timestampISOParser,
   fromISO,
+  toISO,
 } from "../util/timestamp";
 import {type IdentityId, type Name, nameParser} from "../ledger/identity";
 import {parser as uuidParser} from "../util/uuid";
@@ -94,6 +95,8 @@ export type MintPeriod = {|
   +weight: number,
 |};
 
+const ONE_WEEK_IN_MS = 7 * 24 * 60 * 60 * 1000;
+
 export const mintPeriodParser: C.Parser<MintPeriod> = C.object({
   startTime: timestampISOParser,
   weight: C.number,
@@ -132,6 +135,16 @@ export function ensureIdentityExists(
       const id = ledger.createIdentity("PROJECT", dep.name);
       if (dep.autoActivateOnIdentityCreation) {
         ledger.activate(id);
+      }
+      if (!dep.periods.length) {
+        // Set default start period to one week from adding the dependency
+        return {
+          ...dep,
+          id,
+          periods: [
+            {"startTime": toISO(Date.now() + ONE_WEEK_IN_MS), "weight": 0.05},
+          ],
+        };
       }
       return {...dep, id};
     }

--- a/src/api/dependenciesConfig.test.js
+++ b/src/api/dependenciesConfig.test.js
@@ -70,7 +70,7 @@ describe("api/dependenciesConfig", () => {
       expect(periods[0].weight).toBe(autoInjectStartingPeriodWeight);
       expect(fromISO(periods[0].startTime)).toBe(fakeNow);
     });
-    it("does not inject default period if it already exists", () => {
+    it("does not inject default period if any period already exists", () => {
       const ledger = new Ledger();
       const config = {
         name: n("foo"),

--- a/src/api/dependenciesConfig.test.js
+++ b/src/api/dependenciesConfig.test.js
@@ -4,7 +4,7 @@ import {Ledger} from "../ledger/ledger";
 import {toDependencyPolicy, ensureIdentityExists} from "./dependenciesConfig";
 import {nameFromString as n} from "../ledger/identity";
 import {random as randomUuid} from "../util/uuid";
-import {fromISO, validateTimestampISO} from "../util/timestamp";
+import {fromISO, toISO, validateTimestampISO} from "../util/timestamp";
 
 describe("api/dependenciesConfig", () => {
   describe("ensureIdentityExists", () => {
@@ -31,13 +31,15 @@ describe("api/dependenciesConfig", () => {
       const events = ledger.eventLog();
       const config_ = ensureIdentityExists(config, ledger);
       expect(config_.id).toEqual(id);
+      // No modification to the periods
+      expect(config_.periods).toEqual(config.periods);
       // No modification to the Ledger.
       expect(ledger.eventLog()).toEqual(events);
     });
-    it("assigns an id and creates identity if needed", () => {
+    it("assigns an id and creates identity + default period if needed", () => {
       const ledger = new Ledger();
       const config = {name: n("foo"), periods: []};
-      const {id} = ensureIdentityExists(config, ledger);
+      const {id, periods} = ensureIdentityExists(config, ledger);
       if (id == null) {
         // Will never happen in practice, but needed to appease Flow
         throw new Error("invariant violation");
@@ -46,6 +48,24 @@ describe("api/dependenciesConfig", () => {
       expect(account.identity.name).toEqual(config.name);
       expect(account.identity.subtype).toEqual("PROJECT");
       expect(account.active).toBe(false);
+      expect(periods).toHaveLength(1);
+    });
+    it("sets default period if needed", () => {
+      const ledger = new Ledger();
+      const config = {name: n("foo"), periods: []};
+      const {periods} = ensureIdentityExists(config, ledger);
+      expect(periods).toHaveLength(1);
+      expect(periods[0].weight).toBe(0.05);
+      expect(fromISO(periods[0].startTime)).toBeGreaterThan(Date.now());
+    });
+    it("does not set default period if it already exists", () => {
+      const ledger = new Ledger();
+      const config = {
+        name: n("foo"),
+        periods: [{startTime: toISO(1), weight: 0.05}],
+      };
+      const {periods} = ensureIdentityExists(config, ledger);
+      expect(periods).toEqual(config.periods);
     });
     it("can activate newly-created identities", () => {
       const ledger = new Ledger();
@@ -54,7 +74,7 @@ describe("api/dependenciesConfig", () => {
         periods: [],
         autoActivateOnIdentityCreation: true,
       };
-      const {id} = ensureIdentityExists(config, ledger);
+      const {id, periods} = ensureIdentityExists(config, ledger);
       if (id == null) {
         // Will never happen in practice, but needed to appease Flow
         throw new Error("invariant violation");
@@ -63,6 +83,7 @@ describe("api/dependenciesConfig", () => {
       expect(account.identity.name).toEqual(config.name);
       expect(account.identity.subtype).toEqual("PROJECT");
       expect(account.active).toBe(true);
+      expect(periods).toHaveLength(1);
     });
     it("does not activate new identities if autoActivateOnIdentityCreation is unset", () => {
       const ledger = new Ledger();
@@ -70,13 +91,14 @@ describe("api/dependenciesConfig", () => {
         name: n("foo"),
         periods: [],
       };
-      const {id} = ensureIdentityExists(config, ledger);
+      const {id, periods} = ensureIdentityExists(config, ledger);
       if (id == null) {
         // Will never happen in practice, but needed to appease Flow
         throw new Error("invariant violation");
       }
       const account = ledger.account(id);
       expect(account.active).toBe(false);
+      expect(periods).toHaveLength(1);
     });
     it("does not activate new identities if autoActivateOnIdentityCreation is set to false", () => {
       const ledger = new Ledger();
@@ -85,13 +107,14 @@ describe("api/dependenciesConfig", () => {
         periods: [],
         autoActivateOnIdentityCreation: false,
       };
-      const {id} = ensureIdentityExists(config, ledger);
+      const {id, periods} = ensureIdentityExists(config, ledger);
       if (id == null) {
         // Will never happen in practice, but needed to appease Flow
         throw new Error("invariant violation");
       }
       const account = ledger.account(id);
       expect(account.active).toBe(false);
+      expect(periods).toHaveLength(1);
     });
     it("does not activate if the identity already exists (specified by id)", () => {
       const ledger = new Ledger();


### PR DESCRIPTION
This fixes the issue of having to keep the "startTime" value up to date in the template
instance by setting it automatically to one week from the time the dependencyId was first
created in the ledger (i.e. when the user first added the dependency). The default weight
is set to 0.05, or 5% of the total cred.

Test Plan: Create a dependencyConfig that has an empty array for periods, run sourcecred
commands to generate the instance, and ensure the dependencyConfig.json is updated with a
period startTime of one week from the current time.