### PR TITLE
add IntervalSequence

### DIFF
--- a/src/analysis/credData.js
+++ b/src/analysis/credData.js
@@ -7,7 +7,7 @@ import {
 } from "../core/dependenciesMintPolicy";
 import {type NodeAddressT, NodeAddress} from "../core/graph";
 import {IDENTITY_PREFIX} from "../ledger/identity";
-import type {Interval} from "../core/interval";
+import {type IntervalSequence, intervalSequence} from "../core/interval";
 
 /**
  * Comprehensive data on a cred distribution.
@@ -18,7 +18,7 @@ export type CredData = {|
   +nodeOverTime: $ReadOnlyArray<NodeCredOverTime | null>,
   +edgeSummaries: $ReadOnlyArray<EdgeCredSummary>,
   +edgeOverTime: $ReadOnlyArray<EdgeCredOverTime | null>,
-  +intervals: $ReadOnlyArray<Interval>,
+  +intervals: IntervalSequence,
 |};
 
 /** Summary of a node's cred across all time.
@@ -83,10 +83,10 @@ export function computeCredData(
       nodeOverTime: [],
       edgeSummaries: [],
       edgeOverTime: [],
-      intervals: [],
+      intervals: intervalSequence([]),
     };
   }
-  const intervals = scores.map((d) => d.interval);
+  const intervals = intervalSequence(scores.map((d) => d.interval));
   const processedDependencyPolicies = dependencyPolicies.map((p) =>
     processMintPolicy(p, nodeOrder, intervals)
   );
@@ -168,7 +168,7 @@ export function computeCredData(
     nodeOverTime,
     edgeSummaries,
     edgeOverTime,
-    intervals,
+    intervals: intervalSequence(intervals),
   };
 }
 

--- a/src/analysis/credData.test.js
+++ b/src/analysis/credData.test.js
@@ -5,6 +5,7 @@ import type {TimelineCredScores} from "../core/algorithm/distributionToCred";
 import type {DependencyMintPolicy} from "../core/dependenciesMintPolicy";
 import {NodeAddress} from "../core/graph";
 import {IDENTITY_PREFIX} from "../ledger/identity";
+import {intervalSequence} from "../core/interval";
 
 describe("src/analysis/credData", () => {
   it("handles empty scores correctly", () => {
@@ -145,10 +146,10 @@ describe("src/analysis/credData", () => {
     expect(computeCredData(scores, nodeOrder, mintPolicies)).toEqual(expected);
   });
   it("compresses by threshold correctly", () => {
-    const intervals = [
+    const intervals = intervalSequence([
       {startTimeMs: 0, endTimeMs: 100},
       {startTimeMs: 100, endTimeMs: 200},
-    ];
+    ]);
     const nodeSummaries = [
       {cred: 14, seedFlow: 0, syntheticLoopFlow: 0.2, dependencyMintedCred: 0},
       {cred: 20, seedFlow: 20, syntheticLoopFlow: 0, dependencyMintedCred: 0},

--- a/src/analysis/credView.js
+++ b/src/analysis/credView.js
@@ -7,7 +7,7 @@ import {type TimelineCredParameters} from "./timeline/params";
 import {type PluginDeclarations} from "./pluginDeclaration";
 import {type NodeType, type EdgeType} from "./types";
 import {IDENTITY_PREFIX} from "../ledger/identity";
-import {type Interval} from "../core/interval";
+import {type IntervalSequence} from "../core/interval";
 
 import {get as nullGet} from "../util/null";
 import type {TimestampMs} from "../util/timestamp";
@@ -161,7 +161,7 @@ export class CredView {
     return this._credResult.plugins;
   }
 
-  intervals(): $ReadOnlyArray<Interval> {
+  intervals(): IntervalSequence {
     return this._credResult.credData.intervals;
   }
 
@@ -318,7 +318,7 @@ function xor(a: boolean, b: boolean): boolean {
 
 // Exported separately for testing purposes.
 export function _getIntervalIndex(
-  intervals: $ReadOnlyArray<Interval>,
+  intervals: IntervalSequence,
   ts: TimestampMs
 ): number {
   const ends = intervals.map((x) => x.endTimeMs);

--- a/src/analysis/credView.test.js
+++ b/src/analysis/credView.test.js
@@ -10,6 +10,7 @@ import {
 import {defaultParams} from "./timeline/params";
 import {compute} from "./credResult";
 import {CredView, _getIntervalIndex} from "./credView";
+import {intervalSequence} from "../core/interval";
 
 describe("analysis/credView", () => {
   async function example() {
@@ -252,38 +253,38 @@ describe("analysis/credView", () => {
 
   describe("_getIntervalIndex", () => {
     it("works for the zero-th index", () => {
-      const intervals = [
+      const intervals = intervalSequence([
         {startTimeMs: 0, endTimeMs: 100},
         {startTimeMs: 100, endTimeMs: 200},
         {startTimeMs: 200, endTimeMs: 300},
-      ];
+      ]);
       expect(_getIntervalIndex(intervals, 0)).toEqual(0);
       expect(_getIntervalIndex(intervals, 100)).toEqual(0);
     });
     it("works for a middle index", () => {
-      const intervals = [
+      const intervals = intervalSequence([
         {startTimeMs: 0, endTimeMs: 100},
         {startTimeMs: 100, endTimeMs: 200},
         {startTimeMs: 200, endTimeMs: 300},
-      ];
+      ]);
       expect(_getIntervalIndex(intervals, 101)).toEqual(1);
       expect(_getIntervalIndex(intervals, 200)).toEqual(1);
     });
     it("works for the last index", () => {
-      const intervals = [
+      const intervals = intervalSequence([
         {startTimeMs: 0, endTimeMs: 100},
         {startTimeMs: 100, endTimeMs: 200},
         {startTimeMs: 200, endTimeMs: 300},
-      ];
+      ]);
       expect(_getIntervalIndex(intervals, 299)).toEqual(2);
       expect(_getIntervalIndex(intervals, 300)).toEqual(2);
     });
     it("errors for an index out of bound", () => {
-      const intervals = [
+      const intervals = intervalSequence([
         {startTimeMs: 0, endTimeMs: 100},
         {startTimeMs: 100, endTimeMs: 200},
         {startTimeMs: 200, endTimeMs: 300},
-      ];
+      ]);
       const thunk = () => _getIntervalIndex(intervals, 301);
       expect(thunk).toThrowError("timestamp out of interval range");
     });

--- a/src/core/algorithm/timelinePagerank.js
+++ b/src/core/algorithm/timelinePagerank.js
@@ -14,7 +14,12 @@ import {
   type Node,
 } from "../graph";
 import {type WeightedGraph} from "../weightedGraph";
-import {type Interval, partitionGraph} from "../interval";
+import {
+  type Interval,
+  partitionGraph,
+  type IntervalSequence,
+  intervalSequence,
+} from "../interval";
 import {
   nodeWeightEvaluator,
   edgeWeightEvaluator,
@@ -139,7 +144,9 @@ export async function timelinePagerank(
   if (graphPartitionSlices.length === 0) {
     return [];
   }
-  const intervals = graphPartitionSlices.map((x) => x.interval);
+  const intervals = intervalSequence(
+    graphPartitionSlices.map((x) => x.interval)
+  );
   const nodeCreationHistory = graphPartitionSlices.map((x) => x.nodes);
   const edgeCreationHistory = graphPartitionSlices.map((x) => x.edges);
   const nodeOrder = Array.from(weightedGraph.graph.nodes()).map(
@@ -223,7 +230,7 @@ export function* _timelineNodeToConnections(
 export async function _computeTimelineDistribution(
   nodeOrder: $ReadOnlyArray<NodeAddressT>,
   edgeOrder: $ReadOnlyArray<EdgeAddressT>,
-  intervals: $ReadOnlyArray<Interval>,
+  intervals: IntervalSequence,
   nodeWeightIterator: Iterator<Map<NodeAddressT, number>>,
   nodeToConnectionsIterator: Iterator<NodeToConnections>,
   alpha: number

--- a/src/core/dependenciesMintPolicy.js
+++ b/src/core/dependenciesMintPolicy.js
@@ -47,7 +47,7 @@
  */
 import {type NodeAddressT, NodeAddress} from "./graph";
 import {type TimestampMs} from "../util/timestamp";
