### PR TITLE
flow: fix and enable “types first” mode

### DIFF
--- a/.flowconfig
+++ b/.flowconfig
@@ -10,6 +10,5 @@ flow-typed
 
 [options]
 include_warnings=true
-types_first=false
 
 [strict]

--- a/config/env.js
+++ b/config/env.js
@@ -57,9 +57,29 @@ process.env.NODE_PATH = (process.env.NODE_PATH || "")
   .map((folder) => path.resolve(appDirectory, folder))
   .join(path.delimiter);
 
+/*::
+type Env = {|
+  // Environment like `process.env`: e.g., `raw["NODE_ENV"] === "development"`.
+  +raw: {|+[string]: string|},
+  // Environment whose values are stringified for transclusion into JS
+  // source code: e.g.,
+  //
+  //     stringified["process.env"]["NODE_ENV"] === '"development"'
+  //
+  // (note extra quotes).
+  +stringified: {|+"process.env": {|+[string]: string|}|},
+  // Like `stringified`, but the keys are `process.env.*` expressions:
+  //
+  //     individuallyStringified["process.env.NODE_ENV"] === '"development"'
+  +individuallyStringified: {|+[string]: string|},
+|};
+ */
+
 // TODO: When we have switched fully to the instance system, we can remove
 // the projectIds argument.
