### PR TITLE
util: add `retry` module

### DIFF
--- a/src/util/retry.js
+++ b/src/util/retry.js
@@ -1,0 +1,142 @@
+// @flow
+
+// The outcome of a single attempt of a retryable operation.
+export type AttemptOutcome<+T, +E> =
+  // The operation has terminated successfully.
+  | {|+type: "DONE", +value: T|}
+  // The operation has terminated with a fatal error.
+  | {|+type: "FATAL", +err: E|}
+  // The operation has encountered a transient error and should retry
+  // after a delay, if retries are still available.
+  | {|+type: "RETRY", +err: E|}
+  // The operation has exceeded its rate-limit budget and should wait
+  // until the given timestamp for that budget to be refreshed, then
+  // retry.
+  | {|+type: "WAIT", +until: Date, +err: E|};
+
+// The final result of executing an operation after retrying zero or more
+// times.
+export type Result<+T, +E> =
+  // The operation terminated successfully.
+  | {|+type: "DONE", +value: T|}
+  // The operation encountered a fatal error, or tried to retry or wait
+  // more times than permitted by the policy.
+  | {|+type: "FAILED", +err: E|};
+
+export type RetryPolicy = {|
+  // How long to wait before the first retry, in milliseconds. Defaults
+  // to 1000 (i.e., 1 second).
+  +initialDelayMs: number,
+  // The factor by which to increase the retry delay after each attempt.
+  // Defaults to 2.0.
+  +backoffRatio: number,
+  // The extreme factor by which delays may be subject to jitter. The
+  // actual jitter factor is chosen from the uniform distribution from
+  // `1.0` to `jitterRatio`. For example, if `jitterRatio` is `1.2` and
+  // the nominal delay for an attempt is `4.0` seconds, then the actual
+  // delay is chosen uniformly between `4.0` and `4.8` seconds. Jitter
+  // is not cumulative; the actual jitter factor is independent for each
+  // attempt. Defaults to `1.2`.
+  +jitterRatio: number,
+  // The number of times that a `RETRY` outcome will be honored before
+  // giving up. Note that if an operation always retries, it will
+  // execute `maxRetries + 1` times in total. Defaults to 3.
+  +maxRetries: number,
+  // The number of times that a `WAIT` outcome will be honored before
+  // giving up. Defaults to 1.
+  +maxWaits: number,
+|};
+
+function defaultPolicy(): RetryPolicy {
+  return {
+    initialDelayMs: 1000,
+    backoffRatio: 2.0,
+    jitterRatio: 1.2,
+    maxRetries: 3,
+    maxWaits: 1,
+  };
+}
+
+export interface Io {
+  // Return a new `Date` object representing the current instant.
+  now(): Date;
+  // Return a promise that resolves after the given number of milliseconds.
+  sleepMs(ms: number): Promise<void>;
+  // Rolls an actual jitter factor given a maximum jitter ratio.
+  rollJitter(r: number): number;
+}
+
+/**
+ * Run a retryable operation until it terminates or exhausts its retry
+ * policy. If `attempt` ever rejects, this function also immediately
+ * rejects with the same value.
+ */
+export default async function retry<T, E>(
+  attempt: () => Promise<AttemptOutcome<T, E>>,
+  policy?: $Shape<RetryPolicy>,
+  // istanbul ignore next: impure non-test implementation
+  io?: Io = realIo
+): Promise<Result<T, E>> {
+  const fullPolicy: RetryPolicy = {...defaultPolicy(), ...policy};
+  let nextRetryDelayMs = fullPolicy.initialDelayMs;
+  let retries = 0;
+  let waits = 0;
+  while (true) {
+    const outcome = await attempt();
+    switch (outcome.type) {
+      case "DONE":
+        return {type: "DONE", value: outcome.value};
+      case "FATAL":
+        return {type: "FAILED", err: outcome.err};
+      case "RETRY": {
+        if (retries >= fullPolicy.maxRetries) {
+          return {type: "FAILED", err: outcome.err};
+        }
+        retries++;
+        const delayMs =
+          nextRetryDelayMs * io.rollJitter(fullPolicy.jitterRatio);
+        await io.sleepMs(delayMs);
+        nextRetryDelayMs *= fullPolicy.backoffRatio;
+        break;
+      }
+      case "WAIT": {
+        if (waits >= fullPolicy.maxWaits) {
+          return {type: "FAILED", err: outcome.err};
+        }
+        waits++;
+        const now = io.now();
+        const delayMs = outcome.until - now;
+        if (delayMs < 0) {
+          throw new Error(
+            "wait-until time in the past: " +
+              `@${String(+outcome.until)} < @${String(+now)}`
+          );
+        }
+        await io.sleepMs(delayMs);
+        break;
+      }
+      // istanbul ignore next: unreachable per flow
+      default:
+        throw new Error((outcome.type: empty));
+    }
+  }
+  // istanbul ignore next: unreachable
+  throw new Error("unreachable");
+}
+
+const realIo = {
+  // istanbul ignore next: impure non-test implementation
+  now(): Date {
+    return new Date();
+  },
+  // istanbul ignore next: impure non-test implementation
+  sleepMs(ms: number): Promise<void> {
+    return new Promise((resolve) => {
+      setTimeout(resolve, ms);
+    });
+  },
+  // istanbul ignore next: impure non-test implementation
+  rollJitter(r: number): number {
+    return 1 + Math.random() * (r - 1);
+  },
+};

