### PR TITLE
discord: cleanup createGraph arguments

### DIFF
--- a/src/plugins/experimental-discord/createGraph.js
+++ b/src/plugins/experimental-discord/createGraph.js
@@ -3,7 +3,7 @@
 import {escape} from "entities";
 import * as NullUtil from "../../util/null";
 import {type WeightedGraph as WeightedGraphT} from "../../core/weightedGraph";
-import {type Weights, type NodeWeight} from "../../core/weights";
+import {type NodeWeight, empty as emptyWeights} from "../../core/weights";
 import {
   Graph,
   NodeAddress,
@@ -204,14 +204,13 @@ export type ChannelWeightConfig = {|
 export function createGraph(
   guild: Model.Snowflake,
   repo: SqliteMirrorRepository,
-  declarationWeights: Weights,
   emojiWeights: EmojiWeightMap,
   roleWeightConfig: RoleWeightConfig,
   channelWeightConfig: ChannelWeightConfig
 ): WeightedGraphT {
   const wg = {
     graph: new Graph(),
-    weights: declarationWeights,
+    weights: emptyWeights(),
   };
 
   const memberMap = new Map(repo.members().map((m) => [m.user.id, m]));


### PR DESCRIPTION
This commit does a minor refactor of the Discord createGraph method so
that it no longer takes the declaration weights. It's unnecessary for
the createGraph method to know about the default weights, we can mix
them in outside the createGraph method instead. This is more consistent
with the other plugins (e.g. GitHub and Discourse both do it this way),
and lets us remove complexity from the createGraph method, which is nice
because that function is starting to get a bit too complex.

Test plan: It's a trivial change, I checked score parity before/after
making it.