### PR TITLE
credrank: make parameters accessible on MPG

### DIFF
--- a/src/core/credrank/markovProcessGraph.js
+++ b/src/core/credrank/markovProcessGraph.js
@@ -147,6 +147,7 @@ export type MarkovProcessGraphJSON = Compatible<{|
   // The -Infinity and +Infinity epoch boundaries must be stripped before
   // JSON serialization.
   +finiteEpochBoundaries: $ReadOnlyArray<number>,
+  +parameters: Parameters,
 |}>;
 
 export class MarkovProcessGraph {
@@ -154,6 +155,7 @@ export class MarkovProcessGraph {
   _edges: $ReadOnlyMap<MarkovEdgeAddressT, MarkovEdge>;
   _participants: $ReadOnlyArray<Participant>;
   _epochBoundaries: $ReadOnlyArray<number>;
+  _parameters: Parameters;
   _nodeIndex: $ReadOnlyMap<NodeAddressT, number>;
   _edgeIndex: $ReadOnlyMap<MarkovEdgeAddressT, number>;
 
@@ -161,12 +163,14 @@ export class MarkovProcessGraph {
     nodes: Map<NodeAddressT, MarkovNode>,
     edges: Map<MarkovEdgeAddressT, MarkovEdge>,
     participants: $ReadOnlyArray<Participant>,
-    epochBoundaries: $ReadOnlyArray<number>
+    epochBoundaries: $ReadOnlyArray<number>,
+    parameters: Parameters
   ) {
     this._nodes = nodes;
     this._edges = edges;
     this._epochBoundaries = deepFreeze(epochBoundaries);
     this._participants = deepFreeze(participants);
+    this._parameters = deepFreeze(parameters);
     // Precompute the index maps
     this._nodeIndex = new Map(
       [
@@ -440,7 +444,13 @@ export class MarkovProcessGraph {
       }
     }
 
-    return new MarkovProcessGraph(_nodes, _edges, participants, timeBoundaries);
+    return new MarkovProcessGraph(
+      _nodes,
+      _edges,
+      participants,
+      timeBoundaries,
+      parameters
+    );
   }
 
   epochBoundaries(): $ReadOnlyArray<number> {
@@ -449,6 +459,10 @@ export class MarkovProcessGraph {
 
   participants(): $ReadOnlyArray<Participant> {
     return this._participants;
+  }
+
+  parameters(): Parameters {
+    return this._parameters;
   }
 
   /**
@@ -609,6 +623,7 @@ export class MarkovProcessGraph {
         1,
         this._epochBoundaries.length - 1
       ),
+      parameters: this._parameters,
     });
   }
 
@@ -618,6 +633,7 @@ export class MarkovProcessGraph {
       indexedEdges,
       participants,
       finiteEpochBoundaries,
+      parameters,
     } = fromCompat(COMPAT_INFO, j);
     const epochBoundaries = [-Infinity, ...finiteEpochBoundaries, Infinity];
     const nodeOrder = [
@@ -636,7 +652,8 @@ export class MarkovProcessGraph {
       new Map(nodes.map((n) => [n.address, n])),
       new Map(edges.map((e) => [markovEdgeAddressFromMarkovEdge(e), e])),
       participants,
-      epochBoundaries
+      epochBoundaries,
+      parameters
     );
   }
 }

--- a/src/core/credrank/markovProcessGraph.test.js
+++ b/src/core/credrank/markovProcessGraph.test.js
@@ -195,11 +195,6 @@ describe("core/credrank/markovProcessGraph", () => {
     });
   });
 
-  it("has the correct epoch boundaries for the given intervals", () => {
-    const expected = [-Infinity, 0, 2, Infinity];
-    expect(markovProcessGraph().epochBoundaries()).toEqual(expected);
-  });
-
   describe("gadgets", () => {
     describe("seed", () => {
       it("has a seed node", () => {
@@ -413,6 +408,16 @@ describe("core/credrank/markovProcessGraph", () => {
       edgeOrder.forEach((n, i) => {
         expect(mpg.edgeIndex(n)).toEqual(i);
       });
+    });
+    it("has the correct epoch boundaries for the given intervals", () => {
+      const expected = [-Infinity, 0, 2, Infinity];
+      expect(markovProcessGraph().epochBoundaries()).toEqual(expected);
+    });
+    it("has the right participants", () => {
+      expect(markovProcessGraph().participants()).toEqual([participant]);
+    });
+    it("has the right parameters", () => {
+      expect(markovProcessGraph().parameters()).toEqual(parameters);
     });
   });
 


### PR DESCRIPTION
We need the parameters to be accessible on the object, so that we can
reference them when creating the fibration edges.

Test plan: I added a simple test. :)