### PR TITLE
DRAFT2: credrank: add dependency cred

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "lodash.isequal": "^4.5.0",
     "lodash.sortby": "^4.7.0",
     "lodash.sortedindex": "^4.1.0",
+    "lodash.sortedlastindexby": "^4.6.0",
     "object-assign": "^4.1.1",
     "pako": "^1.0.11",
     "promise": "^8.1.0",

--- a/src/cli/common.js
+++ b/src/cli/common.js
@@ -3,20 +3,29 @@
 import {join as pathJoin} from "path";
 import fs from "fs-extra";
 import {loadJson, mkdirx} from "../util/disk";
+import deepEqual from "lodash.isequal";
+import stringify from "json-stable-stringify";
 
+import {type DependencyMintPolicy} from "../core/dependenciesMintPolicy";
 import type {PluginDirectoryContext} from "../api/plugin";
 import {
   parser as configParser,
   type InstanceConfig,
 } from "../api/instanceConfig";
-
+import {Ledger} from "../ledger/ledger";
+import {contractions as identityContractions} from "../ledger/identity";
+import {
+  parser as dependenciesParser,
+  ensureIdentityExists,
+  toDependencyPolicy,
+} from "../api/dependenciesConfig";
 import {
   type WeightedGraph,
   merge,
   overrideWeights,
   fromJSON as weightedGraphFromJSON,
 } from "../core/weightedGraph";
-import {loadJsonWithDefault} from "../util/disk";
+import {loadFileWithDefault, loadJsonWithDefault} from "../util/disk";
 
 import * as Weights from "../core/weights";
 
@@ -60,6 +69,68 @@ export function pluginDirectoryContext(
   };
 }
 
+/**
+ * This method pipelines the data loading needed to run Cred analysis.
+ *
+ * It's a bit of a kitchen sink, but I think it's still valuable to have as its
+ * own method. In particular, there are some non-obvious relationships between the constituent components:
+ * it's important that the identities be computed after loading the dependencies, because
+ * loading the dependencies may create new identities. Thus, I prefer to expose this API which sequences
+ * the steps correctly, rather than trusting the caller to do this themselves.
+ */
+export async function prepareCredData(
+  baseDir: string,
+  config: InstanceConfig
+): Promise<{|
+  graph: WeightedGraph,
+  ledger: Ledger,
+  dependencies: $ReadOnlyArray<DependencyMintPolicy>,
+|}> {
+  const weightedGraph = await loadWeightedGraph(baseDir, config);
+  const ledger = await loadLedger(baseDir);
+
+  // We need to load the dependencies before we get identities, because
+  // this step may create new identities in the ledger.
+  const dependencies = await loadDependenciesAndWriteChanges(baseDir, ledger);
+
+  const identities = ledger.accounts().map((a) => a.identity);
+  const contractedGraph = weightedGraph.graph.contractNodes(
+    identityContractions(identities)
+  );
+  const contractedWeightedGraph = {
+    graph: contractedGraph,
+    weights: weightedGraph.weights,
+  };
+  return {graph: contractedWeightedGraph, ledger, dependencies};
+}
+
+async function loadDependenciesAndWriteChanges(
+  baseDir: string,
+  ledger: Ledger
+): Promise<$ReadOnlyArray<DependencyMintPolicy>> {
+  const dependenciesPath = pathJoin(baseDir, "config", "dependencies.json");
+  const dependencies = await loadJsonWithDefault(
+    dependenciesPath,
+    dependenciesParser,
+    () => []
+  );
+  const dependenciesWithIds = dependencies.map((d) =>
+    // This mutates the ledger, adding new identites when needed.
+    ensureIdentityExists(d, ledger)
+  );
+  if (!deepEqual(dependenciesWithIds, dependencies)) {
+    // Save the new dependencies, with canonical IDs set.
+    await fs.writeFile(
+      dependenciesPath,
+      stringify(dependenciesWithIds, {space: 4})
+    );
+    // Save the Ledger, since we may have added/activated identities.
+    await saveLedger(baseDir, ledger);
+  }
+
+  return dependenciesWithIds.map((d) => toDependencyPolicy(d, ledger));
+}
+
 export async function loadWeightedGraph(
   baseDir: string,
   config: InstanceConfig
@@ -85,4 +156,19 @@ export async function loadWeightedGraph(
     Weights.empty
   );
   return overrideWeights(combinedGraph, weights);
+}
+
+export async function loadLedger(baseDir: string): Promise<Ledger> {
+  const ledgerPath = pathJoin(baseDir, "data", "ledger.json");
+  return Ledger.parse(
+    await loadFileWithDefault(ledgerPath, () => new Ledger().serialize())
+  );
+}
+
+export async function saveLedger(
+  baseDir: string,
+  ledger: Ledger
+): Promise<void> {
+  const ledgerPath = pathJoin(baseDir, "data", "ledger.json");
+  await fs.writeFile(ledgerPath, ledger.serialize());
 }