-import {type Interval} from "./interval";
+import {type IntervalSequence} from "./interval";
 
 export type DependencyMintPolicy = {|
   // The node address that will receieve the extra minted Cred
@@ -83,7 +83,7 @@ export type ProcessedDependencyMintPolicy = {|
 export function processMintPolicy(
   policy: DependencyMintPolicy,
   nodeOrder: $ReadOnlyArray<NodeAddressT>,
-  intervals: $ReadOnlyArray<Interval>
+  intervals: IntervalSequence
 ): ProcessedDependencyMintPolicy {
   const {address, periods} = policy;
   const nodeIndex = nodeOrder.indexOf(address);

--- a/src/core/dependenciesMintPolicy.test.js
+++ b/src/core/dependenciesMintPolicy.test.js
@@ -6,6 +6,7 @@ import {
   _alignPeriodsToIntervals,
   processMintPolicy,
 } from "./dependenciesMintPolicy";
+import {intervalSequence} from "./interval";
 
 describe("core/dependenciesMintPolicy", () => {
   describe("_alignPeriodsToIntervals", () => {
@@ -90,12 +91,14 @@ describe("core/dependenciesMintPolicy", () => {
     const n3 = NodeAddress.fromParts(["3"]);
     const nx = NodeAddress.fromParts(["x"]);
     const nodeOrder = deepFreeze([n1, n2, n3]);
-    const intervals = deepFreeze([
-      {startTimeMs: 1, endTimeMs: 2},
-      {startTimeMs: 2, endTimeMs: 3},
-      {startTimeMs: 3, endTimeMs: 4},
-      {startTimeMs: 4, endTimeMs: 5},
-    ]);
+    const intervals = deepFreeze(
+      intervalSequence([
+        {startTimeMs: 1, endTimeMs: 2},
+        {startTimeMs: 2, endTimeMs: 3},
+        {startTimeMs: 3, endTimeMs: 4},
+        {startTimeMs: 4, endTimeMs: 5},
+      ])
+    );
     const periods = [deepFreeze({startTimeMs: 2, weight: 0.5})];
     it("converts the address and periods correctly", () => {
       const policy = {address: n2, periods};

--- a/src/ledger/applyDistributions.js
+++ b/src/ledger/applyDistributions.js
@@ -1,7 +1,7 @@
 // @flow
 
 import {type TimestampMs} from "../util/timestamp";
-import {type Interval} from "../core/interval";
+import {type IntervalSequence, intervalSequence} from "../core/interval";
 import {Ledger} from "./ledger";
 import {type AllocationPolicy} from "./grainAllocation";
 import {CredView} from "../analysis/credView";
@@ -66,11 +66,11 @@ export function applyDistributions(
 }
 
 export function _chooseDistributionIntervals(
-  credIntervals: $ReadOnlyArray<Interval>,
+  credIntervals: IntervalSequence,
   lastDistributionTimestamp: TimestampMs,
   currentTimestamp: TimestampMs,
   maxSimultaneousDistributions: number
-): $ReadOnlyArray<Interval> {
+): IntervalSequence {
   // Slice off the final interval--we may assume that it is not yet finished.
   const completeIntervals = credIntervals.filter(
     (x) => x.endTimeMs <= currentTimestamp
@@ -78,8 +78,9 @@ export function _chooseDistributionIntervals(
   const undistributedIntervals = completeIntervals.filter(
     (i) => i.endTimeMs > lastDistributionTimestamp
   );
-  return undistributedIntervals.slice(
+  const sequence = undistributedIntervals.slice(
     undistributedIntervals.length - maxSimultaneousDistributions,
     undistributedIntervals.length
   );
+  return intervalSequence(sequence);
 }

--- a/src/ledger/applyDistributions.test.js
+++ b/src/ledger/applyDistributions.test.js
@@ -1,15 +1,16 @@
 // @flow
 
 import {_chooseDistributionIntervals} from "./applyDistributions";
+import {intervalSequence} from "../core/interval";
 
 describe("ledger/applyDistributions", () => {
   describe("_chooseDistributionIntervals", () => {
     it("handles a case where we want to distribute for every interval except latest", () => {
-      const credIntervals = [
+      const credIntervals = intervalSequence([
         {startTimeMs: 0, endTimeMs: 100},
         {startTimeMs: 100, endTimeMs: 200},
         {startTimeMs: 200, endTimeMs: 300},
-      ];
+      ]);
       const lastDistributionTimestamp = -Infinity;
       const maxSimultaneousDistributions = Infinity;
       const expected = [
@@ -26,11 +27,11 @@ describe("ledger/applyDistributions", () => {
       ).toEqual(expected);
     });
     it("handles the case where maxSimultaneousDistributions === 0", () => {
-      const credIntervals = [
+      const credIntervals = intervalSequence([
         {startTimeMs: 0, endTimeMs: 100},
         {startTimeMs: 100, endTimeMs: 200},
         {startTimeMs: 200, endTimeMs: 300},
-      ];
+      ]);
       const lastDistributionTimestamp = -Infinity;
       const maxSimultaneousDistributions = 0;
       const expected = [];
@@ -44,11 +45,11 @@ describe("ledger/applyDistributions", () => {
       ).toEqual(expected);
     });
     it("handles the case where we've already distributed for the finished intervals", () => {
-      const credIntervals = [
+      const credIntervals = intervalSequence([
         {startTimeMs: 0, endTimeMs: 100},
         {startTimeMs: 100, endTimeMs: 200},
         {startTimeMs: 200, endTimeMs: 300},
-      ];
+      ]);
       const lastDistributionTimestamp = 2;
       const maxSimultaneousDistributions = 0;
       const expected = [];
@@ -62,11 +63,11 @@ describe("ledger/applyDistributions", () => {
       ).toEqual(expected);
     });
     it("handles the case where we're limited by maxSimultaneousDistributions", () => {
-      const credIntervals = [
+      const credIntervals = intervalSequence([
         {startTimeMs: 0, endTimeMs: 100},
         {startTimeMs: 100, endTimeMs: 200},
         {startTimeMs: 200, endTimeMs: 300},
-      ];
+      ]);
       const lastDistributionTimestamp = -Infinity;
       const maxSimultaneousDistributions = 1;
       const expected = [{startTimeMs: 100, endTimeMs: 200}];
@@ -80,11 +81,11 @@ describe("ledger/applyDistributions", () => {
       ).toEqual(expected);
     });
     it("handles the case where the latest interval is complete", () => {
-      const credIntervals = [
+      const credIntervals = intervalSequence([
         {startTimeMs: 0, endTimeMs: 100},
         {startTimeMs: 100, endTimeMs: 200},
         {startTimeMs: 200, endTimeMs: 300},
-      ];
+      ]);
       const lastDistributionTimestamp = -Infinity;
       const maxSimultaneousDistributions = 1;
       const expected = [{startTimeMs: 200, endTimeMs: 300}];

--- a/src/ledger/computeDistribution.test.js
+++ b/src/ledger/computeDistribution.test.js
@@ -4,6 +4,7 @@ import {Ledger} from "./ledger";
 import {NodeAddress} from "../core/graph";
 import {_allocationIdentities} from "./computeDistribution";
 import * as G from "./grain";
+import {intervalSequence} from "../core/interval";
 
 describe("ledger/computeDistribution", () => {
   describe("_allocationIdentities", () => {
@@ -28,11 +29,11 @@ describe("ledger/computeDistribution", () => {
           totalCred: 15,
         },
       ];
-      const intervals = [
+      const intervals = intervalSequence([
         {startTimeMs: 121, endTimeMs: 123},
         {startTimeMs: 123, endTimeMs: 125},
         {startTimeMs: 125, endTimeMs: 127},
-      ];
+      ]);
       const accountsData = {
         intervals,
         accounts,
@@ -56,11 +57,11 @@ describe("ledger/computeDistribution", () => {
         cred: [1, 2, 3],
         totalCred: 6,
       }));
-      const intervals = [
+      const intervals = intervalSequence([
         {startTimeMs: 121, endTimeMs: 123},
         {startTimeMs: 123, endTimeMs: 125},
         {startTimeMs: 125, endTimeMs: 127},
-      ];
+      ]);
       const accountsData = {
         intervals,
         accounts,

--- a/src/ledger/credAccounts.js
+++ b/src/ledger/credAccounts.js
@@ -13,7 +13,7 @@ import {sum} from "d3-array";
 import {Ledger, type Account} from "./ledger";
 import {CredView} from "../analysis/credView";
 import {NodeAddress, type NodeAddressT} from "../core/graph";
-import type {Interval} from "../core/interval";
+import {type IntervalSequence} from "../core/interval";
 import {type Alias} from "./identity";
 
 export type Cred = $ReadOnlyArray<number>;
@@ -38,7 +38,7 @@ export type CredAccountData = {|
   +unclaimedAliases: $ReadOnlyArray<UnclaimedAlias>,
   // For interpreting the Cred data associated with cred accounts and
   // unclaimed accounts.
-  +intervals: $ReadOnlyArray<Interval>,
+  +intervals: IntervalSequence,
 |};
 
 export function computeCredAccounts(
@@ -62,7 +62,7 @@ export function computeCredAccounts(
 export function _computeCredAccounts(
   grainAccounts: $ReadOnlyArray<Account>,
   userlikeInfo: Map<NodeAddressT, {|+cred: Cred, +description: string|}>,
-  intervals: $ReadOnlyArray<Interval>
+  intervals: IntervalSequence
 ): CredAccountData {
   const aliasAddresses: Set<NodeAddressT> = new Set();
   const accountAddresses: Set<NodeAddressT> = new Set();

--- a/src/ledger/credAccounts.test.js
+++ b/src/ledger/credAccounts.test.js
@@ -3,6 +3,7 @@
 import {NodeAddress} from "../core/graph";
 import {_computeCredAccounts} from "./credAccounts";
 import {Ledger} from "./ledger";
+import {intervalSequence} from "../core/interval";
 
 describe("ledger/credAccounts", () => {
   describe("_computeCredAccounts", () => {
@@ -20,11 +21,11 @@ describe("ledger/credAccounts", () => {
         ],
         [userAddress, {cred: userCred, description: "Little lost user"}],
       ]);
-      const intervals = [
+      const intervals = intervalSequence([
         {startTimeMs: 121, endTimeMs: 123},
         {startTimeMs: 123, endTimeMs: 125},
         {startTimeMs: 125, endTimeMs: 127},
-      ];
+      ]);
       const expectedCredAccount = {cred: accountCred, account, totalCred: 3};
       const expectedUnclaimedAccount = {
         alias: {
@@ -59,11 +60,11 @@ describe("ledger/credAccounts", () => {
         ],
         [alias.address, {cred: userCred, description: "irrelevant"}],
       ]);
-      const intervals = [
+      const intervals = intervalSequence([
         {startTimeMs: 121, endTimeMs: 123},
         {startTimeMs: 123, endTimeMs: 125},
         {startTimeMs: 125, endTimeMs: 127},
-      ];
+      ]);
 
       const thunk = () => _computeCredAccounts([account], info, intervals);
       expect(thunk).toThrowError(
@@ -78,11 +79,11 @@ describe("ledger/credAccounts", () => {
 
       const account = ledger.accounts()[0];
       const scores = new Map();
-      const intervals = [
+      const intervals = intervalSequence([
         {startTimeMs: 121, endTimeMs: 123},
         {startTimeMs: 123, endTimeMs: 125},
         {startTimeMs: 125, endTimeMs: 127},
-      ];
+      ]);
 
       const thunk = () => _computeCredAccounts([account], scores, intervals);
       expect(thunk).toThrowError(`cred sync error: no info for account`);


### PR DESCRIPTION
An IntervalSequence is an opaque read-only array of intervals, with
runtime validation that the intervals are non-overlapping and also have
no gaps between them, and that every interval has non-negative duration.
This way we can use intervals and not worry that the interval may be
out-of-order or have gaps, etc.

Test plan: Unit tests added to verify that the interval sequences have
the expected properties. Also, `git grep -F '$ReadOnlyArray<Interval>'`
only has hits within the interval module itself.