### PR TITLE
Improve Ledger Admin UX

### DIFF
--- a/src/ui/components/AliasView.js
+++ b/src/ui/components/AliasView.js
@@ -4,7 +4,6 @@ import React, {type Node as ReactNode} from "react";
 import {type IdentityId} from "../../core/identity";
 import Markdown from "react-markdown";
 
-import {makeStyles} from "@material-ui/core/styles";
 import {List, ListItem} from "@material-ui/core";
 import {useLedger} from "../utils/LedgerContext";
 
@@ -12,21 +11,15 @@ type Props = {|
   +selectedId: IdentityId,
 |};
 
-const useStyles = makeStyles({
-  element: {margin: "20px"},
-  aliasesHeader: {margin: "20px", marginBottom: 0},
-});
-
 export function AliasView({selectedId}: Props): ReactNode {
   const {ledger} = useLedger();
-  const classes = useStyles();
   const selectedAccount = ledger.account(selectedId);
 
   return (
     <>
       {selectedAccount.identity.aliases.length > 0 && (
         <>
-          <h3 className={classes.aliasesHeader}>Aliases:</h3>
+          <h3>Aliases:</h3>
           <List dense>
             {selectedAccount.identity.aliases.map((alias) => (
               <ListItem key={alias.address}>

--- a/src/ui/components/IdentityMerger.js
+++ b/src/ui/components/IdentityMerger.js
@@ -58,7 +58,7 @@ export function IdentityMerger({selectedId}: Props): ReactNode {
         getOptionLabel={({name}) => name || ""}
         inputValue={inputValue}
         renderInput={(params) => (
-          <TextField {...params} variant="outlined" label="Merge Identity" />
+          <TextField {...params} variant="outlined" label="Add Alias" />
         )}
       />
     </>

--- a/src/ui/components/IdentityMerger.js
+++ b/src/ui/components/IdentityMerger.js
@@ -3,7 +3,6 @@ import React, {useState, useEffect, type Node as ReactNode} from "react";
 import {useLedger} from "../utils/LedgerContext";
 import {type IdentityId, type Identity} from "../../core/identity";
 
-import {makeStyles} from "@material-ui/core/styles";
 import {TextField} from "@material-ui/core";
 import {Autocomplete} from "@material-ui/lab";
 
@@ -11,14 +10,8 @@ type Props = {|
   +selectedId: IdentityId,
 |};
 
-const useStyles = makeStyles({
-  element: {margin: "20px"},
-  aliasesHeader: {margin: "20px", marginBottom: 0},
-});
-
 export function IdentityMerger({selectedId}: Props): ReactNode {
   const {ledger, updateLedger} = useLedger();
-  const classes = useStyles();
   const [inputValue, setInputValue] = useState("");
 
   const potentialIdentities = ledger
@@ -59,14 +52,13 @@ export function IdentityMerger({selectedId}: Props): ReactNode {
             setInputValue("");
           }
         }}
-        className={classes.element}
         freeSolo
         disableClearable
         options={inputItems}
         getOptionLabel={({name}) => name || ""}
         inputValue={inputValue}
         renderInput={(params) => (
-          <TextField {...params} variant="outlined" label="Identity" />
+          <TextField {...params} variant="outlined" label="Merge Identity" />
         )}
       />
     </>

--- a/src/ui/components/LedgerAdmin.js
+++ b/src/ui/components/LedgerAdmin.js
@@ -1,10 +1,8 @@
 // @flow
 
 import React, {useState, type Node as ReactNode} from "react";
-import {type Identity, type IdentityId} from "../../core/identity";
-import {AliasView} from "./AliasView";
-import {IdentityMerger} from "./IdentityMerger";
 import {makeStyles} from "@material-ui/core/styles";
+import ButtonGroup from "@material-ui/core/ButtonGroup";
 import {
   Button,
   Checkbox,
@@ -16,36 +14,37 @@ import {
   TextField,
 } from "@material-ui/core";
 import {useLedger} from "../utils/LedgerContext";
+import {IdentityMerger} from "./IdentityMerger";
+import {type Identity, type IdentityId} from "../../core/identity";
+import {AliasView} from "./AliasView";
 
 const useStyles = makeStyles((theme) => {
-  const marginNum = 20;
-  const flexBasis = marginNum * 2;
   return {
     root: {
       color: theme.palette.text.primary,
-      width: "80%",
-      margin: "0 auto",
+      width: "100%",
+      maxWidth: "50em",
       padding: "0 5em 5em",
     },
     identityList: {
       backgroundColor: theme.palette.background.paper,
       width: "100%",
-      margin: `${marginNum}px`,
+      marginTop: theme.spacing(3),
+      overflow: "auto",
+      maxHeight: 500,
     },
     centerRow: {
       display: "flex",
       justifyContent: "center",
       alignItems: "center",
     },
-    element: {flex: 1, margin: `${marginNum}px`},
     updateElement: {
       flexGrow: 2,
-      flexBasis: `${flexBasis}px`,
-      margin: `${marginNum}px`,
+      flexBasis: theme.spacing(5),
+      margin: theme.spacing(3, 0),
     },
-    checkboxElement: {flexGrow: 1, flexBasis: 0, margin: `${marginNum}px`},
-    promptStringHeader: {margin: `${marginNum}px`, marginBottom: 0},
-    IdentitiesHeader: {margin: `${marginNum}px`},
+    checkboxElement: {flexGrow: 1, flexBasis: 0, margin: theme.spacing(3)},
+    IdentitiesHeader: {margin: theme.spacing(3, 0)},
   };
 });
 
@@ -125,12 +124,7 @@ export const LedgerAdmin = (): ReactNode => {
         <h1 className={classes.IdentitiesHeader}>Identities</h1>{" "}
         {ledger.accounts().length > 0 && <h3> (click one to update it)</h3>}
       </span>
-      <div className={classes.centerRow}>
-        <List fullWidth className={classes.identityList}>
-          {renderIdentities()}
-        </List>
-      </div>
-      <h3 className={classes.promptStringHeader}>{promptString}</h3>
+      <h3>{promptString}</h3>
       <div className={classes.centerRow}>
         <TextField
           fullWidth
@@ -157,21 +151,11 @@ export const LedgerAdmin = (): ReactNode => {
           />
         )}
       </div>
-      <div className={classes.centerRow}>
-        <Button
-          className={classes.element}
-          size="large"
-          color="primary"
-          variant="contained"
-          onClick={createOrUpdateIdentity}
-        >
+      <ButtonGroup color="primary" variant="contained">
+        <Button onClick={createOrUpdateIdentity}>
           {selectedId ? "update username" : "create identity"}
         </Button>
         <Button
-          className={classes.element}
-          size="large"
-          color="primary"
-          variant="contained"
           onClick={() => {
             fetch("data/ledger.json", {
               headers: {
@@ -185,24 +169,19 @@ export const LedgerAdmin = (): ReactNode => {
         >
           save ledger to disk
         </Button>
-        {selectedId && (
-          <Button
-            className={classes.element}
-            size="large"
-            color="primary"
-            variant="contained"
-            onClick={resetIdentity}
-          >
-            New identity
-          </Button>
-        )}
-      </div>
+        {selectedId && <Button onClick={resetIdentity}>New identity</Button>}
+      </ButtonGroup>
       {selectedId && (
         <>
           <AliasView selectedId={selectedId} />
           <IdentityMerger selectedId={selectedId} />
         </>
       )}
+      <div className={classes.centerRow}>
+        <List fullWidth className={classes.identityList}>
+          {renderIdentities()}
+        </List>
+      </div>
     </Container>
   );
 };

--- a/src/ui/components/Menu.js
+++ b/src/ui/components/Menu.js
@@ -2,10 +2,10 @@
 import React, {type Node as ReactNode} from "react";
 import {useSelector} from "react-redux";
 import {MenuItemLink} from "react-admin";
+import PeopleIcon from "@material-ui/icons/People";
 import ExplorerIcon from "@material-ui/icons/Equalizer";
 import AccountIcon from "@material-ui/icons/AccountBalanceWallet";
 import TransferIcon from "@material-ui/icons/SwapCalls";
-import SettingsIcon from "@material-ui/icons/Settings";
 import {type CurrencyDetails} from "../../api/currencyConfig";
 
 type menuProps = {|onMenuClick: Function|};
@@ -36,8 +36,8 @@ const createMenu = (
           <>
             <MenuItemLink
               to="/admin"
-              primaryText="Ledger Admin"
-              leftIcon={<SettingsIcon />}
+              primaryText="Identities"
+              leftIcon={<PeopleIcon />}
               onClick={onMenuClick}
               sidebarIsOpen={open}
             />


### PR DESCRIPTION
The editor being at the bottom of the Identity list makes it difficult to edit identities since users have to scroll through the list, click an identity, and then scroll all the way down to edit it, all without any visual indicator that a new editor menu is open.

This cleans up the UX by making the list of identities a scrollable box within the page and moving the editor fields / button to the top of the page so that they stay in the same location and user isn't required to scroll through potentially thousands of list items. It also improves some of the labels and buttons to be more descriptive / cleaner.

![image](https://user-images.githubusercontent.com/7143583/95047403-3b582380-06a3-11eb-99e3-b0989255907d.png)

Also renamed the sidebar button from "Ledger Admin" to "Identities" since that's the only thing this page really does. Grain transfer page also modifies the ledger, which means "ledger admin" tasks happen across multiple pages, and therefore no single page should be called "Ledger Admin".

Before:
![2020-10-05 00 35 00](https://user-images.githubusercontent.com/7143583/95047080-a48b6700-06a2-11eb-943d-1ed5a65a5418.gif)

After:
![2020-10-05 00 36 36](https://user-images.githubusercontent.com/7143583/95047203-e87e6c00-06a2-11eb-8c39-68dc3e67c0d4.gif)