--- a/src/cli/credrank.js
+++ b/src/cli/credrank.js
@@ -33,7 +33,7 @@ const credrankCommand: Command = async (args, std) => {
   const config = await loadInstanceConfig(baseDir);
 
   taskReporter.start("load data");
-  const {graph, ledger} = await prepareCredData(baseDir, config);
+  const {graph, ledger, dependencies} = await prepareCredData(baseDir, config);
   taskReporter.finish("load data");
 
   taskReporter.start("create Markov process graph");
@@ -51,12 +51,12 @@ const credrankCommand: Command = async (args, std) => {
     address: identity.address,
     id: identity.id,
   }));
-  const mpg = MarkovProcessGraph.new(
-    graph,
+  const mpg = MarkovProcessGraph.new(graph, {
     participants,
-    fibrationOptions,
-    seedOptions
-  );
+    fibration: fibrationOptions,
+    seed: seedOptions,
+    dependencies: {policies: dependencies},
+  });
   taskReporter.finish("create Markov process graph");
 
   taskReporter.start("run CredRank");

--- a/src/cli/credrank.js
+++ b/src/cli/credrank.js
@@ -7,11 +7,10 @@ import {join as pathJoin} from "path";
 import sortBy from "../util/sortBy";
 import {credrank} from "../core/algorithm/credrank";
 import {CredGraph} from "../core/credGraph";
-import {NodeAddress, type Graph, type NodeAddressT} from "../core/graph";
 import {LoggingTaskReporter} from "../util/taskReporter";
-import {MarkovProcessGraph, type Participant} from "../core/markovProcessGraph";
+import {MarkovProcessGraph} from "../core/markovProcessGraph";
 import type {Command} from "./command";
-import {loadInstanceConfig, loadWeightedGraph} from "./common";
+import {loadInstanceConfig, prepareCredData} from "./common";
 
 const DEFAULT_ALPHA = 0.1;
 const DEFAULT_BETA = 0.4;
