### PR TITLE
credrank: show relative cred in summary table

### DIFF
--- a/src/cli/credrank.js
+++ b/src/cli/credrank.js
@@ -3,6 +3,7 @@
 import fs from "fs-extra";
 import stringify from "json-stable-stringify";
 import {join as pathJoin} from "path";
+import {sum} from "d3-array";
 
 import sortBy from "../util/sortBy";
 import {credrank} from "../core/algorithm/credrank";
@@ -78,13 +79,18 @@ const credrankCommand: Command = async (args, std) => {
 function printCredSummaryTable(credGraph: CredGraph) {
   console.log(`# Top Participants By Cred`);
   console.log();
-  console.log(`| Description | Cred |`);
-  console.log(`| --- | --- |`);
+  console.log(`| Description | Cred | % |`);
+  console.log(`| --- | --- | --- |`);
   const credParticipants = Array.from(credGraph.participants());
   const sortedParticipants = sortBy(credParticipants, (p) => -p.cred);
-  sortedParticipants
-    .slice(0, 20)
-    .forEach((n) => console.log(`| ${n.description} | ${n.cred.toFixed(1)} |`));
+  const totalCred = sum(sortedParticipants, (p) => p.cred);
+  function row({cred, description}) {
+    const percentage = (100 * cred) / totalCred;
+    return `| ${description} | ${cred.toFixed(1)} | ${percentage.toFixed(
+      1
+    )}% |`;
+  }
+  sortedParticipants.slice(0, 20).forEach((n) => console.log(row(n)));
 }
 
 export default credrankCommand;


### PR DESCRIPTION
This commit modifies the credrank command that the summary table shows
relative Cred as well as absolute Cred. This will make testing
dependency minted cred easier.

Test plan:

Run CredRank, see percentages, as follows:

| Description | Cred | % |
| --- | --- | --- |
| decentralion | 23648.2 | 34.0% |
| wchargin | 10297.0 | 14.8% |
| beanow | 5799.3 | 8.3% |
| lbstrobbe | 4585.2 | 6.6% |
| s-ben | 4375.5 | 6.3% |
| hammad | 3226.0 | 4.6% |
| burrrata | 1899.1 | 2.7% |
| vsoch | 1361.6 | 2.0% |
| mzargham | 1348.5 | 1.9% |
| bex | 1061.9 | 1.5% |
| topocount | 1017.6 | 1.5% |
| KuraFire | 959.1 | 1.4% |
| brianlitwin | 886.6 | 1.3% |
| dependabot | 707.5 | 1.0% |
| greenkeeper | 664.6 | 1.0% |
| sandpiper | 498.6 | 0.7% |
| evan | 419.7 | 0.6% |
| yalor | 349.2 | 0.5% |
| benoxmo | 346.7 | 0.5% |
| flyingzumwalt | 307.8 | 0.4% |