### PR TITLE
discord: refactor and test reaction weight logic

### DIFF
--- a/src/plugins/experimental-discord/config.test.js
+++ b/src/plugins/experimental-discord/config.test.js
@@ -1,6 +1,6 @@
 // @flow
 
-import {type DiscordConfig, parser} from "./config";
+import {type DiscordConfig, parser, _upgrade} from "./config";
 
 describe("plugins/experimental-discord/config", () => {
   it("can load a basic config", () => {
@@ -8,11 +8,11 @@ describe("plugins/experimental-discord/config", () => {
       guildId: "453243919774253079",
       reactionWeights: {
         "🥰": 4,
-        ":sourcecred:626763367893303303": 16,
+        "sourcecred:626763367893303303": 16,
       },
       roleWeightConfig: {
         defaultWeight: 0,
-        roleWeights: {
+        weights: {
           "759191073943191613": 0.5,
           "762085832181153872": 1,
           "698296035889381403": 1,
@@ -20,12 +20,27 @@ describe("plugins/experimental-discord/config", () => {
       },
       channelWeightConfig: {
         defaultWeight: 0,
-        channelWeights: {
+        weights: {
           "759191073943191613": 0.25,
         },
       },
     };
     const parsed: DiscordConfig = parser.parseOrThrow(raw);
-    expect(parsed).toEqual(raw);
+    expect(parsed).toEqual(_upgrade(raw));
+  });
+  it("fills in optional properties", () => {
+    const raw = {
+      guildId: "453243919774253079",
+      reactionWeights: {
+        "🥰": 4,
+        "sourcecred:626763367893303303": 16,
+      },
+    };
+    const parsed: DiscordConfig = parser.parseOrThrow(raw);
+    expect(parsed.weights.roleWeights).toEqual({weights: {}, defaultWeight: 1});
+    expect(parsed.weights.channelWeights).toEqual({
+      weights: {},
+      defaultWeight: 1,
+    });
   });
 });

--- a/src/plugins/experimental-discord/plugin.js
+++ b/src/plugins/experimental-discord/plugin.js
@@ -22,7 +22,6 @@ import {
   fromString as pluginIdFromString,
 } from "../../api/pluginId";
 import {loadJson} from "../../util/disk";
-import * as NullUtil from "../../util/null";
 import {createIdentities} from "./createIdentities";
 import type {IdentityProposal} from "../../core/ledger/identityProposal";
 
@@ -68,23 +67,10 @@ export class DiscordPlugin implements Plugin {
     rd: ReferenceDetector
   ): Promise<WeightedGraph> {
     const _ = rd; // TODO(#1808): not yet used
-    const {
-      guildId,
-      reactionWeights,
-      roleWeightConfig,
-      channelWeightConfig,
-    } = await loadConfig(ctx);
+    const {guildId, weights} = await loadConfig(ctx);
     const repo = await repository(ctx, guildId);
-    const defaultRoleWeightConfig = {defaultWeight: 1, roleWeights: {}};
-    const defaultChannelWeightConfig = {defaultWeight: 1, channelWeights: {}};
 
-    const weightedGraph = await createGraph(
-      guildId,
-      repo,
-      reactionWeights,
-      NullUtil.orElse(roleWeightConfig, defaultRoleWeightConfig),
-      NullUtil.orElse(channelWeightConfig, defaultChannelWeightConfig)
-    );
+    const weightedGraph = await createGraph(guildId, repo, weights);
 
     const declarationWeights = weightsForDeclaration(declaration);
     // Add in the type-level weights from the plugin spec

--- a/src/plugins/experimental-discord/reactionWeights.js
+++ b/src/plugins/experimental-discord/reactionWeights.js
@@ -1,0 +1,79 @@
+// @flow
+
+import * as Model from "./models";
+import * as NullUtil from "../../util/null";
+import {type NodeWeight} from "../../core/weights";
+
+export type RoleWeightConfig = {|
+  +defaultWeight: NodeWeight,
+  +weights: {[Model.Snowflake]: NodeWeight},
+|};
+
+export type ChannelWeightConfig = {|
+  +defaultWeight: NodeWeight,
+  +weights: {[Model.Snowflake]: NodeWeight},
+|};
+
+export type EmojiWeightMap = {[Model.Snowflake]: NodeWeight};
+export type EmojiWeightConfig = {|
+  +defaultWeight: NodeWeight,
+  +weights: EmojiWeightMap,
+|};
+
+export type WeightConfig = {|
+  +roleWeights: RoleWeightConfig,
+  +channelWeights: ChannelWeightConfig,
+  +emojiWeights: EmojiWeightConfig,
+|};
+
+export function reactionWeight(
+  weights: WeightConfig,
+  message: Model.Message,
+  reaction: Model.Reaction,
+  reactingMember: Model.GuildMember
+): NodeWeight {
+  if (message.authorId === reaction.authorId) {
+    // Self-reactions do not mint Cred.
+    return 0;
+  }
+
+  return (
+    _roleWeight(weights.roleWeights, reactingMember) *
+    _channelWeight(weights.channelWeights, reaction) *
+    _emojiWeight(weights.emojiWeights, reaction)
+  );
+}
+
+export function _roleWeight(
+  config: RoleWeightConfig,
+  member: Model.GuildMember
+): NodeWeight {
+  const {defaultWeight, weights} = config;
+  let weight = defaultWeight;
+  for (const role of member.roles) {
+    const matchingWeight = weights[role];
+    if (matchingWeight != null && matchingWeight > weight) {
+      weight = matchingWeight;
+    }
+  }
+  return weight;
+}
+
+export function _channelWeight(
+  config: ChannelWeightConfig,
+  reaction: Model.Reaction
+): NodeWeight {
+  const {defaultWeight, weights} = config;
+  return NullUtil.orElse(weights[reaction.channelId], defaultWeight);
+}
+
+export function _emojiWeight(
+  config: EmojiWeightConfig,
+  reaction: Model.Reaction
+): NodeWeight {
+  const {defaultWeight, weights} = config;
+  return NullUtil.orElse(
+    weights[Model.emojiToRef(reaction.emoji)],
+    defaultWeight
+  );
+}

--- a/src/plugins/experimental-discord/reactionWeights.test.js
+++ b/src/plugins/experimental-discord/reactionWeights.test.js
@@ -1,0 +1,139 @@
+// @flow
+
+import deepFreeze from "deep-freeze";
+import type {Message, Reaction, GuildMember} from "./models";
+import {
+  _channelWeight,
+  _roleWeight,
+  _emojiWeight,
+  reactionWeight,
+} from "./reactionWeights";
+
+describe("plugins/experimental-discord/reactionWeights", () => {
+  const channelId = "1";
+  const messageId = "2";
+  const authorId = "4";
+  const reacterId = "5";
+  const badassRoleId = "6";
+  const plebeRoleId = "7";
+  const heartEmoji = {name: "💜", id: null};
+  const sourcecredEmojiId = "8";
+  const sourcecredEmoji = {name: "sourcecred", id: sourcecredEmojiId};
+
+  const message: Message = deepFreeze({
+    id: messageId,
+    channelId,
+    authorId,
+    nonUserAuthor: false,
+    timestampMs: 1,
+    content: "hello world",
+    reactionEmoji: [heartEmoji, sourcecredEmoji],
+    mentions: [reacterId],
+  });
+
+  const authorMember: GuildMember = deepFreeze({
+    user: {
+      id: authorId,
+      username: "author",
+      discriminator: "1234",
+      bot: false,
+    },
+    nick: null,
+    roles: [],
+  });
+
+  const reacterMember: GuildMember = deepFreeze({
+    user: {
+      id: reacterId,
+      username: "reacter",
+      discriminator: "1337",
+      bot: false,
+    },
+    nick: null,
+    roles: [badassRoleId, plebeRoleId],
+  });
+
+  const authorSelfReaction: Reaction = deepFreeze({
+    channelId,
+    messageId,
+    authorId,
+    emoji: heartEmoji,
+  });
+
+  const reacterReaction: Reaction = deepFreeze({
+    channelId,
+    messageId,
+    authorId: reacterId,
+    emoji: sourcecredEmoji,
+  });
+
+  describe("_roleWeight", () => {
+    const roleWeights = deepFreeze({
+      defaultWeight: 0,
+      weights: {[badassRoleId]: 3, [plebeRoleId]: 1},
+    });
+    it("defaults to the defaultWeight if no weights match", () => {
+      expect(_roleWeight(roleWeights, authorMember)).toEqual(
+        roleWeights.defaultWeight
+      );
+    });
+    it("chooses the highest weight if multiple weights match", () => {
+      expect(_roleWeight(roleWeights, reacterMember)).toEqual(
+        roleWeights.weights[badassRoleId]
+      );
+    });
+  });
+
+  describe("_channelWeight", () => {
+    it("defaults to the defaultWeight if no weights match", () => {
+      const cw = {defaultWeight: 7, weights: {}};
+      expect(_channelWeight(cw, authorSelfReaction)).toEqual(cw.defaultWeight);
+    });
+    it("chooses a matching channel weight", () => {
+      const cw = {defaultWeight: 7, weights: {[channelId]: 99}};
+      expect(_channelWeight(cw, authorSelfReaction)).toEqual(99);
+    });
+  });
+
+  describe("_emojiWeight", () => {
+    it("defaults to the defaultWeight if custom emoji weight not specified", () => {
+      const ew = {defaultWeight: 7, weights: {}};
+      expect(_emojiWeight(ew, authorSelfReaction)).toEqual(7);
+    });
+    it("can match an emoji weight for a builtin emoji", () => {
+      const ew = {defaultWeight: 0, weights: {"💜": 9}};
+      expect(_emojiWeight(ew, authorSelfReaction)).toEqual(9);
+    });
+    it("can match an emoji weight for a custom emoji", () => {
+      const ew = {defaultWeight: 0, weights: {"sourcecred:8": 12}};
+      expect(_emojiWeight(ew, reacterReaction)).toEqual(12);
+    });
+  });
+
+  describe("reactionWeight", () => {
+    it("multiplies the channel, message, and role weights", () => {
+      const emojiWeights = {
+        defaultWeight: 1,
+        weights: {"💜": 3, "sourcecred:8": 4},
+      };
+      const roleWeights = {
+        defaultWeight: 1,
+        weights: {[badassRoleId]: 5, [plebeRoleId]: 3},
+      };
+      const channelWeights = {defaultWeight: 1, weights: {[channelId]: 6}};
+      const weights = {emojiWeights, roleWeights, channelWeights};
+      expect(
+        reactionWeight(weights, message, reacterReaction, reacterMember)
+      ).toEqual(4 * 5 * 6);
+    });
+    it("sets the weight to 0 for a self-reaction", () => {
+      const emojiWeights = {defaultWeight: 1, weights: {}};
+      const roleWeights = {defaultWeight: 1, weights: {}};
+      const channelWeights = {defaultWeight: 1, weights: {}};
+      const weights = {emojiWeights, roleWeights, channelWeights};
+      expect(
+        reactionWeight(weights, message, authorSelfReaction, authorMember)
+      ).toEqual(0);
+    });
+  });
+});


### PR DESCRIPTION
The logic for computing Discord reaction weights was starting to get
complicated, and it's all untested, and we want to add more logic still.
This feels like a good opportunity to refactor all the logic before
trying to add any more complexity.

This commit:
- pulls all the logic for computing reaction weights into its own
`reactionWeights.js` module
- tests that logic

I also made a slight tweak to the config format, but I only changed the
new fields that were added since the last release. 1hive will need to
change their config.json, but anyone on the 0.7 branch will not
experience breaking changes. So as to make a cleaner internal interface,
I split the Discord config into two layers: one which is the
json-serialized layer, and one which is the internal in-memory layer,
with an "upgrade" step in-between. Prior to the 0.8.0 release, I'd like
to just refactor the public config file to be a cleaner API, at which
point we can probably remove the upgrade step.

Test plan: All the new unit tests pass, and I tested for
cred-score-stability on an existing instance using the Discord plugin.