### PR TITLE
Eth Plugin: Create the EthAddress type and helpers

### DIFF
--- a/src/plugins/ethereum/ethAddress.js
+++ b/src/plugins/ethereum/ethAddress.js
@@ -1,0 +1,39 @@
+// @flow
+
+import {isAddress, toChecksumAddress} from "web3-utils";
+
+import * as C from "../../util/combo";
+import {compatibleParser} from "../../util/compat";
+
+export opaque type EthAddress: string = string;
+
+export function parseAddress(s: string): EthAddress {
+  if (!isAddress(s)) {
+    throw new Error(`not a valid ethereum address: ${s}`);
+  }
+  return toChecksumAddress(s);
+}
+
+// Utilized for a more readable and recognizable address. This is
+// needed to allow the address to fit within the Identity name requirements
+export function truncateEthAddress(address: EthAddress): string {
+  const prefix = address.slice(0, 6);
+  const suffix = address.slice(-4);
+  return `${prefix}...${suffix}`;
+}
+
+export const ethAddressParser: C.Parser<EthAddress> = C.fmap(
+  C.string,
+  parseAddress
+);
+
+export const COMPAT_INFO = {
+  type: "sourcecred/ethAddressFile",
+  version: "0.0.1",
+};
+
+const addressEntriesParser = C.array(ethAddressParser);
+
+export const parser: C.Parser<
+  Array<EthAddress>
+> = compatibleParser(COMPAT_INFO.type, {"0.0.1": addressEntriesParser});

--- a/src/plugins/ethereum/ethAddress.js
+++ b/src/plugins/ethereum/ethAddress.js
@@ -28,7 +28,7 @@ export const ethAddressParser: C.Parser<EthAddress> = C.fmap(
 );
 
 export const COMPAT_INFO = {
-  type: "sourcecred/ethAddressFile",
+  type: "sourcecred/ethAddress",
   version: "0.0.1",
 };
 

--- a/src/plugins/ethereum/ethAddress.js
+++ b/src/plugins/ethereum/ethAddress.js
@@ -7,6 +7,27 @@ import {compatibleParser} from "../../util/compat";
 
 export opaque type EthAddress: string = string;
 
