### PR TITLE
Reorganize CredRank-related modules

### DIFF
--- a/src/cli/credrank.js
+++ b/src/cli/credrank.js
@@ -6,10 +6,10 @@ import {join as pathJoin} from "path";
 import {sum} from "d3-array";
 
 import sortBy from "../util/sortBy";
-import {credrank} from "../core/algorithm/credrank";
-import {CredGraph} from "../core/credGraph";
+import {credrank} from "../core/credrank/compute";
+import {CredGraph} from "../core/credrank/credGraph";
 import {LoggingTaskReporter} from "../util/taskReporter";
-import {MarkovProcessGraph} from "../core/markovProcessGraph";
+import {MarkovProcessGraph} from "../core/credrank/markovProcessGraph";
 import type {Command} from "./command";
 import {loadInstanceConfig, prepareCredData} from "./common";
 import {graphIntervals} from "../core/interval";

--- a/src/core/credrank/compute.js
+++ b/src/core/credrank/compute.js
@@ -6,17 +6,17 @@ import {
   findStationaryDistribution,
   type PagerankParams,
   type PagerankOptions,
-} from "./markovChain";
+} from "../algorithm/markovChain";
 
 import {type NodeAddressT} from "../graph";
-import {distributionToNodeDistribution} from "./graphToMarkovChain";
+import {distributionToNodeDistribution} from "../algorithm/graphToMarkovChain";
 
-import {uniformDistribution} from "./distribution";
+import {uniformDistribution} from "../algorithm/distribution";
 import {
   type MarkovProcessGraph,
   EPOCH_ACCUMULATOR_PREFIX,
-} from "../markovProcessGraph";
-import {CredGraph} from "../credGraph";
+} from "./markovProcessGraph";
+import {CredGraph} from "./credGraph";
 
 export const DEFAULT_MAX_ITERATIONS = 255;
 export const DEFAULT_CONVERGENCE_THRESHOLD = 1e-7;

--- a/src/core/credrank/credGraph.js
+++ b/src/core/credrank/credGraph.js
@@ -1,8 +1,8 @@
 // @flow
 
-import * as NullUtil from "../util/null";
-import {type Uuid} from "../util/uuid";
-import {type NodeAddressT, type EdgeAddressT} from "./graph";
+import * as NullUtil from "../../util/null";
+import {type Uuid} from "../../util/uuid";
+import {type NodeAddressT, type EdgeAddressT} from "../graph";
 import {
   MarkovProcessGraph,
   type MarkovProcessGraphJSON,
@@ -11,7 +11,7 @@ import {
   markovEdgeAddress,
   payoutAddressForEpoch,
 } from "./markovProcessGraph";
-import {toCompat, fromCompat, type Compatible} from "../util/compat";
+import {toCompat, fromCompat, type Compatible} from "../../util/compat";
 
 export type Node = {|
   +address: NodeAddressT,

--- a/src/core/credrank/markovProcessGraph.js
+++ b/src/core/credrank/markovProcessGraph.js
@@ -1,7 +1,7 @@
 // @flow
 
 import deepFreeze from "deep-freeze";
-import {type Uuid} from "../util/uuid";
+import {type Uuid} from "../../util/uuid";
 
 /**
  * Data structure representing a particular kind of Markov process, as
@@ -56,25 +56,25 @@ import {type Uuid} from "../util/uuid";
  */
 
 import sortedIndex from "lodash.sortedindex";
-import sortBy from "../util/sortBy";
-import {makeAddressModule, type AddressModule} from "./address";
+import sortBy from "../../util/sortBy";
+import {makeAddressModule, type AddressModule} from "../address";
 import {
   type NodeAddressT,
   NodeAddress,
   type EdgeAddressT,
   EdgeAddress,
-} from "./graph";
-import {type WeightedGraph as WeightedGraphT} from "./weightedGraph";
+} from "../graph";
+import {type WeightedGraph as WeightedGraphT} from "../weightedGraph";
 import {
   nodeWeightEvaluator,
   edgeWeightEvaluator,
-} from "./algorithm/weightEvaluator";
-import {toCompat, fromCompat, type Compatible} from "../util/compat";
-import * as NullUtil from "../util/null";
-import * as MapUtil from "../util/map";
-import type {TimestampMs} from "../util/timestamp";
-import {type SparseMarkovChain} from "./algorithm/markovChain";
-import {type IntervalSequence} from "./interval";
+} from "../algorithm/weightEvaluator";
+import {toCompat, fromCompat, type Compatible} from "../../util/compat";
+import * as NullUtil from "../../util/null";
+import * as MapUtil from "../../util/map";
+import type {TimestampMs} from "../../util/timestamp";
+import {type SparseMarkovChain} from "../algorithm/markovChain";
+import {type IntervalSequence} from "../interval";
 
 export type TransitionProbability = number;
 

--- a/src/core/credrank/markovProcessGraph.test.js
+++ b/src/core/credrank/markovProcessGraph.test.js
@@ -1,8 +1,8 @@
 // @flow
 
 import deepFreeze from "deep-freeze";
-import * as NullUtil from "../util/null";
-import {Graph} from "./graph";
+import * as NullUtil from "../../util/null";
+import {Graph} from "../graph";
 import {
   MarkovProcessGraph,
   markovEdgeAddress,
@@ -11,11 +11,11 @@ import {
   type MarkovEdge,
 } from "./markovProcessGraph";
 import * as MPG from "./markovProcessGraph";
-import {NodeAddress as NA, EdgeAddress as EA} from "./graph";
-import * as uuid from "../util/uuid"; // for spy purposes
-import {intervalSequence} from "./interval";
+import {NodeAddress as NA, EdgeAddress as EA} from "../graph";
+import * as uuid from "../../util/uuid"; // for spy purposes
+import {intervalSequence} from "../interval";
 
-describe("core/markovProcessGraph", () => {
+describe("core/credrank/markovProcessGraph", () => {
   const na = (name) => NA.fromParts([name]);
   const ea = (name) => EA.fromParts([name]);
 


### PR DESCRIPTION
This commit moves the core CredRank modules into a folder called
core/credrank. The motivation is that I want to start splitting apart
MarkovProcessGraph into smaller modules, and doing so without moving the
files would result in a disorganized core directory.