### PR TITLE
feature: add channel weights to discord plugin

### DIFF
--- a/src/plugins/experimental-discord/config.js
+++ b/src/plugins/experimental-discord/config.js
@@ -2,7 +2,11 @@
 
 import * as Combo from "../../util/combo";
 import * as Model from "./models";
-import {type EmojiWeightMap, type RoleWeightConfig} from "./createGraph";
+import {
+  type EmojiWeightMap,
+  type RoleWeightConfig,
+  type ChannelWeightConfig,
+} from "./createGraph";
 
 export type {BotToken as DiscordToken} from "./models";
 
@@ -34,6 +38,16 @@ export type DiscordConfig = {|
   // Note that roles use a snowflake id only.
   // defaultWeight is used to set weights for members who don't have a specified role
   +roleWeightConfig?: RoleWeightConfig,
+  // An object mapping a role to a weight, as in:
+  // {
+  //   "defaultWeight": 0,
+  //   "channelWeights": {
+  //     "759191073943191613": 0.25
+  //   }
+  // }
+  // Note that channels use a snowflake id only.
+  // defaultWeight is used to set weights for channels that don't have a specified weight
+  +channelWeightConfig?: ChannelWeightConfig,
 |};
 
 export const parser: Combo.Parser<DiscordConfig> = (() => {
@@ -47,6 +61,10 @@ export const parser: Combo.Parser<DiscordConfig> = (() => {
       roleWeightConfig: C.object({
         defaultWeight: C.number,
         roleWeights: C.dict(C.number),
+      }),
+      channelWeightConfig: C.object({
+        defaultWeight: C.number,
+        channelWeights: C.dict(C.number),
       }),
     }
   );

--- a/src/plugins/experimental-discord/config.js
+++ b/src/plugins/experimental-discord/config.js
@@ -38,7 +38,7 @@ export type DiscordConfig = {|
   // Note that roles use a snowflake id only.
   // defaultWeight is used to set weights for members who don't have a specified role
   +roleWeightConfig?: RoleWeightConfig,
-  // An object mapping a role to a weight, as in:
+  // An object mapping a channel to a weight, as in:
   // {
   //   "defaultWeight": 0,
   //   "channelWeights": {

--- a/src/plugins/experimental-discord/config.test.js
+++ b/src/plugins/experimental-discord/config.test.js
@@ -18,6 +18,12 @@ describe("plugins/experimental-discord/config", () => {
           "698296035889381403": 1,
         },
       },
+      channelWeightConfig: {
+        defaultWeight: 0,
+        channelWeights: {
+          "759191073943191613": 0.25,
+        },
+      },
     };
     const parsed: DiscordConfig = parser.parseOrThrow(raw);
     expect(parsed).toEqual(raw);

--- a/src/plugins/experimental-discord/createGraph.js
+++ b/src/plugins/experimental-discord/createGraph.js
@@ -189,10 +189,16 @@ function mentionsEdge(message: Model.Message, member: Model.GuildMember): Edge {
 
 export type EmojiWeightMap = {[ref: Model.EmojiRef]: NodeWeight};
 export type RoleWeightMap = {[ref: Model.Snowflake]: NodeWeight};
+export type ChannelWeightMap = {[ref: Model.Snowflake]: NodeWeight};
 
 export type RoleWeightConfig = {|
   +defaultWeight: number,
   +roleWeights: RoleWeightMap,
+|};
+
+export type ChannelWeightConfig = {|
+  +defaultWeight: number,
+  +channelWeights: ChannelWeightMap,
 |};
 
 export function createGraph(
@@ -200,7 +206,8 @@ export function createGraph(
   repo: SqliteMirrorRepository,
   declarationWeights: Weights,
   emojiWeights: EmojiWeightMap,
-  roleWeightConfig: RoleWeightConfig
+  roleWeightConfig: RoleWeightConfig,
+  channelWeightConfig: ChannelWeightConfig
 ): WeightedGraphT {
   const wg = {
     graph: new Graph(),
@@ -238,8 +245,17 @@ export function createGraph(
           }
         }
 
+        // get the weight of a given channel
+        const channelWeights = channelWeightConfig.channelWeights;
+        const channelWeight =
+          channelWeights[reaction.channelId] ||
+          channelWeightConfig.defaultWeight;
+
         const node = reactionNode(reaction, message.timestampMs, guild);
-        wg.weights.nodeWeights.set(node.address, roleWeight * reactionWeight);
+        wg.weights.nodeWeights.set(
+          node.address,
+          channelWeight * roleWeight * reactionWeight
+        );
         wg.graph.addNode(node);
         wg.graph.addNode(memberNode(reactingMember));
         wg.graph.addEdge(reactsToEdge(reaction, message));

--- a/src/plugins/experimental-discord/createGraph.js
+++ b/src/plugins/experimental-discord/createGraph.js
@@ -247,9 +247,10 @@ export function createGraph(
 
         // get the weight of a given channel
         const channelWeights = channelWeightConfig.channelWeights;
-        const channelWeight =
-          channelWeights[reaction.channelId] ||
-          channelWeightConfig.defaultWeight;
+        const channelWeight = NullUtil.orElse(
+          channelWeights[reaction.channelId],
+          channelWeightConfig.defaultWeight
+        );
 
         const node = reactionNode(reaction, message.timestampMs, guild);
         wg.weights.nodeWeights.set(

--- a/src/plugins/experimental-discord/plugin.js
+++ b/src/plugins/experimental-discord/plugin.js
@@ -66,16 +66,24 @@ export class DiscordPlugin implements Plugin {
     rd: ReferenceDetector
   ): Promise<WeightedGraph> {
     const _ = rd; // TODO(#1808): not yet used
-    const {guildId, reactionWeights, roleWeightConfig} = await loadConfig(ctx);
+    const {
+      guildId,
+      reactionWeights,
+      roleWeightConfig,
+      channelWeightConfig,
+    } = await loadConfig(ctx);
     const repo = await repository(ctx, guildId);
     const declarationWeights = weightsForDeclaration(declaration);
     const defaultRoleWeightConfig = {defaultWeight: 1, roleWeights: {}};
+    const defaultChannelWeightConfig = {defaultWeight: 1, channelWeights: {}};
+
     return await createGraph(
       guildId,
       repo,
       declarationWeights,
       reactionWeights,
-      roleWeightConfig || defaultRoleWeightConfig
+      roleWeightConfig || defaultRoleWeightConfig,
+      channelWeightConfig || defaultChannelWeightConfig
     );
   }
 

--- a/src/plugins/experimental-discord/plugin.js
+++ b/src/plugins/experimental-discord/plugin.js
@@ -21,6 +21,7 @@ import {
   fromString as pluginIdFromString,
 } from "../../api/pluginId";
 import {loadJson} from "../../util/disk";
+import * as NullUtil from "../../util/null";
 import {createIdentities} from "./createIdentities";
 import type {IdentityProposal} from "../../core/ledger/identityProposal";
 
@@ -82,8 +83,8 @@ export class DiscordPlugin implements Plugin {
       repo,
       declarationWeights,
       reactionWeights,
-      roleWeightConfig || defaultRoleWeightConfig,
-      channelWeightConfig || defaultChannelWeightConfig
+      NullUtil.orElse(roleWeightConfig, defaultRoleWeightConfig),
+      NullUtil.orElse(channelWeightConfig, defaultChannelWeightConfig)
     );
   }
 


### PR DESCRIPTION
This PR builds on #2390. It adds the functionality to set weights to channels, along with a default property for the ones that are not weighted in the config.

I ran this plugin on the current 1Hive instance, sanity checked with @befitsandpiper and all tests are passing.