### PR TITLE
AdminApp: remove unnecessary `credView` prop

### DIFF
--- a/src/ui/components/AdminApp.js
+++ b/src/ui/components/AdminApp.js
@@ -58,7 +58,7 @@ const customRoutes = (
   ];
   const backendRoutes = [
     <Route key="admin" exact path="/admin">
-      <LedgerAdmin credView={credView} />
+      <LedgerAdmin />
     </Route>,
     <Route key="explorer-home" exact path="/explorer-home">
       <ExplorerHome initialView={credView} />


### PR DESCRIPTION
Summary:
This parameter was removed in #2137, so the call site no longer needs to
pass it. This fixes a new Flow error in `types-first` land.

Test Plan:
That Flow passes suffices.

wchargin-branch: adminapp-unnecessary-credview