-function getClientEnvironment(projectIds /*: $ReadOnlyArray<string> | null*/) {
+function getClientEnvironment(
+  projectIds /*: $ReadOnlyArray<string> | null */
+) /*: Env */ {
   const raw = {};
   // Useful for determining whether we’re running in production mode.
   // Most importantly, it switches React into the correct mode.

--- a/config/jest/cssTransform.js
+++ b/config/jest/cssTransform.js
@@ -3,10 +3,10 @@
 // http://facebook.github.io/jest/docs/en/webpack.html
 
 module.exports = {
-  process() {
+  process() /*: string */ {
     return "module.exports = {};";
   },
-  getCacheKey() {
+  getCacheKey() /*: string */ {
     // The output is always the same.
     return "cssTransform";
   },

--- a/config/jest/fileTransform.js
+++ b/config/jest/fileTransform.js
@@ -5,7 +5,7 @@ const path = require("path");
 // http://facebook.github.io/jest/docs/en/webpack.html
 
 module.exports = {
-  process(src /*: string */, filename /*: string */) {
+  process(src /*: string */, filename /*: string */) /*: string */ {
     return `module.exports = ${JSON.stringify(path.basename(filename))};`;
   },
 };

--- a/config/paths.js
+++ b/config/paths.js
@@ -4,43 +4,46 @@ const fs = require("fs");
 
 // Make sure any symlinks in the project folder are resolved:
 // https://github.com/facebookincubator/create-react-app/issues/637
-const appDirectory = fs.realpathSync(process.cwd());
-const resolveApp = (relativePath) => path.resolve(appDirectory, relativePath);
+const appDirectory /*: string */ = fs.realpathSync(process.cwd());
+const resolveApp = (relativePath /*: string */) /*: string */ =>
+  path.resolve(appDirectory, relativePath);
 
 // config after eject: we're in ./config/
 module.exports = {
   root: appDirectory,
-  dotenv: resolveApp(".env"),
-  favicon: resolveApp("src/assets/logo/rasterized/logo_32.png"),
-  appBuild: resolveApp("build"),
-  appIndexJs: resolveApp("src/ui/index.js"),
-  serverInfoJson: resolveApp("src/ui/server-info.json"),
-  appServerSideRenderingIndexJs: resolveApp("src/ui/server.js"),
-  appPackageJson: resolveApp("package.json"),
-  appSrc: resolveApp("src"),
-  yarnLockFile: resolveApp("yarn.lock"),
-  appNodeModules: resolveApp("node_modules"),
+  dotenv: (resolveApp(".env") /*: string */),
+  favicon: (resolveApp("src/assets/logo/rasterized/logo_32.png") /*: string */),
+  appBuild: (resolveApp("build") /*: string */),
+  appIndexJs: (resolveApp("src/ui/index.js") /*: string */),
+  serverInfoJson: (resolveApp("src/ui/server-info.json") /*: string */),
+  appServerSideRenderingIndexJs: (resolveApp("src/ui/server.js") /*: string */),
+  appPackageJson: (resolveApp("package.json") /*: string */),
+  appSrc: (resolveApp("src") /*: string */),
+  yarnLockFile: (resolveApp("yarn.lock") /*: string */),
+  appNodeModules: (resolveApp("node_modules") /*: string */),
 
-  apiIndexJs: resolveApp("src/api/index.js"),
-  apiBuild: resolveApp("dist"),
+  apiIndexJs: (resolveApp("src/api/index.js") /*: string */),
+  apiBuild: (resolveApp("dist") /*: string */),
 
-  backendBuild: resolveApp("bin"),
+  backendBuild: (resolveApp("bin") /*: string */),
   // This object should have one key-value pair per entry point. For
   // each key, the value should be the path to the entry point for the
   // source file, and the key will be the filename of the bundled entry
   // point within the build directory.
   backendEntryPoints: {
-    sourcecred: resolveApp("src/cli/main.js"),
+    sourcecred: (resolveApp("src/cli/main.js") /*: string */),
     //
-    generateGithubGraphqlFlowTypes: resolveApp(
+    generateGithubGraphqlFlowTypes: (resolveApp(
       "src/plugins/github/bin/generateGraphqlFlowTypes.js"
-    ),
-    fetchAndPrintGithubRepo: resolveApp(
+    ) /*: string */),
+    fetchAndPrintGithubRepo: (resolveApp(
       "src/plugins/github/bin/fetchAndPrintGithubRepo.js"
-    ),
-    fetchAndPrintGithubOrg: resolveApp(
+    ) /*: string */),
+    fetchAndPrintGithubOrg: (resolveApp(
       "src/plugins/github/bin/fetchAndPrintGithubOrg.js"
-    ),
-    createExampleRepo: resolveApp("src/plugins/git/bin/createExampleRepo.js"),
+    ) /*: string */),
+    createExampleRepo: (resolveApp(
+      "src/plugins/git/bin/createExampleRepo.js"
+    ) /*: string */),
   },
 };

--- a/config/webpack.config.api.js
+++ b/config/webpack.config.api.js
@@ -12,7 +12,7 @@ const getClientEnvironment = require("./env");
 
 const env = getClientEnvironment(null);
 
-module.exports = {
+module.exports = ({
   // Don't attempt to continue if there are any errors.
   bail: true,
   node: {
@@ -72,4 +72,4 @@ module.exports = {
     new webpack.DefinePlugin(env.individuallyStringified),
   ],
   mode: process.env.NODE_ENV,
-};
+} /*: any */);

--- a/config/webpack.config.backend.js
+++ b/config/webpack.config.backend.js
@@ -16,7 +16,7 @@ const env = getClientEnvironment(null);
 
 // This is the backend configuration. It builds applications that target
 // Node and will not run in a browser.
-module.exports = {
+module.exports = ({
   // Don't attempt to continue if there are any errors.
   bail: true,
   // Target Node instead of the browser.
@@ -75,4 +75,4 @@ module.exports = {
     new webpack.BannerPlugin({banner: "#!/usr/bin/env node", raw: true}),
   ],
   mode: process.env.NODE_ENV,
-};
+} /*: any */);

--- a/config/webpack.config.web.js
+++ b/config/webpack.config.web.js
@@ -318,4 +318,4 @@ function getMode() {
   return mode;
 }
 
-module.exports = makeConfig(getMode());
+module.exports = (makeConfig(getMode()) /*: any */);

--- a/src/api/index.js
+++ b/src/api/index.js
@@ -25,7 +25,7 @@ import * as ledger from "../ledger/ledger";
 import * as grain from "../ledger/grain";
 import * as identity from "../ledger/identity";
 
-export default deepFreeze({
+const api = {
   core: {
     address,
     algorithm: {
@@ -63,4 +63,6 @@ export default deepFreeze({
       declaration: initiativesDeclaration,
     },
   },
-});
+};
+
+export default (deepFreeze(api): typeof api);

--- a/src/core/algorithm/distribution.js
+++ b/src/core/algorithm/distribution.js
@@ -20,7 +20,7 @@ export function uniformDistribution(n: number): Distribution {
  *
  * Equivalent to $\norm{pi0 - pi1}_\infty$.
  */
-export function computeDelta(pi0: Distribution, pi1: Distribution) {
+export function computeDelta(pi0: Distribution, pi1: Distribution): number {
   if (pi0.length === 0 || pi0.length !== pi1.length) {
     throw new Error("invalid input");
   }

--- a/src/core/algorithm/graphToMarkovChain.js
+++ b/src/core/algorithm/graphToMarkovChain.js
@@ -19,7 +19,7 @@ export type Connection = {|
   +weight: Probability,
 |};
 
-export function adjacencySource(target: NodeAddressT, adjacency: Adjacency) {
+export function adjacencySource(target: NodeAddressT, adjacency: Adjacency): NodeAddressT {
   switch (adjacency.type) {
     case "SYNTHETIC_LOOP":
       return target;

--- a/src/core/algorithm/graphToMarkovChain.js
+++ b/src/core/algorithm/graphToMarkovChain.js
@@ -19,7 +19,10 @@ export type Connection = {|
   +weight: Probability,
 |};
 
-export function adjacencySource(target: NodeAddressT, adjacency: Adjacency): NodeAddressT {
+export function adjacencySource(
+  target: NodeAddressT,
+  adjacency: Adjacency
+): NodeAddressT {
   switch (adjacency.type) {
     case "SYNTHETIC_LOOP":
       return target;

--- a/src/core/graphTestUtil.js
+++ b/src/core/graphTestUtil.js
@@ -1,6 +1,7 @@
 // @flow
 
-import deepFreeze from "deep-freeze";
+import type {NodeAddressT, EdgeAddressT} from "./graph.js";
+import type {TimestampMs} from "../util/timestamp.js";import deepFreeze from "deep-freeze";
 import {EdgeAddress, Graph, NodeAddress, type Node, type Edge} from "./graph";
 
 /**
@@ -57,7 +58,86 @@ export function edge(name: string, src: Node, dst: Node): Edge {
   return partsEdge([name], src, dst);
 }
 
-export function advancedGraph() {
+export function advancedGraph(): {|
+  edges: {|
+    fullDanglingEdge: {|
+      +address: EdgeAddressT,
+      +dst: NodeAddressT,
+      +src: NodeAddressT,
+      +timestampMs: TimestampMs,
+    |},
+    halfDanglingEdge: {|
+      +address: EdgeAddressT,
+      +dst: NodeAddressT,
+      +src: NodeAddressT,
+      +timestampMs: TimestampMs,
+    |},
+    hom1: {|
+      +address: EdgeAddressT,
+      +dst: NodeAddressT,
+      +src: NodeAddressT,
+      +timestampMs: TimestampMs,
+    |},
+    hom2: {|
+      +address: EdgeAddressT,
+      +dst: NodeAddressT,
+      +src: NodeAddressT,
+      +timestampMs: TimestampMs,
+    |},
+    loopLoop: {|
+      +address: EdgeAddressT,
+      +dst: NodeAddressT,
+      +src: NodeAddressT,
+      +timestampMs: TimestampMs,
+    |},
+    phantomEdge1: {|
+      +address: EdgeAddressT,
+      +dst: NodeAddressT,
+      +src: NodeAddressT,
+      +timestampMs: TimestampMs,
+    |},
+    phantomEdge2: {|
+      +address: EdgeAddressT,
+      +dst: NodeAddressT,
+      +src: NodeAddressT,
+      +timestampMs: TimestampMs,
+    |},
+  |},
+  graph1: () => Graph,
+  graph2: () => Graph,
+  nodes: {|
+    dst: {|
+      +address: NodeAddressT,
+      +description: string,
+      +timestampMs: TimestampMs | null,
+    |},
+    halfIsolated: {|
+      +address: NodeAddressT,
+      +description: string,
+      +timestampMs: TimestampMs | null,
+    |},
+    isolated: {|
+      +address: NodeAddressT,
+      +description: string,
+      +timestampMs: TimestampMs | null,
+    |},
+    loop: {|
+      +address: NodeAddressT,
+      +description: string,
+      +timestampMs: TimestampMs | null,
+    |},
+    phantomNode: {|
+      +address: NodeAddressT,
+      +description: string,
+      +timestampMs: TimestampMs | null,
+    |},
+    src: {|
+      +address: NodeAddressT,
+      +description: string,
+      +timestampMs: TimestampMs | null,
+    |},
+  |},
+|} {
   // The advanced graph has the following features:
   // - Multiple edges of same hom, from `src` to `dst`
   // - An isolated node, `isolated`

--- a/src/core/graphTestUtil.js
+++ b/src/core/graphTestUtil.js
@@ -1,9 +1,16 @@
 // @flow
 
-import type {NodeAddressT, EdgeAddressT} from "./graph.js";
-import type {TimestampMs} from "../util/timestamp.js";
 import deepFreeze from "deep-freeze";
-import {EdgeAddress, Graph, NodeAddress, type Node, type Edge} from "./graph";
+import {
+  EdgeAddress,
+  Graph,
+  NodeAddress,
+  type Node,
+  type Edge,
+  type NodeAddressT,
+  type EdgeAddressT,
+} from "./graph";
+import type {TimestampMs} from "../util/timestamp";
 
 /**
  * Create a new Node from an array of string address parts.

--- a/src/core/graphTestUtil.js
+++ b/src/core/graphTestUtil.js
@@ -1,7 +1,8 @@
 // @flow
 
 import type {NodeAddressT, EdgeAddressT} from "./graph.js";
-import type {TimestampMs} from "../util/timestamp.js";import deepFreeze from "deep-freeze";
+import type {TimestampMs} from "../util/timestamp.js";
+import deepFreeze from "deep-freeze";
 import {EdgeAddress, Graph, NodeAddress, type Node, type Edge} from "./graph";
 
 /**

--- a/src/core/markovProcessGraph.js
+++ b/src/core/markovProcessGraph.js
@@ -171,7 +171,7 @@ export function userEpochNodeAddressFromRaw(
 }
 
 // TODO(@wchargin): Expose more cleanly.
-export const EPOCH_ACCUMULATOR_PREFIX = NodeAddress.append(
+export const EPOCH_ACCUMULATOR_PREFIX: NodeAddressT = NodeAddress.append(
   CORE_NODE_PREFIX,
   "EPOCH"
 );
@@ -269,7 +269,7 @@ export class MarkovProcessGraph {
     wg: WeightedGraphT,
     fibration: FibrationOptions,
     seed: SeedOptions
-  ) {
+  ): MarkovProcessGraph {
     const _nodes = new Map();
     const _edges = new Map();
     const _scoringAddresses = new Set(fibration.scoringAddresses);

--- a/src/core/trie.js
+++ b/src/core/trie.js
@@ -9,7 +9,7 @@ import {
 } from "./graph";
 import * as NullUtil from "../util/null";
 
-const EMPTY_ENTRY_SYMBOL = Symbol("EMPTY");
+const EMPTY_ENTRY_SYMBOL: symbol = Symbol("EMPTY");
 
 type Entry<V> = {|+map: RecursiveMap<V>, value: V | typeof EMPTY_ENTRY_SYMBOL|};
 type RecursiveMap<V> = Map<string, Entry<V>>;

--- a/src/core/weights.js
+++ b/src/core/weights.js
@@ -162,6 +162,6 @@ export function toJSON(weights: Weights): WeightsJSON {
   return toCompat(COMPAT_INFO, serialize_0_2_0(weights));
 }
 
-export function fromJSON(json: WeightsJSON) {
+export function fromJSON(json: WeightsJSON): Weights {
   return parser.parseOrThrow(json);
 }

--- a/src/graphql/mirror.js
+++ b/src/graphql/mirror.js
@@ -2341,7 +2341,11 @@ type UpdateResult = {
     | NodeConnectionsUpdateResult,
 };
 
-export const _FIELD_PREFIXES: {|NODE_CONNECTIONS: string, OWN_DATA: string, TYPENAMES: string|} = deepFreeze({
+export const _FIELD_PREFIXES: {|
+  NODE_CONNECTIONS: string,
+  OWN_DATA: string,
+  TYPENAMES: string,
+|} = deepFreeze({
   /**
    * A key of an `UpdateResult` has this prefix if and only if the
    * corresponding value represents `TypenamesUpdateResult`s.

--- a/src/graphql/mirror.js
+++ b/src/graphql/mirror.js
@@ -2341,7 +2341,7 @@ type UpdateResult = {
     | NodeConnectionsUpdateResult,
 };
 
-export const _FIELD_PREFIXES = deepFreeze({
+export const _FIELD_PREFIXES: {|NODE_CONNECTIONS: string, OWN_DATA: string, TYPENAMES: string|} = deepFreeze({
   /**
    * A key of an `UpdateResult` has this prefix if and only if the
    * corresponding value represents `TypenamesUpdateResult`s.

--- a/src/graphql/schema.js
+++ b/src/graphql/schema.js
@@ -109,7 +109,7 @@ export function faithful(): Fidelity {
   return {type: "FAITHFUL"};
 }
 
-export function unfaithful(actualTypenames: $ReadOnlyArray<Typename>) {
+export function unfaithful(actualTypenames: $ReadOnlyArray<Typename>): {|actualTypenames: {[Typename]: true}, type: string|} {
   const actualTypenamesObject: {|[Typename]: true|} = ({}: any);
   for (const t of actualTypenames) {
     actualTypenamesObject[t] = true;

--- a/src/graphql/schema.js
+++ b/src/graphql/schema.js
@@ -109,7 +109,9 @@ export function faithful(): Fidelity {
   return {type: "FAITHFUL"};
 }
 
-export function unfaithful(actualTypenames: $ReadOnlyArray<Typename>): {|actualTypenames: {[Typename]: true}, type: string|} {
+export function unfaithful(
+  actualTypenames: $ReadOnlyArray<Typename>
+): {|actualTypenames: {[Typename]: true}, type: string|} {
   const actualTypenamesObject: {|[Typename]: true|} = ({}: any);
   for (const t of actualTypenames) {
     actualTypenamesObject[t] = true;

--- a/src/graphql/schema.js
+++ b/src/graphql/schema.js
@@ -111,7 +111,7 @@ export function faithful(): Fidelity {
 
 export function unfaithful(
   actualTypenames: $ReadOnlyArray<Typename>
-): {|actualTypenames: {[Typename]: true}, type: string|} {
+): Fidelity {
   const actualTypenamesObject: {|[Typename]: true|} = ({}: any);
   for (const t of actualTypenames) {
     actualTypenamesObject[t] = true;

--- a/src/ledger/identity/identity.js
+++ b/src/ledger/identity/identity.js
@@ -37,7 +37,7 @@ export type Identity = {|
 
 // It's not in the typical [owner, name] format because it isn't provided by a plugin.
 // Instead, it's a raw type owned by SourceCred project.
-export const IDENTITY_PREFIX = NodeAddress.fromParts([
+export const IDENTITY_PREFIX: NodeAddressT = NodeAddress.fromParts([
   "sourcecred",
   "core",
   "IDENTITY",

--- a/src/ledger/ledger.js
+++ b/src/ledger/ledger.js
@@ -495,7 +495,7 @@ export class Ledger {
     to: IdentityId,
     amount: G.Grain,
     memo: string | null,
-  |}) {
+  |}): this {
     const {from, to, amount, memo} = opts;
     this._createAndProcessEvent({
       from,

--- a/src/plugins/demo/graph.js
+++ b/src/plugins/demo/graph.js
@@ -1,17 +1,27 @@
 // @flow
 
-import type {Node, Edge} from "../../core/graph.js";import deepFreeze from "deep-freeze";
+import type {Node, Edge} from "../../core/graph.js";
+import deepFreeze from "deep-freeze";
 import {Graph} from "../../core/graph";
 import {partsNode, partsEdge} from "../../core/graphTestUtil";
 
-export const nodes: {|inserter1: Node, inserter2: Node, machine1: Node, machine2: Node|} = deepFreeze({
+export const nodes: {|
+  inserter1: Node,
+  inserter2: Node,
+  machine1: Node,
+  machine2: Node,
+|} = deepFreeze({
   inserter1: partsNode(["factorio", "inserter", "1"]),
   machine1: partsNode(["factorio", "machine", "1"]),
   inserter2: partsNode(["factorio", "inserter", "2"]),
   machine2: partsNode(["factorio", "machine", "2"]),
 });
 
-export const edges: {|assembles1: Edge, transports1: Edge, transports2: Edge|} = deepFreeze({
+export const edges: {|
+  assembles1: Edge,
+  transports1: Edge,
+  transports2: Edge,
+|} = deepFreeze({
   transports1: partsEdge(
     ["factorio", "transports", "1"],
     nodes.inserter1,

--- a/src/plugins/demo/graph.js
+++ b/src/plugins/demo/graph.js
@@ -1,8 +1,7 @@
 // @flow
 
-import type {Node, Edge} from "../../core/graph.js";
 import deepFreeze from "deep-freeze";
-import {Graph} from "../../core/graph";
+import {Graph, type Node, type Edge} from "../../core/graph";
 import {partsNode, partsEdge} from "../../core/graphTestUtil";
 
 export const nodes: {|

--- a/src/plugins/demo/graph.js
+++ b/src/plugins/demo/graph.js
@@ -1,17 +1,17 @@
 // @flow
 
-import deepFreeze from "deep-freeze";
+import type {Node, Edge} from "../../core/graph.js";import deepFreeze from "deep-freeze";
 import {Graph} from "../../core/graph";
 import {partsNode, partsEdge} from "../../core/graphTestUtil";
 
-export const nodes = deepFreeze({
+export const nodes: {|inserter1: Node, inserter2: Node, machine1: Node, machine2: Node|} = deepFreeze({
   inserter1: partsNode(["factorio", "inserter", "1"]),
   machine1: partsNode(["factorio", "machine", "1"]),
   inserter2: partsNode(["factorio", "inserter", "2"]),
   machine2: partsNode(["factorio", "machine", "2"]),
 });
 
-export const edges = deepFreeze({
+export const edges: {|assembles1: Edge, transports1: Edge, transports2: Edge|} = deepFreeze({
   transports1: partsEdge(
     ["factorio", "transports", "1"],
     nodes.inserter1,
@@ -29,7 +29,7 @@ export const edges = deepFreeze({
   ),
 });
 
-export function graph() {
+export function graph(): Graph {
   return new Graph()
     .addNode(nodes.inserter1)
     .addNode(nodes.inserter2)

--- a/src/plugins/discourse/declaration.js
+++ b/src/plugins/discourse/declaration.js
@@ -1,12 +1,12 @@
 // @flow
 
-import deepFreeze from "deep-freeze";
+import type {NodeAddressT, EdgeAddressT} from "../../core/graph.js";import deepFreeze from "deep-freeze";
 import type {PluginDeclaration} from "../../analysis/pluginDeclaration";
 import type {NodeType, EdgeType} from "../../analysis/types";
 import {NodeAddress, EdgeAddress} from "../../core/graph";
 
-export const nodePrefix = NodeAddress.fromParts(["sourcecred", "discourse"]);
-export const edgePrefix = EdgeAddress.fromParts(["sourcecred", "discourse"]);
+export const nodePrefix: NodeAddressT = NodeAddress.fromParts(["sourcecred", "discourse"]);
+export const edgePrefix: EdgeAddressT = EdgeAddress.fromParts(["sourcecred", "discourse"]);
 
 export const topicNodeType: NodeType = deepFreeze({
   name: "Topic",

--- a/src/plugins/discourse/declaration.js
+++ b/src/plugins/discourse/declaration.js
@@ -1,12 +1,19 @@
 // @flow
 
-import type {NodeAddressT, EdgeAddressT} from "../../core/graph.js";import deepFreeze from "deep-freeze";
+import type {NodeAddressT, EdgeAddressT} from "../../core/graph.js";
+import deepFreeze from "deep-freeze";
 import type {PluginDeclaration} from "../../analysis/pluginDeclaration";
 import type {NodeType, EdgeType} from "../../analysis/types";
 import {NodeAddress, EdgeAddress} from "../../core/graph";
 
-export const nodePrefix: NodeAddressT = NodeAddress.fromParts(["sourcecred", "discourse"]);
-export const edgePrefix: EdgeAddressT = EdgeAddress.fromParts(["sourcecred", "discourse"]);
+export const nodePrefix: NodeAddressT = NodeAddress.fromParts([
+  "sourcecred",
+  "discourse",
+]);
+export const edgePrefix: EdgeAddressT = EdgeAddress.fromParts([
+  "sourcecred",
+  "discourse",
+]);
 
 export const topicNodeType: NodeType = deepFreeze({
   name: "Topic",

--- a/src/plugins/discourse/declaration.js
+++ b/src/plugins/discourse/declaration.js
@@ -1,10 +1,14 @@
 // @flow
 
-import type {NodeAddressT, EdgeAddressT} from "../../core/graph.js";
 import deepFreeze from "deep-freeze";
 import type {PluginDeclaration} from "../../analysis/pluginDeclaration";
 import type {NodeType, EdgeType} from "../../analysis/types";
-import {NodeAddress, EdgeAddress} from "../../core/graph";
+import {
+  NodeAddress,
+  EdgeAddress,
+  type NodeAddressT,
+  type EdgeAddressT,
+} from "../../core/graph";
 
 export const nodePrefix: NodeAddressT = NodeAddress.fromParts([
   "sourcecred",

--- a/src/plugins/discourse/mockSnapshotFetcher.js
+++ b/src/plugins/discourse/mockSnapshotFetcher.js
@@ -21,4 +21,4 @@ async function snapshotFetch(url: string | Request | URL): Promise<Response> {
     throw new Error(`couldn't load snapshot for ${file}`);
   }
 }
-export const snapshotFetcher = () => new Fetcher(options, snapshotFetch, 0);
+export const snapshotFetcher = (): Fetcher => new Fetcher(options, snapshotFetch, 0);

--- a/src/plugins/discourse/mockSnapshotFetcher.js
+++ b/src/plugins/discourse/mockSnapshotFetcher.js
@@ -21,4 +21,5 @@ async function snapshotFetch(url: string | Request | URL): Promise<Response> {
     throw new Error(`couldn't load snapshot for ${file}`);
   }
 }
-export const snapshotFetcher = (): Fetcher => new Fetcher(options, snapshotFetch, 0);
+export const snapshotFetcher = (): Fetcher =>
+  new Fetcher(options, snapshotFetch, 0);

--- a/src/plugins/experimental-discord/declaration.js
+++ b/src/plugins/experimental-discord/declaration.js
@@ -1,12 +1,19 @@
 // @flow
 
-import type {NodeAddressT, EdgeAddressT} from "../../core/graph.js";import deepFreeze from "deep-freeze";
+import type {NodeAddressT, EdgeAddressT} from "../../core/graph.js";
+import deepFreeze from "deep-freeze";
 import type {PluginDeclaration} from "../../analysis/pluginDeclaration";
 import type {NodeType, EdgeType} from "../../analysis/types";
 import {NodeAddress, EdgeAddress} from "../../core/graph";
 
-export const nodePrefix: NodeAddressT = NodeAddress.fromParts(["sourcecred", "discord"]);
-export const edgePrefix: EdgeAddressT = EdgeAddress.fromParts(["sourcecred", "discord"]);
+export const nodePrefix: NodeAddressT = NodeAddress.fromParts([
+  "sourcecred",
+  "discord",
+]);
+export const edgePrefix: EdgeAddressT = EdgeAddress.fromParts([
+  "sourcecred",
+  "discord",
+]);
 
 export const memberNodeType: NodeType = deepFreeze({
   name: "Member",

--- a/src/plugins/experimental-discord/declaration.js
+++ b/src/plugins/experimental-discord/declaration.js
@@ -1,12 +1,12 @@
 // @flow
 
-import deepFreeze from "deep-freeze";
+import type {NodeAddressT, EdgeAddressT} from "../../core/graph.js";import deepFreeze from "deep-freeze";
 import type {PluginDeclaration} from "../../analysis/pluginDeclaration";
 import type {NodeType, EdgeType} from "../../analysis/types";
 import {NodeAddress, EdgeAddress} from "../../core/graph";
 
-export const nodePrefix = NodeAddress.fromParts(["sourcecred", "discord"]);
-export const edgePrefix = EdgeAddress.fromParts(["sourcecred", "discord"]);
+export const nodePrefix: NodeAddressT = NodeAddress.fromParts(["sourcecred", "discord"]);
+export const edgePrefix: EdgeAddressT = EdgeAddress.fromParts(["sourcecred", "discord"]);
 
 export const memberNodeType: NodeType = deepFreeze({
   name: "Member",

--- a/src/plugins/experimental-discord/declaration.js
+++ b/src/plugins/experimental-discord/declaration.js
@@ -1,10 +1,14 @@
 // @flow
 
-import type {NodeAddressT, EdgeAddressT} from "../../core/graph.js";
 import deepFreeze from "deep-freeze";
 import type {PluginDeclaration} from "../../analysis/pluginDeclaration";
 import type {NodeType, EdgeType} from "../../analysis/types";
-import {NodeAddress, EdgeAddress} from "../../core/graph";
+import {
+  NodeAddress,
+  EdgeAddress,
+  type NodeAddressT,
+  type EdgeAddressT,
+} from "../../core/graph";
 
 export const nodePrefix: NodeAddressT = NodeAddress.fromParts([
   "sourcecred",

--- a/src/plugins/experimental-discord/mirror.js
+++ b/src/plugins/experimental-discord/mirror.js
@@ -5,7 +5,8 @@ import type {
   Message as $IMPORTED_TYPE$_Message,
   GuildMember,
   Channel,
-} from "./models.js";import {TaskReporter} from "../../util/taskReporter";
+} from "./models.js";
+import {TaskReporter} from "../../util/taskReporter";
 import {type DiscordApi} from "./fetcher";
 import {SqliteMirrorRepository} from "./mirrorRepository";
 import * as Model from "./models";
@@ -45,9 +46,11 @@ export class Mirror {
     reporter.finish(`discord/${guild.name}`);
   }
 
-  async validateGuildId(): Promise<
-  {|+id: $IMPORTED_TYPE$_Snowflake, +name: string, +permissions: number|},
-> {
+  async validateGuildId(): Promise<{|
+    +id: $IMPORTED_TYPE$_Snowflake,
+    +name: string,
+    +permissions: number,
+  |}> {
     const guilds = await this._api.guilds();
     const guild = guilds.find((g) => g.id === this.guild);
     if (!guild) {
@@ -76,7 +79,10 @@ export class Mirror {
     return this._repo.channels();
   }
 
-  async addMessages(channel: Model.Snowflake, messageLimit?: number): Promise<$ReadOnlyArray<$IMPORTED_TYPE$_Message>> {
+  async addMessages(
+    channel: Model.Snowflake,
+    messageLimit?: number
+  ): Promise<$ReadOnlyArray<$IMPORTED_TYPE$_Message>> {
     const loadStart = this._repo.nthMessageFromTail(channel, RELOAD_DEPTH);
     // console.log(channel, (loadStart || {}).id);
 

--- a/src/plugins/experimental-discord/mirror.js
+++ b/src/plugins/experimental-discord/mirror.js
@@ -1,11 +1,6 @@
 // @flow
 
-import type {
-  Snowflake as $IMPORTED_TYPE$_Snowflake,
-  Message as $IMPORTED_TYPE$_Message,
-  GuildMember,
-  Channel,
-} from "./models.js";
+import type {GuildMember, Channel} from "./models.js";
 import {TaskReporter} from "../../util/taskReporter";
 import {type DiscordApi} from "./fetcher";
 import {SqliteMirrorRepository} from "./mirrorRepository";
@@ -47,7 +42,7 @@ export class Mirror {
   }
 
   async validateGuildId(): Promise<{|
-    +id: $IMPORTED_TYPE$_Snowflake,
+    +id: Model.Snowflake,
     +name: string,
     +permissions: number,
   |}> {
@@ -82,7 +77,7 @@ export class Mirror {
   async addMessages(
     channel: Model.Snowflake,
     messageLimit?: number
-  ): Promise<$ReadOnlyArray<$IMPORTED_TYPE$_Message>> {
+  ): Promise<$ReadOnlyArray<Model.Message>> {
     const loadStart = this._repo.nthMessageFromTail(channel, RELOAD_DEPTH);
     // console.log(channel, (loadStart || {}).id);
 

--- a/src/plugins/experimental-discord/mirror.js
+++ b/src/plugins/experimental-discord/mirror.js
@@ -1,6 +1,5 @@
 // @flow
 
-import type {GuildMember, Channel} from "./models.js";
 import {TaskReporter} from "../../util/taskReporter";
 import {type DiscordApi} from "./fetcher";
 import {SqliteMirrorRepository} from "./mirrorRepository";
@@ -57,7 +56,7 @@ export class Mirror {
     return guild;
   }
 
-  async addMembers(): Promise<$ReadOnlyArray<GuildMember>> {
+  async addMembers(): Promise<$ReadOnlyArray<Model.GuildMember>> {
     const members = await this._api.members(this.guild);
     for (const member of members) {
       this._repo.addMember(member);
@@ -65,7 +64,7 @@ export class Mirror {
     return this._repo.members();
   }
 
-  async addTextChannels(): Promise<$ReadOnlyArray<Channel>> {
+  async addTextChannels(): Promise<$ReadOnlyArray<Model.Channel>> {
     const channels = await this._api.channels(this.guild);
     for (const channel of channels) {
       if (channel.type !== "GUILD_TEXT") continue;

--- a/src/plugins/experimental-discord/mirror.js
+++ b/src/plugins/experimental-discord/mirror.js
@@ -1,6 +1,11 @@
 // @flow
 
-import {TaskReporter} from "../../util/taskReporter";
+import type {
+  Snowflake as $IMPORTED_TYPE$_Snowflake,
+  Message as $IMPORTED_TYPE$_Message,
+  GuildMember,
+  Channel,
+} from "./models.js";import {TaskReporter} from "../../util/taskReporter";
 import {type DiscordApi} from "./fetcher";
 import {SqliteMirrorRepository} from "./mirrorRepository";
 import * as Model from "./models";
@@ -40,7 +45,9 @@ export class Mirror {
     reporter.finish(`discord/${guild.name}`);
   }
 
-  async validateGuildId() {
+  async validateGuildId(): Promise<
+  {|+id: $IMPORTED_TYPE$_Snowflake, +name: string, +permissions: number|},
+> {
     const guilds = await this._api.guilds();
     const guild = guilds.find((g) => g.id === this.guild);
     if (!guild) {
@@ -52,7 +59,7 @@ export class Mirror {
     return guild;
   }
 
-  async addMembers() {
+  async addMembers(): Promise<$ReadOnlyArray<GuildMember>> {
     const members = await this._api.members(this.guild);
     for (const member of members) {
       this._repo.addMember(member);
@@ -60,7 +67,7 @@ export class Mirror {
     return this._repo.members();
   }
 
-  async addTextChannels() {
+  async addTextChannels(): Promise<$ReadOnlyArray<Channel>> {
     const channels = await this._api.channels(this.guild);
     for (const channel of channels) {
       if (channel.type !== "GUILD_TEXT") continue;
@@ -69,7 +76,7 @@ export class Mirror {
     return this._repo.channels();
   }
 
-  async addMessages(channel: Model.Snowflake, messageLimit?: number) {
+  async addMessages(channel: Model.Snowflake, messageLimit?: number): Promise<$ReadOnlyArray<$IMPORTED_TYPE$_Message>> {
     const loadStart = this._repo.nthMessageFromTail(channel, RELOAD_DEPTH);
     // console.log(channel, (loadStart || {}).id);
 

--- a/src/plugins/experimental-discord/mockSnapshotFetcher.js
+++ b/src/plugins/experimental-discord/mockSnapshotFetcher.js
@@ -17,7 +17,7 @@ async function snapshotFetch(url: string | Request | URL): Promise<Response> {
   }
 }
 
-export const snapshotFetcher = () =>
+export const snapshotFetcher = (): Fetcher =>
   new Fetcher({
     fetch: snapshotFetch,
     token: "mock-token",

--- a/src/plugins/git/edges.js
+++ b/src/plugins/git/edges.js
@@ -1,6 +1,6 @@
 // @flow
 
-import deepFreeze from "deep-freeze";
+import type {CommitAddress as $IMPORTED_TYPE$_CommitAddress} from "./nodes.js";import deepFreeze from "deep-freeze";
 import {
   type Edge,
   type EdgeAddressT,
@@ -23,7 +23,7 @@ function gitEdgeAddress(...parts: string[]): RawAddress {
   return EdgeAddress.append(GIT_PREFIX, ...parts);
 }
 
-export const Prefix = deepFreeze({
+export const Prefix: {|base: EdgeAddressT, hasParent: RawAddress|} = deepFreeze({
   base: GIT_PREFIX,
   hasParent: gitEdgeAddress(HAS_PARENT_TYPE),
 });
@@ -36,7 +36,13 @@ export type HasParentAddress = {|
 
 export type StructuredAddress = HasParentAddress;
 
-export const createEdge = deepFreeze({
+export const createEdge: {|
+  hasParent: (
+    child: $IMPORTED_TYPE$_CommitAddress,
+    parent: $IMPORTED_TYPE$_CommitAddress,
+    timestampMs: TimestampMs
+  ) => Edge,
+|} = deepFreeze({
   hasParent: (
     child: GitNode.CommitAddress,
     parent: GitNode.CommitAddress,

--- a/src/plugins/git/edges.js
+++ b/src/plugins/git/edges.js
@@ -1,6 +1,5 @@
 // @flow
 
-import type {CommitAddress as $IMPORTED_TYPE$_CommitAddress} from "./nodes.js";
 import deepFreeze from "deep-freeze";
 import {
   type Edge,
@@ -41,8 +40,8 @@ export type StructuredAddress = HasParentAddress;
 
 export const createEdge: {|
   hasParent: (
-    child: $IMPORTED_TYPE$_CommitAddress,
-    parent: $IMPORTED_TYPE$_CommitAddress,
+    child: GitNode.CommitAddress,
+    parent: GitNode.CommitAddress,
     timestampMs: TimestampMs
   ) => Edge,
 |} = deepFreeze({

--- a/src/plugins/git/edges.js
+++ b/src/plugins/git/edges.js
@@ -1,6 +1,7 @@
 // @flow
 
-import type {CommitAddress as $IMPORTED_TYPE$_CommitAddress} from "./nodes.js";import deepFreeze from "deep-freeze";
+import type {CommitAddress as $IMPORTED_TYPE$_CommitAddress} from "./nodes.js";
+import deepFreeze from "deep-freeze";
 import {
   type Edge,
   type EdgeAddressT,
@@ -23,10 +24,12 @@ function gitEdgeAddress(...parts: string[]): RawAddress {
   return EdgeAddress.append(GIT_PREFIX, ...parts);
 }
 
-export const Prefix: {|base: EdgeAddressT, hasParent: RawAddress|} = deepFreeze({
-  base: GIT_PREFIX,
-  hasParent: gitEdgeAddress(HAS_PARENT_TYPE),
-});
+export const Prefix: {|base: EdgeAddressT, hasParent: RawAddress|} = deepFreeze(
+  {
+    base: GIT_PREFIX,
+    hasParent: gitEdgeAddress(HAS_PARENT_TYPE),
+  }
+);
 
 export type HasParentAddress = {|
   type: typeof HAS_PARENT_TYPE,

--- a/src/plugins/git/nodes.js
+++ b/src/plugins/git/nodes.js
@@ -13,7 +13,7 @@ export function _gitAddress(...parts: string[]): RawAddress {
 
 export const COMMIT_TYPE: "COMMIT" = "COMMIT";
 
-export const Prefix = deepFreeze({
+export const Prefix: {|base: NodeAddressT, commit: RawAddress|} = deepFreeze({
   base: GIT_PREFIX,
   commit: _gitAddress(COMMIT_TYPE),
 });

--- a/src/plugins/git/render.js
+++ b/src/plugins/git/render.js
@@ -1,6 +1,7 @@
 // @flow
 
-import type {Element} from "React";import React from "react";
+import type {Element} from "React";
+import React from "react";
 import Link from "../../webutil/Link";
 import * as N from "./nodes";
 import type {Repository} from "./types";

--- a/src/plugins/git/render.js
+++ b/src/plugins/git/render.js
@@ -1,6 +1,6 @@
 // @flow
 
-import React from "react";
+import type {Element} from "React";import React from "react";
 import Link from "../../webutil/Link";
 import * as N from "./nodes";
 import type {Repository} from "./types";
@@ -11,7 +11,7 @@ export function description(
   address: N.StructuredAddress,
   repository: Repository,
   gateway: GitGateway
-) {
+): Element<"code"> | Element<"span"> {
   switch (address.type) {
     case "COMMIT": {
       const hash = address.hash;

--- a/src/plugins/git/render.js
+++ b/src/plugins/git/render.js
@@ -1,7 +1,6 @@
 // @flow
 
-import type {Element} from "React";
-import React from "react";
+import React, {type Element as ReactElement} from "react";
 import Link from "../../webutil/Link";
 import * as N from "./nodes";
 import type {Repository} from "./types";
@@ -12,7 +11,7 @@ export function description(
   address: N.StructuredAddress,
   repository: Repository,
   gateway: GitGateway
-): Element<"code"> | Element<"span"> {
+): ReactElement<"code"> | ReactElement<"span"> {
   switch (address.type) {
     case "COMMIT": {
       const hash = address.hash;

--- a/src/plugins/github/declaration.js
+++ b/src/plugins/github/declaration.js
@@ -1,6 +1,7 @@
 // @flow
 
-import type {NodeAddressT} from "../../core/graph.js";import deepFreeze from "deep-freeze";
+import type {NodeAddressT} from "../../core/graph.js";
+import deepFreeze from "deep-freeze";
 import type {PluginDeclaration} from "../../analysis/pluginDeclaration";
 import * as N from "./nodes";
 import * as E from "./edges";

--- a/src/plugins/github/declaration.js
+++ b/src/plugins/github/declaration.js
@@ -1,12 +1,18 @@
 // @flow
 
-import deepFreeze from "deep-freeze";
+import type {NodeAddressT} from "../../core/graph.js";import deepFreeze from "deep-freeze";
 import type {PluginDeclaration} from "../../analysis/pluginDeclaration";
 import * as N from "./nodes";
 import * as E from "./edges";
 import dedent from "../../util/dedent";
 
-export const repoNodeType = deepFreeze({
+export const repoNodeType: {|
+  +defaultWeight: number,
+  +description: string,
+  +name: string,
+  +pluralName: string,
+  +prefix: NodeAddressT,
+|} = deepFreeze({
   name: "Repository",
   pluralName: "Repositories",
   prefix: N.Prefix.repo,
@@ -55,7 +61,13 @@ const commitNodeType = deepFreeze({
     "Represents a particular Git commit on GitHub, i.e. scoped to a particular repository",
 });
 
-export const userNodeType = deepFreeze({
+export const userNodeType: {|
+  +defaultWeight: number,
+  +description: string,
+  +name: string,
+  +pluralName: string,
+  +prefix: NodeAddressT,
+|} = deepFreeze({
   name: "User",
   pluralName: "Users",
   prefix: N.Prefix.user,

--- a/src/plugins/github/declaration.js
+++ b/src/plugins/github/declaration.js
@@ -1,10 +1,10 @@
 // @flow
 
-import type {NodeAddressT} from "../../core/graph.js";
 import deepFreeze from "deep-freeze";
 import type {PluginDeclaration} from "../../analysis/pluginDeclaration";
 import * as N from "./nodes";
 import * as E from "./edges";
+import type {NodeAddressT} from "../../core/graph";
 import dedent from "../../util/dedent";
 
 export const repoNodeType: {|

--- a/src/plugins/github/edges.js
+++ b/src/plugins/github/edges.js
@@ -1,17 +1,5 @@
 // @flow
 
-import type {
-  UserlikeAddress as $IMPORTED_TYPE$_UserlikeAddress,
-  TextContentAddress as $IMPORTED_TYPE$_TextContentAddress,
-  ReferentAddress as $IMPORTED_TYPE$_ReferentAddress,
-  ReactableAddress as $IMPORTED_TYPE$_ReactableAddress,
-  PullAddress as $IMPORTED_TYPE$_PullAddress,
-  ParentAddress as $IMPORTED_TYPE$_ParentAddress,
-  CommitAddress as $IMPORTED_TYPE$_CommitAddress,
-  ChildAddress as $IMPORTED_TYPE$_ChildAddress,
-  AuthorableAddress as $IMPORTED_TYPE$_AuthorableAddress,
-} from "./nodes.js";
-import type {CommitAddress as $IMPORTED_TYPE$_CommitAddress_1} from "../git/nodes.js";
 import deepFreeze from "deep-freeze";
 import {
   type Edge,
@@ -110,34 +98,34 @@ export type StructuredAddress =
 
 export const createEdge: {|
   authors: (
-    author: $IMPORTED_TYPE$_UserlikeAddress,
-    content: $IMPORTED_TYPE$_AuthorableAddress,
+    author: GithubNode.UserlikeAddress,
+    content: GithubNode.AuthorableAddress,
     timestampMs: TimestampMs
   ) => Edge,
   correspondsToCommit: (
-    githubCommit: $IMPORTED_TYPE$_CommitAddress,
-    gitCommit: $IMPORTED_TYPE$_CommitAddress_1,
+    githubCommit: GithubNode.CommitAddress,
+    gitCommit: GitNode.CommitAddress,
     timestampMs: TimestampMs
   ) => Edge,
   hasParent: (
-    child: $IMPORTED_TYPE$_ChildAddress,
-    parent: $IMPORTED_TYPE$_ParentAddress,
+    child: GithubNode.ChildAddress,
+    parent: GithubNode.ParentAddress,
     timestampMs: TimestampMs
   ) => Edge,
   mergedAs: (
-    pull: $IMPORTED_TYPE$_PullAddress,
-    commit: $IMPORTED_TYPE$_CommitAddress,
+    pull: GithubNode.PullAddress,
+    commit: GithubNode.CommitAddress,
     timestampMs: TimestampMs
   ) => Edge,
   reacts: (
     reactionType: ReactionContent,
-    user: $IMPORTED_TYPE$_UserlikeAddress,
-    reactable: $IMPORTED_TYPE$_ReactableAddress,
+    user: GithubNode.UserlikeAddress,
+    reactable: GithubNode.ReactableAddress,
     timestampMs: TimestampMs
   ) => Edge,
   references: (
-    referrer: $IMPORTED_TYPE$_TextContentAddress,
-    referent: $IMPORTED_TYPE$_ReferentAddress,
+    referrer: GithubNode.TextContentAddress,
+    referent: GithubNode.ReferentAddress,
     timestampMs: TimestampMs
   ) => Edge,
 |} = deepFreeze({

--- a/src/plugins/github/edges.js
+++ b/src/plugins/github/edges.js
@@ -11,7 +11,8 @@ import type {
   ChildAddress as $IMPORTED_TYPE$_ChildAddress,
   AuthorableAddress as $IMPORTED_TYPE$_AuthorableAddress,
 } from "./nodes.js";
-import type {CommitAddress as $IMPORTED_TYPE$_CommitAddress_1} from "../git/nodes.js";import deepFreeze from "deep-freeze";
+import type {CommitAddress as $IMPORTED_TYPE$_CommitAddress_1} from "../git/nodes.js";
+import deepFreeze from "deep-freeze";
 import {
   type Edge,
   type EdgeAddressT,

--- a/src/plugins/github/edges.js
+++ b/src/plugins/github/edges.js
@@ -1,6 +1,17 @@
 // @flow
 
-import deepFreeze from "deep-freeze";
+import type {
+  UserlikeAddress as $IMPORTED_TYPE$_UserlikeAddress,
+  TextContentAddress as $IMPORTED_TYPE$_TextContentAddress,
+  ReferentAddress as $IMPORTED_TYPE$_ReferentAddress,
+  ReactableAddress as $IMPORTED_TYPE$_ReactableAddress,
+  PullAddress as $IMPORTED_TYPE$_PullAddress,
+  ParentAddress as $IMPORTED_TYPE$_ParentAddress,
+  CommitAddress as $IMPORTED_TYPE$_CommitAddress,
+  ChildAddress as $IMPORTED_TYPE$_ChildAddress,
+  AuthorableAddress as $IMPORTED_TYPE$_AuthorableAddress,
+} from "./nodes.js";
+import type {CommitAddress as $IMPORTED_TYPE$_CommitAddress_1} from "../git/nodes.js";import deepFreeze from "deep-freeze";
 import {
   type Edge,
   type EdgeAddressT,
@@ -33,7 +44,19 @@ function githubEdgeAddress(...parts: string[]): RawAddress {
   return EdgeAddress.append(GITHUB_PREFIX, ...parts);
 }
 
-export const Prefix = deepFreeze({
+export const Prefix: {|
+  authors: RawAddress,
+  base: EdgeAddressT,
+  correspondsToCommit: RawAddress,
+  hasParent: RawAddress,
+  mergedAs: RawAddress,
+  reacts: RawAddress,
+  reactsHeart: RawAddress,
+  reactsHooray: RawAddress,
+  reactsRocket: RawAddress,
+  reactsThumbsUp: RawAddress,
+  references: RawAddress,
+|} = deepFreeze({
   base: GITHUB_PREFIX,
   authors: githubEdgeAddress(AUTHORS_TYPE),
   mergedAs: githubEdgeAddress(MERGED_AS_TYPE),
@@ -84,7 +107,39 @@ export type StructuredAddress =
   | ReactsAddress
   | CorrespondsToCommitAddress;
 
-export const createEdge = deepFreeze({
+export const createEdge: {|
+  authors: (
+    author: $IMPORTED_TYPE$_UserlikeAddress,
+    content: $IMPORTED_TYPE$_AuthorableAddress,
+    timestampMs: TimestampMs
+  ) => Edge,
+  correspondsToCommit: (
+    githubCommit: $IMPORTED_TYPE$_CommitAddress,
+    gitCommit: $IMPORTED_TYPE$_CommitAddress_1,
+    timestampMs: TimestampMs
+  ) => Edge,
+  hasParent: (
+    child: $IMPORTED_TYPE$_ChildAddress,
+    parent: $IMPORTED_TYPE$_ParentAddress,
+    timestampMs: TimestampMs
+  ) => Edge,
+  mergedAs: (
+    pull: $IMPORTED_TYPE$_PullAddress,
+    commit: $IMPORTED_TYPE$_CommitAddress,
+    timestampMs: TimestampMs
+  ) => Edge,
+  reacts: (
+    reactionType: ReactionContent,
+    user: $IMPORTED_TYPE$_UserlikeAddress,
+    reactable: $IMPORTED_TYPE$_ReactableAddress,
+    timestampMs: TimestampMs
+  ) => Edge,
+  references: (
+    referrer: $IMPORTED_TYPE$_TextContentAddress,
+    referent: $IMPORTED_TYPE$_ReferentAddress,
+    timestampMs: TimestampMs
+  ) => Edge,
+|} = deepFreeze({
   authors: (
     author: GithubNode.UserlikeAddress,
     content: GithubNode.AuthorableAddress,

--- a/src/plugins/github/example/example.js
+++ b/src/plugins/github/example/example.js
@@ -1,6 +1,6 @@
 // @flow
 
-import {RelationalView} from "../relationalView";
+import type {Userlike, Review, Repo, Pull, Issue, Commit, Comment} from "/home/wchargin/tmp/flowcodemod/relationalView.js";import {RelationalView} from "../relationalView";
 import type {Repository} from "../graphqlTypes";
 import {type WeightedGraph} from "../../../core/weightedGraph";
 import cloneDeep from "lodash.clonedeep";
@@ -20,7 +20,15 @@ export function exampleGraph(): WeightedGraph {
   return createGraph(exampleRelationalView());
 }
 
-export function exampleEntities() {
+export function exampleEntities(): {|
+  comment: Comment,
+  commit: Commit,
+  issue: Issue,
+  pull: Pull,
+  repo: Repo,
+  review: Review,
+  userlike: Userlike,
+|} {
   const view = exampleRelationalView();
   const repo = Array.from(view.repos())[0];
   const issue = Array.from(repo.issues())[1];

--- a/src/plugins/github/example/example.js
+++ b/src/plugins/github/example/example.js
@@ -1,6 +1,15 @@
 // @flow
 
-import type {Userlike, Review, Repo, Pull, Issue, Commit, Comment} from "/home/wchargin/tmp/flowcodemod/relationalView.js";import {RelationalView} from "../relationalView";
+import type {
+  Userlike,
+  Review,
+  Repo,
+  Pull,
+  Issue,
+  Commit,
+  Comment,
+} from "/home/wchargin/tmp/flowcodemod/relationalView.js";
+import {RelationalView} from "../relationalView";
 import type {Repository} from "../graphqlTypes";
 import {type WeightedGraph} from "../../../core/weightedGraph";
 import cloneDeep from "lodash.clonedeep";

--- a/src/plugins/github/example/example.js
+++ b/src/plugins/github/example/example.js
@@ -8,7 +8,7 @@ import type {
   Issue,
   Commit,
   Comment,
-} from "/home/wchargin/tmp/flowcodemod/relationalView.js";
+} from "../relationalView";
 import {RelationalView} from "../relationalView";
 import type {Repository} from "../graphqlTypes";
 import {type WeightedGraph} from "../../../core/weightedGraph";

--- a/src/plugins/github/generateGraphqlFlowTypes.js
+++ b/src/plugins/github/generateGraphqlFlowTypes.js
@@ -5,7 +5,7 @@ import prettier from "prettier";
 import generateFlowTypes from "../../graphql/generateFlowTypes";
 import schema from "./schema";
 
-export default function generateGraphqlFlowTypes() {
+export default function generateGraphqlFlowTypes(): string {
   const prettierOptions = {
     parser: "babel",
     ...prettier.resolveConfig.sync(__filename),

--- a/src/plugins/github/nodes.js
+++ b/src/plugins/github/nodes.js
@@ -21,7 +21,21 @@ export const USERLIKE_TYPE: "USERLIKE" = "USERLIKE";
 export const USER_SUBTYPE: "USER" = "USER";
 export const BOT_SUBTYPE: "BOT" = "BOT";
 
-export const Prefix = deepFreeze({
+export const Prefix: {|
+  base: NodeAddressT,
+  bot: RawAddress,
+  comment: RawAddress,
+  commit: RawAddress,
+  issue: RawAddress,
+  issueComment: RawAddress,
+  pull: RawAddress,
+  pullComment: RawAddress,
+  repo: RawAddress,
+  review: RawAddress,
+  reviewComment: RawAddress,
+  user: RawAddress,
+  userlike: RawAddress,
+|} = deepFreeze({
   base: GITHUB_PREFIX,
   repo: _githubAddress(REPO_TYPE),
   issue: _githubAddress(ISSUE_TYPE),

--- a/src/plugins/initiatives/declaration.js
+++ b/src/plugins/initiatives/declaration.js
@@ -1,13 +1,20 @@
 // @flow
 
-import type {NodeAddressT, EdgeAddressT} from "../../core/graph.js";import deepFreeze from "deep-freeze";
+import type {NodeAddressT, EdgeAddressT} from "../../core/graph.js";
+import deepFreeze from "deep-freeze";
 import type {PluginDeclaration} from "../../analysis/pluginDeclaration";
 import type {NodeType, EdgeType} from "../../analysis/types";
 import {NodeAddress, EdgeAddress} from "../../core/graph";
 import type {NodeEntryField} from "./nodeEntry";
 
-export const nodePrefix: NodeAddressT = NodeAddress.fromParts(["sourcecred", "initiatives"]);
-export const edgePrefix: EdgeAddressT = EdgeAddress.fromParts(["sourcecred", "initiatives"]);
+export const nodePrefix: NodeAddressT = NodeAddress.fromParts([
+  "sourcecred",
+  "initiatives",
+]);
+export const edgePrefix: EdgeAddressT = EdgeAddress.fromParts([
+  "sourcecred",
+  "initiatives",
+]);
 
 export const initiativeNodeType: NodeType = deepFreeze({
   name: "Initiative",

--- a/src/plugins/initiatives/declaration.js
+++ b/src/plugins/initiatives/declaration.js
@@ -1,13 +1,13 @@
 // @flow
 
-import deepFreeze from "deep-freeze";
+import type {NodeAddressT, EdgeAddressT} from "../../core/graph.js";import deepFreeze from "deep-freeze";
 import type {PluginDeclaration} from "../../analysis/pluginDeclaration";
 import type {NodeType, EdgeType} from "../../analysis/types";
 import {NodeAddress, EdgeAddress} from "../../core/graph";
 import type {NodeEntryField} from "./nodeEntry";
 
-export const nodePrefix = NodeAddress.fromParts(["sourcecred", "initiatives"]);
-export const edgePrefix = EdgeAddress.fromParts(["sourcecred", "initiatives"]);
+export const nodePrefix: NodeAddressT = NodeAddress.fromParts(["sourcecred", "initiatives"]);
+export const edgePrefix: EdgeAddressT = EdgeAddress.fromParts(["sourcecred", "initiatives"]);
 
 export const initiativeNodeType: NodeType = deepFreeze({
   name: "Initiative",

--- a/src/plugins/initiatives/declaration.js
+++ b/src/plugins/initiatives/declaration.js
@@ -1,10 +1,14 @@
 // @flow
 
-import type {NodeAddressT, EdgeAddressT} from "../../core/graph.js";
 import deepFreeze from "deep-freeze";
 import type {PluginDeclaration} from "../../analysis/pluginDeclaration";
 import type {NodeType, EdgeType} from "../../analysis/types";
-import {NodeAddress, EdgeAddress} from "../../core/graph";
+import {
+  NodeAddress,
+  EdgeAddress,
+  type NodeAddressT,
+  type EdgeAddressT,
+} from "../../core/graph";
 import type {NodeEntryField} from "./nodeEntry";
 
 export const nodePrefix: NodeAddressT = NodeAddress.fromParts([

--- a/src/ui/components/AccountOverview.js
+++ b/src/ui/components/AccountOverview.js
@@ -1,6 +1,7 @@
 // @flow
 
-import type {Node} from "React";import React from "react";
+import type {Node} from "React";
+import React from "react";
 import Table from "@material-ui/core/Table";
 import TableBody from "@material-ui/core/TableBody";
 import TableCell from "@material-ui/core/TableCell";

--- a/src/ui/components/AccountOverview.js
+++ b/src/ui/components/AccountOverview.js
@@ -1,7 +1,6 @@
 // @flow
 
-import type {Node} from "React";
-import React from "react";
+import React, {type Node as ReactNode} from "react";
 import Table from "@material-ui/core/Table";
 import TableBody from "@material-ui/core/TableBody";
 import TableCell from "@material-ui/core/TableCell";
@@ -27,7 +26,7 @@ const useStyles = makeStyles(() => {
 
 export const AccountOverview = ({
   currency: {suffix: currencySuffix},
-}: OverviewProps): Node => {
+}: OverviewProps): ReactNode => {
   const {ledger} = useLedger();
   const classes = useStyles();
 

--- a/src/ui/components/AccountOverview.js
+++ b/src/ui/components/AccountOverview.js
@@ -1,6 +1,6 @@
 // @flow
 
-import React from "react";
+import type {Node} from "React";import React from "react";
 import Table from "@material-ui/core/Table";
 import TableBody from "@material-ui/core/TableBody";
 import TableCell from "@material-ui/core/TableCell";
@@ -26,7 +26,7 @@ const useStyles = makeStyles(() => {
 
 export const AccountOverview = ({
   currency: {suffix: currencySuffix},
-}: OverviewProps) => {
+}: OverviewProps): Node => {
   const {ledger} = useLedger();
   const classes = useStyles();
 

--- a/src/ui/components/AccountSelector.js
+++ b/src/ui/components/AccountSelector.js
@@ -1,5 +1,5 @@
 // @flow
-import React from "react";
+import type {Node} from "React";import React from "react";
 import {makeStyles} from "@material-ui/core/styles";
 import {TextField} from "@material-ui/core";
 import {Autocomplete} from "@material-ui/lab";
@@ -17,7 +17,7 @@ export default function AccountDropdown({
   placeholder,
   setCurrentAccount,
   ledger,
-}: DropdownProps) {
+}: DropdownProps): Node {
   const classes = useStyles();
   const items = ledger.accounts().filter((a) => a.active);
 

--- a/src/ui/components/AccountSelector.js
+++ b/src/ui/components/AccountSelector.js
@@ -1,5 +1,6 @@
 // @flow
-import type {Node} from "React";import React from "react";
+import type {Node} from "React";
+import React from "react";
 import {makeStyles} from "@material-ui/core/styles";
 import {TextField} from "@material-ui/core";
 import {Autocomplete} from "@material-ui/lab";

--- a/src/ui/components/AccountSelector.js
+++ b/src/ui/components/AccountSelector.js
@@ -1,6 +1,5 @@
 // @flow
-import type {Node} from "React";
-import React from "react";
+import React, {type Node as ReactNode} from "react";
 import {makeStyles} from "@material-ui/core/styles";
 import {TextField} from "@material-ui/core";
 import {Autocomplete} from "@material-ui/lab";
@@ -18,7 +17,7 @@ export default function AccountDropdown({
   placeholder,
   setCurrentAccount,
   ledger,
-}: DropdownProps): Node {
+}: DropdownProps): ReactNode {
   const classes = useStyles();
   const items = ledger.accounts().filter((a) => a.active);
 

--- a/src/ui/components/AdminApp.js
+++ b/src/ui/components/AdminApp.js
@@ -1,7 +1,6 @@
 // @flow
 
-import type {Node, Element} from "React";
-import React, {useEffect, useState} from "react";
+import React, {type Node as ReactNode, useEffect, useState} from "react";
 import {Redirect, Route, useHistory} from "react-router-dom";
 import {Admin, Resource, Layout, Loading} from "react-admin";
 import {createMuiTheme} from "@material-ui/core/styles";
@@ -74,7 +73,7 @@ const customRoutes = (
   return routes.concat(hasBackend ? backendRoutes : []);
 };
 
-const AdminApp = (): Element<"div"> | Node => {
+const AdminApp = (): ReactNode => {
   const [loadResult, setLoadResult] = useState<LoadResult | null>(null);
   useEffect(() => {
     load().then(setLoadResult);

--- a/src/ui/components/AdminApp.js
+++ b/src/ui/components/AdminApp.js
@@ -1,6 +1,7 @@
 // @flow
 
-import type {Node, Element} from "React";import React, {useEffect, useState} from "react";
+import type {Node, Element} from "React";
+import React, {useEffect, useState} from "react";
 import {Redirect, Route, useHistory} from "react-router-dom";
 import {Admin, Resource, Layout, Loading} from "react-admin";
 import {createMuiTheme} from "@material-ui/core/styles";

--- a/src/ui/components/AdminApp.js
+++ b/src/ui/components/AdminApp.js
@@ -1,6 +1,6 @@
 // @flow
 
-import React, {useEffect, useState} from "react";
+import type {Node, Element} from "React";import React, {useEffect, useState} from "react";
 import {Redirect, Route, useHistory} from "react-router-dom";
 import {Admin, Resource, Layout, Loading} from "react-admin";
 import {createMuiTheme} from "@material-ui/core/styles";
@@ -73,7 +73,7 @@ const customRoutes = (
   return routes.concat(hasBackend ? backendRoutes : []);
 };
 
-const AdminApp = () => {
+const AdminApp = (): Element<"div"> | Node => {
   const [loadResult, setLoadResult] = useState<LoadResult | null>(null);
   useEffect(() => {
     load().then(setLoadResult);

--- a/src/ui/components/AliasView.js
+++ b/src/ui/components/AliasView.js
@@ -1,6 +1,6 @@
 // @flow
 
-import React from "react";
+import type {Node} from "React";import React from "react";
 import {type IdentityId} from "../../ledger/identity";
 import Markdown from "react-markdown";
 
@@ -17,7 +17,7 @@ const useStyles = makeStyles({
   aliasesHeader: {margin: "20px", marginBottom: 0},
 });
 
-export function AliasView({selectedId}: Props) {
+export function AliasView({selectedId}: Props): Node {
   const {ledger} = useLedger();
   const classes = useStyles();
   const selectedAccount = ledger.account(selectedId);

--- a/src/ui/components/AliasView.js
+++ b/src/ui/components/AliasView.js
@@ -1,6 +1,7 @@
 // @flow
 
-import type {Node} from "React";import React from "react";
+import type {Node} from "React";
+import React from "react";
 import {type IdentityId} from "../../ledger/identity";
 import Markdown from "react-markdown";
 

--- a/src/ui/components/AliasView.js
+++ b/src/ui/components/AliasView.js
@@ -1,7 +1,6 @@
 // @flow
 
-import type {Node} from "React";
-import React from "react";
+import React, {type Node as ReactNode} from "react";
 import {type IdentityId} from "../../ledger/identity";
 import Markdown from "react-markdown";
 
@@ -18,7 +17,7 @@ const useStyles = makeStyles({
   aliasesHeader: {margin: "20px", marginBottom: 0},
 });
 
-export function AliasView({selectedId}: Props): Node {
+export function AliasView({selectedId}: Props): ReactNode {
   const {ledger} = useLedger();
   const classes = useStyles();
   const selectedAccount = ledger.account(selectedId);

--- a/src/ui/components/AppBar.js
+++ b/src/ui/components/AppBar.js
@@ -80,7 +80,7 @@ const useStyles = makeStyles(
  *    );
  *};
  */
-const AppBar = (props: Props) => {
+const AppBar = (props: Props): React.Node => {
   const {
     children,
     classes: _ /*classesOverride*/,

--- a/src/ui/components/Explorer/CredRow.js
+++ b/src/ui/components/Explorer/CredRow.js
@@ -1,5 +1,4 @@
 // @flow
-import type {Node as $IMPORTED_TYPE$_Node} from "React";
 import React, {type Node as ReactNode, useState} from "react";
 import Markdown from "react-markdown";
 import {IconButton, Link, TableCell, TableRow} from "@material-ui/core";
@@ -27,7 +26,7 @@ const CredRow = ({
   description,
   depth,
   indent,
-}: CredRowProps): $IMPORTED_TYPE$_Node => {
+}: CredRowProps): ReactNode => {
   const [expanded, setExpanded] = useState(false);
   const backgroundColor = `hsla(150,100%,28%,${1 - 0.9 ** depth})`;
   const makeGradient = (color) => `linear-gradient(to top, ${color}, ${color})`;

--- a/src/ui/components/Explorer/CredRow.js
+++ b/src/ui/components/Explorer/CredRow.js
@@ -1,5 +1,6 @@
 // @flow
-import type {Node as $IMPORTED_TYPE$_Node} from "React";import React, {type Node as ReactNode, useState} from "react";
+import type {Node as $IMPORTED_TYPE$_Node} from "React";
+import React, {type Node as ReactNode, useState} from "react";
 import Markdown from "react-markdown";
 import {IconButton, Link, TableCell, TableRow} from "@material-ui/core";
 import {StyleSheet, css} from "aphrodite/no-important";

--- a/src/ui/components/Explorer/CredRow.js
+++ b/src/ui/components/Explorer/CredRow.js
@@ -1,5 +1,5 @@
 // @flow
-import React, {type Node as ReactNode, useState} from "react";
+import type {Node as $IMPORTED_TYPE$_Node} from "React";import React, {type Node as ReactNode, useState} from "react";
 import Markdown from "react-markdown";
 import {IconButton, Link, TableCell, TableRow} from "@material-ui/core";
 import {StyleSheet, css} from "aphrodite/no-important";
@@ -26,7 +26,7 @@ const CredRow = ({
   description,
   depth,
   indent,
-}: CredRowProps) => {
+}: CredRowProps): $IMPORTED_TYPE$_Node => {
   const [expanded, setExpanded] = useState(false);
   const backgroundColor = `hsla(150,100%,28%,${1 - 0.9 ** depth})`;
   const makeGradient = (color) => `linear-gradient(to top, ${color}, ${color})`;

--- a/src/ui/components/Explorer/CredTimeline.js
+++ b/src/ui/components/Explorer/CredTimeline.js
@@ -1,10 +1,10 @@
 // @flow
-import React from "react";
+import type {Element} from "React";import React from "react";
 import {extent} from "d3-array";
 import {scaleLinear} from "d3-scale";
 import {line} from "d3-shape";
 
-const CredTimeline = ({data}: {|+data: $ReadOnlyArray<number> | null|}) => {
+const CredTimeline = ({data}: {|+data: $ReadOnlyArray<number> | null|}): Element<"svg"> | string => {
   if (data == null) {
     return "";
   }

--- a/src/ui/components/Explorer/CredTimeline.js
+++ b/src/ui/components/Explorer/CredTimeline.js
@@ -1,6 +1,5 @@
 // @flow
-import type {Element} from "React";
-import React from "react";
+import React, {type Node as ReactNode} from "react";
 import {extent} from "d3-array";
 import {scaleLinear} from "d3-scale";
 import {line} from "d3-shape";
@@ -9,7 +8,7 @@ const CredTimeline = ({
   data,
 }: {|
   +data: $ReadOnlyArray<number> | null,
-|}): Element<"svg"> | string => {
+|}): ReactNode => {
   if (data == null) {
     return "";
   }

--- a/src/ui/components/Explorer/CredTimeline.js
+++ b/src/ui/components/Explorer/CredTimeline.js
@@ -1,10 +1,15 @@
 // @flow
-import type {Element} from "React";import React from "react";
+import type {Element} from "React";
+import React from "react";
 import {extent} from "d3-array";
 import {scaleLinear} from "d3-scale";
 import {line} from "d3-shape";
 
-const CredTimeline = ({data}: {|+data: $ReadOnlyArray<number> | null|}): Element<"svg"> | string => {
+const CredTimeline = ({
+  data,
+}: {|
+  +data: $ReadOnlyArray<number> | null,
+|}): Element<"svg"> | string => {
   if (data == null) {
     return "";
   }

--- a/src/ui/components/Explorer/Explorer.js
+++ b/src/ui/components/Explorer/Explorer.js
@@ -1,6 +1,5 @@
 // @flow
-import type {Node, Element} from "React";
-import React from "react";
+import React, {type Node as ReactNode} from "react";
 import {
   Button,
   Grid,
@@ -99,7 +98,7 @@ export class Explorer extends React.Component<ExplorerProps, ExplorerState> {
   };
 
   // Renders the dropdown that lets the user select a type
-  renderFilterSelect(): Node {
+  renderFilterSelect(): ReactNode {
     const plugins = this.state.view.plugins();
     const optionGroup = (declaration: PluginDeclaration) => {
       const header = (
@@ -193,7 +192,7 @@ export class Explorer extends React.Component<ExplorerProps, ExplorerState> {
     );
   }
 
-  renderConfigurationRow(): Node {
+  renderConfigurationRow(): ReactNode {
     const {showWeightConfig, view, params, weights} = this.state;
     const weightFileManager = (
       <WeightsFileManager
@@ -314,7 +313,7 @@ export class Explorer extends React.Component<ExplorerProps, ExplorerState> {
     this.setState({view, recalculating: false});
   }
 
-  render(): Element<"div"> {
+  render(): ReactNode {
     const {filter, view, recalculating, name} = this.state;
     const nodes =
       filter == null ? view.userNodes() : view.nodes({prefix: filter});

--- a/src/ui/components/Explorer/Explorer.js
+++ b/src/ui/components/Explorer/Explorer.js
@@ -1,5 +1,5 @@
 // @flow
-import React from "react";
+import type {Node, Element} from "React";import React from "react";
 import {
   Button,
   Grid,
@@ -91,14 +91,14 @@ export class Explorer extends React.Component<ExplorerProps, ExplorerState> {
     };
   }
 
-  handleMenuClose = () => {
+  handleMenuClose: (() => void) = () => {
     this.setState({
       anchorEl: null,
     });
   };
 
   // Renders the dropdown that lets the user select a type
-  renderFilterSelect() {
+  renderFilterSelect(): Node {
     const plugins = this.state.view.plugins();
     const optionGroup = (declaration: PluginDeclaration) => {
       const header = (
@@ -192,7 +192,7 @@ export class Explorer extends React.Component<ExplorerProps, ExplorerState> {
     );
   }
 
-  renderConfigurationRow() {
+  renderConfigurationRow(): Node {
     const {showWeightConfig, view, params, weights} = this.state;
     const weightFileManager = (
       <WeightsFileManager
@@ -313,7 +313,7 @@ export class Explorer extends React.Component<ExplorerProps, ExplorerState> {
     this.setState({view, recalculating: false});
   }
 
-  render() {
+  render(): Element<"div"> {
     const {filter, view, recalculating, name} = this.state;
     const nodes =
       filter == null ? view.userNodes() : view.nodes({prefix: filter});

--- a/src/ui/components/Explorer/Explorer.js
+++ b/src/ui/components/Explorer/Explorer.js
@@ -1,5 +1,6 @@
 // @flow
-import type {Node, Element} from "React";import React from "react";
+import type {Node, Element} from "React";
+import React from "react";
 import {
   Button,
   Grid,
@@ -91,7 +92,7 @@ export class Explorer extends React.Component<ExplorerProps, ExplorerState> {
     };
   }
 
-  handleMenuClose: (() => void) = () => {
+  handleMenuClose: () => void = () => {
     this.setState({
       anchorEl: null,
     });

--- a/src/ui/components/Explorer/ExplorerApp.js
+++ b/src/ui/components/Explorer/ExplorerApp.js
@@ -1,9 +1,9 @@
 // @flow
-import React, {useState, useEffect} from "react";
+import type {Node, Element} from "React";import React, {useState, useEffect} from "react";
 import {Explorer} from "./Explorer.js";
 import {load, type LoadResult} from "../../load";
 
-const App = () => {
+const App = (): Element<"div"> | Element<"h1"> | Node => {
   const [loadResult: LoadResult | null, setLoadResult] = useState(null);
 
   useEffect(() => {

--- a/src/ui/components/Explorer/ExplorerApp.js
+++ b/src/ui/components/Explorer/ExplorerApp.js
@@ -1,10 +1,9 @@
 // @flow
-import type {Node, Element} from "React";
-import React, {useState, useEffect} from "react";
+import React, {type Node as ReactNode, useState, useEffect} from "react";
 import {Explorer} from "./Explorer.js";
 import {load, type LoadResult} from "../../load";
 
-const App = (): Element<"div"> | Element<"h1"> | Node => {
+const App = (): ReactNode => {
   const [loadResult: LoadResult | null, setLoadResult] = useState(null);
 
   useEffect(() => {

--- a/src/ui/components/Explorer/ExplorerApp.js
+++ b/src/ui/components/Explorer/ExplorerApp.js
@@ -1,5 +1,6 @@
 // @flow
-import type {Node, Element} from "React";import React, {useState, useEffect} from "react";
+import type {Node, Element} from "React";
+import React, {useState, useEffect} from "react";
 import {Explorer} from "./Explorer.js";
 import {load, type LoadResult} from "../../load";
 

--- a/src/ui/components/Explorer/FlowsRow.js
+++ b/src/ui/components/Explorer/FlowsRow.js
@@ -1,5 +1,6 @@
 // @flow
-import type {Node} from "React";import React from "react";
+import type {Node} from "React";
+import React from "react";
 import sortBy from "../../../util/sortBy";
 import CredRow from "./CredRow";
 import NodeRow from "./NodeRow";

--- a/src/ui/components/Explorer/FlowsRow.js
+++ b/src/ui/components/Explorer/FlowsRow.js
@@ -1,6 +1,5 @@
 // @flow
-import type {Node} from "React";
-import React from "react";
+import React, {type Node as ReactNode} from "react";
 import sortBy from "../../../util/sortBy";
 import CredRow from "./CredRow";
 import NodeRow from "./NodeRow";
@@ -76,7 +75,7 @@ const FlowsRow = ({
   +view: CredView,
   +node: CredNode,
   +depth: number,
-|}): Node => {
+|}): ReactNode => {
   const inflows = view.inflows(node.address);
   if (inflows == null) {
     throw new Error("no flows");

--- a/src/ui/components/Explorer/FlowsRow.js
+++ b/src/ui/components/Explorer/FlowsRow.js
@@ -1,5 +1,5 @@
 // @flow
-import React from "react";
+import type {Node} from "React";import React from "react";
 import sortBy from "../../../util/sortBy";
 import CredRow from "./CredRow";
 import NodeRow from "./NodeRow";
@@ -75,7 +75,7 @@ const FlowsRow = ({
   +view: CredView,
   +node: CredNode,
   +depth: number,
-|}) => {
+|}): Node => {
   const inflows = view.inflows(node.address);
   if (inflows == null) {
     throw new Error("no flows");

--- a/src/ui/components/Explorer/NodeRow.js
+++ b/src/ui/components/Explorer/NodeRow.js
@@ -1,6 +1,5 @@
 // @flow
-import type {Node} from "React";
-import React from "react";
+import React, {type Node as ReactNode} from "react";
 import CredRow from "./CredRow";
 import FlowsRow from "./FlowsRow";
 import {CredView, type CredNode} from "../../../analysis/credView";
@@ -13,7 +12,13 @@ type NodeRowProps = {
   +showChart: boolean,
 };
 
-const NodeRow = ({node, total, view, depth, showChart}: NodeRowProps): Node => {
+const NodeRow = ({
+  node,
+  total,
+  view,
+  depth,
+  showChart,
+}: NodeRowProps): ReactNode => {
   const {address, description, credSummary, credOverTime} = node;
   const cred = credSummary.cred;
   const credTimeline =

--- a/src/ui/components/Explorer/NodeRow.js
+++ b/src/ui/components/Explorer/NodeRow.js
@@ -1,5 +1,6 @@
 // @flow
-import type {Node} from "React";import React from "react";
+import type {Node} from "React";
+import React from "react";
 import CredRow from "./CredRow";
 import FlowsRow from "./FlowsRow";
 import {CredView, type CredNode} from "../../../analysis/credView";

--- a/src/ui/components/Explorer/NodeRow.js
+++ b/src/ui/components/Explorer/NodeRow.js
@@ -1,5 +1,5 @@
 // @flow
-import React from "react";
+import type {Node} from "React";import React from "react";
 import CredRow from "./CredRow";
 import FlowsRow from "./FlowsRow";
 import {CredView, type CredNode} from "../../../analysis/credView";
@@ -12,7 +12,7 @@ type NodeRowProps = {
   +showChart: boolean,
 };
 
-const NodeRow = ({node, total, view, depth, showChart}: NodeRowProps) => {
+const NodeRow = ({node, total, view, depth, showChart}: NodeRowProps): Node => {
   const {address, description, credSummary, credOverTime} = node;
   const cred = credSummary.cred;
   const credTimeline =

--- a/src/ui/components/ExplorerHome/CredTimeline.js
+++ b/src/ui/components/ExplorerHome/CredTimeline.js
@@ -1,5 +1,5 @@
 // @flow
-import React from "react";
+import type {Element} from "React";import React from "react";
 import {extent} from "d3-array";
 import {scaleLinear} from "d3-scale";
 import {line} from "d3-shape";
@@ -10,7 +10,7 @@ type CredTimelineProps = {|
   +height?: number,
 |};
 
-const CredTimeline = (props: CredTimelineProps) => {
+const CredTimeline = (props: CredTimelineProps): Element<"svg"> | string => {
   const {data} = props;
   if (data == null) {
     return "";

--- a/src/ui/components/ExplorerHome/CredTimeline.js
+++ b/src/ui/components/ExplorerHome/CredTimeline.js
@@ -1,6 +1,5 @@
 // @flow
-import type {Element} from "React";
-import React from "react";
+import React, {type Node as ReactNode} from "react";
 import {extent} from "d3-array";
 import {scaleLinear} from "d3-scale";
 import {line} from "d3-shape";
@@ -11,7 +10,7 @@ type CredTimelineProps = {|
   +height?: number,
 |};
 
-const CredTimeline = (props: CredTimelineProps): Element<"svg"> | string => {
+const CredTimeline = (props: CredTimelineProps): ReactNode => {
   const {data} = props;
   if (data == null) {
     return "";

--- a/src/ui/components/ExplorerHome/CredTimeline.js
+++ b/src/ui/components/ExplorerHome/CredTimeline.js
@@ -1,5 +1,6 @@
 // @flow
-import type {Element} from "React";import React from "react";
+import type {Element} from "React";
+import React from "react";
 import {extent} from "d3-array";
 import {scaleLinear} from "d3-scale";
 import {line} from "d3-shape";

--- a/src/ui/components/ExplorerHome/ExplorerHome.js
+++ b/src/ui/components/ExplorerHome/ExplorerHome.js
@@ -1,5 +1,6 @@
 // @flow
-import type {Node} from "React";import React, {useState} from "react";
+import type {Node} from "React";
+import React, {useState} from "react";
 import {
   Checkbox,
   Container,

--- a/src/ui/components/ExplorerHome/ExplorerHome.js
+++ b/src/ui/components/ExplorerHome/ExplorerHome.js
@@ -1,5 +1,5 @@
 // @flow
-import React, {useState} from "react";
+import type {Node} from "React";import React, {useState} from "react";
 import {
   Checkbox,
   Container,
@@ -94,7 +94,7 @@ type ExplorerHomeProps = {|
   +initialView: CredView,
 |};
 
-export const ExplorerHome = ({initialView}: ExplorerHomeProps) => {
+export const ExplorerHome = ({initialView}: ExplorerHomeProps): Node => {
   const classes = useStyles();
   const [tab, setTab] = useState<number>(1);
   const [checkboxes, setCheckboxes] = useState({

--- a/src/ui/components/ExplorerHome/ExplorerHome.js
+++ b/src/ui/components/ExplorerHome/ExplorerHome.js
@@ -1,6 +1,5 @@
 // @flow
-import type {Node} from "React";
-import React, {useState} from "react";
+import React, {useState, type Node as ReactNode} from "react";
 import {
   Checkbox,
   Container,
@@ -95,7 +94,7 @@ type ExplorerHomeProps = {|
   +initialView: CredView,
 |};
 
-export const ExplorerHome = ({initialView}: ExplorerHomeProps): Node => {
+export const ExplorerHome = ({initialView}: ExplorerHomeProps): ReactNode => {
   const classes = useStyles();
   const [tab, setTab] = useState<number>(1);
   const [checkboxes, setCheckboxes] = useState({

--- a/src/ui/components/IdentityMerger.js
+++ b/src/ui/components/IdentityMerger.js
@@ -1,5 +1,6 @@
 // @flow
-import type {Node} from "React";import React, {useState, useEffect} from "react";
+import type {Node} from "React";
+import React, {useState, useEffect} from "react";
 import {useLedger} from "../utils/LedgerContext";
 import {type IdentityId, type Identity} from "../../ledger/identity";
 

--- a/src/ui/components/IdentityMerger.js
+++ b/src/ui/components/IdentityMerger.js
@@ -1,6 +1,5 @@
 // @flow
-import type {Node} from "React";
-import React, {useState, useEffect} from "react";
+import React, {useState, useEffect, type Node as ReactNode} from "react";
 import {useLedger} from "../utils/LedgerContext";
 import {type IdentityId, type Identity} from "../../ledger/identity";
 
@@ -17,7 +16,7 @@ const useStyles = makeStyles({
   aliasesHeader: {margin: "20px", marginBottom: 0},
 });
 
-export function IdentityMerger({selectedId}: Props): Node {
+export function IdentityMerger({selectedId}: Props): ReactNode {
   const {ledger, updateLedger} = useLedger();
   const classes = useStyles();
   const [inputValue, setInputValue] = useState("");

--- a/src/ui/components/IdentityMerger.js
+++ b/src/ui/components/IdentityMerger.js
@@ -1,5 +1,5 @@
 // @flow
-import React, {useState, useEffect} from "react";
+import type {Node} from "React";import React, {useState, useEffect} from "react";
 import {useLedger} from "../utils/LedgerContext";
 import {type IdentityId, type Identity} from "../../ledger/identity";
 
@@ -16,7 +16,7 @@ const useStyles = makeStyles({
   aliasesHeader: {margin: "20px", marginBottom: 0},
 });
 
-export function IdentityMerger({selectedId}: Props) {
+export function IdentityMerger({selectedId}: Props): Node {
   const {ledger, updateLedger} = useLedger();
   const classes = useStyles();
   const [inputValue, setInputValue] = useState("");

--- a/src/ui/components/LedgerAdmin.js
+++ b/src/ui/components/LedgerAdmin.js
@@ -1,6 +1,7 @@
 // @flow
 
-import type {Node} from "React";import React, {useState} from "react";
+import type {Node} from "React";
+import React, {useState} from "react";
 import {type Identity, type IdentityId} from "../../ledger/identity";
 import {AliasView} from "./AliasView";
 import {IdentityMerger} from "./IdentityMerger";

--- a/src/ui/components/LedgerAdmin.js
+++ b/src/ui/components/LedgerAdmin.js
@@ -1,6 +1,6 @@
 // @flow
 
-import React, {useState} from "react";
+import type {Node} from "React";import React, {useState} from "react";
 import {type Identity, type IdentityId} from "../../ledger/identity";
 import {AliasView} from "./AliasView";
 import {IdentityMerger} from "./IdentityMerger";
@@ -49,7 +49,7 @@ const useStyles = makeStyles((theme) => {
   };
 });
 
-export const LedgerAdmin = () => {
+export const LedgerAdmin = (): Node => {
   const {ledger, updateLedger} = useLedger();
 
   const classes = useStyles();

--- a/src/ui/components/LedgerAdmin.js
+++ b/src/ui/components/LedgerAdmin.js
@@ -1,7 +1,6 @@
 // @flow
 
-import type {Node} from "React";
-import React, {useState} from "react";
+import React, {useState, type Node as ReactNode} from "react";
 import {type Identity, type IdentityId} from "../../ledger/identity";
 import {AliasView} from "./AliasView";
 import {IdentityMerger} from "./IdentityMerger";
@@ -50,7 +49,7 @@ const useStyles = makeStyles((theme) => {
   };
 });
 
-export const LedgerAdmin = (): Node => {
+export const LedgerAdmin = (): ReactNode => {
   const {ledger, updateLedger} = useLedger();
 
   const classes = useStyles();

--- a/src/ui/components/LoadingIndicator.js
+++ b/src/ui/components/LoadingIndicator.js
@@ -15,7 +15,7 @@ const useStyles = makeStyles(
   {name: "RaLoadingIndicator"}
 );
 
-const LoadingIndicator = (props: Props) => {
+const LoadingIndicator = (props: Props): React.Node | boolean => {
   const {classes: _ /*classesOverride*/, className} = props;
   useRefreshWhenVisible();
   const loading = useSelector((state) => state.admin.loading > 0);

--- a/src/ui/components/Menu.js
+++ b/src/ui/components/Menu.js
@@ -1,5 +1,6 @@
 // @flow
-import type {Node} from "React";import React from "react";
+import type {Node} from "React";
+import React from "react";
 import {useSelector} from "react-redux";
 import {MenuItemLink} from "react-admin";
 import TrendingUpIcon from "@material-ui/icons/TrendingUp";

--- a/src/ui/components/Menu.js
+++ b/src/ui/components/Menu.js
@@ -1,5 +1,5 @@
 // @flow
-import React from "react";
+import type {Node} from "React";import React from "react";
 import {useSelector} from "react-redux";
 import {MenuItemLink} from "react-admin";
 import TrendingUpIcon from "@material-ui/icons/TrendingUp";
@@ -12,7 +12,7 @@ type menuProps = {|onMenuClick: Function|};
 const createMenu = (
   hasBackend: Boolean,
   {name: currencyName}: CurrencyDetails
-) => {
+): ((menuProps) => Node) => {
   const Menu = ({onMenuClick}: menuProps) => {
     const open = useSelector((state) => state.admin.ui.sidebarOpen);
     return (

--- a/src/ui/components/Menu.js
+++ b/src/ui/components/Menu.js
@@ -1,6 +1,5 @@
 // @flow
-import type {Node} from "React";
-import React from "react";
+import React, {type Node as ReactNode} from "react";
 import {useSelector} from "react-redux";
 import {MenuItemLink} from "react-admin";
 import TrendingUpIcon from "@material-ui/icons/TrendingUp";
@@ -13,7 +12,7 @@ type menuProps = {|onMenuClick: Function|};
 const createMenu = (
   hasBackend: Boolean,
   {name: currencyName}: CurrencyDetails
-): ((menuProps) => Node) => {
+): ((menuProps) => ReactNode) => {
   const Menu = ({onMenuClick}: menuProps) => {
     const open = useSelector((state) => state.admin.ui.sidebarOpen);
     return (

--- a/src/ui/components/SpecialDistribution.js
+++ b/src/ui/components/SpecialDistribution.js
@@ -1,5 +1,5 @@
 // @flow
-import React, {useState} from "react";
+import type {Node} from "React";import React, {useState} from "react";
 import {Button, Container, TextField} from "@material-ui/core";
 import {Alert} from "@material-ui/lab";
 import {makeStyles} from "@material-ui/core/styles";
@@ -53,7 +53,7 @@ type SpecialDistributionProps = {|+currency: CurrencyDetails|};
 
 export const SpecialDistribution = ({
   currency: {name: currencyName},
-}: SpecialDistributionProps) => {
+}: SpecialDistributionProps): Node => {
   const {ledger, updateLedger} = useLedger();
 
   const classes = useStyles();

--- a/src/ui/components/SpecialDistribution.js
+++ b/src/ui/components/SpecialDistribution.js
@@ -1,5 +1,6 @@
 // @flow
-import type {Node} from "React";import React, {useState} from "react";
+import type {Node} from "React";
+import React, {useState} from "react";
 import {Button, Container, TextField} from "@material-ui/core";
 import {Alert} from "@material-ui/lab";
 import {makeStyles} from "@material-ui/core/styles";

--- a/src/ui/components/SpecialDistribution.js
+++ b/src/ui/components/SpecialDistribution.js
@@ -1,6 +1,5 @@
 // @flow
-import type {Node} from "React";
-import React, {useState} from "react";
+import React, {useState, type Node as ReactNode} from "react";
 import {Button, Container, TextField} from "@material-ui/core";
 import {Alert} from "@material-ui/lab";
 import {makeStyles} from "@material-ui/core/styles";
@@ -54,7 +53,7 @@ type SpecialDistributionProps = {|+currency: CurrencyDetails|};
 
 export const SpecialDistribution = ({
   currency: {name: currencyName},
-}: SpecialDistributionProps): Node => {
+}: SpecialDistributionProps): ReactNode => {
   const {ledger, updateLedger} = useLedger();
 
   const classes = useStyles();

--- a/src/ui/components/Transfer.js
+++ b/src/ui/components/Transfer.js
@@ -1,5 +1,5 @@
 // @flow
-import React, {useState} from "react";
+import type {Node} from "React";import React, {useState} from "react";
 import {Button, Container, TextField} from "@material-ui/core";
 import {makeStyles} from "@material-ui/core/styles";
 import {div, format, gt, lt, fromFloatString} from "../../ledger/grain";
@@ -49,7 +49,7 @@ type TransferProps = {|+currency: CurrencyDetails|};
 
 export const Transfer = ({
   currency: {name: currencyName, suffix: currencySuffix},
-}: TransferProps) => {
+}: TransferProps): Node => {
   const {ledger, updateLedger} = useLedger();
 
   const classes = useStyles();

--- a/src/ui/components/Transfer.js
+++ b/src/ui/components/Transfer.js
@@ -1,5 +1,6 @@
 // @flow
-import type {Node} from "React";import React, {useState} from "react";
+import type {Node} from "React";
+import React, {useState} from "react";
 import {Button, Container, TextField} from "@material-ui/core";
 import {makeStyles} from "@material-ui/core/styles";
 import {div, format, gt, lt, fromFloatString} from "../../ledger/grain";

--- a/src/ui/components/Transfer.js
+++ b/src/ui/components/Transfer.js
@@ -1,6 +1,5 @@
 // @flow
-import type {Node} from "React";
-import React, {useState} from "react";
+import React, {useState, type Node as ReactNode} from "react";
 import {Button, Container, TextField} from "@material-ui/core";
 import {makeStyles} from "@material-ui/core/styles";
 import {div, format, gt, lt, fromFloatString} from "../../ledger/grain";
@@ -50,7 +49,7 @@ type TransferProps = {|+currency: CurrencyDetails|};
 
 export const Transfer = ({
   currency: {name: currencyName, suffix: currencySuffix},
-}: TransferProps): Node => {
+}: TransferProps): ReactNode => {
   const {ledger, updateLedger} = useLedger();
 
   const classes = useStyles();

--- a/src/ui/utils/LedgerContext.js
+++ b/src/ui/utils/LedgerContext.js
@@ -21,7 +21,7 @@ type LedgerProviderProps = {|
 export const LedgerProvider = ({
   children,
   initialLedger,
-}: LedgerProviderProps) => {
+}: LedgerProviderProps): React.Node => {
   const [{ledger}, setLedgerState] = React.useState({ledger: initialLedger});
 
   const updateLedger = (ledger: Ledger) => setLedgerState({ledger});
@@ -33,6 +33,6 @@ export const LedgerProvider = ({
   );
 };
 
-export const useLedger = () => {
+export const useLedger = (): LedgerContextValue => {
   return React.useContext(LedgerContext);
 };

--- a/src/ui/weights/EdgeTypeConfig.js
+++ b/src/ui/weights/EdgeTypeConfig.js
@@ -1,6 +1,7 @@
 // @flow
 
-import type {Node, Element} from "React";import React from "react";
+import type {Node, Element} from "React";
+import React from "react";
 import {WeightSlider, type Props as WeightSliderProps} from "./WeightSlider";
 
 import type {EdgeType} from "../../analysis/types";

--- a/src/ui/weights/EdgeTypeConfig.js
+++ b/src/ui/weights/EdgeTypeConfig.js
@@ -1,7 +1,6 @@
 // @flow
 
-import type {Node, Element} from "React";
-import React from "react";
+import React, {type Node as ReactNode} from "react";
 import {WeightSlider, type Props as WeightSliderProps} from "./WeightSlider";
 
 import type {EdgeType} from "../../analysis/types";
@@ -12,7 +11,7 @@ export class EdgeTypeConfig extends React.Component<{
   +type: EdgeType,
   +onChange: (EdgeWeight) => void,
 }> {
-  render(): Element<"div"> {
+  render(): ReactNode {
     const {weight, type} = this.props;
     const {forwards, backwards} = weight;
     const {forwardName, backwardName, description} = type;
@@ -42,7 +41,7 @@ export class EdgeTypeConfig extends React.Component<{
   }
 }
 
-export function styledVariable(letter: string): Element<"span"> {
+export function styledVariable(letter: string): ReactNode {
   return (
     // marginRight accounts for italicization
     <span style={{fontWeight: 700, fontStyle: "italic", marginRight: "0.15em"}}>
@@ -52,7 +51,7 @@ export function styledVariable(letter: string): Element<"span"> {
 }
 
 export class EdgeWeightSlider extends React.Component<WeightSliderProps> {
-  render(): Node {
+  render(): ReactNode {
     const modifiedName = (
       <React.Fragment>
         {styledVariable("α")} {this.props.name} {styledVariable("β")}

--- a/src/ui/weights/EdgeTypeConfig.js
+++ b/src/ui/weights/EdgeTypeConfig.js
@@ -1,6 +1,6 @@
 // @flow
 
-import React from "react";
+import type {Node, Element} from "React";import React from "react";
 import {WeightSlider, type Props as WeightSliderProps} from "./WeightSlider";
 
 import type {EdgeType} from "../../analysis/types";
@@ -11,7 +11,7 @@ export class EdgeTypeConfig extends React.Component<{
   +type: EdgeType,
   +onChange: (EdgeWeight) => void,
 }> {
-  render() {
+  render(): Element<"div"> {
     const {weight, type} = this.props;
     const {forwards, backwards} = weight;
     const {forwardName, backwardName, description} = type;
@@ -41,7 +41,7 @@ export class EdgeTypeConfig extends React.Component<{
   }
 }
 
-export function styledVariable(letter: string) {
+export function styledVariable(letter: string): Element<"span"> {
   return (
     // marginRight accounts for italicization
     <span style={{fontWeight: 700, fontStyle: "italic", marginRight: "0.15em"}}>
@@ -51,7 +51,7 @@ export function styledVariable(letter: string) {
 }
 
 export class EdgeWeightSlider extends React.Component<WeightSliderProps> {
-  render() {
+  render(): Node {
     const modifiedName = (
       <React.Fragment>
         {styledVariable("α")} {this.props.name} {styledVariable("β")}

--- a/src/ui/weights/NodeTypeConfig.js
+++ b/src/ui/weights/NodeTypeConfig.js
@@ -1,6 +1,6 @@
 // @flow
 
-import React from "react";
+import type {Node} from "React";import React from "react";
 import {WeightSlider} from "./WeightSlider";
 import type {NodeType} from "../../analysis/types";
 import type {NodeWeight} from "../../core/weights";
@@ -10,7 +10,7 @@ export class NodeTypeConfig extends React.Component<{
   +type: NodeType,
   +onChange: (NodeWeight) => void,
 }> {
-  render() {
+  render(): Node {
     return (
       <WeightSlider
         name={this.props.type.name}

--- a/src/ui/weights/NodeTypeConfig.js
+++ b/src/ui/weights/NodeTypeConfig.js
@@ -1,7 +1,6 @@
 // @flow
 
-import type {Node} from "React";
-import React from "react";
+import React, {type Node as ReactNode} from "react";
 import {WeightSlider} from "./WeightSlider";
 import type {NodeType} from "../../analysis/types";
 import type {NodeWeight} from "../../core/weights";
@@ -11,7 +10,7 @@ export class NodeTypeConfig extends React.Component<{
   +type: NodeType,
   +onChange: (NodeWeight) => void,
 }> {
-  render(): Node {
+  render(): ReactNode {
     return (
       <WeightSlider
         name={this.props.type.name}

--- a/src/ui/weights/NodeTypeConfig.js
+++ b/src/ui/weights/NodeTypeConfig.js
@@ -1,6 +1,7 @@
 // @flow
 
-import type {Node} from "React";import React from "react";
+import type {Node} from "React";
+import React from "react";
 import {WeightSlider} from "./WeightSlider";
 import type {NodeType} from "../../analysis/types";
 import type {NodeWeight} from "../../core/weights";

--- a/src/ui/weights/WeightConfig.js
+++ b/src/ui/weights/WeightConfig.js
@@ -1,6 +1,6 @@
 // @flow
 
-import React from "react";
+import type {Node} from "React";import React from "react";
 import * as NullUtil from "../../util/null";
 import {Grid} from "@material-ui/core";
 import {type NodeAddressT, type EdgeAddressT} from "../../core/graph";
@@ -33,7 +33,7 @@ type Props = {|
  * `onNodeWeightChange` or `onEdgeWeightChange` is called with the new weight.
  */
 export class WeightConfig extends React.Component<Props> {
-  _nodeConfig(type: NodeType) {
+  _nodeConfig(type: NodeType): Node {
     const {prefix, defaultWeight} = type;
     const {onNodeWeightChange, nodeWeights} = this.props;
     const weight = NullUtil.orElse(nodeWeights.get(prefix), defaultWeight);
@@ -48,7 +48,7 @@ export class WeightConfig extends React.Component<Props> {
     );
   }
 
-  _edgeConfig(type: EdgeType) {
+  _edgeConfig(type: EdgeType): Node {
     const {prefix, defaultWeight} = type;
     const {onEdgeWeightChange, edgeWeights} = this.props;
     const weight = NullUtil.orElse(edgeWeights.get(prefix), defaultWeight);
@@ -63,7 +63,7 @@ export class WeightConfig extends React.Component<Props> {
     );
   }
 
-  _renderPlugin(declaration: PluginDeclaration) {
+  _renderPlugin(declaration: PluginDeclaration): Node {
     const {name, nodeTypes, edgeTypes, userTypes} = declaration;
     const nonUserTypes = nodeTypes.filter(
       ({prefix}) => !userTypes.some((t) => t.prefix === prefix)
@@ -84,7 +84,7 @@ export class WeightConfig extends React.Component<Props> {
     );
   }
 
-  render() {
+  render(): Node {
     return (
       <Grid container spacing={2}>
         {this.props.declarations.map((x) => this._renderPlugin(x))}

--- a/src/ui/weights/WeightConfig.js
+++ b/src/ui/weights/WeightConfig.js
@@ -1,7 +1,6 @@
 // @flow
 
-import type {Node} from "React";
-import React from "react";
+import React, {type Node as ReactNode} from "react";
 import * as NullUtil from "../../util/null";
 import {Grid} from "@material-ui/core";
 import {type NodeAddressT, type EdgeAddressT} from "../../core/graph";
@@ -24,7 +23,7 @@ type Props = {|
 /**
  * A React component that lets users set Type-level weights.
  *
- * The WeightConfig component renders a slider for every Node and Edge type
+ * The WeightConfig component renders a slider for every ReactNode and Edge type
  * within the array of declarations it's been provided. The sliders are
  * organized by plugin at the top level, and then by whether they represent
  * node or edge types at the level beneath.
@@ -34,7 +33,7 @@ type Props = {|
  * `onNodeWeightChange` or `onEdgeWeightChange` is called with the new weight.
  */
 export class WeightConfig extends React.Component<Props> {
-  _nodeConfig(type: NodeType): Node {
+  _nodeConfig(type: NodeType): ReactNode {
     const {prefix, defaultWeight} = type;
     const {onNodeWeightChange, nodeWeights} = this.props;
     const weight = NullUtil.orElse(nodeWeights.get(prefix), defaultWeight);
@@ -49,7 +48,7 @@ export class WeightConfig extends React.Component<Props> {
     );
   }
 
-  _edgeConfig(type: EdgeType): Node {
+  _edgeConfig(type: EdgeType): ReactNode {
     const {prefix, defaultWeight} = type;
     const {onEdgeWeightChange, edgeWeights} = this.props;
     const weight = NullUtil.orElse(edgeWeights.get(prefix), defaultWeight);
@@ -64,7 +63,7 @@ export class WeightConfig extends React.Component<Props> {
     );
   }
 
-  _renderPlugin(declaration: PluginDeclaration): Node {
+  _renderPlugin(declaration: PluginDeclaration): ReactNode {
     const {name, nodeTypes, edgeTypes, userTypes} = declaration;
     const nonUserTypes = nodeTypes.filter(
       ({prefix}) => !userTypes.some((t) => t.prefix === prefix)
@@ -74,7 +73,7 @@ export class WeightConfig extends React.Component<Props> {
     return (
       <Grid item xs={4} key={name}>
         <h3>{name}</h3>
-        <h4 style={{marginBottom: "0.3em"}}>Node weights</h4>
+        <h4 style={{marginBottom: "0.3em"}}>ReactNode weights</h4>
         {nodeConfigs}
         <h4 style={{marginBottom: "0.3em"}}>Edge weights</h4>
         <p style={{marginBottom: "0.6em", marginTop: "0.6em"}}>
@@ -85,7 +84,7 @@ export class WeightConfig extends React.Component<Props> {
     );
   }
 
-  render(): Node {
+  render(): ReactNode {
     return (
       <Grid container spacing={2}>
         {this.props.declarations.map((x) => this._renderPlugin(x))}

--- a/src/ui/weights/WeightConfig.js
+++ b/src/ui/weights/WeightConfig.js
@@ -1,6 +1,7 @@
 // @flow
 
-import type {Node} from "React";import React from "react";
+import type {Node} from "React";
+import React from "react";
 import * as NullUtil from "../../util/null";
 import {Grid} from "@material-ui/core";
 import {type NodeAddressT, type EdgeAddressT} from "../../core/graph";

--- a/src/ui/weights/WeightSlider.js
+++ b/src/ui/weights/WeightSlider.js
@@ -1,7 +1,6 @@
 // @flow
 
-import type {Node} from "React";
-import React from "react";
+import React, {type Node as ReactNode} from "react";
 import {Grid, Slider, Tooltip} from "@material-ui/core";
 
 /**
@@ -55,7 +54,7 @@ export type Props = {|
  * [range input]: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/range
  */
 export class WeightSlider extends React.Component<Props> {
-  render(): Node {
+  render(): ReactNode {
     return (
       <Tooltip title={this.props.description} placement="top">
         <Grid container justify="space-between">

--- a/src/ui/weights/WeightSlider.js
+++ b/src/ui/weights/WeightSlider.js
@@ -1,6 +1,7 @@
 // @flow
 
-import type {Node} from "React";import React from "react";
+import type {Node} from "React";
+import React from "react";
 import {Grid, Slider, Tooltip} from "@material-ui/core";
 
 /**

--- a/src/ui/weights/WeightSlider.js
+++ b/src/ui/weights/WeightSlider.js
@@ -1,6 +1,6 @@
 // @flow
 
-import React from "react";
+import type {Node} from "React";import React from "react";
 import {Grid, Slider, Tooltip} from "@material-ui/core";
 
 /**
@@ -54,7 +54,7 @@ export type Props = {|
  * [range input]: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/range
  */
 export class WeightSlider extends React.Component<Props> {
-  render() {
+  render(): Node {
     return (
       <Tooltip title={this.props.description} placement="top">
         <Grid container justify="space-between">
@@ -137,7 +137,7 @@ export function sliderToWeight(sliderPosition: SliderPosition): Weight {
   return sliderPosition === MIN_SLIDER ? 0 : 2 ** sliderPosition;
 }
 
-export function formatWeight(n: number) {
+export function formatWeight(n: number): string {
   if (n < 0 || !isFinite(n)) {
     throw new Error(`Invalid weight: ${n}`);
   }

--- a/src/ui/weights/WeightsFileManager.js
+++ b/src/ui/weights/WeightsFileManager.js
@@ -1,6 +1,7 @@
 // @flow
 
-import type {Element} from "React";import stringify from "json-stable-stringify";
+import type {Element} from "React";
+import stringify from "json-stable-stringify";
 import React from "react";
 import {FileUploader} from "../../util/FileUploader";
 import Link from "../../webutil/Link";

--- a/src/ui/weights/WeightsFileManager.js
+++ b/src/ui/weights/WeightsFileManager.js
@@ -1,8 +1,7 @@
 // @flow
 
-import type {Element} from "React";
+import React, {type Node as ReactNode} from "react";
 import stringify from "json-stable-stringify";
-import React from "react";
 import {FileUploader} from "../../util/FileUploader";
 import Link from "../../webutil/Link";
 import {MdFileDownload, MdFileUpload} from "react-icons/md";
@@ -13,7 +12,7 @@ export type Props = {|
   +onWeightsChange: (Weights) => void,
 |};
 export class WeightsFileManager extends React.Component<Props> {
-  render(): Element<"div"> {
+  render(): ReactNode {
     const weightsJSON = stringify(toJSON(this.props.weights));
     const onUpload = (json) => this.props.onWeightsChange(fromJSON(json));
     return (

--- a/src/ui/weights/WeightsFileManager.js
+++ b/src/ui/weights/WeightsFileManager.js
@@ -1,6 +1,6 @@
 // @flow
 
-import stringify from "json-stable-stringify";
+import type {Element} from "React";import stringify from "json-stable-stringify";
 import React from "react";
 import {FileUploader} from "../../util/FileUploader";
 import Link from "../../webutil/Link";
@@ -12,7 +12,7 @@ export type Props = {|
   +onWeightsChange: (Weights) => void,
 |};
 export class WeightsFileManager extends React.Component<Props> {
-  render() {
+  render(): Element<"div"> {
     const weightsJSON = stringify(toJSON(this.props.weights));
     const onUpload = (json) => this.props.onWeightsChange(fromJSON(json));
     return (

--- a/src/util/FileUploader.js
+++ b/src/util/FileUploader.js
@@ -1,6 +1,6 @@
 // @flow
 
-import React, {type Node} from "react";
+import type {Element} from "React";import React, {type Node} from "react";
 
 export type Props = {|
   +onUpload: (any) => void,
@@ -20,7 +20,7 @@ export type Props = {|
 // You may do so by running `yarn start` and navigating to:
 // http://localhost:8080/test/FileUploader/
 export class FileUploader extends React.Component<Props> {
-  render() {
+  render(): Element<"label"> {
     const onUpload = (e) => {
       const file = e.target.files[0];
       const reader = new FileReader();

--- a/src/util/FileUploader.js
+++ b/src/util/FileUploader.js
@@ -1,6 +1,7 @@
 // @flow
 
-import type {Element} from "React";import React, {type Node} from "react";
+import type {Element} from "React";
+import React, {type Node} from "react";
 
 export type Props = {|
   +onUpload: (any) => void,

--- a/src/util/FileUploader.js
+++ b/src/util/FileUploader.js
@@ -1,12 +1,11 @@
 // @flow
 
-import type {Element} from "React";
-import React, {type Node} from "react";
+import React, {type Node as ReactNode} from "react";
 
 export type Props = {|
   +onUpload: (any) => void,
   +title: string,
-  +children: Node,
+  +children: ReactNode,
 |};
 
 /**
@@ -21,7 +20,7 @@ export type Props = {|
 // You may do so by running `yarn start` and navigating to:
 // http://localhost:8080/test/FileUploader/
 export class FileUploader extends React.Component<Props> {
-  render(): Element<"label"> {
+  render(): ReactNode {
     const onUpload = (e) => {
       const file = e.target.files[0];
       const reader = new FileReader();

--- a/src/util/FileUploaderInspectionTest.js
+++ b/src/util/FileUploaderInspectionTest.js
@@ -1,6 +1,6 @@
 // @flow
 
-import React from "react";
+import type {Element} from "React";import React from "react";
 import Markdown from "react-markdown";
 import {MdFileUpload} from "react-icons/md";
 
@@ -13,8 +13,8 @@ export default class FileUploaderInspectionTest extends React.Component<
   {|+assets: Assets|},
   {|json: ?mixed|}
 > {
-  state = {json: null};
-  render() {
+  state: {|json: mixed|} = {json: null};
+  render(): Element<"div"> {
     const onUpload = (json) => {
       this.setState({json});
     };

--- a/src/util/FileUploaderInspectionTest.js
+++ b/src/util/FileUploaderInspectionTest.js
@@ -1,6 +1,7 @@
 // @flow
 
-import type {Element} from "React";import React from "react";
+import type {Element} from "React";
+import React from "react";
 import Markdown from "react-markdown";
 import {MdFileUpload} from "react-icons/md";
 

--- a/src/util/FileUploaderInspectionTest.js
+++ b/src/util/FileUploaderInspectionTest.js
@@ -1,7 +1,6 @@
 // @flow
 
-import type {Element} from "React";
-import React from "react";
+import React, {type Node as ReactNode} from "react";
 import Markdown from "react-markdown";
 import {MdFileUpload} from "react-icons/md";
 
@@ -15,7 +14,7 @@ export default class FileUploaderInspectionTest extends React.Component<
   {|json: ?mixed|}
 > {
   state: {|json: mixed|} = {json: null};
-  render(): Element<"div"> {
+  render(): ReactNode {
     const onUpload = (json) => {
       this.setState({json});
     };

--- a/src/util/dedent.js
+++ b/src/util/dedent.js
@@ -18,7 +18,7 @@
  *
  * Lines that contain only whitespace are not used for measuring.
  */
-export default function dedent(strings: string[], ...values: string[]) {
+export default function dedent(strings: string[], ...values: string[]): string {
   const lineLengths = strings
     .join("")
     .split("\n")

--- a/src/util/pathNormalize.js
+++ b/src/util/pathNormalize.js
@@ -29,7 +29,7 @@
  *
  * A `TypeError` is thrown if `path` is not a string.
  */
-export default function normalize(path: string) {
+export default function normalize(path: string): string {
   assertPath(path);
 
   if (path.length === 0) return ".";

--- a/src/util/taskReporter.js
+++ b/src/util/taskReporter.js
@@ -40,7 +40,7 @@ export class LoggingTaskReporter implements TaskReporter {
     this.activeTasks = new Map();
   }
 
-  start(taskId: TaskId) {
+  start(taskId: TaskId): this {
     if (this.activeTasks.has(taskId)) {
       throw new Error(`task ${taskId} already registered`);
     }
@@ -49,7 +49,7 @@ export class LoggingTaskReporter implements TaskReporter {
     return this;
   }
 
-  finish(taskId: TaskId) {
+  finish(taskId: TaskId): this {
     const startTime = this.activeTasks.get(taskId);
     if (startTime == null) {
       throw new Error(`task ${taskId} not registered`);
@@ -84,7 +84,7 @@ export class SilentTaskReporter implements TaskReporter {
     this._activeTasks = new Set();
     this._entries = [];
   }
-  start(taskId: TaskId) {
+  start(taskId: TaskId): this {
     if (this._activeTasks.has(taskId)) {
       throw new Error(`task ${taskId} already active`);
     }
@@ -92,7 +92,7 @@ export class SilentTaskReporter implements TaskReporter {
     this._entries.push({taskId, type: "START"});
     return this;
   }
-  finish(taskId: TaskId) {
+  finish(taskId: TaskId): this {
     if (!this._activeTasks.has(taskId)) {
       throw new Error(`task ${taskId} not active`);
     }
@@ -142,12 +142,12 @@ export class ScopedTaskReporter implements TaskReporter {
     return `${this._prefix}: ${taskId}`;
   }
 
-  start(taskId: TaskId) {
+  start(taskId: TaskId): this {
     this._delegate.start(this._scoped(taskId));
     return this;
   }
 
-  finish(taskId: TaskId) {
+  finish(taskId: TaskId): this {
     this._delegate.finish(this._scoped(taskId));
     return this;
   }

--- a/src/webutil/Link.js
+++ b/src/webutil/Link.js
@@ -1,7 +1,6 @@
 // @flow
 
-import type {Node, Element} from "React";
-import React, {Component} from "react";
+import React, {Component, type Node as ReactNode} from "react";
 import {Link as RouterLink} from "react-router-dom";
 import {StyleSheet, css} from "aphrodite/no-important";
 
@@ -30,7 +29,7 @@ type LinkProps = $ReadOnly<{
   > /* Aphrodite styles, as passed to `css` */,
 }>;
 export default class Link extends Component<LinkProps> {
-  render(): Node | Element<string> {
+  render(): ReactNode {
     const {styles: customStyles, children, ...rest} = this.props;
     const linkClass = css(styles.link, customStyles);
     const className = this.props.className

--- a/src/webutil/Link.js
+++ b/src/webutil/Link.js
@@ -1,6 +1,7 @@
 // @flow
 
-import type {Node, Element} from "React";import React, {Component} from "react";
+import type {Node, Element} from "React";
+import React, {Component} from "react";
 import {Link as RouterLink} from "react-router-dom";
 import {StyleSheet, css} from "aphrodite/no-important";
 

--- a/src/webutil/Link.js
+++ b/src/webutil/Link.js
@@ -1,6 +1,6 @@
 // @flow
 
-import React, {Component} from "react";
+import type {Node, Element} from "React";import React, {Component} from "react";
 import {Link as RouterLink} from "react-router-dom";
 import {StyleSheet, css} from "aphrodite/no-important";
 
@@ -29,7 +29,7 @@ type LinkProps = $ReadOnly<{
   > /* Aphrodite styles, as passed to `css` */,
 }>;
 export default class Link extends Component<LinkProps> {
-  render() {
+  render(): Node | Element<string> {
     const {styles: customStyles, children, ...rest} = this.props;
     const linkClass = css(styles.link, customStyles);
     const className = this.props.className

--- a/src/webutil/assets.js
+++ b/src/webutil/assets.js
@@ -31,7 +31,7 @@ export class Assets {
    * represent the same file. It is an error to specify a file that is
    * above the root, like "../bad".
    */
-  resolve(path: string) {
+  resolve(path: string): any {
     if (normalize(path.replace(/^\/+/, "")).startsWith("..")) {
       // It doesn't make sense to traverse past the site's root. This is
       // likely an error in the caller.
@@ -55,7 +55,7 @@ export class Assets {
  *
  * If the argument does not start with "/", an error will be thrown.
  */
-export function rootFromPath(path: string) {
+export function rootFromPath(path: string): any {
   const normalized = normalize(path);
   if (normalized[0] !== "/") {
     throw new Error("expected absolute path: " + JSON.stringify(path));

--- a/src/webutil/testLocalStore.js
+++ b/src/webutil/testLocalStore.js
@@ -3,4 +3,4 @@
 import CheckedLocalStore from "./checkedLocalStore";
 import MemoryLocalStore from "./memoryLocalStore";
 
-export default () => new CheckedLocalStore(new MemoryLocalStore());
+export default (): CheckedLocalStore => new CheckedLocalStore(new MemoryLocalStore());

--- a/src/webutil/testLocalStore.js
+++ b/src/webutil/testLocalStore.js
@@ -3,4 +3,5 @@
 import CheckedLocalStore from "./checkedLocalStore";
 import MemoryLocalStore from "./memoryLocalStore";
 
-export default (): CheckedLocalStore => new CheckedLocalStore(new MemoryLocalStore());
+export default (): CheckedLocalStore =>
+  new CheckedLocalStore(new MemoryLocalStore());


### PR DESCRIPTION
Summary:
“Types First” is a new architecture for Flow that is now on by default
and will be mandatory by January 2021:
<https://medium.com/flow-type/types-first-a-scalable-new-architecture-for-flow-3d8c7ba1d4eb>

The change basically amounts to “module boundaries must be explicitly
typed rather than inferred”, which is generally a good thing for
readability anyway.

Currently, we’ve opted out of types-first mode. This patch fixes all the
errors (150-ish of them) and opts us in.

This is written with the help of a codemod (~400 lines generated by
`yarn flow codemod annotate-exports --write --repeat src/`) but with
many manual changes on top (~350 lines), amounting to:

  - migrating the `config/` subtree manually, using comment syntax
  - fixing the inferred type for `Schema.unfaithful`
  - fixing an incorrectly absolute import path
  - defining a typed interface for the `api` module
  - replacing `$IMPORTED_TYPE$` placeholders with direct resolutions
  - retargeting and opacifying `"React"`
  - rewriting imports from `"filename.js"` (rather than `"filename"`)
  - enabling types-first mode in `.flowconfig`

Test Plan:
That `yarn flow` passes is the main thing; that `yarn test` passes
primarily indicates that the codemod didn’t break any import paths. (Or,
rather, that I fixed all the import paths that it broke.)
