### PR TITLE
helper fn for prepping graph, ledger, and deps

### DIFF
--- a/src/cli/graph.js
+++ b/src/cli/graph.js
@@ -4,7 +4,6 @@ import fs from "fs-extra";
 import sortBy from "lodash.sortby";
 import stringify from "json-stable-stringify";
 import {join as pathJoin} from "path";
-import {loadFileWithDefault} from "../util/disk";
 
 import {Ledger} from "../ledger/ledger";
 import * as NullUtil from "../util/null";
@@ -18,6 +17,8 @@ import {
   makePluginDir,
   loadInstanceConfig,
   pluginDirectoryContext,
+  loadLedger,
+  saveLedger,
 } from "./common";
 import {toJSON as weightedGraphToJSON} from "../core/weightedGraph";
 import * as pluginId from "../api/pluginId";
@@ -34,10 +35,7 @@ const graphCommand: Command = async (args, std) => {
   const baseDir = process.cwd();
   const config: InstanceConfig = await loadInstanceConfig(baseDir);
 
-  const ledgerPath = pathJoin(baseDir, "data", "ledger.json");
-  const ledger = Ledger.parse(
-    await loadFileWithDefault(ledgerPath, () => new Ledger().serialize())
-  );
+  const ledger = await loadLedger(baseDir);
 
   let pluginsToLoad = [];
   if (args.length === 0) {
@@ -81,7 +79,7 @@ const graphCommand: Command = async (args, std) => {
     }
     taskReporter.finish(task);
   }
-  await fs.writeFile(ledgerPath, ledger.serialize());
+  await saveLedger(baseDir, ledger);
   taskReporter.finish("graph");
   return 0;
 };

--- a/src/cli/score.js
+++ b/src/cli/score.js
@@ -1,13 +1,12 @@
 // @flow
 
 import fs from "fs-extra";
-import stringify from "json-stable-stringify";
 import {join as pathJoin} from "path";
-import deepEqual from "lodash.isequal";
+import stringify from "json-stable-stringify";
 
 import type {Command} from "./command";
-import {loadInstanceConfig, loadWeightedGraph} from "./common";
-import {loadFileWithDefault, loadJsonWithDefault} from "../util/disk";
+import {loadInstanceConfig, prepareCredData} from "./common";
+import {loadJsonWithDefault} from "../util/disk";
 import dedent from "../util/dedent";
 import {LoggingTaskReporter} from "../util/taskReporter";
 import {
@@ -17,14 +16,7 @@ import {
 } from "../analysis/credResult";
 import {CredView} from "../analysis/credView";
 import * as Params from "../analysis/timeline/params";
-import {contractions as identityContractions} from "../ledger/identity";
-import {Ledger} from "../ledger/ledger";
 import {computeCredAccounts} from "../ledger/credAccounts";
-import {
-  parser as dependenciesParser,
-  ensureIdentityExists,
-  toDependencyPolicy,
-} from "../api/dependenciesConfig";
 
 function die(std, message) {
   std.err("fatal: " + message);
@@ -40,44 +32,10 @@ const scoreCommand: Command = async (args, std) => {
   const baseDir = process.cwd();
   const config = await loadInstanceConfig(baseDir);
 
-  const weightedGraph = await loadWeightedGraph(baseDir, config);
-
-  const ledgerPath = pathJoin(baseDir, "data", "ledger.json");
-  const ledger = Ledger.parse(
-    await loadFileWithDefault(ledgerPath, () => new Ledger().serialize())
+  const {weightedGraph, ledger, dependencies} = await prepareCredData(
+    baseDir,
+    config
   );
-
-  const dependenciesPath = pathJoin(baseDir, "config", "dependencies.json");
-  const dependencies = await loadJsonWithDefault(
-    dependenciesPath,
-    dependenciesParser,
-    () => []
-  );
-  const dependenciesWithIds = dependencies.map((d) =>
-    ensureIdentityExists(d, ledger)
-  );
-  if (!deepEqual(dependenciesWithIds, dependencies)) {
-    // Save the new dependencies, with canonical IDs set.
-    await fs.writeFile(
-      dependenciesPath,
-      stringify(dependenciesWithIds, {space: 4})
-    );
-    // Save the Ledger, since we may have added/activated identities.
-    await fs.writeFile(ledgerPath, ledger.serialize());
-  }
-
-  const dependencyPolicies = dependenciesWithIds.map((d) =>
-    toDependencyPolicy(d, ledger)
-  );
-
-  const identities = ledger.accounts().map((a) => a.identity);
-  const contractedGraph = weightedGraph.graph.contractNodes(
-    identityContractions(identities)
-  );
-  const contractedWeightedGraph = {
-    graph: contractedGraph,
-    weights: weightedGraph.weights,
-  };
 
   const plugins = Array.from(config.bundledPlugins.values());
   const declarations = plugins.map((x) => x.declaration());
@@ -91,10 +49,10 @@ const scoreCommand: Command = async (args, std) => {
   );
 
   const credResult = await compute(
-    contractedWeightedGraph,
+    weightedGraph,
     params,
     declarations,
-    dependencyPolicies
+    dependencies
   );
   // Throw away over-time data for all non-user nodes; we may not have that
   // information available once we merge CredRank, anyway.


### PR DESCRIPTION
This adds a cli/common helper method for loading the graph, ledger, and
dependency policies for Cred computation. These three are intertwined in
that the dependency policies may modify the ledger, and the ledger then
modifies the graph, so it makes sense to have a single helper that
orchestrates this. I also added helpers for loading/saving the ledger.
This commit refactors the existing CLI score command to use the helper;
it will make a future change to CredRank easier as well.

Test plan: run `sourcecred score` in an existing instance. Scores should
not change. Run `sourcecred score` in an instance with unset ids in the
dependency file, and verify that they are set and serialized to both the
ledger and the dependencies file correctly. (nb. the template instance
is fine for this purpose.)