### PR TITLE
credrank: use identity contractions

### DIFF
--- a/src/core/credGraph.js
+++ b/src/core/credGraph.js
@@ -1,6 +1,7 @@
 // @flow
 
 import * as NullUtil from "../util/null";
+import {type Uuid} from "../util/uuid";
 import {type NodeAddressT, type EdgeAddressT} from "./graph";
 import {
   MarkovProcessGraph,
@@ -34,6 +35,7 @@ export type Participant = {|
   +description: string,
   +cred: number,
   +credPerEpoch: $ReadOnlyArray<number>,
+  +id: Uuid,
 |};
 
 export type CredGraphJSON = Compatible<{|
@@ -84,7 +86,7 @@ export class CredGraph {
   }
 
   *participants(): Iterator<Participant> {
-    for (const {address, description} of this._mpg.participants()) {
+    for (const {address, description, id} of this._mpg.participants()) {
       const epochs = this._mpg.epochBoundaries().map((epochStart) => ({
         type: "USER_EPOCH",
         owner: address,
@@ -104,7 +106,7 @@ export class CredGraph {
         totalCred += cred;
         return cred;
       });
-      yield {address, description, credPerEpoch, cred: totalCred};
+      yield {address, description, credPerEpoch, cred: totalCred, id};
     }
   }
 

--- a/src/core/markovProcessGraph.js
+++ b/src/core/markovProcessGraph.js
@@ -1,6 +1,7 @@
 // @flow
 
 import deepFreeze from "deep-freeze";
+import {type Uuid} from "../util/uuid";
 
 /**
  * Data structure representing a particular kind of Markov process, as
@@ -111,6 +112,7 @@ export type MarkovEdge = {|
 export type Participant = {|
   +address: NodeAddressT,
   +description: string,
+  +id: Uuid,
 |};
 
 export opaque type MarkovEdgeAddressT: string = string;


### PR DESCRIPTION
This commit modifies the credrank command to use a graph that has been
properly contracted per the participant identities. I also updated the
participant type to pass along the identity id.

Test plan: Compare cred before merging identities (i.e. before this
commit) and after merging identities, and see if summing a user's
accounts approximately equals the combined identity's cred. In the data
below, decentralion is the only identity where all of the aliases are in
the top-20, and the sums are equal to within 1.5%. Also, post CredRank,
the scores are very similar to the published TimelineCred scores, with
the overall ordering of the top-20 being the same except for 4 adjacent
swaps.

Here is the un-merged identity cred:

| Description | Cred |
| --- | --- |
| github/decentralion | 14745.1 |
| github/wchargin | 9603.2 |
| discord/decentralion#1337 | 5104.8 |
| discourse/decentralion | 4152.0 |
| github/Beanow | 3172.9 |
| discord/LBS#6541 | 2882.0 |
| discord/s_ben#7872 | 2260.2 |
| github/hammadj | 2019.6 |
| discourse/s_ben | 1997.5 |
| discourse/LB | 1880.9 |
| discord/Beanow#5887 | 1649.0 |
| discord/hammadj#6801 | 1466.2 |
| discourse/burrrata | 1295.3 |
| discourse/Beanow | 990.4 |
| discord/mZ#3472 | 942.2 |
| discord/Faruk#9564 | 791.4 |
| github/vsoch | 768.5 |
| github/topocount | 746.1 |
| discord/Bex#7189 | 737.5 |
| discord/burrrata#0232 | 638.7 |

Here is the cred with identities merged:

| Description | Cred |
| --- | --- |
| decentralion | 23648.2 |
| wchargin | 10297.0 |
| beanow | 5799.3 |
| lbstrobbe | 4585.2 |
| s-ben | 4375.5 |
| hammad | 3226.0 |
| burrrata | 1899.1 |
| vsoch | 1361.6 |
| mzargham | 1348.5 |
| bex | 1061.9 |
| topocount | 1017.6 |
| KuraFire | 959.1 |
| brianlitwin | 886.6 |
| dependabot | 707.5 |
| greenkeeper | 664.6 |
| sandpiper | 498.6 |
| evan | 419.7 |
| yalor | 349.2 |
| benoxmo | 346.7 |
| flyingzumwalt | 307.8 |