### PR TITLE
feature: add channel weights to discord plugin

### DIFF
--- a/src/plugins/experimental-discord/config.js
+++ b/src/plugins/experimental-discord/config.js
@@ -24,12 +24,15 @@ export type DiscordConfig = {|
   +reactionWeights: EmojiWeightMap,
   // An object mapping a role to a weight, as in:
   // {
-  //   "default": 0,
-  //   "core:626763367893303303": 2,
-  //   "contributor:456763457893303303": 1,
+  //   "defaultWeight": 0,
+  //   "roleWeights": {
+  //     "759191073943191613": 0.5,
+  //     "762085832181153872": 1,
+  //     "698296035889381403": 1
+  //   }
   // }
-  // Note that roles have a snowflake identifier.
-  // default is used to set weights for members who don't have a specified role
+  // Note that roles use a snowflake id only.
+  // defaultWeight is used to set weights for members who don't have a specified role
   +roleWeightConfig: RoleWeightConfig,
 |};
 

--- a/src/plugins/experimental-discord/config.js
+++ b/src/plugins/experimental-discord/config.js
@@ -2,7 +2,7 @@
 
 import * as Combo from "../../util/combo";
 import * as Model from "./models";
-import {type EmojiWeightMap} from "./createGraph";
+import {type EmojiWeightMap, type RoleWeightConfig} from "./createGraph";
 
 export type {BotToken as DiscordToken} from "./models";
 