@@ -33,12 +32,9 @@ const credrankCommand: Command = async (args, std) => {
   const baseDir = process.cwd();
   const config = await loadInstanceConfig(baseDir);
 
-  const plugins = Array.from(config.bundledPlugins.values());
-  const declarations = plugins.map((x) => x.declaration());
-
-  taskReporter.start("load weighted graph");
-  const wg = await loadWeightedGraph(baseDir, config);
-  taskReporter.finish("load weighted graph");
+  taskReporter.start("load data");
+  const {graph, ledger} = await prepareCredData(baseDir, config);
+  taskReporter.finish("load data");
 
   taskReporter.start("create Markov process graph");
   // TODO: Support loading transition probability params from config.
@@ -50,12 +46,13 @@ const credrankCommand: Command = async (args, std) => {
   const seedOptions = {
     alpha: DEFAULT_ALPHA,
   };
-  const participants = findParticipants(
-    wg.graph,
-    [].concat(...declarations.map((d) => d.userTypes.map((t) => t.prefix)))
-  );
+  const participants = ledger.accounts().map(({identity}) => ({
+    description: identity.name,
+    address: identity.address,
+    id: identity.id,
+  }));
   const mpg = MarkovProcessGraph.new(
-    wg,
+    graph,
     participants,
     fibrationOptions,
     seedOptions
@@ -88,19 +85,6 @@ function printCredSummaryTable(credGraph: CredGraph) {
   sortedParticipants
     .slice(0, 20)
     .forEach((n) => console.log(`| ${n.description} | ${n.cred.toFixed(1)} |`));
-}
-
-function findParticipants(
-  graph: Graph,
-  scoringPrefixes: $ReadOnlyArray<NodeAddressT>
-): $ReadOnlyArray<Participant> {
-  const result = [];
-  for (const {address, description} of graph.nodes()) {
-    if (scoringPrefixes.some((p) => NodeAddress.hasPrefix(address, p))) {
-      result.push({address, description});
-    }
-  }
-  return result;
 }
 
 export default credrankCommand;

--- a/src/cli/graph.js
+++ b/src/cli/graph.js
@@ -4,7 +4,6 @@ import fs from "fs-extra";
 import sortBy from "lodash.sortby";
 import stringify from "json-stable-stringify";
 import {join as pathJoin} from "path";
-import {loadFileWithDefault} from "../util/disk";
 
 import {Ledger} from "../ledger/ledger";
 import * as NullUtil from "../util/null";
@@ -18,6 +17,8 @@ import {
   makePluginDir,
   loadInstanceConfig,
   pluginDirectoryContext,
+  loadLedger,
+  saveLedger,
 } from "./common";
 import {toJSON as weightedGraphToJSON} from "../core/weightedGraph";
 import * as pluginId from "../api/pluginId";
@@ -34,10 +35,7 @@ const graphCommand: Command = async (args, std) => {
   const baseDir = process.cwd();
   const config: InstanceConfig = await loadInstanceConfig(baseDir);
 
-  const ledgerPath = pathJoin(baseDir, "data", "ledger.json");
-  const ledger = Ledger.parse(
-    await loadFileWithDefault(ledgerPath, () => new Ledger().serialize())
-  );
+  const ledger = await loadLedger(baseDir);
 
   let pluginsToLoad = [];
   if (args.length === 0) {
@@ -81,7 +79,7 @@ const graphCommand: Command = async (args, std) => {
     }
     taskReporter.finish(task);
   }
-  await fs.writeFile(ledgerPath, ledger.serialize());
+  await saveLedger(baseDir, ledger);
   taskReporter.finish("graph");
   return 0;
 };

--- a/src/core/credGraph.js
+++ b/src/core/credGraph.js
@@ -1,6 +1,7 @@
 // @flow
 
 import * as NullUtil from "../util/null";
+import {type Uuid} from "../util/uuid";
 import {type NodeAddressT, type EdgeAddressT} from "./graph";
 import {
   MarkovProcessGraph,
@@ -34,6 +35,7 @@ export type Participant = {|
   +description: string,
   +cred: number,
   +credPerEpoch: $ReadOnlyArray<number>,
+  +id: Uuid,
 |};
 
 export type CredGraphJSON = Compatible<{|
@@ -84,7 +86,7 @@ export class CredGraph {
   }
 
   *participants(): Iterator<Participant> {
-    for (const {address, description} of this._mpg.participants()) {
+    for (const {address, description, id} of this._mpg.participants()) {
       const epochs = this._mpg.epochBoundaries().map((epochStart) => ({
         type: "USER_EPOCH",
         owner: address,
@@ -104,7 +106,7 @@ export class CredGraph {
         totalCred += cred;
         return cred;
       });
-      yield {address, description, credPerEpoch, cred: totalCred};
+      yield {address, description, credPerEpoch, cred: totalCred, id};
     }
   }
 

--- a/src/core/markovProcessGraph.js
+++ b/src/core/markovProcessGraph.js
@@ -1,6 +1,7 @@
 // @flow
 
 import deepFreeze from "deep-freeze";
+import {type Uuid} from "../util/uuid";
 
 /**
  * Data structure representing a particular kind of Markov process, as
@@ -111,6 +112,7 @@ export type MarkovEdge = {|
 export type Participant = {|
   +address: NodeAddressT,
   +description: string,
+  +id: Uuid,
 |};
 
 export opaque type MarkovEdgeAddressT: string = string;

--- a/yarn.lock
+++ b/yarn.lock
@@ -6976,6 +6976,11 @@ lodash.sortedindex@^4.1.0:
   resolved "https://registry.yarnpkg.com/lodash.sortedindex/-/lodash.sortedindex-4.1.0.tgz#3f6417ee20e8b22416ab005bfa16344a0446b448"
   integrity sha1-P2QX7iDosiQWqwBb+hY0SgRGtEg=
 
+lodash.sortedlastindexby@^4.6.0:
+  version "4.6.0"
+  resolved "https://registry.yarnpkg.com/lodash.sortedlastindexby/-/lodash.sortedlastindexby-4.6.0.tgz#b754fe135fa210b522b012d041983d69c17c7f40"
+  integrity sha1-t1T+E1+iELUisBLQQZg9acF8f0A=
+
 lodash.throttle@^4.1.1:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/lodash.throttle/-/lodash.throttle-4.1.1.tgz#c23e91b710242ac70c37f1e1cda9274cc39bf2f4"


### PR DESCRIPTION
This is a functional version of #2282. It still needs testing.

One small test: run `credrank` inside the sc cred instance. Currently,
mints about 7x more dependency cred for SourceCred than is intended. We
should demonstrate that the mint amount is stable around our intention,
and independent of the choice of beta.

Paired with @wchargin, see #2282