### PR TITLE
allow creating new identity with starting aliases

### DIFF
--- a/src/core/identity/identity.js
+++ b/src/core/identity/identity.js
@@ -43,19 +43,29 @@ export const IDENTITY_PREFIX: NodeAddressT = NodeAddress.fromParts([
   "IDENTITY",
 ]);
 
-export function newIdentity(subtype: IdentityType, name: string): Identity {
+export function newIdentity(
+  subtype: IdentityType,
+  name: string,
+  aliases?: $ReadOnlyArray<Alias>
+): Identity {
   const id = randomUuid();
   try {
     identityTypeParser.parseOrThrow(subtype);
   } catch (e) {
     throw new Error(`invalid identity subtype: ${subtype}`);
   }
+  const actualAliases = aliases == null ? [] : aliases;
+  const addresses = actualAliases.map((a) => a.address);
+  const numDistinctAddresses = new Set(addresses).size;
+  if (numDistinctAddresses !== actualAliases.length) {
+    throw new Error(`multiple aliases share an address`);
+  }
   return {
     id,
     subtype,
     address: NodeAddress.append(IDENTITY_PREFIX, id),
     name: nameFromString(name),
-    aliases: [],
+    aliases: actualAliases,
   };
 }
 

--- a/src/core/identity/identity.test.js
+++ b/src/core/identity/identity.test.js
@@ -8,9 +8,20 @@ import {graphNode, type Identity, newIdentity} from "./identity";
 describe("core/identity/identity", () => {
   const example: Identity = deepFreeze(newIdentity("USER", "foo"));
   describe("newIdentity", () => {
-    it("new identities don't have aliases", () => {
+    it("by default, new identities don't have aliases", () => {
       const identity = newIdentity("USER", "foo");
       expect(identity.aliases).toEqual([]);
+    });
+    it("new identities may have aliases", () => {
+      const alias = {description: "alias", address: NodeAddress.empty};
+      const identity = newIdentity("USER", "foo", [alias]);
+      expect(identity.aliases).toEqual([alias]);
+    });
+    it("errors if a new identity has multiple aliases with the same address", () => {
+      const a1 = {description: "a1", address: NodeAddress.empty};
+      const a2 = {description: "a2", address: NodeAddress.empty};
+      const thunk = () => newIdentity("USER", "foo", [a1, a2]);
+      expect(thunk).toThrowError("multiple aliases share an address");
     });
     it("identity addresses are as expected", () => {
       const subtypes = ["USER", "BOT", "PROJECT", "ORGANIZATION"];


### PR DESCRIPTION
Part of work on #2339. Decided to factor this out as a nice clean atomic
starting commit. I added logic around verifying that aliases are not
duplicated, so that the updated `ledger.createIdentity` could have
consistent behavior with `ledger.addAlias` (erroring if there's an
attempt to give the same alias to the same identity multiple times).

Test plan: `yarn test`, note unit tests were added.