### PR TITLE
Update sidebar icons in front end

### DIFF
--- a/src/ui/components/Menu.js
+++ b/src/ui/components/Menu.js
@@ -2,9 +2,10 @@
 import React, {type Node as ReactNode} from "react";
 import {useSelector} from "react-redux";
 import {MenuItemLink} from "react-admin";
-import TrendingUpIcon from "@material-ui/icons/TrendingUp";
-import DefaultIcon from "@material-ui/icons/ViewList";
-import TransformIcon from "@material-ui/icons/Transform";
+import ExplorerIcon from "@material-ui/icons/Equalizer";
+import AccountIcon from "@material-ui/icons/AccountBalanceWallet";
+import TransferIcon from "@material-ui/icons/SwapCalls";
+import SettingsIcon from "@material-ui/icons/Settings";
 import {type CurrencyDetails} from "../../api/currencyConfig";
 
 type menuProps = {|onMenuClick: Function|};
@@ -20,14 +21,14 @@ const createMenu = (
         <MenuItemLink
           to="/explorer"
           primaryText="Explorer"
-          leftIcon={<TrendingUpIcon />}
+          leftIcon={<ExplorerIcon />}
           onClick={onMenuClick}
           sidebarIsOpen={open}
         />
         <MenuItemLink
           to="/accounts"
           primaryText={`${currencyName} Accounts`}
-          leftIcon={<DefaultIcon />}
+          leftIcon={<AccountIcon />}
           onClick={onMenuClick}
           sidebarIsOpen={open}
         />
@@ -36,14 +37,14 @@ const createMenu = (
             <MenuItemLink
               to="/admin"
               primaryText="Ledger Admin"
-              leftIcon={<DefaultIcon />}
+              leftIcon={<SettingsIcon />}
               onClick={onMenuClick}
               sidebarIsOpen={open}
             />
             <MenuItemLink
               to="/transfer"
               primaryText={`Transfer ${currencyName}`}
-              leftIcon={<TransformIcon />}
+              leftIcon={<TransferIcon />}
               onClick={onMenuClick}
               sidebarIsOpen={open}
             />


### PR DESCRIPTION
Some of the icons were being used twice, and the icon choice wasnt ideal for the intended feature.
Updated to use more appropriate icons (e.g. gear icon for ledger admin)

Before:
![Screen Shot 2020-10-04 at 10 28 42 PM](https://user-images.githubusercontent.com/7143583/95040550-3e4a1880-0691-11eb-914f-ed632005a874.png)

After:
![Screen Shot 2020-10-04 at 10 29 00 PM](https://user-images.githubusercontent.com/7143583/95040553-4013dc00-0691-11eb-9283-ac8b90051368.png)


Test Plan: Ensure the frontend is showing updated icons in sidebar