--- a/src/util/retry.js
+++ b/src/util/retry.js
@@ -121,6 +121,8 @@ export default async function retry<T, E>(
     }
   }
   // istanbul ignore next: unreachable
+  // ESLint knows that this next line is unreachable, but Flow doesn't. :-)
+  // eslint-disable-next-line no-unreachable
   throw new Error("unreachable");
 }
 

--- a/src/util/retry.js
+++ b/src/util/retry.js
@@ -107,9 +107,9 @@ export default async function retry<T, E>(
         const now = io.now();
         const delayMs = outcome.until - now;
         if (delayMs < 0) {
+          const fmt = (d: Date): string => `@${(+d / 1000).toFixed(3)}`;
           throw new Error(
-            "wait-until time in the past: " +
-              `@${String(+outcome.until)} < @${String(+now)}`
+            `wait-until time in the past: ${fmt(outcome.until)} < ${fmt(now)}`
           );
         }
         await io.sleepMs(delayMs);

--- a/src/util/retry.test.js
+++ b/src/util/retry.test.js
@@ -1,6 +1,6 @@
 // @flow
 
-import retry, {type AttemptOutcome, type Io, type Result} from "./retry";
+import retry, {type Io} from "./retry";
 
 /**
  * Simple world with a self-contained clock, treated consistently across

--- a/src/util/retry.test.js
+++ b/src/util/retry.test.js
@@ -1,0 +1,260 @@
+// @flow
+
+import retry, {type AttemptOutcome, type Io, type Result} from "./retry";
+
+/**
+ * Simple world with a self-contained clock, treated consistently across
+ * calls to `now` and `sleepMs`, and a customizable, deterministic
+ * jitter function. The jitter function is defined by an infinite
+ * sequence of uniform variates (i.e., reals in `[0.0, 1.0]`) that
+ * determine how much jitter to apply (`0.0` = none, `1.0` = full).
+ * A finite prefix of the uniform variate sequence is given to the
+ * constructor; all subsequent elements are `0.0`.
+ */
+class World implements Io {
+  +_startMs: number;
+  _nowMs: number;
+  _uniformVariates: number[];
+
+  constructor(uniformVariates: number[] = []) {
+    // Use a realistic anchor time (2001-02-03 01:04:05.678 UTC).
+    this._startMs = 981162245678;
+    this._nowMs = this._startMs;
+    this._uniformVariates = uniformVariates;
+  }
+
+  now() {
+    return new Date(this._nowMs);
+  }
+
+  elapsed() {
+    return this._nowMs - this._startMs;
+  }
+
+  sleepMs(ms: number): Promise<void> {
+    return new Promise((resolve) => {
+      setTimeout(() => {
+        this._nowMs += ms;
+        resolve();
+      }, 0);
+    });
+  }
+
+  rollJitter(r: number): number {
+    const u = this._uniformVariates.shift() || 0;
+    return 1 + u * (r - 1);
+  }
+}
+
+describe("util/retry", () => {
+  it("passes through immediate termination", async () => {
+    const w = new World();
+    const calledAt = [];
+    const attempt = async () => {
+      calledAt.push(w.elapsed());
+      return {type: "DONE", value: 777};
+    };
+    const result = await retry(attempt, {}, w);
+    expect(result).toEqual({type: "DONE", value: 777});
+    expect(calledAt).toEqual([0]);
+  });
+
+  it("passes through rejection", async () => {
+    const attempt = async () => {
+      throw "I have failed you";
+    };
+    await expect(() => retry(attempt, {}, new World())).rejects.toEqual(
+      "I have failed you"
+    );
+  });
+
+  it("retries within the policy limit", async () => {
+    const w = new World();
+    const calledAt = [];
+    const attempt = async () => {
+      calledAt.push(w.elapsed());
+      if (calledAt.length >= 4) {
+        return {type: "DONE", value: null};
+      } else {
+        return {type: "RETRY", err: "again"};
+      }
+    };
+    const result = await retry(attempt, {maxRetries: 5, jitterRatio: 1.0}, w);
+    expect(result).toEqual({type: "DONE", value: null});
+    expect(calledAt).toEqual([0, 1000, 3000, 7000]);
+  });
+
+  it("respects the max-retries limit, taking the latest error", async () => {
+    const w = new World();
+    const calledAt = [];
+    const attempt = async () => {
+      calledAt.push(w.elapsed());
+      expect(calledAt.length).toBeLessThan(100); // prevent runaway
+      return {type: "RETRY", err: `n=${calledAt.length}`};
+    };
+    const result = await retry(attempt, {maxRetries: 5, jitterRatio: 1.0}, w);
+    expect(result).toEqual({type: "FAILED", err: "n=6"});
+    expect(calledAt).toHaveLength(1 + 5);
+    expect(calledAt).toEqual([0, 1000, 3000, 7000, 15000, 31000]);
+  });
+
+  it("respects a max-retries limit of 0", async () => {
+    const w = new World();
+    const calledAt = [];
+    const attempt = async () => {
+      calledAt.push(w.elapsed());
+      expect(calledAt.length).toBeLessThan(100); // prevent runaway
+      return {type: "RETRY", err: "never"};
+    };
+    const result = await retry(attempt, {maxRetries: 0}, w);
+    expect(result).toEqual({type: "FAILED", err: "never"});
+    expect(calledAt).toEqual([0]);
+  });
+
+  it("includes jitter for retry delays", async () => {
+    const w = new World([1.0, 0.0, 0.25]);
+    const calledAt = [];
+    const attempt = async () => {
+      calledAt.push(w.elapsed());
+      if (calledAt.length >= 4) {
+        return {type: "DONE", value: null};
+      } else {
+        return {type: "RETRY", err: "again"};
+      }
+    };
+    const result = await retry(attempt, {maxRetries: 5, jitterRatio: 1.5}, w);
+    expect(result).toEqual({type: "DONE", value: null});
+    const expectedDeltas = [1000 * 1.5, 2000 * 1.0, 4000 * 1.125];
+    expect(calledAt).toEqual(prefixSums(expectedDeltas));
+  });
+
+  it("waits until a specified instant", async () => {
+    const w = new World();
+    const calledAt = [];
+    const attempt = async () => {
+      calledAt.push(w.elapsed());
+      switch (calledAt.length) {
+        case 1:
+          return {type: "WAIT", until: new Date(+w.now() + 2500), err: "one"};
+        case 2:
+          return {type: "WAIT", until: new Date(+w.now() + 1000), err: "two"};
+        case 3:
+          return {type: "DONE", value: null};
+        default:
+          throw new Error(`unreachable calledAt.length: ${calledAt.length}`);
+      }
+    };
+    const result = await retry(attempt, {maxWaits: 3}, w);
+    expect(result).toEqual({type: "DONE", value: null});
+    expect(calledAt).toEqual([0, 2500, 3500]);
+  });
+
+  it("ignores jitter for wait-until outcomes", async () => {
+    const w = new World([1.0, 1.0, 1.0]);
+    const calledAt = [];
+    const attempt = async () => {
+      calledAt.push(w.elapsed());
+      switch (calledAt.length) {
+        case 1:
+          return {type: "WAIT", until: new Date(+w.now() + 2500), err: "one"};
+        case 2:
+          return {type: "WAIT", until: new Date(+w.now() + 1000), err: "two"};
+        case 3:
+          return {type: "DONE", value: null};
+        default:
+          throw new Error(`unreachable calledAt.length: ${calledAt.length}`);
+      }
+    };
+    const result = await retry(attempt, {maxWaits: 3, jitterRatio: 1.5}, w);
+    expect(result).toEqual({type: "DONE", value: null});
+    expect(calledAt).toEqual([0, 2500, 3500]);
+  });
+
+  it("respects the max-waits limit, taking the latest error", async () => {
+    const w = new World([1.0, 1.0, 1.0]);
+    const calledAt = [];
+    const attempt = async () => {
+      calledAt.push(w.elapsed());
+      switch (calledAt.length) {
+        case 1:
+          return {type: "WAIT", until: new Date(+w.now() + 2500), err: "one"};
+        case 2:
+          return {type: "WAIT", until: new Date(+w.now() + 1000), err: "two"};
+        default:
+          throw new Error(`unreachable calledAt.length: ${calledAt.length}`);
+      }
+    };
+    const result = await retry(attempt, {maxWaits: 1}, w);
+    expect(result).toEqual({type: "FAILED", err: "two"});
+    expect(calledAt).toEqual([0, 2500]);
+  });
+
+  it("respects a max-waits limit of 0", async () => {
+    const w = new World([1.0, 1.0, 1.0]);
+    const calledAt = [];
+    const attempt = async () => {
+      calledAt.push(w.elapsed());
+      switch (calledAt.length) {
+        case 1:
+          return {type: "WAIT", until: new Date(+w.now() + 2500), err: "wait"};
+        default:
+          throw new Error(`unreachable calledAt.length: ${calledAt.length}`);
+      }
+    };
+    const result = await retry(attempt, {maxWaits: 0}, w);
+    expect(result).toEqual({type: "FAILED", err: "wait"});
+    expect(calledAt).toEqual([0]);
+  });
+
+  it("interleaves retries and waits", async () => {
+    const w = new World([1.0, 0.25, 0.75]);
+    const calledAt = [];
+    const attempt = async () => {
+      calledAt.push(w.elapsed());
+      switch (calledAt.length) {
+        case 1:
+          return {type: "RETRY", err: 1};
+        case 2:
+          return {type: "WAIT", until: new Date(+w.now() + 1234), err: 2};
+        case 3:
+          return {type: "RETRY", err: 3};
+        case 4:
+          return {type: "RETRY", err: 4};
+        case 5:
+          return {type: "WAIT", until: new Date(+w.now() + 6789), err: 5};
+        case 6:
+          return {type: "DONE", value: "voila"};
+        default:
+          throw new Error(`unreachable calledAt.length: ${calledAt.length}`);
+      }
+    };
+    const result = await retry(
+      attempt,
+      {maxRetries: 10, maxWaits: 10, jitterRatio: 1.5},
+      w
+    );
+    expect(result).toEqual({type: "DONE", value: "voila"});
+    const expectedDeltas = [1000 * 1.5, 1234, 2000 * 1.125, 4000 * 1.375, 6789];
+    expect(calledAt).toEqual(prefixSums(expectedDeltas));
+  });
+
+  it("rejects on a wait time in the past", async () => {
+    const w = new World();
+    const attempt = async () => {
+      return {type: "WAIT", until: new Date(+w.now() - 1234), err: "again"};
+    };
+    await expect(() => retry(attempt, {}, w)).rejects.toThrow(
+      "wait-until time in the past"
+    );
+  });
+});
+
+// `scanl (+) 0`: e.g., [1, 10, 3] -> [0, 1, 11, 14]
+function prefixSums(xs: $ReadOnlyArray<number>): number[] {
+  const partials = [0];
+  for (const x of xs) {
+    const last = partials[partials.length - 1];
+    partials.push(last + x);
+  }
+  return partials;
+}


### PR DESCRIPTION
Summary:
The GitHub plugin uses the NPM `retry` module to retry individual
queries. But that module’s API is too restrictive for us, on two counts:

 1. There’s no way to say “wait until this specific time, after which my
    API quota will have refreshed”. Or, from another perspective, every
    operation has just a single retry policy.
 2. The jitter range is hardcoded to `Uniform[1.0, 2.0]`; I’d prefer
    that it be something more like `1.2` to reduce variance.

This patch introduces a simple `retry` module that fits our needs more
precisely. It distinguishes a “retry with backoff” due to transient
error from a “wait until this time” due to quota exhaustion. Other
benefits of this module include:

  - The API is simpler. Clients don’t have to maintain a reference to a
    stateful operation object and manually request retries. Instead, a
    client simply provides an async function.
  - Since “retries” and “waits” are distinguished, we can test that
    logic in the retry module itself.
  - The module has Flow types and is written in a type-friendly style.

If useful, the `Result<T>` type could be enhanced with a record of all
the retry events: “waited 2.1 seconds due to transient error, then
waited 10 minutes for budget refresh, then waited 3.9 seconds due to
transient error”. This would be easy to add, but we don’t need it yet.

Test Plan:
Unit tests included, with full coverage.

wchargin-branch: util-retry