+/**
+ * parseAddress will accept any 20-byte hexadecimal ethereum address encoded as
+ * a string, optionally prefixed with `0x`.
+ *
+ * Per EIP-55 (https://eips.ethereum.org/EIPS/eip-55), parseAddress throws if
+ * the provided string is mixed-case but not checksum-encoded. All valid
+ * addresses in lower- and upper-case format will not throw.
+ *
+ * For consistency, all valid addresses are converted and returned in
+ * mixed-case form with the `0x` prefix included
+ *
+ * valid formats:
+ * "2Ccc7cD913677553766873483ed9eEDdB77A0Bb0"
+ * "0x2Ccc7cD913677553766873483ed9eEDdB77A0Bb0"
+ * "0X2CCC7CD913677553766873483ED9EEDDB77A0BB0"
+ * "0x2ccc7cd913677553766873483ed9eeddb77a0bb0"
+ *
+ * invalid formats:
+ * "0x2ccc7cD913677553766873483ed9eEDdB77A0Bb0"
+ * "2ccc7cD913677553766873483ed9eEDdB77A0Bb0"
+ */
 export function parseAddress(s: string): EthAddress {
   if (!isAddress(s)) {
     throw new Error(`not a valid ethereum address: ${s}`);

--- a/src/plugins/ethereum/ethAddress.test.js
+++ b/src/plugins/ethereum/ethAddress.test.js
@@ -17,6 +17,10 @@ describe("plugins/ethereum/ethAddress", () => {
         "0x2Ccc7cD913677553766873483ed9eEDdB77A0Bb0",
         "0x2Ccc7cD913677553766873483ed9eEDdB77A0Bb0".toUpperCase(),
         "0x2Ccc7cD913677553766873483ed9eEDdB77A0Bb0".toLowerCase(),
+        // upper-case with lower-cased `0x`
+        "0x2CCC7CD913677553766873483ED9EEDDB77A0BB0",
+        // lower-case with upper-cased `0x`
+        "0X2ccc7cd913677553766873483ed9eeddb77a0bb0",
       ].forEach((a: string) => {
         expect(parseAddress(a)).toBe(
           "0x2Ccc7cD913677553766873483ed9eEDdB77A0Bb0"
@@ -26,10 +30,11 @@ describe("plugins/ethereum/ethAddress", () => {
     it("throws when attempting to parse a malformed address", () => {
       [
         "0x",
-        // malformed mixed-case
-        "0x2ccc7cD913677553766873483ed9eEDdB77A0Bb0",
         "abc123",
         "",
+        // malformed mixed-case
+        "0x2ccc7cD913677553766873483ed9eEDdB77A0Bb0",
+        "2ccc7cD913677553766873483ed9eEDdB77A0Bb0",
       ].forEach((a: string) => {
         expect(() => parseAddress(a)).toThrow(
           `not a valid ethereum address: ${a}`
@@ -38,13 +43,17 @@ describe("plugins/ethereum/ethAddress", () => {
     });
   });
 
-  describe("truncateEthAddres", () => {
+  describe("truncateEthAddress", () => {
     it("creates well-formed truncated addresses", () => {
       [
-        //$FlowExpectedError[incompatible-type]
-        ["0x2Ccc7cD913677553766873483ed9eEDdB77A0Bb0", "0x2Ccc...0Bb0"],
-        //$FlowExpectedError[incompatible-type]
-        ["0xb4124cEB3451635DAcedd11767f004d8a28c6eE7", "0xb412...6eE7"],
+        [
+          parseAddress("0x2Ccc7cD913677553766873483ed9eEDdB77A0Bb0"),
+          "0x2Ccc...0Bb0",
+        ],
+        [
+          parseAddress("0xb4124cEB3451635DAcedd11767f004d8a28c6eE7"),
+          "0xb412...6eE7",
+        ],
       ].forEach(([a, t]: [EthAddress, string]) => {
         expect(truncate(a)).toBe(t);
       });

--- a/src/plugins/ethereum/ethAddress.test.js
+++ b/src/plugins/ethereum/ethAddress.test.js
@@ -1,0 +1,65 @@
+// @flow
+
+import {
+  parseAddress,
+  truncateEthAddress as truncate,
+  COMPAT_INFO,
+  parser,
+  type EthAddress,
+} from "./ethAddress";
+import {toCompat} from "../../util/compat";
+
+describe("plugins/ethereum/ethAddress", () => {
+  describe("parseAddress", () => {
+    it("can parse a well-formed ethereum address", () => {
+      [
+        "2Ccc7cD913677553766873483ed9eEDdB77A0Bb0",
+        "0x2Ccc7cD913677553766873483ed9eEDdB77A0Bb0",
+        "0x2Ccc7cD913677553766873483ed9eEDdB77A0Bb0".toUpperCase(),
+        "0x2Ccc7cD913677553766873483ed9eEDdB77A0Bb0".toLowerCase(),
+      ].forEach((a: string) => {
+        expect(parseAddress(a)).toBe(
+          "0x2Ccc7cD913677553766873483ed9eEDdB77A0Bb0"
+        );
+      });
+    });
+    it("throws when attempting to parse a malformed address", () => {
+      [
+        "0x",
+        // malformed mixed-case
+        "0x2ccc7cD913677553766873483ed9eEDdB77A0Bb0",
+        "abc123",
+        "",
+      ].forEach((a: string) => {
+        expect(() => parseAddress(a)).toThrow(
+          `not a valid ethereum address: ${a}`
+        );
+      });
+    });
+  });
+
+  describe("truncateEthAddres", () => {
+    it("creates well-formed truncated addresses", () => {
+      [
+        //$FlowExpectedError[incompatible-type]
+        ["0x2Ccc7cD913677553766873483ed9eEDdB77A0Bb0", "0x2Ccc...0Bb0"],
+        //$FlowExpectedError[incompatible-type]
+        ["0xb4124cEB3451635DAcedd11767f004d8a28c6eE7", "0xb412...6eE7"],
+      ].forEach(([a, t]: [EthAddress, string]) => {
+        expect(truncate(a)).toBe(t);
+      });
+    });
+  });
+
+  describe("compatible JsonLog", () => {
+    const address1 = "0x2Ccc7cD913677553766873483ed9eEDdB77A0Bb0";
+    const address2 = "0xb4124cEB3451635DAcedd11767f004d8a28c6eE7";
+    const address3 = "0x8401Eb5ff34cc943f096A32EF3d5113FEbE8D4Eb";
+    const addressArray = [address1, address2, address3];
+    it("can create an exported JsonLog instance", () => {
+      const compatibleEthLog = toCompat(COMPAT_INFO, addressArray);
+      const result = parser.parseOrThrow(compatibleEthLog).values();
+      expect(Array.from(result)).toEqual(addressArray);
+    });
+  });
+});

--- a/src/plugins/ethereum/ethAddress.test.js
+++ b/src/plugins/ethereum/ethAddress.test.js
@@ -51,15 +51,15 @@ describe("plugins/ethereum/ethAddress", () => {
     });
   });
 
-  describe("compatible JsonLog", () => {
+  describe("compatible ethAddress", () => {
     const address1 = "0x2Ccc7cD913677553766873483ed9eEDdB77A0Bb0";
     const address2 = "0xb4124cEB3451635DAcedd11767f004d8a28c6eE7";
     const address3 = "0x8401Eb5ff34cc943f096A32EF3d5113FEbE8D4Eb";
     const addressArray = [address1, address2, address3];
-    it("can create an exported JsonLog instance", () => {
+    it("can create an exported ethAddress instance", () => {
       const compatibleEthLog = toCompat(COMPAT_INFO, addressArray);
-      const result = parser.parseOrThrow(compatibleEthLog).values();
-      expect(Array.from(result)).toEqual(addressArray);
+      const result = parser.parseOrThrow(compatibleEthLog);
+      expect(result).toEqual(addressArray);
     });
   });
 });

--- a/src/plugins/ethereum/ethAddress.test.js
+++ b/src/plugins/ethereum/ethAddress.test.js
@@ -65,7 +65,7 @@ describe("plugins/ethereum/ethAddress", () => {
     const address2 = "0xb4124cEB3451635DAcedd11767f004d8a28c6eE7";
     const address3 = "0x8401Eb5ff34cc943f096A32EF3d5113FEbE8D4Eb";
     const addressArray = [address1, address2, address3];
-    it("can create an exported ethAddress instance", () => {
+    it("can create a parseable ethAddress compat array", () => {
       const compatibleEthLog = toCompat(COMPAT_INFO, addressArray);
       const result = parser.parseOrThrow(compatibleEthLog);
       expect(result).toEqual(addressArray);


### PR DESCRIPTION
EthAddresses types represent ethereum addresses. They are stored in the ethereum plugin in a registry file.

This is one of a series of PRs that implements the snapshot-tested skeleton of the Ethereum address plugin:
- #2418 (this one)
- #2419: Scaffolding
- #2420: integrate plugin into instance snapshot tests

The immediate purpose of this plugin is to act as a backend store for provably owned ethereum addresses. 

**User story this work supports:** In self-service admin, users will be able to prove ownership of these addresses by submitting a message signed with the address' private key. The admin service will attempt to verify the signature, and if successful, the address will be added to the store and the identity in the identity asserted in the message will be created if it doesn't exist and possibly linked if prior ownership of the existing Identity has been established. I'm working in conjunction with @hammadj to implement this story.

For now, these addresses are intended to just be an identity alias for participants
primarily for the purpose of authenticating in a self-service frontend.

Under the hood, eth addresses are serialized into a jsonArray in the plugin config.
Serialized compat files don't preserve the readability of jsonLogs, so
there is little reason to utilize it now. Some compat serialization
logic is needed to preserve readability. This will be important to
implement before wider release in order to better accomodate readable
diffs in a UI and within Git.

test plan: unit tests are provided for the functions utilized by
parsers.