### PR TITLE
Scale back Dependabot run to once a week

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,5 +8,6 @@ updates:
   - package-ecosystem: "npm" # See documentation for possible values
     directory: "/" # Location of package manifests
     schedule:
-      interval: "daily"
-    open-pull-requests-limit: 10
+      interval: "weekly"
+      day: "saturday"
+    open-pull-requests-limit: 30


### PR DESCRIPTION
Rather than getting new rounds of pull requests every day, we'll get
them on Saturdays.

Rather than disabling this entirely, I think keeping dependencies up to
date on a weekly basis will mitigate the time spent reactively
troublehooting any dependency-related bugs that spring up.