### PR TITLE
Bugfix: Separate out node and frontend api.js bundles

### DIFF
--- a/config/paths.js
+++ b/config/paths.js
@@ -32,6 +32,7 @@ module.exports = {
   // point within the build directory.
   backendEntryPoints: {
     sourcecred: (resolveApp("src/cli/main.js") /*: string */),
+    api: (resolveApp("src/api/index.js") /*: string */),
     //
     generateGithubGraphqlFlowTypes: (resolveApp(
       "src/plugins/github/bin/generateGraphqlFlowTypes.js"

--- a/config/webpack.config.api.js
+++ b/config/webpack.config.api.js
@@ -47,9 +47,6 @@ module.exports = ({
       new ModuleScopePlugin(paths.appSrc, [paths.appPackageJson]),
     ],
   },
-  externals: {
-    "crypto": "crypto",
-  },
   module: {
     strictExportPresence: true,
     rules: [


### PR DESCRIPTION
Since introducing a package that requires secure crypto libaries into
the ledger to generate UUIDs, Node has required that we expose the api
bundle to target its global crypto package. This opening works fine in
the browser, since the browser also provides a crypto library, but it
doesn't work with ObservableHQ notebooks.

The solution in these changes is to continue building dist/api.js to
target the frontend and ObservableHQ notebooks, and create another api
entrypoint in the backend webpack config that targets node.

test plan:
1. importing/uploading the api.js file into observableHQ and requiring
should succeed
2. the api bundle targeting node can create and activate an identity in
the node REPL

resolves #2351 