### PR TITLE
credrank: precompute node/edge indices

### DIFF
--- a/src/core/credrank/compute.js
+++ b/src/core/credrank/compute.js
@@ -8,7 +8,6 @@ import {
   type PagerankOptions,
 } from "../algorithm/markovChain";
 
-import {type NodeAddressT} from "../graph";
 import {distributionToNodeDistribution} from "../algorithm/graphToMarkovChain";
 
 import {uniformDistribution} from "../algorithm/distribution";
@@ -50,16 +49,12 @@ export async function credrank(
       NullUtil.get(pi.get(n.address))
     )
   );
-  const cred: Map<NodeAddressT, number> = new Map();
   let totalNodeWeight = 0;
   for (const {mint: weight} of mpg.nodes()) {
     totalNodeWeight += weight;
   }
-  osmc.nodeOrder.forEach((node, index) => {
-    cred.set(
-      node,
-      (distributionResult.pi[index] / matchingScore) * totalNodeWeight
-    );
-  });
-  return new CredGraph(mpg, cred);
+  const scores = osmc.nodeOrder.map(
+    (_, i) => (distributionResult.pi[i] / matchingScore) * totalNodeWeight
+  );
+  return new CredGraph(mpg, scores);
 }

--- a/src/core/credrank/markovProcessGraph.test.js
+++ b/src/core/credrank/markovProcessGraph.test.js
@@ -400,6 +400,20 @@ describe("core/credrank/markovProcessGraph", () => {
       const edgesExpected = edgeOrder.map((x) => mpg.edge(x));
       expect(edgesActual).toEqual(edgesExpected);
     });
+    it("nodeIndex is consonant with nodeOrder", () => {
+      const mpg = markovProcessGraph();
+      const nodeOrder = [...mpg.nodeOrder()];
+      nodeOrder.forEach((n, i) => {
+        expect(mpg.nodeIndex(n)).toEqual(i);
+      });
+    });
+    it("edgeIndex is consonant with edgeOrder", () => {
+      const mpg = markovProcessGraph();
+      const edgeOrder = [...mpg.edgeOrder()];
+      edgeOrder.forEach((n, i) => {
+        expect(mpg.edgeIndex(n)).toEqual(i);
+      });
+    });
   });
 
   describe("to/froJSON", () => {


### PR DESCRIPTION
This modifies the MarkovProcessGraph so that we precompute node and edge
indices, since we wind up needing them in several cases. This also
allows us to simplify the CredGraph data structure.

Test plan: Tests pass, credrank results are stable.