### PR TITLE
Discord Asymptotic Reaction Weights

### DIFF
--- a/src/plugins/experimental-discord/config.js
+++ b/src/plugins/experimental-discord/config.js
@@ -12,6 +12,11 @@ export type DiscordConfig = {|
   // go to the "Advanced" section and enable "Developer Mode".
   // Then right click on the server icon and choose "copy ID".
   +guildId: Model.Snowflake,
+  // Decay a member's subsequent reactions on the same message by powers of 2.
+  //
+  // This is to avoid spamming emojis on messages and small group collusion
+  // from producing outsized amounts of cred
+  +useAsymptoticReactionWeights?: boolean,
   // An object mapping a reaction to a weight, as in:
   // {
   //   "🥰": 16,
@@ -44,6 +49,7 @@ export const parser: Combo.Parser<DiscordConfig> = (() => {
       reactionWeights: C.dict(C.number),
     },
     {
+      useAsymptoticReactionWeights: C.boolean,
       roleWeightConfig: C.object({
         defaultWeight: C.number,
         roleWeights: C.dict(C.number),

--- a/src/plugins/experimental-discord/config.test.js
+++ b/src/plugins/experimental-discord/config.test.js
@@ -9,7 +9,7 @@ describe("plugins/experimental-discord/config", () => {
       useAsymptoticReactionWeights: true,
       reactionWeights: {
         "🥰": 4,
-        ":sourcecred:626763367893303303": 16,
+        "sourcecred:626763367893303303": 16,
       },
       roleWeightConfig: {
         defaultWeight: 0,

--- a/src/plugins/experimental-discord/config.test.js
+++ b/src/plugins/experimental-discord/config.test.js
@@ -6,6 +6,7 @@ describe("plugins/experimental-discord/config", () => {
   it("can load a basic config", () => {
     const raw = {
       guildId: "453243919774253079",
+      useAsymptoticReactionWeights: true,
       reactionWeights: {
         "🥰": 4,
         ":sourcecred:626763367893303303": 16,

--- a/src/plugins/experimental-discord/plugin.js
+++ b/src/plugins/experimental-discord/plugin.js
@@ -66,12 +66,18 @@ export class DiscordPlugin implements Plugin {
     rd: ReferenceDetector
   ): Promise<WeightedGraph> {
     const _ = rd; // TODO(#1808): not yet used
-    const {guildId, reactionWeights, roleWeightConfig} = await loadConfig(ctx);
+    const {
+      guildId,
+      useAsymptoticReactionWeights,
+      reactionWeights,
+      roleWeightConfig,
+    } = await loadConfig(ctx);
     const repo = await repository(ctx, guildId);
     const declarationWeights = weightsForDeclaration(declaration);
     const defaultRoleWeightConfig = {defaultWeight: 1, roleWeights: {}};
     return await createGraph(
       guildId,
+      useAsymptoticReactionWeights || false,
       repo,
       declarationWeights,
       reactionWeights,

--- a/src/plugins/experimental-discord/plugin.js
+++ b/src/plugins/experimental-discord/plugin.js
@@ -7,6 +7,7 @@ import type {PluginDeclaration} from "../../analysis/pluginDeclaration";
 import {parser, type DiscordConfig, type DiscordToken} from "./config";
 import {declaration} from "./declaration";
 import {join as pathJoin} from "path";
+import * as NullUtil from "../../util/null";
 import {type TaskReporter} from "../../util/taskReporter";
 import {Fetcher} from "./fetcher";
 import {Mirror} from "./mirror";
@@ -77,11 +78,11 @@ export class DiscordPlugin implements Plugin {
     const defaultRoleWeightConfig = {defaultWeight: 1, roleWeights: {}};
     return await createGraph(
       guildId,
-      useAsymptoticReactionWeights || false,
+      NullUtil.orElse(useAsymptoticReactionWeights, false),
       repo,
       declarationWeights,
       reactionWeights,
-      roleWeightConfig || defaultRoleWeightConfig
+      NullUtil.orElse(roleWeightConfig, defaultRoleWeightConfig)
     );
   }
 


### PR DESCRIPTION
This PR adds a flag to the discord config that switches discord reaction weights from being linear on the number of reacts to having an exponential decay making the total cred one member can mint on a single message roughly approach 2x the highest weight emoji, asymptotically.

The asymptoticReactionWeights function first separates reactions on a message by author. After this the reactions for a member are sorted from highest to lowest reaction weight. The function then calls a modified form of the old reaction weighting loop in 
the sharedReactionWeights function. Here there is a conditional to apply a weight dropoff, reducing each successive emoji weight by powers of 2. In the case where asymptotic weights are not applied, the sharedReactionWeights function is called directly, which has the old default behavior.

The motivation behind this feature is to reduce the effectiveness of discord members trying to cheat the cred system through light sybilling and/or long term small group collusion spamming huge numbers of emojis on each other's messages.

Test Plan: Tests pass locally, no errors when running on 1hive instance, sanity check cred against 1hive instance