### PR TITLE
Fix random number generation in API build

### DIFF
--- a/config/webpack.config.api.js
+++ b/config/webpack.config.api.js
@@ -47,6 +47,9 @@ module.exports = ({
       new ModuleScopePlugin(paths.appSrc, [paths.appPackageJson]),
     ],
   },
+  externals: {
+    "crypto": "crypto",
+  },
   module: {
     strictExportPresence: true,
     rules: [


### PR DESCRIPTION
Currently when you try activating an identityId using the API from the sourcecred npm package,
it results in a "Error: No secure random number generator available." error. This is a result of
webpack trying to bundle the built-in crypto module from node which may not be compatible with
the end users environment. Setting "crypto" as an external in webpack will prevent that and instead
will import it at runtime, which prevents environment incompatibility issues since it will use
the crypto package from the users installed node version.

Test Plan: Using the NPM package, call `ledger.activate(identityId)` and ensure no errors are thrown.