### PR TITLE
Fix CredRank JSON serialization

### DIFF
--- a/src/core/credrank/markovProcessGraph.js
+++ b/src/core/credrank/markovProcessGraph.js
@@ -591,7 +591,7 @@ export class MarkovProcessGraph {
 
   static fromJSON(j: MarkovProcessGraphJSON): MarkovProcessGraph {
     const {
-      sortedNodes,
+      nodes,
       indexedEdges,
       participants,
       finiteEpochBoundaries,
@@ -599,14 +599,14 @@ export class MarkovProcessGraph {
     const edges = indexedEdges.map((e) => ({
       address: e.address,
       reversed: e.reversed,
-      src: sortedNodes[e.src].address,
-      dst: sortedNodes[e.dst].address,
+      src: nodes[e.src].address,
+      dst: nodes[e.dst].address,
       transitionProbability: e.transitionProbability,
     }));
 
     return new MarkovProcessGraph(
-      new Map(sortedNodes.map((n) => [n.address, n])),
-      new Map(edges.map((e) => [e.address, e])),
+      new Map(nodes.map((n) => [n.address, n])),
+      new Map(edges.map((e) => [markovEdgeAddressFromMarkovEdge(e), e])),
       participants,
       [-Infinity, ...finiteEpochBoundaries, Infinity]
     );

--- a/src/core/credrank/markovProcessGraph.test.js
+++ b/src/core/credrank/markovProcessGraph.test.js
@@ -401,4 +401,23 @@ describe("core/credrank/markovProcessGraph", () => {
       expect(edgesActual).toEqual(edgesExpected);
     });
   });
+
+  describe("to/froJSON", () => {
+    it("has round trip equality", () => {
+      const mpg = markovProcessGraph();
+      const mpgJson = mpg.toJSON();
+      const mpg_ = MarkovProcessGraph.fromJSON(mpgJson);
+      const mpgJson_ = mpg_.toJSON();
+      expect(mpg).toEqual(mpg_);
+      expect(mpgJson).toEqual(mpgJson_);
+    });
+    it("serialization does not change node/edge iteration order", () => {
+      const mpg1 = markovProcessGraph();
+      const mpg2 = MarkovProcessGraph.fromJSON(mpg1.toJSON());
+      expect([...mpg1.nodeOrder()]).toEqual([...mpg2.nodeOrder()]);
+      expect([...mpg1.edgeOrder()]).toEqual([...mpg2.edgeOrder()]);
+      expect([...mpg1.nodes()]).toEqual([...mpg2.nodes()]);
+      expect([...mpg1.edges()]).toEqual([...mpg2.edges()]);
+    });
+  });
 });


### PR DESCRIPTION
As a prelude to node virtualization, I've added a test to verify that
JSON serialization is a proper round trip. In so doing, I discovered
that our current JSON serialization does not work as intended, due to a
subtle issue where we store markov edges by their address property,
which (as the docs note) is not actually a full address. I'm considering
that we may want to refactor so that `MarkovEdgeAddress.address` is
actually a markov edge address, to avoid confusion like this in the
future.

Test plan: `yarn test`, passes, and credrank scores are stable.