@@ -22,6 +22,15 @@ export type DiscordConfig = {|
   // You can get a custom emoji ID by right clicking the custom emoji and
   // copying it's URL, with the ID being the image file name.
   +reactionWeights: EmojiWeightMap,
+  // An object mapping a role to a weight, as in:
+  // {
+  //   "default": 0,
+  //   "core:626763367893303303": 2,
+  //   "contributor:456763457893303303": 1,
+  // }
+  // Note that roles have a snowflake identifier.
+  // default is used to set weights for members who don't have a specified role
+  +roleWeightConfig: RoleWeightConfig,
 |};
 
 export const parser: Combo.Parser<DiscordConfig> = (() => {
@@ -29,5 +38,9 @@ export const parser: Combo.Parser<DiscordConfig> = (() => {
   return C.object({
     guildId: C.string,
     reactionWeights: C.dict(C.number),
+    roleWeightConfig: C.object({
+      defaultWeight: C.number,
+      roleWeights: C.dict(C.number),
+    }),
   });
 })();

--- a/src/plugins/experimental-discord/config.js
+++ b/src/plugins/experimental-discord/config.js
@@ -2,7 +2,11 @@
 
 import * as Combo from "../../util/combo";
 import * as Model from "./models";
-import {type EmojiWeightMap, type RoleWeightConfig} from "./createGraph";
+import {
+  type EmojiWeightMap,
+  type RoleWeightConfig,
+  type ChannelWeightConfig,
+} from "./createGraph";
 
 export type {BotToken as DiscordToken} from "./models";
 
@@ -34,6 +38,16 @@ export type DiscordConfig = {|
   // Note that roles use a snowflake id only.
   // defaultWeight is used to set weights for members who don't have a specified role
   +roleWeightConfig: RoleWeightConfig,
+  // An object mapping a role to a weight, as in:
+  // {
+  //   "defaultWeight": 0,
+  //   "channelWeights": {
+  //     "759191073943191613": 0.25
+  //   }
+  // }
+  // Note that roles use a snowflake id only.
+  // defaultWeight is used to set weights for members who don't have a specified role
+  +channelWeightConfig: ChannelWeightConfig,
 |};
 
 export const parser: Combo.Parser<DiscordConfig> = (() => {
@@ -44,6 +58,10 @@ export const parser: Combo.Parser<DiscordConfig> = (() => {
     roleWeightConfig: C.object({
       defaultWeight: C.number,
       roleWeights: C.dict(C.number),
+    }),
+    channelWeightConfig: C.object({
+      defaultWeight: C.number,
+      channelWeights: C.dict(C.number),
     }),
   });
 })();

--- a/src/plugins/experimental-discord/config.test.js
+++ b/src/plugins/experimental-discord/config.test.js
@@ -13,8 +13,9 @@ describe("plugins/experimental-discord/config", () => {
       roleWeightConfig: {
         defaultWeight: 0,
         roleWeights: {
-          "core:626763367893303303": 2,
-          "contributor:456763457893303303": 1,
+          "759191073943191613": 0.5,
+          "762085832181153872": 1,
+          "698296035889381403": 1,
         },
       },
     };

--- a/src/plugins/experimental-discord/config.test.js
+++ b/src/plugins/experimental-discord/config.test.js
@@ -18,6 +18,12 @@ describe("plugins/experimental-discord/config", () => {
           "698296035889381403": 1,
         },
       },
+      channelWeightConfig: {
+        defaultWeight: 0,
+        channelWeights: {
+          "759191073943191613": 0.25,
+        },
+      },
     };
     const parsed: DiscordConfig = parser.parseOrThrow(raw);
     expect(parsed).toEqual(raw);

--- a/src/plugins/experimental-discord/config.test.js
+++ b/src/plugins/experimental-discord/config.test.js
@@ -10,6 +10,13 @@ describe("plugins/experimental-discord/config", () => {
         "🥰": 4,
         ":sourcecred:626763367893303303": 16,
       },
+      roleWeightConfig: {
+        defaultWeight: 0,
+        roleWeights: {
+          "core:626763367893303303": 2,
+          "contributor:456763457893303303": 1,
+        },
+      },
     };
     const parsed: DiscordConfig = parser.parseOrThrow(raw);
     expect(parsed).toEqual(raw);

--- a/src/plugins/experimental-discord/createGraph.js
+++ b/src/plugins/experimental-discord/createGraph.js
@@ -219,7 +219,10 @@ export function createGraph(
       const reactions = repo.reactions(channel.id, message.id);
       for (const reaction of reactions) {
         const emojiRef = Model.emojiToRef(reaction.emoji);
-        const reactionWeight = emojiWeights[emojiRef];
+        let reactionWeight = emojiWeights[emojiRef];
+        if (reactionWeight === null || reactionWeight === undefined) {
+          reactionWeight = 1;
+        }
 
         const reactingMember = memberMap.get(reaction.authorId);
         if (!reactingMember) {
@@ -228,7 +231,7 @@ export function createGraph(
         }
 
         // get the weight of the highest weight role the reacting user has
-        let roleWeight = roleWeightConfig.defaultWeight || 1;
+        let roleWeight = roleWeightConfig.defaultWeight;
         const roleWeights = roleWeightConfig.roleWeights;
         for (const roleRef of reactingMember.roles) {
           if (roleWeights[roleRef] > roleWeight) {
@@ -237,9 +240,7 @@ export function createGraph(
         }
 
         const node = reactionNode(reaction, message.timestampMs, guild);
-        if (reactionWeight != null) {
-          wg.weights.nodeWeights.set(node.address, roleWeight * reactionWeight);
-        }
+        wg.weights.nodeWeights.set(node.address, roleWeight * reactionWeight);
         wg.graph.addNode(node);
         wg.graph.addNode(memberNode(reactingMember));
         wg.graph.addEdge(reactsToEdge(reaction, message));

--- a/src/plugins/experimental-discord/createGraph.js
+++ b/src/plugins/experimental-discord/createGraph.js
@@ -1,6 +1,7 @@
 // @flow
 
 import {escape} from "entities";
+import * as NullUtil from "../../util/null";
 import {type WeightedGraph as WeightedGraphT} from "../../core/weightedGraph";
 import {type Weights, type NodeWeight} from "../../core/weights";
 import {
@@ -219,12 +220,9 @@ export function createGraph(
       const reactions = repo.reactions(channel.id, message.id);
       for (const reaction of reactions) {
         const emojiRef = Model.emojiToRef(reaction.emoji);
-        let reactionWeight = emojiWeights[emojiRef];
-        if (reactionWeight === null || reactionWeight === undefined) {
-          reactionWeight = 1;
-        }
-
+        const reactionWeight = NullUtil.orElse(emojiWeights[emojiRef], 1);
         const reactingMember = memberMap.get(reaction.authorId);
+
         if (!reactingMember) {
           // Probably this user left the server.
           continue;
@@ -234,8 +232,9 @@ export function createGraph(
         let roleWeight = roleWeightConfig.defaultWeight;
         const roleWeights = roleWeightConfig.roleWeights;
         for (const roleRef of reactingMember.roles) {
-          if (roleWeights[roleRef] > roleWeight) {
-            roleWeight = roleWeights[roleRef];
+          const matchingWeight = roleWeights[roleRef];
+          if (matchingWeight != null && matchingWeight > roleWeight) {
+            roleWeight = matchingWeight;
           }
         }
 

--- a/src/plugins/experimental-discord/plugin.js
+++ b/src/plugins/experimental-discord/plugin.js
@@ -66,7 +66,12 @@ export class DiscordPlugin implements Plugin {
     rd: ReferenceDetector
   ): Promise<WeightedGraph> {
     const _ = rd; // TODO(#1808): not yet used
-    const {guildId, reactionWeights, roleWeightConfig} = await loadConfig(ctx);
+    const {
+      guildId,
+      reactionWeights,
+      roleWeightConfig,
+      channelWeightConfig,
+    } = await loadConfig(ctx);
     const repo = await repository(ctx, guildId);
     const declarationWeights = weightsForDeclaration(declaration);
     return await createGraph(
@@ -74,7 +79,8 @@ export class DiscordPlugin implements Plugin {
       repo,
       declarationWeights,
       reactionWeights,
-      roleWeightConfig
+      roleWeightConfig,
+      channelWeightConfig
     );
   }
 

--- a/src/plugins/experimental-discord/plugin.js
+++ b/src/plugins/experimental-discord/plugin.js
@@ -66,14 +66,15 @@ export class DiscordPlugin implements Plugin {
     rd: ReferenceDetector
   ): Promise<WeightedGraph> {
     const _ = rd; // TODO(#1808): not yet used
-    const {guildId, reactionWeights} = await loadConfig(ctx);
+    const {guildId, reactionWeights, roleWeightConfig} = await loadConfig(ctx);
     const repo = await repository(ctx, guildId);
     const declarationWeights = weightsForDeclaration(declaration);
     return await createGraph(
       guildId,
       repo,
       declarationWeights,
-      reactionWeights
+      reactionWeights,
+      roleWeightConfig
     );
   }
 

--- a/src/ui/components/AdminApp.js
+++ b/src/ui/components/AdminApp.js
@@ -67,7 +67,7 @@ const customRoutes = (
       <AccountOverview currency={currency} />
     </Route>,
     <Route key="ledger" exact path="/ledger">
-      <LedgerViewer />
+      <LedgerViewer currency={currency} />
     </Route>,
   ];
   const backendRoutes = [

--- a/src/ui/components/LedgerViewer.js
+++ b/src/ui/components/LedgerViewer.js
@@ -1,10 +1,20 @@
 // @flow
 
-import React, {type Node as ReactNode, useMemo} from "react";
+import React, {
+  memo,
+  type Node as ReactNode,
+  useCallback,
+  useMemo,
+  useState,
+} from "react";
 import Table from "@material-ui/core/Table";
 import Typography from "@material-ui/core/Typography";
 import Box from "@material-ui/core/Box";
 import TableBody from "@material-ui/core/TableBody";
+import VisibilityIcon from "@material-ui/icons/Visibility";
+import Dialog from "@material-ui/core/Dialog";
+import * as G from "../../core/ledger/grain";
+import DialogContent from "@material-ui/core/DialogContent";
 import Tooltip from "@material-ui/core/Tooltip";
 import Chip from "@material-ui/core/Chip";
 import TableCell from "@material-ui/core/TableCell";
@@ -17,6 +27,8 @@ import {useLedger} from "../utils/LedgerContext";
 import {makeStyles} from "@material-ui/core/styles";
 import {formatTimestamp} from "../utils/dateHelpers";
 import type {IdentityId} from "../../core/identity/identity";
+import type {Allocation, GrainReceipt} from "../../core/ledger/grainAllocation";
+import type {CurrencyDetails} from "../../api/currencyConfig";
 
 const useStyles = makeStyles(() => {
   return {
@@ -25,14 +37,31 @@ const useStyles = makeStyles(() => {
       maxWidth: "60em",
       margin: "0 auto",
     },
+    dialog: {
+      paddingTop: "0 !important",
+      padding: 0,
+    },
   };
 });
 
-export const LedgerViewer = (): ReactNode => {
+export const LedgerViewer = ({
+  currency: {suffix: currencySuffix},
+}: {
+  currency: CurrencyDetails,
+}): ReactNode => {
   const {ledger} = useLedger();
   const classes = useStyles();
+  const [allocation, setAllocation] = useState<Allocation | null>(null);
 
-  const events = useMemo(() => ledger.eventLog(), [ledger]);
+  const handleClickOpen = useCallback((allocation: Allocation) => {
+    setAllocation(allocation);
+  }, []);
+
+  const handleClose = useCallback(() => {
+    setAllocation(null);
+  }, []);
+
+  const events = useMemo(() => [...ledger.eventLog()].reverse(), [ledger]);
 
   return (
     <TableContainer component={Paper} className={classes.container}>
@@ -46,16 +75,149 @@ export const LedgerViewer = (): ReactNode => {
         </TableHead>
         <TableBody>
           {events.map((e) => (
-            <LedgerEventRow key={e.uuid} event={e} ledger={ledger} />
+            <LedgerEventRow
+              key={e.uuid}
+              event={e}
+              ledger={ledger}
+              currencySuffix={currencySuffix}
+              handleClickOpen={handleClickOpen}
+            />
           ))}
         </TableBody>
       </Table>
+      <Dialog open={!!allocation} onClose={handleClose} scroll="paper">
+        <DialogContent className={classes.dialog}>
+          <GrainReceiptTable
+            allocation={allocation}
+            ledger={ledger}
+            currencySuffix={currencySuffix}
+          />
+        </DialogContent>
+      </Dialog>
     </TableContainer>
   );
 };
 
+function comparator(a: GrainReceipt, b: GrainReceipt) {
+  if (a.amount === b.amount) {
+    return 0;
+  }
+  return G.gt(a.amount, b.amount) ? -1 : 1;
+}
+
+const GrainReceiptTable = memo(
+  ({
+    allocation,
+    ledger,
+    currencySuffix,
+  }: {
+    allocation: Allocation | null,
+    ledger: Ledger,
+    currencySuffix: string,
+  }) => {
+    if (!allocation) return null;
+    return (
+      <Table stickyHeader>
+        <TableHead>
+          <TableRow>
+            <TableCell>Participant</TableCell>
+            <TableCell align="right">Amount</TableCell>
+          </TableRow>
+        </TableHead>
+        <TableBody>
+          {allocation
+            ? [...allocation.receipts].sort(comparator).map((r) => {
+                const account = ledger.account(r.id);
+
+                return (
+                  <TableRow key={r.id}>
+                    <TableCell component="th" scope="row">
+                      <IdentityDetails
+                        id={account.identity.id}
+                        name={account.identity.name}
+                      />
+                    </TableCell>
+                    <TableCell align="right">
+                      {G.format(r.amount, 4, currencySuffix)}
+                    </TableCell>
+                  </TableRow>
+                );
+              })
+            : null}
+        </TableBody>
+      </Table>
+    );
+  }
+);
+
+GrainReceiptTable.displayName = "GrainReceiptTable";
+
 const LedgerEventRow = React.memo(
-  ({event, ledger}: {event: LedgerEvent, ledger: Ledger}) => {
+  ({
+    event,
+    ledger,
+    currencySuffix,
+    handleClickOpen,
+  }: {
+    event: LedgerEvent,
+    ledger: Ledger,
+    currencySuffix: string,
+    handleClickOpen: (a: Allocation) => void,
+  }) => {
+    const {action} = event;
+    const getEventDetails = () => {
+      switch (action.type) {
+        case "CREATE_IDENTITY":
+          return (
+            <>
+              <IdentityDetails
+                id={action.identity.id}
+                name={action.identity.name}
+              />
+              <Chip label={action.identity.subtype} size="small" />
+            </>
+          );
+        case "TOGGLE_ACTIVATION":
+          try {
+            const account = ledger.account(action.identityId);
+            return (
+              <IdentityDetails
+                id={account.identity.id}
+                name={account.identity.name}
+              />
+            );
+          } catch (e) {
+            console.warn("Unable to find account for action: ", action);
+            return (
+              <IdentityDetails
+                id={action.identityId}
+                name="[Unknown Account]"
+              />
+            );
+          }
+        case "DISTRIBUTE_GRAIN":
+          return action.distribution.allocations.map((a, i) => (
+            <Box mr={2} key={`${a.policy.policyType}-${i}`}>
+              <Chip
+                label={`${a.policy.policyType}: ${G.format(
+                  a.policy.budget,
+                  0,
+                  currencySuffix
+                )}`}
+                clickable
+                onClick={() => handleClickOpen(a)}
+                onDelete={() => handleClickOpen(a)}
+                size="small"
+                deleteIcon={<VisibilityIcon />}
+              />
+            </Box>
+          ));
+
+        default:
+          return "";
+      }
+    };
+
     return (
       <TableRow>
         <TableCell component="th" scope="row">
@@ -65,7 +227,7 @@ const LedgerEventRow = React.memo(
         </TableCell>
         <TableCell>
           <Box display="flex" flexDirection="row" alignItems="center">
-            {getEventDetails(event, ledger)}
+            {getEventDetails()}
           </Box>
         </TableCell>
         <TableCell align="right">
@@ -90,37 +252,4 @@ const IdentityDetails = ({
       <Box mr={1}>{`${name}`}</Box>
     </Tooltip>
   );
-};
-
-const getEventDetails = ({action}: LedgerEvent, ledger: Ledger): ReactNode => {
-  switch (action.type) {
-    case "CREATE_IDENTITY":
-      return (
-        <>
-          <IdentityDetails
-            id={action.identity.id}
-            name={action.identity.name}
-          />
-          <Chip label={action.identity.subtype} size="small" />
-        </>
-      );
-    case "TOGGLE_ACTIVATION":
-      try {
-        const account = ledger.account(action.identityId);
-        return (
-          <IdentityDetails
-            id={account.identity.id}
-            name={account.identity.name}
-          />
-        );
-      } catch (e) {
-        console.warn("Unable to find account for action: ", action);
-        return (
-          <IdentityDetails id={action.identityId} name="[Unknown Account]" />
-        );
-      }
-
-    default:
-      return "";
-  }
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -4608,10 +4608,10 @@ extsprintf@^1.2.0:
   resolved "https://registry.yarnpkg.com/extsprintf/-/extsprintf-1.4.0.tgz#e2689f8f356fad62cca65a3a91c5df5f9551692f"
   integrity sha1-4mifjzVvrWLMplo6kcXfX5VRaS8=
 
-fakerest@~2.1.0:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/fakerest/-/fakerest-2.1.0.tgz#f66d0b8fbae7455efa7c666e3f6cdeec70a83860"
-  integrity sha512-c5x7iayu46Qa/h/W7k3PJiElNc56yxCkWY4mxs38be/D9YNfQSy8fn8xtlIPYGIUxDHAcpmVF9YXrA/SqJp1cA==
+fakerest@^2.2.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/fakerest/-/fakerest-2.2.0.tgz#68fc7663baee9243d998dcdb20c9f555ae7b6065"
+  integrity sha512-6ByPB2f7NfK7UJ7W4xt2oz6Cq/gefYCV5NJTCkDmZS+hh2scheLl7eLqOCmdx/yw67JinTvG8TgOufjhkM0UOg==
   dependencies:
     babel-runtime "^6.22.0"
 
@@ -8505,10 +8505,10 @@ querystringify@^2.1.1:
   resolved "https://registry.yarnpkg.com/querystringify/-/querystringify-2.1.1.tgz#60e5a5fd64a7f8bfa4d2ab2ed6fdf4c85bad154e"
   integrity sha512-w7fLxIRCRT7U8Qu53jQnJyPkYZIaR4n5151KMfcJlO/A9397Wxb1amJvROTK6TOnp7PfoAmg/qXiNHI+08jRfA==
 
-ra-core@^3.8.5:
-  version "3.8.5"
-  resolved "https://registry.yarnpkg.com/ra-core/-/ra-core-3.8.5.tgz#d39c3bfe6eaa60ad06509e72f63591ac5540039e"
-  integrity sha512-TLZqREIb5B1lZGJDOBmu1+SN+kXgHQSVjp5KWW1/AOvw1N99uCkciOKnWiF8LBkCCvM/zNREFIV/Yh6FTf2Rlw==
+ra-core@^3.9.3:
+  version "3.9.3"
+  resolved "https://registry.yarnpkg.com/ra-core/-/ra-core-3.9.3.tgz#9721f9904a6eb8bbe5e98f1f9ba563a7cb6ebafd"
+  integrity sha512-bVENEjoY9n2LLMrj9WlQGoTS6n8uheatcj1NSuSFH5u2CeU/JpKrThJpmhrFjDPXwQo5UoGdhJv9DQ0NJOnN3w==
   dependencies:
     "@testing-library/react" "^8.0.7"
     classnames "~2.2.5"
@@ -8521,31 +8521,31 @@ ra-core@^3.8.5:
     reselect "~3.0.0"
 
 ra-data-fakerest@^3.6.2:
-  version "3.6.2"
-  resolved "https://registry.yarnpkg.com/ra-data-fakerest/-/ra-data-fakerest-3.6.2.tgz#07412bae43993947fd067a75cb4a49cda3bad158"
-  integrity sha512-lYZb039YLCZBXowM5nRMfsQ6kRosHBb3O2O+g7Q7/dbeORMXvWPVULBa31tRks25kp9AKnEgbEROQy+KGc7Q1Q==
+  version "3.9.3"
+  resolved "https://registry.yarnpkg.com/ra-data-fakerest/-/ra-data-fakerest-3.9.3.tgz#5c00b8b890feaa441fd971c8444b44d6ea188cee"
+  integrity sha512-yIZx38mcUqtmczU1Ws2PRnqhN+1AMuBa+4Cp96N9K/A0Z0wAEBvsnYun/14wIJYntshFeJ1PhiJL56EQy86aXw==
   dependencies:
-    fakerest "~2.1.0"
+    fakerest "^2.2.0"
 
-ra-i18n-polyglot@^3.8.5:
-  version "3.8.5"
-  resolved "https://registry.yarnpkg.com/ra-i18n-polyglot/-/ra-i18n-polyglot-3.8.5.tgz#f59a17a757234add7164cbce6fc0a95a925f0065"
-  integrity sha512-ck3g3eZHb5jm0IdKpljSyMvlcH38esjFJBbGxKoGx8sQM3v0T1TtnErI2/s+VGTPFC53n5jqnjKPbfzqV7js/g==
+ra-i18n-polyglot@^3.9.3:
+  version "3.9.3"
+  resolved "https://registry.yarnpkg.com/ra-i18n-polyglot/-/ra-i18n-polyglot-3.9.3.tgz#5802605ebecc125f0d1c900157b0d959d5a9512b"
+  integrity sha512-NrZiNYIHR4cm74bQMjGJxWmkzUZZ9XbnVV0GRKcx0xZYNPmIrWKr/ZClHABgEDX40DY+J2409swIhPpReaVTUg==
   dependencies:
     node-polyglot "^2.2.2"
-    ra-core "^3.8.5"
+    ra-core "^3.9.3"
 
-ra-language-english@^3.8.5:
-  version "3.8.5"
-  resolved "https://registry.yarnpkg.com/ra-language-english/-/ra-language-english-3.8.5.tgz#d31f40a7836972fe252c3c98643f246afde24899"
-  integrity sha512-j8O/AMGQaEWzRyQpY1tU3erCozmPdX0AHE+tZM7hNBY34MGmIeqhnySc7o7rBN4gS8vGU1tIejgld8xu0QOMdg==
+ra-language-english@^3.9.3:
+  version "3.9.3"
+  resolved "https://registry.yarnpkg.com/ra-language-english/-/ra-language-english-3.9.3.tgz#469ee3a3bc42eaaac9ed9b5afa989f7134bc011f"
+  integrity sha512-ITzy/JR+2UGZpXjKDkfHnKyxc1u1UQTFI9YQg+T/Lpo6JSVI8NOCIkPPxZu0t5VcELJKIsf+SC81MsXngf+g5Q==
   dependencies:
-    ra-core "^3.8.5"
+    ra-core "^3.9.3"
 
-ra-ui-materialui@^3.8.5:
-  version "3.8.5"
-  resolved "https://registry.yarnpkg.com/ra-ui-materialui/-/ra-ui-materialui-3.8.5.tgz#3e449befd135c3da7d192dfa629355f0696fae03"
-  integrity sha512-xe0KznjJNy5hJZH+MHLnKPZhp9WvEoORZJv6TpI5tOWPuTRxrT6xrDt3WtwdDJ4SDau5AjUu+4duyjwPsERn9A==
+ra-ui-materialui@^3.9.3:
+  version "3.9.3"
+  resolved "https://registry.yarnpkg.com/ra-ui-materialui/-/ra-ui-materialui-3.9.3.tgz#f8e245212ffc2716b0dd0bb778d0e099c85ce1f0"
+  integrity sha512-+ENBWlE/j5m9fmDwEgAX1J5WEHZR4XKWq6x7vdgv8eCkMiFzmo0UkC9HCe82dXLY7BFvz03DSTUpXY7cgjOsUQ==
   dependencies:
     autosuggest-highlight "^3.1.1"
     classnames "~2.2.5"
@@ -8631,9 +8631,9 @@ rc@^1.2.7:
     strip-json-comments "~2.0.1"
 
 react-admin@^3.6.2:
-  version "3.8.5"
-  resolved "https://registry.yarnpkg.com/react-admin/-/react-admin-3.8.5.tgz#37418758455544617a189f3bcc822567f5309750"
-  integrity sha512-jTxZG7E3efVNZ4MGgBnlYm/dw5m63S+sgHcOw+mlh4xTch8KZgwlJxik59Rejtm2K8bjR2yc4p91XZw83IlwUA==
+  version "3.9.3"
+  resolved "https://registry.yarnpkg.com/react-admin/-/react-admin-3.9.3.tgz#fec68af55b5511e792f57a255cf1b4899b254549"
+  integrity sha512-ibgyK6ODZC9yiKhetOipwQPPbuUkwKBB55DnTEoruLJpPINzcRUWKxEVGVMZfTRSeKjRNeZTTVYipx4SRnKfSg==
   dependencies:
     "@material-ui/core" "^4.3.3"
     "@material-ui/icons" "^4.2.1"
@@ -8641,10 +8641,10 @@ react-admin@^3.6.2:
     connected-react-router "^6.5.2"
     final-form "^4.18.5"
     final-form-arrays "^3.0.1"
-    ra-core "^3.8.5"
-    ra-i18n-polyglot "^3.8.5"
-    ra-language-english "^3.8.5"
-    ra-ui-materialui "^3.8.5"
+    ra-core "^3.9.3"
+    ra-i18n-polyglot "^3.9.3"
+    ra-language-english "^3.9.3"
+    ra-ui-materialui "^3.9.3"
     react-final-form "^6.3.3"
     react-final-form-arrays "^3.1.1"
     react-redux "^7.1.0"


### PR DESCRIPTION
This PR builds on #2390. It adds the functionality to set weights to channels, along with a default property for the ones that are not weighted in the config.

I ran this plugin on the current 1Hive instance, sanity checked with @befitsandpiper and all tests are passing.