### PR TITLE
credrank: create a payout gadget

### DIFF
--- a/src/core/credrank/credGraph.js
+++ b/src/core/credrank/credGraph.js
@@ -6,14 +6,10 @@ import {type NodeAddressT, type EdgeAddressT} from "../graph";
 import {
   MarkovProcessGraph,
   type MarkovProcessGraphJSON,
-  payoutAddressForEpoch,
 } from "./markovProcessGraph";
-import {
-  type MarkovEdge,
-  type TransitionProbability,
-  markovEdgeAddress,
-} from "./markovEdge";
+import {type MarkovEdge, type TransitionProbability} from "./markovEdge";
 import {toCompat, fromCompat, type Compatible} from "../../util/compat";
+import {payoutGadget} from "./edgeGadgets";
 
 export type Node = {|
   +address: NodeAddressT,
@@ -119,14 +115,8 @@ export class CredGraph {
       }));
       let totalCred = 0;
       const credPerEpoch = epochs.map((e) => {
-        const payoutEdgeAddress = payoutAddressForEpoch(e);
-        const payoutMarkovEdgeAddress = markovEdgeAddress(
-          payoutEdgeAddress,
-          "F"
-        );
-        const payoutMarkovEdge = NullUtil.get(
-          this._mpg.edge(payoutMarkovEdgeAddress)
-        );
+        const payoutAddress = payoutGadget.toRaw(e);
+        const payoutMarkovEdge = NullUtil.get(this._mpg.edge(payoutAddress));
         const cred = this._credFlow(payoutMarkovEdge);
         totalCred += cred;
         return cred;

--- a/src/core/credrank/markovProcessGraph.test.js
+++ b/src/core/credrank/markovProcessGraph.test.js
@@ -21,6 +21,7 @@ import {
   accumulatorRadiationGadget,
   epochRadiationGadget,
   seedMintGadget,
+  payoutGadget,
 } from "./edgeGadgets";
 
 describe("core/credrank/markovProcessGraph", () => {
@@ -277,19 +278,11 @@ describe("core/credrank/markovProcessGraph", () => {
           owner: participant.address,
           epochStart: boundary,
         };
-        const epochAddress = epochGadget.toRaw(structuredAddress);
-        const accumulatorAddress = accumulatorGadget.toRaw({
-          epochStart: boundary,
-        });
         // Find the "payout" edge, directed to the correct epoch accumulator
-        const payoutAddress = MPG.payoutAddressForEpoch(structuredAddress);
-        const payoutEdge = {
-          address: payoutAddress,
-          reversed: false,
-          src: epochAddress,
-          dst: accumulatorAddress,
-          transitionProbability: parameters.beta,
-        };
+        const payoutEdge = payoutGadget.markovEdge(
+          structuredAddress,
+          parameters.beta
+        );
         checkMarkovEdge(mpg, payoutEdge);
       }
     });


### PR DESCRIPTION
This adds an EdgeGadget for the payout edges that connect participant
epoch nodes to the accumulator epoch nodes.

It's a simple example of adding a gadget.

Test plan: Unit tests.