### PR TITLE
Retry github fetch after 1 hour if rate limit hit

### DIFF
--- a/src/plugins/github/fetchGithubRepo.js
+++ b/src/plugins/github/fetchGithubRepo.js
@@ -261,11 +261,15 @@ export async function postQuery(
           );
           break;
         case "RATE_LIMIT_EXCEEDED":
-          console.error(
+          console.warn(
             "You've exceeded your hourly GitHub rate limit.\n" +
               "You'll need to wait until it resets."
           );
-          break;
+          return setTimeout(
+            () => retryGithubFetch(fetch, fetchOptions),
+            // wait 1 hour for rate limit to reset
+            1000 * 60 * 60
+          );
         case "FETCH_ERROR":
           // Network error; no need for additional commentary.
           break;


### PR DESCRIPTION
this should fix issues with instances having too many repos.
At the moment this only effects 1hive.

Test Plan: tests pass. We may need a new test for this, unsure