### PR TITLE
Update max name length to 42 chars

### DIFF
--- a/src/core/identity/name.js
+++ b/src/core/identity/name.js
@@ -14,8 +14,8 @@ import * as C from "../../util/combo";
 export opaque type Name: string = string;
 const NAME_PATTERN = /^[A-Za-z0-9-]+$/;
 
-// Based on GitHub's requirements.
-const MAXIMUM_NAME_LENGTH = 39;
+// Based on the length of an Ethereum address (with '0x' prefix)
+const MAXIMUM_NAME_LENGTH = 42;
 
 /**
  * Parse a Name from a string.

--- a/src/core/identity/name.test.js
+++ b/src/core/identity/name.test.js
@@ -5,7 +5,7 @@ import {nameFromString, coerce} from "./name";
 describe("core/identity/name", () => {
   describe("nameFromString", () => {
     it("fails on very long names", () => {
-      const bad = "1234567890123456789012345678901234567890";
+      const bad = "1234567890123456789012345678901234567890123";
       expect(() => nameFromString(bad)).toThrowError("too long");
     });
     it("fails on names with invalid characters", () => {
@@ -45,7 +45,7 @@ describe("core/identity/name", () => {
     it("still fails on names with invalid length", () => {
       const t1 = () => coerce("");
       expect(t1).toThrowError("invalid name");
-      const t2 = () => coerce("1234567890123456789012345678901234567890");
+      const t2 = () => coerce("1234567890123456789012345678901234567890123");
       expect(t2).toThrowError("too long");
     });
   });

--- a/src/core/identity/name.test.js
+++ b/src/core/identity/name.test.js
@@ -22,7 +22,13 @@ describe("core/identity/name", () => {
       }
     });
     it("succeeds on valid names", () => {
-      const names = ["h", "hi-there", "ZaX99324cab"];
+      const names = [
+        "h",
+        "hi-there",
+        "ZaX99324cab",
+        // full ethereum address
+        "0xb4124cEB3451635DAcedd11767f004d8a28c6eE7",
+      ];
       for (const n of names) {
         expect(nameFromString(n)).toEqual(n);
       }


### PR DESCRIPTION
This increase accomodates full-fidelity Ethereum addresses.

test plan: unit tests have been updated