### PR TITLE
Add roleWeights to discord plugin

### DIFF
--- a/src/plugins/experimental-discord/config.js
+++ b/src/plugins/experimental-discord/config.js
@@ -2,7 +2,7 @@
 
 import * as Combo from "../../util/combo";
 import * as Model from "./models";
-import {type EmojiWeightMap, type RoleWeightMap} from "./createGraph";
+import {type EmojiWeightMap, type RoleWeightConfig} from "./createGraph";
 
 export type {BotToken as DiscordToken} from "./models";
 
@@ -30,7 +30,7 @@ export type DiscordConfig = {|
   // }
   // Note that roles have a snowflake identifier.
   // default is used to set weights for members who don't have a specified role
-  +roleWeights: RoleWeightMap,
+  +roleWeightConfig: RoleWeightConfig,
 |};
 
 export const parser: Combo.Parser<DiscordConfig> = (() => {
@@ -38,6 +38,9 @@ export const parser: Combo.Parser<DiscordConfig> = (() => {
   return C.object({
     guildId: C.string,
     reactionWeights: C.dict(C.number),
-    roleWeights: C.dict(C.number),
+    roleWeightConfig: C.object({
+      defaultWeight: C.number,
+      roleWeights: C.dict(C.number),
+    }),
   });
 })();

--- a/src/plugins/experimental-discord/config.js
+++ b/src/plugins/experimental-discord/config.js
@@ -24,12 +24,15 @@ export type DiscordConfig = {|
   +reactionWeights: EmojiWeightMap,
   // An object mapping a role to a weight, as in:
   // {
-  //   "default": 0,
-  //   "core:626763367893303303": 2,
-  //   "contributor:456763457893303303": 1,
+  //   "defaultWeight": 0,
+  //   "roleWeights": {
+  //     "759191073943191613": 0.5,
+  //     "762085832181153872": 1,
+  //     "698296035889381403": 1
+  //   }
   // }
-  // Note that roles have a snowflake identifier.
-  // default is used to set weights for members who don't have a specified role
+  // Note that roles use a snowflake id only.
+  // defaultWeight is used to set weights for members who don't have a specified role
   +roleWeightConfig: RoleWeightConfig,
 |};
 

--- a/src/plugins/experimental-discord/config.js
+++ b/src/plugins/experimental-discord/config.js
@@ -33,17 +33,21 @@ export type DiscordConfig = {|
   // }
   // Note that roles use a snowflake id only.
   // defaultWeight is used to set weights for members who don't have a specified role
-  +roleWeightConfig: RoleWeightConfig,
+  +roleWeightConfig?: RoleWeightConfig,
 |};
 
 export const parser: Combo.Parser<DiscordConfig> = (() => {
   const C = Combo;
-  return C.object({
-    guildId: C.string,
-    reactionWeights: C.dict(C.number),
-    roleWeightConfig: C.object({
-      defaultWeight: C.number,
-      roleWeights: C.dict(C.number),
-    }),
-  });
+  return C.object(
+    {
+      guildId: C.string,
+      reactionWeights: C.dict(C.number),
+    },
+    {
+      roleWeightConfig: C.object({
+        defaultWeight: C.number,
+        roleWeights: C.dict(C.number),
+      }),
+    }
+  );
 })();

--- a/src/plugins/experimental-discord/config.js
+++ b/src/plugins/experimental-discord/config.js
@@ -2,7 +2,7 @@
 
 import * as Combo from "../../util/combo";
 import * as Model from "./models";
-import {type EmojiWeightMap} from "./createGraph";
+import {type EmojiWeightMap, type RoleWeightMap} from "./createGraph";
 
 export type {BotToken as DiscordToken} from "./models";
 
@@ -22,6 +22,15 @@ export type DiscordConfig = {|
   // You can get a custom emoji ID by right clicking the custom emoji and
   // copying it's URL, with the ID being the image file name.
   +reactionWeights: EmojiWeightMap,
+  // An object mapping a role to a weight, as in:
+  // {
+  //   "default": 0,
+  //   "core:626763367893303303": 2,
+  //   "contributor:456763457893303303": 1,
+  // }
+  // Note that roles have a snowflake identifier.
+  // default is used to set weights for members who don't have a specified role
+  +roleWeights: RoleWeightMap,
 |};
 
 export const parser: Combo.Parser<DiscordConfig> = (() => {
@@ -29,5 +38,6 @@ export const parser: Combo.Parser<DiscordConfig> = (() => {
   return C.object({
     guildId: C.string,
     reactionWeights: C.dict(C.number),
+    roleWeights: C.dict(C.number),
   });
 })();

--- a/src/plugins/experimental-discord/config.test.js
+++ b/src/plugins/experimental-discord/config.test.js
@@ -13,8 +13,9 @@ describe("plugins/experimental-discord/config", () => {
       roleWeightConfig: {
         defaultWeight: 0,
         roleWeights: {
-          "core:626763367893303303": 2,
-          "contributor:456763457893303303": 1,
+          "759191073943191613": 0.5,
+          "762085832181153872": 1,
+          "698296035889381403": 1,
         },
       },
     };

--- a/src/plugins/experimental-discord/config.test.js
+++ b/src/plugins/experimental-discord/config.test.js
@@ -10,10 +10,12 @@ describe("plugins/experimental-discord/config", () => {
         "🥰": 4,
         ":sourcecred:626763367893303303": 16,
       },
-      roleWeights: {
-        "default": 0,
-        "core:626763367893303303": 2,
-        "contributor:456763457893303303": 1,
+      roleWeightConfig: {
+        defaultWeight: 0,
+        roleWeights: {
+          "core:626763367893303303": 2,
+          "contributor:456763457893303303": 1,
+        },
       },
     };
     const parsed: DiscordConfig = parser.parseOrThrow(raw);

--- a/src/plugins/experimental-discord/config.test.js
+++ b/src/plugins/experimental-discord/config.test.js
@@ -10,6 +10,11 @@ describe("plugins/experimental-discord/config", () => {
         "🥰": 4,
         ":sourcecred:626763367893303303": 16,
       },
+      roleWeights: {
+        "default": 0,
+        "core:626763367893303303": 2,
+        "contributor:456763457893303303": 1,
+      },
     };
     const parsed: DiscordConfig = parser.parseOrThrow(raw);
     expect(parsed).toEqual(raw);

--- a/src/plugins/experimental-discord/createGraph.js
+++ b/src/plugins/experimental-discord/createGraph.js
@@ -219,7 +219,10 @@ export function createGraph(
       const reactions = repo.reactions(channel.id, message.id);
       for (const reaction of reactions) {
         const emojiRef = Model.emojiToRef(reaction.emoji);
-        const reactionWeight = emojiWeights[emojiRef];
+        let reactionWeight = emojiWeights[emojiRef];
+        if (reactionWeight === null || reactionWeight === undefined) {
+          reactionWeight = 1;
+        }
 
         const reactingMember = memberMap.get(reaction.authorId);
         if (!reactingMember) {
@@ -228,7 +231,7 @@ export function createGraph(
         }
 
         // get the weight of the highest weight role the reacting user has
-        let roleWeight = roleWeightConfig.defaultWeight || 1;
+        let roleWeight = roleWeightConfig.defaultWeight;
         const roleWeights = roleWeightConfig.roleWeights;
         for (const roleRef of reactingMember.roles) {
           if (roleWeights[roleRef] > roleWeight) {
@@ -237,9 +240,7 @@ export function createGraph(
         }
 
         const node = reactionNode(reaction, message.timestampMs, guild);
-        if (reactionWeight != null) {
-          wg.weights.nodeWeights.set(node.address, roleWeight * reactionWeight);
-        }
+        wg.weights.nodeWeights.set(node.address, roleWeight * reactionWeight);
         wg.graph.addNode(node);
         wg.graph.addNode(memberNode(reactingMember));
         wg.graph.addEdge(reactsToEdge(reaction, message));

--- a/src/plugins/experimental-discord/createGraph.js
+++ b/src/plugins/experimental-discord/createGraph.js
@@ -187,14 +187,19 @@ function mentionsEdge(message: Model.Message, member: Model.GuildMember): Edge {
 }
 
 export type EmojiWeightMap = {[ref: Model.EmojiRef]: NodeWeight};
-export type RoleWeightMap = {[ref: string]: NodeWeight};
+export type RoleWeightMap = {[ref: Model.Snowflake]: NodeWeight};
+
+export type RoleWeightConfig = {|
+  +defaultWeight: number,
+  +roleWeights: RoleWeightMap,
+|};
 
 export function createGraph(
   guild: Model.Snowflake,
   repo: SqliteMirrorRepository,
   declarationWeights: Weights,
   emojiWeights: EmojiWeightMap,
-  roleWeights: RoleWeightMap
+  roleWeightConfig: RoleWeightConfig
 ): WeightedGraphT {
   const wg = {
     graph: new Graph(),
@@ -223,7 +228,8 @@ export function createGraph(
         }
 
         // get the weight of the highest weight role the reacting user has
-        let roleWeight = roleWeights.default || 1;
+        let roleWeight = roleWeightConfig.defaultWeight || 1;
+        const roleWeights = roleWeightConfig.roleWeights;
         for (const roleRef of reactingMember.roles) {
           if (roleWeights[roleRef] > roleWeight) {
             roleWeight = roleWeights[roleRef];

--- a/src/plugins/experimental-discord/createGraph.js
+++ b/src/plugins/experimental-discord/createGraph.js
@@ -187,12 +187,14 @@ function mentionsEdge(message: Model.Message, member: Model.GuildMember): Edge {
 }
 
 export type EmojiWeightMap = {[ref: Model.EmojiRef]: NodeWeight};
+export type RoleWeightMap = {[ref: string]: NodeWeight};
 
 export function createGraph(
   guild: Model.Snowflake,
   repo: SqliteMirrorRepository,
   declarationWeights: Weights,
-  emojiWeights: EmojiWeightMap
+  emojiWeights: EmojiWeightMap,
+  roleWeights: RoleWeightMap
 ): WeightedGraphT {
   const wg = {
     graph: new Graph(),
@@ -220,9 +222,17 @@ export function createGraph(
           continue;
         }
 
+        // get the weight of the highest weight role the reacting user has
+        let roleWeight = roleWeights.default || 1;
+        for (const roleRef of reactingMember.roles) {
+          if (roleWeights[roleRef] > roleWeight) {
+            roleWeight = roleWeights[roleRef];
+          }
+        }
+
         const node = reactionNode(reaction, message.timestampMs, guild);
         if (reactionWeight != null) {
-          wg.weights.nodeWeights.set(node.address, reactionWeight);
+          wg.weights.nodeWeights.set(node.address, roleWeight * reactionWeight);
         }
         wg.graph.addNode(node);
         wg.graph.addNode(memberNode(reactingMember));

--- a/src/plugins/experimental-discord/createGraph.js
+++ b/src/plugins/experimental-discord/createGraph.js
@@ -1,6 +1,7 @@
 // @flow
 
 import {escape} from "entities";
+import * as NullUtil from "../../util/null";
 import {type WeightedGraph as WeightedGraphT} from "../../core/weightedGraph";
 import {type Weights, type NodeWeight} from "../../core/weights";
 import {
@@ -219,12 +220,9 @@ export function createGraph(
       const reactions = repo.reactions(channel.id, message.id);
       for (const reaction of reactions) {
         const emojiRef = Model.emojiToRef(reaction.emoji);
-        let reactionWeight = emojiWeights[emojiRef];
-        if (reactionWeight === null || reactionWeight === undefined) {
-          reactionWeight = 1;
-        }
-
+        const reactionWeight = NullUtil.orElse(emojiWeights[emojiRef], 1);
         const reactingMember = memberMap.get(reaction.authorId);
+
         if (!reactingMember) {
           // Probably this user left the server.
           continue;
@@ -234,8 +232,9 @@ export function createGraph(
         let roleWeight = roleWeightConfig.defaultWeight;
         const roleWeights = roleWeightConfig.roleWeights;
         for (const roleRef of reactingMember.roles) {
-          if (roleWeights[roleRef] > roleWeight) {
-            roleWeight = roleWeights[roleRef];
+          const matchingWeight = roleWeights[roleRef];
+          if (matchingWeight != null && matchingWeight > roleWeight) {
+            roleWeight = matchingWeight;
           }
         }
 

--- a/src/plugins/experimental-discord/plugin.js
+++ b/src/plugins/experimental-discord/plugin.js
@@ -66,14 +66,15 @@ export class DiscordPlugin implements Plugin {
     rd: ReferenceDetector
   ): Promise<WeightedGraph> {
     const _ = rd; // TODO(#1808): not yet used
-    const {guildId, reactionWeights} = await loadConfig(ctx);
+    const {guildId, reactionWeights, roleWeights} = await loadConfig(ctx);
     const repo = await repository(ctx, guildId);
     const declarationWeights = weightsForDeclaration(declaration);
     return await createGraph(
       guildId,
       repo,
       declarationWeights,
-      reactionWeights
+      reactionWeights,
+      roleWeights
     );
   }
 

--- a/src/plugins/experimental-discord/plugin.js
+++ b/src/plugins/experimental-discord/plugin.js
@@ -69,12 +69,13 @@ export class DiscordPlugin implements Plugin {
     const {guildId, reactionWeights, roleWeightConfig} = await loadConfig(ctx);
     const repo = await repository(ctx, guildId);
     const declarationWeights = weightsForDeclaration(declaration);
+    const defaultRoleWeightConfig = {defaultWeight: 1, roleWeights: {}};
     return await createGraph(
       guildId,
       repo,
       declarationWeights,
       reactionWeights,
-      roleWeightConfig
+      roleWeightConfig || defaultRoleWeightConfig
     );
   }
 

--- a/src/plugins/experimental-discord/plugin.js
+++ b/src/plugins/experimental-discord/plugin.js
@@ -66,7 +66,7 @@ export class DiscordPlugin implements Plugin {
     rd: ReferenceDetector
   ): Promise<WeightedGraph> {
     const _ = rd; // TODO(#1808): not yet used
-    const {guildId, reactionWeights, roleWeights} = await loadConfig(ctx);
+    const {guildId, reactionWeights, roleWeightConfig} = await loadConfig(ctx);
     const repo = await repository(ctx, guildId);
     const declarationWeights = weightsForDeclaration(declaration);
     return await createGraph(
@@ -74,7 +74,7 @@ export class DiscordPlugin implements Plugin {
       repo,
       declarationWeights,
       reactionWeights,
-      roleWeights
+      roleWeightConfig
     );
   }
 


### PR DESCRIPTION
add to config, set user reaction weights based on highest role weight they have.
Also create a default weight property for users without specified roles.

Test Plan: all tests pass, ran on 1hive instance and sanity checked cred distribution