### PR TITLE
Admin: Memoize Ledger Identity Calcs in Render Loop

### DIFF
--- a/src/ui/components/LedgerAdmin.js
+++ b/src/ui/components/LedgerAdmin.js
@@ -1,6 +1,6 @@
 // @flow
 
-import React, {useState, type Node as ReactNode} from "react";
+import React, {useState, type Node as ReactNode, useMemo} from "react";
 import {makeStyles} from "@material-ui/core/styles";
 import ButtonGroup from "@material-ui/core/ButtonGroup";
 import {
@@ -118,6 +118,12 @@ export const LedgerAdmin = (): ReactNode => {
     );
   };
 
+  const memoizedIdentities = useMemo(() => renderIdentities(), [
+    // Only recalculate the identity list when a new identity is added
+    // or identities are merged
+    ledger.accounts().length,
+  ]);
+
   return (
     <Container className={classes.root}>
       <span className={classes.centerRow}>
@@ -179,7 +185,7 @@ export const LedgerAdmin = (): ReactNode => {
       )}
       <div className={classes.centerRow}>
         <List fullWidth className={classes.identityList}>
-          {renderIdentities()}
+          {memoizedIdentities}
         </List>
       </div>
     </Container>


### PR DESCRIPTION
The ledger identity list is is recalculated on every render. It only
needs to be recalculated if an identity is added or if identities are
merged. This should enhance performance with larger communities where
the list of identites is longer. 

I wasn't able to replicate this original laggy behavior in the prod UI build,
but this change doesn't add significant complexity to the Admin view code
so I think it's a solid change.

before:
![type-broke](https://user-images.githubusercontent.com/17910833/95415123-135ffe80-08f5-11eb-8635-c6e19ea5bd7c.gif)

after:
![type-fix](https://user-images.githubusercontent.com/17910833/95415140-1e1a9380-08f5-11eb-82ed-28393d2d52eb.gif)


test plan: load the prod SC cred instance. Update an existing identity
name and ensure the UI keeps up with your typing.