### PR TITLE
Disable github publish workflow for now

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,8 +1,9 @@
 name: Publish Release
 on:
   # Publish when a new release is created on GitHub
-  release:
-    types: [published]
+  # disable for now in favor of authenticated CLI workflow
+  # release:
+  #   types: [published]
 
 jobs:
   publish:


### PR DESCRIPTION
test plan: using the publish UI on github should not trigger the npm
publish workflow