### PR TITLE
Add pagination to LedgerViewer

### DIFF
--- a/src/ui/components/LedgerViewer.js
+++ b/src/ui/components/LedgerViewer.js
@@ -35,7 +35,6 @@ import * as G from "../../core/ledger/grain";
 const useStyles = makeStyles((theme) => {
   return {
     container: {
-      maxWidth: "60em",
       width: "100%",
     },
     table: {
@@ -266,10 +265,10 @@ const LedgerEventRow = React.memo(
         <TableCell>
           <Box
             display="flex"
+            flex={1}
             flexDirection="row"
             alignItems="center"
             flexWrap="wrap"
-            maxWidth={50}
           >
             {getEventDetails()}
           </Box>


### PR DESCRIPTION
The LedgerViewer is now much more performant with a large number of events. The pagination
controls at the bottom allow users to go back and forth between pages of ledger events.
They will also be able to select between 25, 50, or 100 rows per page (default 25).
Tested with 2600+ ledger events with snappy performance.
UI for mobile also cleaned up to be much more usable.

Test Plan:
- On the LedgerViewer page, click the right arrow to go go the next page of the ledger events and ensure
they are in the correct order.
- Change the number of Rows to 50 and 100 and ensure the ledger events are shown in the correct order.

![2020-10-15 03 54 47](https://user-images.githubusercontent.com/7143583/96107902-3745b600-0e9a-11eb-8735-3681026a2021.gif)
