### PR TITLE
credrank: collapse all radiation to a single type

### DIFF
--- a/src/core/credrank/edgeGadgets.js
+++ b/src/core/credrank/edgeGadgets.js
@@ -17,7 +17,6 @@ import {
 } from "./markovEdge";
 import {
   seedGadget,
-  type EpochAccumulatorAddress,
   accumulatorGadget,
   type ParticipantEpochAddress,
   epochGadget,
@@ -70,44 +69,12 @@ function makeSeedGadget<T>({
   return Object.freeze({prefix, toRaw, fromRaw, markovEdge});
 }
 
-export const contributionRadiationGadget: EdgeGadget<NodeAddressT> = makeSeedGadget(
-  {
-    edgePrefix: EdgeAddress.fromParts([
-      "sourcecred",
-      "core",
-      "CONTRIBUTION_RADIATION",
-    ]),
-    seedIsSrc: false,
-    toParts: (x) => NodeAddress.toParts(x),
-    fromParts: (x) => NodeAddress.fromParts(x),
-  }
-);
-
-export const accumulatorRadiationGadget: EdgeGadget<EpochAccumulatorAddress> = makeSeedGadget(
-  {
-    edgePrefix: EdgeAddress.fromParts([
-      "sourcecred",
-      "core",
-      "ACCUMULATOR_RADIATION",
-    ]),
-    seedIsSrc: false,
-    toParts: (x) => NodeAddress.toParts(accumulatorGadget.toRaw(x)),
-    fromParts: (x) => accumulatorGadget.fromRaw(NodeAddress.fromParts(x)),
-  }
-);
-
-export const epochRadiationGadget: EdgeGadget<ParticipantEpochAddress> = makeSeedGadget(
-  {
-    edgePrefix: EdgeAddress.fromParts([
-      "sourcecred",
-      "core",
-      "PARTICIPANT_EPOCH",
-    ]),
-    seedIsSrc: false,
-    toParts: (x) => NodeAddress.toParts(epochGadget.toRaw(x)),
-    fromParts: (x) => epochGadget.fromRaw(NodeAddress.fromParts(x)),
-  }
-);
+export const radiationGadget: EdgeGadget<NodeAddressT> = makeSeedGadget({
+  edgePrefix: EdgeAddress.fromParts(["sourcecred", "core", "RADIATION"]),
+  seedIsSrc: false,
+  toParts: (x) => NodeAddress.toParts(x),
+  fromParts: (x) => NodeAddress.fromParts(x),
+});
 
 export const seedMintGadget: EdgeGadget<NodeAddressT> = makeSeedGadget({
   edgePrefix: EdgeAddress.fromParts(["sourcecred", "core", "SEED_MINT"]),

--- a/src/core/credrank/markovProcessGraph.js
+++ b/src/core/credrank/markovProcessGraph.js
@@ -87,9 +87,7 @@ import {
 } from "./nodeGadgets";
 
 import {
-  accumulatorRadiationGadget,
-  epochRadiationGadget,
-  contributionRadiationGadget,
+  radiationGadget,
   seedMintGadget,
   payoutGadget,
   forwardWebbingGadget,
@@ -428,29 +426,7 @@ export class MarkovProcessGraph {
       const transitionProbability =
         1 - NullUtil.orElse(_nodeOutMasses.get(node.address), 0);
       if (node.address === seedGadget.prefix) continue;
-      if (NodeAddress.hasPrefix(node.address, epochGadget.prefix)) {
-        const target = epochGadget.fromRaw(node.address);
-        addEdge(epochRadiationGadget.markovEdge(target, transitionProbability));
-      } else if (
-        NodeAddress.hasPrefix(node.address, accumulatorGadget.prefix)
-      ) {
-        const target = accumulatorGadget.fromRaw(node.address);
-        addEdge(
-          accumulatorRadiationGadget.markovEdge(target, transitionProbability)
-        );
-      } else if (NodeAddress.hasPrefix(node.address, CORE_NODE_PREFIX)) {
-        throw new Error(
-          "invariant violation: unknown core node: " +
-            NodeAddress.toString(node.address)
-        );
-      } else {
-        addEdge(
-          contributionRadiationGadget.markovEdge(
-            node.address,
-            transitionProbability
-          )
-        );
-      }
+      addEdge(radiationGadget.markovEdge(node.address, transitionProbability));
     }
 
     return new MarkovProcessGraph(

--- a/src/core/credrank/markovProcessGraph.test.js
+++ b/src/core/credrank/markovProcessGraph.test.js
@@ -16,9 +16,7 @@ import {intervalSequence} from "../interval";
 
 import {seedGadget, accumulatorGadget, epochGadget} from "./nodeGadgets";
 import {
-  contributionRadiationGadget,
-  accumulatorRadiationGadget,
-  epochRadiationGadget,
+  radiationGadget,
   seedMintGadget,
   payoutGadget,
   forwardWebbingGadget,
@@ -225,10 +223,7 @@ describe("core/credrank/markovProcessGraph", () => {
         const mpg = markovProcessGraph();
         const organicNodes = [c0, c1];
         for (const {address} of organicNodes) {
-          const edge = contributionRadiationGadget.markovEdge(
-            address,
-            parameters.alpha
-          );
+          const edge = radiationGadget.markovEdge(address, parameters.alpha);
           checkMarkovEdge(mpg, edge);
         }
       });
@@ -272,8 +267,8 @@ describe("core/credrank/markovProcessGraph", () => {
             .set(Infinity, 1 - parameters.gammaBackward - parameters.beta)
             .get(boundary)
         );
-        const radiationEdgeExpected = epochRadiationGadget.markovEdge(
-          structuredAddress,
+        const radiationEdgeExpected = radiationGadget.markovEdge(
+          epochGadget.toRaw(structuredAddress),
           radiationTransitionProbability
         );
         checkMarkovEdge(mpg, radiationEdgeExpected);
@@ -342,8 +337,8 @@ describe("core/credrank/markovProcessGraph", () => {
         expect(mpg.node(accumulatorGadget.toRaw(accumulatorAddress))).toEqual(
           accumulatorGadget.node(accumulatorAddress)
         );
-        const radiationEdge = accumulatorRadiationGadget.markovEdge(
-          accumulatorAddress,
+        const radiationEdge = radiationGadget.markovEdge(
+          accumulatorGadget.toRaw(accumulatorAddress),
           1
         );
         checkMarkovEdge(mpg, radiationEdge);


### PR DESCRIPTION
This collapses the three radiation edge types (contribution,
accumulator, and epoch) into a single edge type and gadget. The
structure was very repetitive so I don't see any real benefit to giving
these edges separate types.

Test plan: Tests pass, cred scores are consistent