### PR TITLE
Implement MVP of Ledger History Viewer

### DIFF
--- a/src/ui/components/AdminApp.js
+++ b/src/ui/components/AdminApp.js
@@ -19,6 +19,7 @@ import {withRouter} from "react-router-dom";
 import AppBar from "./AppBar";
 import createMenu from "./Menu";
 import {LedgerProvider} from "../utils/LedgerContext";
+import {LedgerViewer} from "./LedgerViewer";
 
 const dataProvider = fakeDataProvider({}, true);
 
@@ -26,6 +27,16 @@ const theme = createMuiTheme({
   palette: {
     type: "dark",
     primary: pink,
+  },
+  overrides: {
+    MuiChip: {
+      sizeSmall: {
+        height: "21px",
+      },
+      labelSmall: {
+        fontSize: "0.66rem",
+      },
+    },
   },
 });
 
@@ -54,6 +65,9 @@ const customRoutes = (
     </Route>,
     <Route key="accounts" exact path="/accounts">
       <AccountOverview currency={currency} />
+    </Route>,
+    <Route key="ledger" exact path="/ledger">
+      <LedgerViewer />
     </Route>,
   ];
   const backendRoutes = [

--- a/src/ui/components/LedgerViewer.js
+++ b/src/ui/components/LedgerViewer.js
@@ -1,0 +1,126 @@
+// @flow
+
+import React, {type Node as ReactNode, useMemo} from "react";
+import Table from "@material-ui/core/Table";
+import Typography from "@material-ui/core/Typography";
+import Box from "@material-ui/core/Box";
+import TableBody from "@material-ui/core/TableBody";
+import Tooltip from "@material-ui/core/Tooltip";
+import Chip from "@material-ui/core/Chip";
+import TableCell from "@material-ui/core/TableCell";
+import TableContainer from "@material-ui/core/TableContainer";
+import TableHead from "@material-ui/core/TableHead";
+import TableRow from "@material-ui/core/TableRow";
+import Paper from "@material-ui/core/Paper";
+import {Ledger, type LedgerEvent} from "../../core/ledger/ledger";
+import {useLedger} from "../utils/LedgerContext";
+import {makeStyles} from "@material-ui/core/styles";
+import {formatTimestamp} from "../utils/dateHelpers";
+import type {IdentityId} from "../../core/identity/identity";
+
+const useStyles = makeStyles(() => {
+  return {
+    container: {
+      maxHeight: "90vh",
+      maxWidth: "60em",
+      margin: "0 auto",
+    },
+  };
+});
+
+export const LedgerViewer = (): ReactNode => {
+  const {ledger} = useLedger();
+  const classes = useStyles();
+
+  const events = useMemo(() => ledger.eventLog(), [ledger]);
+
+  return (
+    <TableContainer component={Paper} className={classes.container}>
+      <Table stickyHeader size="small">
+        <TableHead>
+          <TableRow>
+            <TableCell>Event</TableCell>
+            <TableCell>Details</TableCell>
+            <TableCell align="right">Date</TableCell>
+          </TableRow>
+        </TableHead>
+        <TableBody>
+          {events.map((e) => (
+            <LedgerEventRow key={e.uuid} event={e} ledger={ledger} />
+          ))}
+        </TableBody>
+      </Table>
+    </TableContainer>
+  );
+};
+
+const LedgerEventRow = React.memo(
+  ({event, ledger}: {event: LedgerEvent, ledger: Ledger}) => {
+    return (
+      <TableRow>
+        <TableCell component="th" scope="row">
+          <Typography variant="button">
+            {event.action.type.replace("_", " ")}
+          </Typography>
+        </TableCell>
+        <TableCell>
+          <Box display="flex" flexDirection="row" alignItems="center">
+            {getEventDetails(event, ledger)}
+          </Box>
+        </TableCell>
+        <TableCell align="right">
+          {formatTimestamp(event.ledgerTimestamp)}
+        </TableCell>
+      </TableRow>
+    );
+  }
+);
+
+LedgerEventRow.displayName = "LedgerEventRow";
+
+const IdentityDetails = ({
+  id,
+  name,
+}: {
+  id: IdentityId,
+  name: string,
+}): ReactNode => {
+  return (
+    <Tooltip title={`ID: ${id}`} interactive placement="left">
+      <Box mr={1}>{`${name}`}</Box>
+    </Tooltip>
+  );
+};
+
+const getEventDetails = ({action}: LedgerEvent, ledger: Ledger): ReactNode => {
+  switch (action.type) {
+    case "CREATE_IDENTITY":
+      return (
+        <>
+          <IdentityDetails
+            id={action.identity.id}
+            name={action.identity.name}
+          />
+          <Chip label={action.identity.subtype} size="small" />
+        </>
+      );
+    case "TOGGLE_ACTIVATION":
+      try {
+        const account = ledger.account(action.identityId);
+        return (
+          <IdentityDetails
+            id={account.identity.id}
+            name={account.identity.name}
+          />
+        );
+      } catch (e) {
+        console.warn("Unable to find account for action: ", action);
+        return (
+          <IdentityDetails id={action.identityId} name="[Unknown Account]" />
+        );
+      }
+
+    default:
+      return "";
+  }
+};

--- a/src/ui/components/Menu.js
+++ b/src/ui/components/Menu.js
@@ -4,6 +4,7 @@ import {useSelector} from "react-redux";
 import {MenuItemLink} from "react-admin";
 import ExplorerIcon from "@material-ui/icons/Equalizer";
 import AccountIcon from "@material-ui/icons/AccountBalanceWallet";
+import HistoryIcon from "@material-ui/icons/History";
 import TransferIcon from "@material-ui/icons/SwapCalls";
 import SettingsIcon from "@material-ui/icons/Settings";
 import {type CurrencyDetails} from "../../api/currencyConfig";
@@ -29,6 +30,13 @@ const createMenu = (
           to="/accounts"
           primaryText={`${currencyName} Accounts`}
           leftIcon={<AccountIcon />}
+          onClick={onMenuClick}
+          sidebarIsOpen={open}
+        />
+        <MenuItemLink
+          to="/ledger"
+          primaryText="Ledger History"
+          leftIcon={<HistoryIcon />}
           onClick={onMenuClick}
           sidebarIsOpen={open}
         />

--- a/src/ui/utils/dateHelpers.js
+++ b/src/ui/utils/dateHelpers.js
@@ -1,0 +1,16 @@
+// @flow
+
+import type {TimestampMs} from "../../util/timestamp";
+
+export const formatTimestamp = (
+  timestamp: TimestampMs | number,
+  opts?: Intl$DateTimeFormatOptions
+): string =>
+  new Date(timestamp).toLocaleString("en", {
+    month: "numeric",
+    day: "numeric",
+    hour: "numeric",
+    minute: "numeric",
+    year: "2-digit",
+    ...opts,
+  });


### PR DESCRIPTION
Super basic start for having the ledger event history visible on the frontend. Currently
shows the event name, date / time, and info about the identities for "CREATE_IDENTITY" and
"TOGGLE_ACTIVATION" events. For advanced users, to get the identityId for a specific user/event,
you can hover over the name of the identity and it will appear in a tooltip.

Will expand on the info for other events in future PRs, wanted to get the basics in first

Test Plan:
Ensure the ledger UI is accessible from the "Ledger History" button in the sidebar,
and that it displays a chronological list of events from the ledger with correct dates.

![image](https://user-images.githubusercontent.com/7143583/95056121-7a8d7100-06b1-11eb-98d3-00117f60167a.png)
