### PR TITLE
MPG: Expose node and edge order

### DIFF
--- a/src/core/markovProcessGraph.test.js
+++ b/src/core/markovProcessGraph.test.js
@@ -446,4 +446,21 @@ describe("core/markovProcessGraph", () => {
       checkMarkovEdge(mpg, e1B);
     });
   });
+
+  describe("accessors", () => {
+    it("nodes() yields nodes in nodeOrder", () => {
+      const mpg = markovProcessGraph();
+      const nodeOrder = [...mpg.nodeOrder()];
+      const nodesActual = [...mpg.nodes()];
+      const nodesExpected = nodeOrder.map((x) => mpg.node(x));
+      expect(nodesActual).toEqual(nodesExpected);
+    });
+    it("edges() yields edges in edgeOrder", () => {
+      const mpg = markovProcessGraph();
+      const edgeOrder = [...mpg.edgeOrder()];
+      const edgesActual = [...mpg.edges()];
+      const edgesExpected = edgeOrder.map((x) => mpg.edge(x));
+      expect(edgesActual).toEqual(edgesExpected);
+    });
+  });
 });


### PR DESCRIPTION
This commit updates the MarkovProcessGraph so that it exposes a
canonical node and edge order. On its face, this is a nice change
because it cleans up the API in CredGraph (we no longer poke inside the
JSON representation in order to get a canonical node order). However,
this has an added benefit. It allows us to re-write the `nodes` and
`edges` accessors so that they just iterate over the order,
filtering if appropriate, and then call the `node` or `edge` accessor
for each element in the order.

This is nice because it makes it cleaner to apply future refactors which
"virtualize the gadgets", i.e. stop representing each gadget node and
edge directly in maps (which is wasteful of memory/disk). Instead, we
can just make sure that the virtualized gadgets are included in the
order, and that the node/edge accessors can retrieve virtualized gadget
nodes and edges.

Test plan: Some unit tests added, `yarn test` passes, and I also re-ran
CredRank on the real SC instance and verified the scores haven't
changed.

Thanks to @wchargin for significant improvements to this commit.