### PR TITLE
credrank: gadgets track participants by id

### DIFF
--- a/src/core/credrank/credGraph.js
+++ b/src/core/credrank/credGraph.js
@@ -110,7 +110,7 @@ export class CredGraph {
   *participants(): Iterator<Participant> {
     for (const {address, description, id} of this._mpg.participants()) {
       const epochs = this._mpg.epochBoundaries().map((epochStart) => ({
-        owner: address,
+        owner: id,
         epochStart,
       }));
       let totalCred = 0;

--- a/src/core/credrank/edgeGadgets.js
+++ b/src/core/credrank/edgeGadgets.js
@@ -1,6 +1,7 @@
 // @flow
 
 import type {TimestampMs} from "../../util/timestamp";
+import {fromString as uuidFromString, type Uuid} from "../../util/uuid";
 import {
   NodeAddress,
   type NodeAddressT,
@@ -129,23 +130,15 @@ export const payoutGadget: EdgeGadget<ParticipantEpochAddress> = (() => {
   const prefix = markovEdgeAddress(edgePrefix, "F");
   const prefixLength = MarkovEdgeAddress.toParts(prefix).length;
   const toRaw = ({epochStart, owner}) =>
-    MarkovEdgeAddress.append(
-      prefix,
-      String(epochStart),
-      ...NodeAddress.toParts(owner)
-    );
+    MarkovEdgeAddress.append(prefix, String(epochStart), owner);
   const fromRaw = (addr) => {
     const parts = MarkovEdgeAddress.toParts(addr).slice(prefixLength);
     const epochStart = +parts[0];
-    const owner = NodeAddress.fromParts(parts.slice(1));
+    const owner = uuidFromString(parts[1]);
     return {epochStart, owner};
   };
   const markovEdge = ({owner, epochStart}, transitionProbability) => ({
-    address: EdgeAddress.append(
-      edgePrefix,
-      String(epochStart),
-      ...NodeAddress.toParts(owner)
-    ),
+    address: EdgeAddress.append(edgePrefix, String(epochStart), owner),
     reversed: false,
     src: epochGadget.toRaw({owner, epochStart}),
     dst: accumulatorGadget.toRaw({epochStart}),
@@ -157,7 +150,7 @@ export const payoutGadget: EdgeGadget<ParticipantEpochAddress> = (() => {
 export type WebbingAddress = {|
   +thisStart: TimestampMs,
   +lastStart: TimestampMs,
-  +owner: NodeAddressT,
+  +owner: Uuid,
 |};
 const webbingEdgePrefix = EdgeAddress.fromParts([
   "sourcecred",
@@ -178,13 +171,13 @@ export const forwardWebbingGadget: EdgeGadget<WebbingAddress> = (() => {
       prefix,
       String(lastStart),
       String(thisStart),
-      ...NodeAddress.toParts(owner)
+      owner
     );
   const fromRaw = (address) => {
     const parts = MarkovEdgeAddress.toParts(address).slice(prefixLength);
     const lastStart = +parts[0];
     const thisStart = +parts[1];
-    const owner = NodeAddress.fromParts(parts.slice(2));
+    const owner = uuidFromString(parts[2]);
     return {lastStart, thisStart, owner};
   };
   const markovEdge = ({thisStart, lastStart, owner}, transitionProbability) => {
@@ -195,7 +188,7 @@ export const forwardWebbingGadget: EdgeGadget<WebbingAddress> = (() => {
         webbingEdgePrefix,
         String(lastStart),
         String(thisStart),
-        ...NodeAddress.toParts(owner)
+        owner
       ),
       reversed: false,
       src: epochGadget.toRaw(lastEpoch),
@@ -220,13 +213,13 @@ export const backwardWebbingGadget: EdgeGadget<WebbingAddress> = (() => {
       prefix,
       String(lastStart),
       String(thisStart),
-      ...NodeAddress.toParts(owner)
+      owner
     );
   const fromRaw = (address) => {
     const parts = MarkovEdgeAddress.toParts(address).slice(prefixLength);
     const lastStart = +parts[0];
     const thisStart = +parts[1];
-    const owner = NodeAddress.fromParts(parts.slice(2));
+    const owner = uuidFromString(parts[2]);
     return {lastStart, thisStart, owner};
   };
   const markovEdge = ({thisStart, lastStart, owner}, transitionProbability) => {
@@ -237,7 +230,7 @@ export const backwardWebbingGadget: EdgeGadget<WebbingAddress> = (() => {
         webbingEdgePrefix,
         String(lastStart),
         String(thisStart),
-        ...NodeAddress.toParts(owner)
+        owner
       ),
       reversed: true,
       src: epochGadget.toRaw(thisEpoch),

--- a/src/core/credrank/markovProcessGraph.js
+++ b/src/core/credrank/markovProcessGraph.js
@@ -173,6 +173,9 @@ export class MarkovProcessGraph {
     const _nodes = new Map();
     const _edges = new Map();
 
+    const _scoringAddressToId = new Map(
+      participants.map((p) => [p.address, p.id])
+    );
     const _scoringAddresses = new Set(participants.map((p) => p.address));
 
     // _nodeOutMasses[a] = sum(e.pr for e in edges if e.src == a)
@@ -263,9 +266,9 @@ export class MarkovProcessGraph {
         epochStart: boundary,
       };
       addNode(accumulatorGadget.node(accumulator));
-      for (const scoringAddress of _scoringAddresses) {
+      for (const participant of participants) {
         const thisEpoch = {
-          owner: scoringAddress,
+          owner: participant.id,
           epochStart: boundary,
         };
         addNode(epochGadget.node(thisEpoch));
@@ -274,7 +277,7 @@ export class MarkovProcessGraph {
           const webbingAddress = {
             thisStart: boundary,
             lastStart: lastBoundary,
-            owner: scoringAddress,
+            owner: participant.id,
           };
           addEdge(
             forwardWebbingGadget.markovEdge(webbingAddress, gammaForward)
@@ -313,14 +316,15 @@ export class MarkovProcessGraph {
       address: NodeAddressT,
       edgeTimestampMs: TimestampMs
     ): NodeAddressT => {
-      if (!_scoringAddresses.has(address)) {
+      const owner = _scoringAddressToId.get(address);
+      if (owner == null) {
         return address;
       }
       const epochEndIndex = sortedIndex(timeBoundaries, edgeTimestampMs);
       const epochStartIndex = epochEndIndex - 1;
       const epochTimestampMs = timeBoundaries[epochStartIndex];
       return epochGadget.toRaw({
-        owner: address,
+        owner,
         epochStart: epochTimestampMs,
       });
     };

--- a/src/core/credrank/markovProcessGraph.test.js
+++ b/src/core/credrank/markovProcessGraph.test.js
@@ -230,7 +230,7 @@ describe("core/credrank/markovProcessGraph", () => {
       const mpg = markovProcessGraph();
       for (const boundary of mpg.epochBoundaries()) {
         const address = {
-          owner: participant.address,
+          owner: participant.id,
           epochStart: boundary,
         };
         const node = epochGadget.node(address);
@@ -242,7 +242,7 @@ describe("core/credrank/markovProcessGraph", () => {
       const mpg = markovProcessGraph();
       for (const boundary of mpg.epochBoundaries()) {
         const structuredAddress = {
-          owner: participant.address,
+          owner: participant.id,
           epochStart: boundary,
         };
 
@@ -276,7 +276,7 @@ describe("core/credrank/markovProcessGraph", () => {
       const mpg = markovProcessGraph();
       for (const boundary of mpg.epochBoundaries()) {
         const structuredAddress = {
-          owner: participant.address,
+          owner: participant.id,
           epochStart: boundary,
         };
         // Find the "payout" edge, directed to the correct epoch accumulator
@@ -293,7 +293,7 @@ describe("core/credrank/markovProcessGraph", () => {
       let lastBoundary = null;
       for (const boundary of mpg.epochBoundaries()) {
         const epochAddress = {
-          owner: participant.address,
+          owner: participant.id,
           epochStart: boundary,
         };
         // Find the epoch node
@@ -305,7 +305,7 @@ describe("core/credrank/markovProcessGraph", () => {
           const webbingAddress = {
             lastStart: lastBoundary,
             thisStart: boundary,
-            owner: participant.address,
+            owner: participant.id,
           };
           const forwardWebbing = forwardWebbingGadget.markovEdge(
             webbingAddress,
@@ -343,11 +343,11 @@ describe("core/credrank/markovProcessGraph", () => {
     it("re-writes edges incident to the participants so that they touch the participant epoch node", () => {
       const mpg = markovProcessGraph();
       const epoch0 = epochGadget.toRaw({
-        owner: participant.address,
+        owner: participant.id,
         epochStart: 0,
       });
       const epoch2 = epochGadget.toRaw({
-        owner: participant.address,
+        owner: participant.id,
         epochStart: 2,
       });
       const e0F = {

--- a/src/core/credrank/nodeGadgets.js
+++ b/src/core/credrank/nodeGadgets.js
@@ -4,6 +4,7 @@
  * They are most directly used by markovProcessGraph.js
  */
 
+import {type Uuid, fromString as uuidFromString} from "../../util/uuid";
 import {type NodeAddressT, NodeAddress} from "../graph";
 import type {TimestampMs} from "../../util/timestamp";
 import type {MarkovNode} from "./markovNode";
@@ -78,18 +79,14 @@ export const accumulatorGadget: NodeGadget<EpochAccumulatorAddress> = (() => {
 })();
 
 export type ParticipantEpochAddress = {|
-  +owner: NodeAddressT,
+  +owner: Uuid,
   +epochStart: TimestampMs,
 |};
 export const epochGadget: NodeGadget<ParticipantEpochAddress> = (() => {
   const prefix = NodeAddress.append(CORE_NODE_PREFIX, "USER_EPOCH");
   const epochPrefixLength = NodeAddress.toParts(prefix).length;
   function toRaw(addr: ParticipantEpochAddress): NodeAddressT {
-    return NodeAddress.append(
-      prefix,
-      String(addr.epochStart),
-      ...NodeAddress.toParts(addr.owner)
-    );
+    return NodeAddress.append(prefix, String(addr.epochStart), addr.owner);
   }
   function fromRaw(addr: NodeAddressT): ParticipantEpochAddress {
     if (!NodeAddress.hasPrefix(addr, prefix)) {
@@ -99,7 +96,7 @@ export const epochGadget: NodeGadget<ParticipantEpochAddress> = (() => {
     }
     const parts = NodeAddress.toParts(addr).slice(epochPrefixLength);
     const epochStart = +parts[0];
-    const owner = NodeAddress.fromParts(parts.slice(1));
+    const owner = uuidFromString(parts[1]);
     return {
       owner,
       epochStart,


### PR DESCRIPTION
This refactors CredRank gadgets (and particularly their addressing
structures) to track participants via id rather than their address. This
is cleaner because it allows us to have definite fixed-length addresses,
and avoid an extra layer of translation to/fro embedded node addresses.

Test plan: Unit tests pass, also CredRank results are stable.