### PR TITLE
Implement viewer for Grain Distributions

### DIFF
--- a/src/ui/components/AdminApp.js
+++ b/src/ui/components/AdminApp.js
@@ -67,7 +67,7 @@ const customRoutes = (
       <AccountOverview currency={currency} />
     </Route>,
     <Route key="ledger" exact path="/ledger">
-      <LedgerViewer />
+      <LedgerViewer currency={currency} />
     </Route>,
   ];
   const backendRoutes = [

--- a/src/ui/components/LedgerViewer.js
+++ b/src/ui/components/LedgerViewer.js
@@ -11,6 +11,7 @@ import Table from "@material-ui/core/Table";
 import Typography from "@material-ui/core/Typography";
 import Box from "@material-ui/core/Box";
 import TableBody from "@material-ui/core/TableBody";
+import VisibilityIcon from "@material-ui/icons/Visibility";
 import Dialog from "@material-ui/core/Dialog";
 import * as G from "../../core/ledger/grain";
 import DialogContent from "@material-ui/core/DialogContent";
@@ -199,8 +200,11 @@ const LedgerEventRow = React.memo(
                   0,
                   currencySuffix
                 )}`}
+                clickable
                 onClick={() => handleClickOpen(a)}
+                onDelete={() => handleClickOpen(a)}
                 size="small"
+                deleteIcon={<VisibilityIcon />}
               />
             </Box>
           ));

--- a/src/ui/components/LedgerViewer.js
+++ b/src/ui/components/LedgerViewer.js
@@ -1,10 +1,19 @@
 // @flow
 
-import React, {type Node as ReactNode, useMemo} from "react";
+import React, {
+  memo,
+  type Node as ReactNode,
+  useCallback,
+  useMemo,
+  useState,
+} from "react";
 import Table from "@material-ui/core/Table";
 import Typography from "@material-ui/core/Typography";
 import Box from "@material-ui/core/Box";
 import TableBody from "@material-ui/core/TableBody";
+import Dialog from "@material-ui/core/Dialog";
+import * as G from "../../core/ledger/grain";
+import DialogContent from "@material-ui/core/DialogContent";
 import Tooltip from "@material-ui/core/Tooltip";
 import Chip from "@material-ui/core/Chip";
 import TableCell from "@material-ui/core/TableCell";
@@ -17,6 +26,7 @@ import {useLedger} from "../utils/LedgerContext";
 import {makeStyles} from "@material-ui/core/styles";
 import {formatTimestamp} from "../utils/dateHelpers";
 import type {IdentityId} from "../../core/identity/identity";
+import type {Allocation, GrainReceipt} from "../../core/ledger/grainAllocation";
 
 const useStyles = makeStyles(() => {
   return {
@@ -25,14 +35,29 @@ const useStyles = makeStyles(() => {
       maxWidth: "60em",
       margin: "0 auto",
     },
+    dialog: {
+      paddingTop: "0 !important",
+      padding: 0,
+    },
   };
 });
 
-export const LedgerViewer = (): ReactNode => {
+export const LedgerViewer = ({
+  currency: {suffix: currencySuffix},
+}): ReactNode => {
   const {ledger} = useLedger();
   const classes = useStyles();
+  const [allocation, setAllocation] = useState<Allocation | null>(null);
 
-  const events = useMemo(() => ledger.eventLog(), [ledger]);
+  const handleClickOpen = useCallback((allocation: Distribution) => {
+    setAllocation(allocation);
+  }, []);
+
+  const handleClose = useCallback(() => {
+    setAllocation(null);
+  }, []);
+
+  const events = useMemo(() => ledger.eventLog().reverse(), [ledger]);
 
   return (
     <TableContainer component={Paper} className={classes.container}>
@@ -46,16 +71,145 @@ export const LedgerViewer = (): ReactNode => {
         </TableHead>
         <TableBody>
           {events.map((e) => (
-            <LedgerEventRow key={e.uuid} event={e} ledger={ledger} />
+            <LedgerEventRow
+              key={e.uuid}
+              event={e}
+              ledger={ledger}
+              currencySuffix={currencySuffix}
+              handleClickOpen={handleClickOpen}
+            />
           ))}
         </TableBody>
       </Table>
+      <Dialog open={!!allocation} onClose={handleClose} scroll="paper">
+        <DialogContent className={classes.dialog}>
+          <GrainReceiptTable
+            allocation={allocation}
+            ledger={ledger}
+            currencySuffix={currencySuffix}
+          />
+        </DialogContent>
+      </Dialog>
     </TableContainer>
   );
 };
 
+function comparator(a: GrainReceipt, b: GrainReceipt) {
+  if (a.amount === b.amount) {
+    return 0;
+  }
+  return G.gt(a.amount, b.amount) ? -1 : 1;
+}
+
+const GrainReceiptTable = memo(
+  ({
+    allocation,
+    ledger,
+    currencySuffix,
+  }: {
+    allocation: Allocation,
+    ledger: Ledger,
+    currencySuffix: string,
+  }) => {
+    return (
+      <Table stickyHeader>
+        <TableHead>
+          <TableRow>
+            <TableCell>Participant</TableCell>
+            <TableCell align="right">Amount</TableCell>
+          </TableRow>
+        </TableHead>
+        <TableBody>
+          {allocation
+            ? allocation.receipts.sort(comparator).map((r) => {
+                const account = ledger.account(r.id);
+
+                return (
+                  <TableRow key={r.id}>
+                    <TableCell component="th" scope="row">
+                      <IdentityDetails
+                        id={account.identity.id}
+                        name={account.identity.name}
+                      />
+                    </TableCell>
+                    <TableCell align="right">
+                      {G.format(r.amount, 4, currencySuffix)}
+                    </TableCell>
+                  </TableRow>
+                );
+              })
+            : null}
+        </TableBody>
+      </Table>
+    );
+  }
+);
+
+GrainReceiptTable.displayName = "GrainReceiptTable";
+
 const LedgerEventRow = React.memo(
-  ({event, ledger}: {event: LedgerEvent, ledger: Ledger}) => {
+  ({
+    event,
+    ledger,
+    currencySuffix,
+    handleClickOpen,
+  }: {
+    event: LedgerEvent,
+    ledger: Ledger,
+    currencySuffix: string,
+    handleClickOpen: (a: Allocation) => void,
+  }) => {
+    const {action} = event;
+    const getEventDetails = () => {
+      switch (action.type) {
+        case "CREATE_IDENTITY":
+          return (
+            <>
+              <IdentityDetails
+                id={action.identity.id}
+                name={action.identity.name}
+              />
+              <Chip label={action.identity.subtype} size="small" />
+            </>
+          );
+        case "TOGGLE_ACTIVATION":
+          try {
+            const account = ledger.account(action.identityId);
+            return (
+              <IdentityDetails
+                id={account.identity.id}
+                name={account.identity.name}
+              />
+            );
+          } catch (e) {
+            console.warn("Unable to find account for action: ", action);
+            return (
+              <IdentityDetails
+                id={action.identityId}
+                name="[Unknown Account]"
+              />
+            );
+          }
+        case "DISTRIBUTE_GRAIN":
+          return action.distribution.allocations.map((a, i) => (
+            <Box mr={2} key={`${a.policy.policyType}-${i}`}>
+              <Chip
+                label={`${a.policy.policyType}: ${G.format(
+                  a.policy.budget,
+                  0,
+                  currencySuffix
+                )}`}
+                onClick={() => handleClickOpen(a)}
+                size="small"
+              />
+            </Box>
+          ));
+
+        default:
+          return "";
+      }
+    };
+
     return (
       <TableRow>
         <TableCell component="th" scope="row">
@@ -65,7 +219,7 @@ const LedgerEventRow = React.memo(
         </TableCell>
         <TableCell>
           <Box display="flex" flexDirection="row" alignItems="center">
-            {getEventDetails(event, ledger)}
+            {getEventDetails()}
           </Box>
         </TableCell>
         <TableCell align="right">
@@ -90,37 +244,4 @@ const IdentityDetails = ({
       <Box mr={1}>{`${name}`}</Box>
     </Tooltip>
   );
-};
-
-const getEventDetails = ({action}: LedgerEvent, ledger: Ledger): ReactNode => {
-  switch (action.type) {
-    case "CREATE_IDENTITY":
-      return (
-        <>
-          <IdentityDetails
-            id={action.identity.id}
-            name={action.identity.name}
-          />
-          <Chip label={action.identity.subtype} size="small" />
-        </>
-      );
-    case "TOGGLE_ACTIVATION":
-      try {
-        const account = ledger.account(action.identityId);
-        return (
-          <IdentityDetails
-            id={account.identity.id}
-            name={account.identity.name}
-          />
-        );
-      } catch (e) {
-        console.warn("Unable to find account for action: ", action);
-        return (
-          <IdentityDetails id={action.identityId} name="[Unknown Account]" />
-        );
-      }
-
-    default:
-      return "";
-  }
 };

--- a/src/ui/components/LedgerViewer.js
+++ b/src/ui/components/LedgerViewer.js
@@ -28,6 +28,7 @@ import {makeStyles} from "@material-ui/core/styles";
 import {formatTimestamp} from "../utils/dateHelpers";
 import type {IdentityId} from "../../core/identity/identity";
 import type {Allocation, GrainReceipt} from "../../core/ledger/grainAllocation";
+import type {CurrencyDetails} from "../../api/currencyConfig";
 
 const useStyles = makeStyles(() => {
   return {
@@ -45,12 +46,14 @@ const useStyles = makeStyles(() => {
 
 export const LedgerViewer = ({
   currency: {suffix: currencySuffix},
+}: {
+  currency: CurrencyDetails,
 }): ReactNode => {
   const {ledger} = useLedger();
   const classes = useStyles();
   const [allocation, setAllocation] = useState<Allocation | null>(null);
 
-  const handleClickOpen = useCallback((allocation: Distribution) => {
+  const handleClickOpen = useCallback((allocation: Allocation) => {
     setAllocation(allocation);
   }, []);
 
@@ -58,7 +61,7 @@ export const LedgerViewer = ({
     setAllocation(null);
   }, []);
 
-  const events = useMemo(() => ledger.eventLog().reverse(), [ledger]);
+  const events = useMemo(() => [...ledger.eventLog()].reverse(), [ledger]);
 
   return (
     <TableContainer component={Paper} className={classes.container}>
@@ -108,10 +111,11 @@ const GrainReceiptTable = memo(
     ledger,
     currencySuffix,
   }: {
-    allocation: Allocation,
+    allocation: Allocation | null,
     ledger: Ledger,
     currencySuffix: string,
   }) => {
+    if (!allocation) return null;
     return (
       <Table stickyHeader>
         <TableHead>
@@ -122,7 +126,7 @@ const GrainReceiptTable = memo(
         </TableHead>
         <TableBody>
           {allocation
-            ? allocation.receipts.sort(comparator).map((r) => {
+            ? [...allocation.receipts].sort(comparator).map((r) => {
                 const account = ledger.account(r.id);
 
                 return (


### PR DESCRIPTION
Adds Components to view Grain Distribution events in the Ledger viewer with a breakdown of the
different policies used and the grain amounts received by the participants.

Test Plan: Open the LedgerViewer page, click on the grain distribution amount, and ensure a list of grain receipts is shown

![2020-10-08 05 10 09](https://user-images.githubusercontent.com/7143583/95451128-9482ba00-0924-11eb-8001-ed985c9f2b91.gif)