### PR TITLE
github: request quota refresh time

### DIFF
--- a/src/plugins/github/fetchGithubRepo.js
+++ b/src/plugins/github/fetchGithubRepo.js
@@ -193,7 +193,6 @@ function tryGithubFetch(postBody: string, token: GithubToken): Promise<any> {
       }),
     (e) =>
       Promise.reject(({type: "FETCH_ERROR", error: e}: GithubResponseError))
-<<<<<<< HEAD
   );
 }
 
@@ -242,8 +241,6 @@ async function quotaRefreshAt(token: GithubToken): Promise<Date> {
     "RateLimitReset",
     [],
     [b.field("rateLimit", {}, [b.field("resetAt")])]
-=======
->>>>>>> 7995c9dd98112dd68b88f76984d25d874a789cd5
   );
   const postBody = JSON.stringify({
     query: stringify.body([query], inlineLayout()),
@@ -277,29 +274,6 @@ export function _resolveRefreshTime(now: Date, nominalRefreshTime: Date): Date {
   return new Date(+now + delayMs);
 }
 
-function errorDisposition(
-  e: GithubResponseError
-): AttemptOutcome<empty, GithubResponseError> {
-  if (
-    e.type === "FETCH_ERROR" ||
-    e.type === "GRAPHQL_ERROR" ||
-    e.type === "BAD_CREDENTIALS"
-  ) {
-    return {type: "FATAL", err: e};
-  }
-  if (e.type === "GITHUB_INTERNAL_EXECUTION_ERROR" || e.type === "NO_DATA") {
-    return {type: "RETRY", err: e};
-  }
-  if (e.type === "RATE_LIMIT_EXCEEDED") {
-    // Wait in 15-minute increments. TODO(@wchargin): Ask GitHub
-    // when our token resets (`{ rateLimit { resetAt } }`) and wait
-    // until just then.
-    const delayMs = 15 * 60 * 1000;
-    return {type: "WAIT", until: new Date(Date.now() + delayMs), err: e};
-  }
-  throw new Error((e.type: empty));
-}
-
 async function retryGithubFetch(
   postBody: string,
   token: GithubToken
@@ -316,11 +290,7 @@ async function retryGithubFetch(
       return {type: "DONE", value: await tryGithubFetch(postBody, token)};
     } catch (errAny) {
       const err: GithubResponseError = errAny;
-<<<<<<< HEAD
       return await errorDisposition(err, token);
-=======
-      return errorDisposition(err);
->>>>>>> 7995c9dd98112dd68b88f76984d25d874a789cd5
     }
   }, policy);
   switch (retryResult.type) {

--- a/src/plugins/github/fetchGithubRepo.js
+++ b/src/plugins/github/fetchGithubRepo.js
@@ -142,7 +142,14 @@ type GithubResponseError =
 // Fetch against the GitHub API with the provided options, returning a
 // promise that either resolves to the GraphQL result data or rejects
 // to a `GithubResponseError`.
-function tryGithubFetch(fetch, fetchOptions): Promise<any> {
+function tryGithubFetch(postBody: string, token: string): Promise<any> {
+  const fetchOptions = {
+    method: "POST",
+    body: postBody,
+    headers: {
+      Authorization: `bearer ${token}`,
+    },
+  };
   return fetch(GITHUB_GRAPHQL_SERVER, fetchOptions).then(
     (x) =>
       x.json().then((x) => {
@@ -189,9 +196,10 @@ function tryGithubFetch(fetch, fetchOptions): Promise<any> {
   );
 }
 
-function errorDisposition(
-  e: GithubResponseError
-): AttemptOutcome<empty, GithubResponseError> {
+async function errorDisposition(
+  e: GithubResponseError,
+  token: string
+): Promise<AttemptOutcome<empty, GithubResponseError>> {
   if (
     e.type === "FETCH_ERROR" ||
     e.type === "GRAPHQL_ERROR" ||
@@ -203,18 +211,72 @@ function errorDisposition(
     return {type: "RETRY", err: e};
   }
   if (e.type === "RATE_LIMIT_EXCEEDED") {
-    // Wait in 15-minute increments. TODO(@wchargin): Ask GitHub
-    // when our token resets (`{ rateLimit { resetAt } }`) and wait
-    // until just then.
-    const delayMs = 15 * 60 * 1000;
-    return {type: "WAIT", until: new Date(Date.now() + delayMs), err: e};
+    try {
+      const nominalRefreshTime = await quotaRefreshAt(token);
+      const refreshTime = _resolveRefreshTime(new Date(), nominalRefreshTime);
+      console.warn(
+        "rate limit exceeded; waiting for refresh at " +
+          refreshTime.toISOString()
+      );
+      return {type: "WAIT", until: refreshTime, err: e};
+    } catch (refreshError) {
+      // Fall back to waiting in 15-minute increments.
+      console.warn("rate limit exceeded; waiting 15 minutes");
+      const delayMs = 15 * 60 * 1000;
+      return {type: "WAIT", until: new Date(Date.now() + delayMs), err: e};
+    }
   }
   throw new Error((e.type: empty));
 }
 
+/**
+ * Determine the instant at which our GitHub quota will refresh.
+ *
+ * The returned promise may reject with a `GithubResponseError` or
+ * string error message.
+ */
+async function quotaRefreshAt(token: string): Promise<Date> {
+  const b = Queries.build;
+  const query = b.query(
+    "RateLimitReset",
+    [],
+    [b.field("rateLimit", {}, [b.field("resetAt")])]
+  );
+  const postBody = JSON.stringify({
+    query: stringify.body([query], inlineLayout()),
+    variables: {},
+  });
+  const data = await tryGithubFetch(postBody, token);
+  const dateString = data.rateLimit.resetAt;
+  const result = new Date(dateString);
+  if (isNaN(result)) {
+    throw "got NaN quota reset time: " + JSON.stringify(data);
+  }
+  return result;
+}
+
+/**
+ * Given a `resetAt` date response from GitHub, determine the actual
+ * date until which we want to wait. We clamp to a reasonable range and
+ * apply some padding.
+ */
+export function _resolveRefreshTime(now: Date, nominalRefreshTime: Date): Date {
+  let delayMs = +nominalRefreshTime - +now;
+  const [minDelayMs, maxDelayMs] = [0, 60 * 60 * 1000];
+  if (delayMs < minDelayMs || delayMs > maxDelayMs) {
+    const newDelayMs = Math.max(minDelayMs, Math.min(delayMs, maxDelayMs));
+    console.warn(
+      `clamping refresh delay from ${delayMs} ms to ${newDelayMs} ms`
+    );
+    delayMs = newDelayMs;
+  }
+  delayMs += 60 * 1000; // add 1 minute for padding around clock skew
+  return new Date(+now + delayMs);
+}
+
 async function retryGithubFetch(
-  fetch,
-  fetchOptions
+  postBody: string,
+  token: string
 ): Promise<any /* or rejects to GithubResponseError */> {
   const policy = {
     maxRetries: 5,
@@ -225,10 +287,10 @@ async function retryGithubFetch(
   };
   const retryResult = await retry(async () => {
     try {
-      return {type: "DONE", value: await tryGithubFetch(fetch, fetchOptions)};
+      return {type: "DONE", value: await tryGithubFetch(postBody, token)};
     } catch (errAny) {
       const err: GithubResponseError = errAny;
-      return errorDisposition(err);
+      return await errorDisposition(err, token);
     }
   }, policy);
   switch (retryResult.type) {
@@ -249,14 +311,7 @@ export async function postQuery(
     query: stringify.body(body, inlineLayout()),
     variables: variables,
   });
-  const fetchOptions = {
-    method: "POST",
-    body: postBody,
-    headers: {
-      Authorization: `bearer ${token}`,
-    },
-  };
-  return retryGithubFetch(fetch, fetchOptions).catch(
+  return retryGithubFetch(postBody, token).catch(
     (error: GithubResponseError) => {
       const type = error.type;
       switch (type) {


### PR DESCRIPTION
Summary:
Upon exhausting its quota, the GitHub plugin now asks GitHub when the
quota will be refreshed and waits until that time, rather than just
blindly waiting 15 minutes repeatedly. (You can query for the rate limit
information even if your quota is exhausted.) The new logic is gated
behind a blanket `try`-`catch`; if anything goes wrong, we fall back to
waiting for 15 minutes.

As an incidental change in this PR, we remove the dependency injection
of `fetch`. It was just kind of confusing, and wasn’t helpful; this
module’s networking code has no unit tests that would benefit from the
injection.

We also now log to the console while waiting for a refresh, which seems
nicer than hanging for up to an hour with no output.

Test Plan:
Unit tests included for parts of the logic. As an end-to-end test, I ran
four concurrent loads of [the `1Hive/pollen` instance][1]. This
exhausted my quota in about 10 minutes, after which it properly waited
for refresh and then resumed:

```
  GO   sourcecred/github: github: loading 1Hive/gardens-template
 DONE  sourcecred/github: github: loading 1Hive/gardens-template: 9123ms
  GO   sourcecred/github: github: loading 1Hive/honey-template
 DONE  sourcecred/github: github: loading 1Hive/honey-template: 5766ms
  GO   sourcecred/github: github: loading 1Hive/transactions-app
rate limit exceeded; waiting for refresh at 2020-10-04T21:57:24.000Z
 DONE  sourcecred/github: github: loading 1Hive/transactions-app: 37m 2s
  GO   sourcecred/github: github: loading 1Hive/flora
 DONE  sourcecred/github: github: loading 1Hive/flora: 8714ms
  GO   sourcecred/github: github: loading 1Hive/apiary
 DONE  sourcecred/github: github: loading 1Hive/apiary: 44s
[...]
 DONE  loading sourcecred/github: 1h 9m
 DONE  load: 1h 9m
```

(Note the 37-minute elapsed time for `1Hive/transactions-app`.) The
target time was indeed 60 seconds after my token would be refreshed:

```
$ ghquery '{ rateLimit { remaining resetAt } }'
{"data":{"rateLimit":{"remaining":0,"resetAt":"2020-10-04T21:56:24Z"}}}
```

[1]: https://github.com/1Hive/pollen/tree/55a2a57ee3f8969189af3964865cff0262778653

wchargin-branch: github-ask-for-refresh-time

