### PR TITLE
pull MarkovNode and MarkovEdge into new modules

### DIFF
--- a/src/core/credrank/credGraph.js
+++ b/src/core/credrank/credGraph.js
@@ -6,11 +6,13 @@ import {type NodeAddressT, type EdgeAddressT} from "../graph";
 import {
   MarkovProcessGraph,
   type MarkovProcessGraphJSON,
+  payoutAddressForEpoch,
+} from "./markovProcessGraph";
+import {
   type MarkovEdge,
   type TransitionProbability,
   markovEdgeAddress,
-  payoutAddressForEpoch,
-} from "./markovProcessGraph";
+} from "./markovEdge";
 import {toCompat, fromCompat, type Compatible} from "../../util/compat";
 
 export type Node = {|

--- a/src/core/credrank/markovEdge.js
+++ b/src/core/credrank/markovEdge.js
@@ -1,0 +1,52 @@
+// @flow
+
+import {makeAddressModule, type AddressModule} from "../address";
+import {type NodeAddressT, type EdgeAddressT, EdgeAddress} from "../graph";
+export type TransitionProbability = number;
+export type MarkovEdge = {|
+  // Address of the underlying edge. Note that this attribute alone does
+  // not uniquely identify an edge in the Markov process graph; the
+  // primary key is `(address, reversed)`, not just `address`. For edges
+  // not in the underlying graph (e.g., fibration edges), this will be
+  // an address under the `sourcecred/core` namespace.
+  +address: EdgeAddressT,
+  // If this came from an underlying graph edge or an epoch webbing
+  // edge, have its `src` and `dst` been swapped in the process of
+  // handling the reverse component of a bidirectional edge?
+  +reversed: boolean,
+  // Source node at the Markov chain level.
+  +src: NodeAddressT,
+  // Destination node at the Markov chain level.
+  +dst: NodeAddressT,
+  // Transition probability: $Pr[X_{n+1} = dst | X_{n} = src]$. Must sum
+  // to 1.0 for a given `src`.
+  +transitionProbability: TransitionProbability,
+|};
+
+export opaque type MarkovEdgeAddressT: string = string;
+export const MarkovEdgeAddress: AddressModule<MarkovEdgeAddressT> = (makeAddressModule(
+  {
+    name: "MarkovEdgeAddress",
+    nonce: "ME",
+    otherNonces: new Map().set("N", "NodeAddress").set("E", "EdgeAddress"),
+  }
+): AddressModule<string>);
+
+export function markovEdgeAddress(
+  edgeAddress: EdgeAddressT,
+  direction: "B" | /* Backward */ "F" /* Forward */
+): MarkovEdgeAddressT {
+  return MarkovEdgeAddress.fromParts([
+    direction,
+    ...EdgeAddress.toParts(edgeAddress),
+  ]);
+}
+
+export function markovEdgeAddressFromMarkovEdge(
+  edge: MarkovEdge
+): MarkovEdgeAddressT {
+  return markovEdgeAddress(
+    edge.address,
+    edge.reversed ? "B" /* Backward */ : "F" /* Forward */
+  );
+}

--- a/src/core/credrank/markovNode.js
+++ b/src/core/credrank/markovNode.js
@@ -1,0 +1,14 @@
+// @flow
+
+import {type NodeAddressT} from "../graph";
+
+export type MarkovNode = {|
+  // Node address, unique within a Markov process graph. This is either
+  // the address of a contribution node or an address under the
+  // `sourcecred/core` namespace.
+  +address: NodeAddressT,
+  // Markdown source description, as in `Node` from `core/graph`.
+  +description: string,
+  // Amount of cred to mint at this node.
+  +mint: number,
+|};

--- a/src/core/credrank/markovProcessGraph.js
+++ b/src/core/credrank/markovProcessGraph.js
@@ -56,7 +56,6 @@ import {type Uuid} from "../../util/uuid";
  */
 
 import sortedIndex from "lodash.sortedindex";
-import {makeAddressModule, type AddressModule} from "../address";
 import {
   type NodeAddressT,
   NodeAddress,
@@ -75,71 +74,21 @@ import type {TimestampMs} from "../../util/timestamp";
 import {type SparseMarkovChain} from "../algorithm/markovChain";
 import {type IntervalSequence} from "../interval";
 
-export type TransitionProbability = number;
+import {type MarkovNode} from "./markovNode";
 
-export type MarkovNode = {|
-  // Node address, unique within a Markov process graph. This is either
-  // the address of a contribution node or an address under the
-  // `sourcecred/core` namespace.
-  +address: NodeAddressT,
-  // Markdown source description, as in `Node` from `core/graph`.
-  +description: string,
-  // Amount of cred to mint at this node.
-  +mint: number,
-|};
-export type MarkovEdge = {|
-  // Address of the underlying edge. Note that this attribute alone does
-  // not uniquely identify an edge in the Markov process graph; the
-  // primary key is `(address, reversed)`, not just `address`. For edges
-  // not in the underlying graph (e.g., fibration edges), this will be
-  // an address under the `sourcecred/core` namespace.
-  +address: EdgeAddressT,
-  // If this came from an underlying graph edge or an epoch webbing
-  // edge, have its `src` and `dst` been swapped in the process of
-  // handling the reverse component of a bidirectional edge?
-  +reversed: boolean,
-  // Source node at the Markov chain level.
-  +src: NodeAddressT,
-  // Destination node at the Markov chain level.
-  +dst: NodeAddressT,
-  // Transition probability: $Pr[X_{n+1} = dst | X_{n} = src]$. Must sum
-  // to 1.0 for a given `src`.
-  +transitionProbability: TransitionProbability,
-|};
+import {
+  type MarkovEdge,
+  type MarkovEdgeAddressT,
+  type TransitionProbability,
+  MarkovEdgeAddress,
+  markovEdgeAddressFromMarkovEdge,
+} from "./markovEdge";
 
 export type Participant = {|
   +address: NodeAddressT,
   +description: string,
   +id: Uuid,
 |};
-
-export opaque type MarkovEdgeAddressT: string = string;
-export const MarkovEdgeAddress: AddressModule<MarkovEdgeAddressT> = (makeAddressModule(
-  {
-    name: "MarkovEdgeAddress",
-    nonce: "ME",
-    otherNonces: new Map().set("N", "NodeAddress").set("E", "EdgeAddress"),
-  }
-): AddressModule<string>);
-
-export function markovEdgeAddress(
-  edgeAddress: EdgeAddressT,
-  direction: "B" | /* Backward */ "F" /* Forward */
-): MarkovEdgeAddressT {
-  return MarkovEdgeAddress.fromParts([
-    direction,
-    ...EdgeAddress.toParts(edgeAddress),
-  ]);
-}
-
-export function markovEdgeAddressFromMarkovEdge(
-  edge: MarkovEdge
-): MarkovEdgeAddressT {
-  return markovEdgeAddress(
-    edge.address,
-    edge.reversed ? "B" /* Backward */ : "F" /* Forward */
-  );
-}
 
 export type OrderedSparseMarkovChain = {|
   +nodeOrder: $ReadOnlyArray<NodeAddressT>,

--- a/src/core/credrank/markovProcessGraph.test.js
+++ b/src/core/credrank/markovProcessGraph.test.js
@@ -3,13 +3,13 @@
 import deepFreeze from "deep-freeze";
 import * as NullUtil from "../../util/null";
 import {Graph} from "../graph";
+import {MarkovProcessGraph} from "./markovProcessGraph";
 import {
-  MarkovProcessGraph,
   markovEdgeAddress,
   MarkovEdgeAddress,
   markovEdgeAddressFromMarkovEdge,
   type MarkovEdge,
-} from "./markovProcessGraph";
+} from "./markovEdge";
 import * as MPG from "./markovProcessGraph";
 import {NodeAddress as NA, EdgeAddress as EA} from "../graph";
 import * as uuid from "../../util/uuid"; // for spy purposes


### PR DESCRIPTION
This commit just reorganizes the MarkovNode and MarkovEdge types into
their own submodules. This is another pre-factor for changing how the
gadgets are organized.

Test plan: Just a reorg, look for green CI.