### PR TITLE
Allow Grain table height to conform to the size of the window

### DIFF
--- a/src/ui/components/AccountOverview.js
+++ b/src/ui/components/AccountOverview.js
@@ -19,7 +19,7 @@ type OverviewProps = {|+currency: CurrencyDetails|};
 const useStyles = makeStyles(() => {
   return {
     container: {
-      maxHeight: "40em",
+      maxHeight: "80vh",
     },
   };
 });


### PR DESCRIPTION
Using "vh" units allows element to adjust its size relative to the space
it's provided by the viewport.

test plan: 1. yarn start --instance <path to instance with many
participants>
2. browse to localhost:8080/#/accounts and resize the window a few times
to ensure a second outer scroll bar doesn't appear