### PR TITLE
Reduce autogenerated ledger spam by 2x

### DIFF
--- a/src/core/ledger/identityProposal.js
+++ b/src/core/ledger/identityProposal.js
@@ -68,8 +68,7 @@ export function ensureIdentityExists(
     return;
   }
   const name = _chooseIdentityName(proposal, (n) => ledger.nameAvailable(n));
-  const id = ledger.createIdentity(proposal.type, name);
-  ledger.addAlias(id, proposal.alias);
+  ledger.createIdentity(proposal.type, name, [proposal.alias]);
 }
 
 const MAX_NUMERIC_DISCRIMINATOR = 100;

--- a/src/core/ledger/identityProposal.test.js
+++ b/src/core/ledger/identityProposal.test.js
@@ -42,6 +42,11 @@ describe("core/ledger/identityProposal", () => {
       expect(account.identity.name).toEqual(proposal.name);
       expect(account.identity.aliases).toEqual([alias]);
     });
+    it("creates only one ledger event when creating a single identity", () => {
+      const ledger = new Ledger();
+      ensureIdentityExists(ledger, proposal);
+      expect(ledger.eventLog()).toHaveLength(1);
+    });
     it("uses the discriminator logic from _chooseIdentityName if needed", () => {
       const ledger = new Ledger();
       ledger.createIdentity("USER", "foo");


### PR DESCRIPTION
This commit makes somes solid progress on #2339. Now that we support
creating identities with aliases, we can just do that inside the
identity proposal system. This reduces the number of event entries by
factor 2 when autogenerating identities.

Test plan: Existing behavior is well-covered by unit tests, added one
more checking that we output only a single event.