### PR TITLE
Bugfix: Write custom getRandomValues function

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,6 @@
     "deep-freeze": "^0.0.1",
     "express": "^4.17.1",
     "fs-extra": "^9.0.0",
-    "get-random-values": "^1.2.0",
     "globby": "^11.0.0",
     "history": "^5.0.0",
     "htmlparser2": "^4.1.0",

--- a/src/util/getRandomValues.js
+++ b/src/util/getRandomValues.js
@@ -1,0 +1,51 @@
+// @flow
+
+/**
+ * getRandomValues is a random number generator. It utilizes both Node and
+ * browser crypto libraries to securely generate a Uint8 array of specified
+ * length that contains truly random entries.
+ *
+ * The function takes advantage of javascript's just-in-time compilation in
+ * order to work with Observable notebooks (https://observablehq.com). By
+ * deferring the node crypto module import until it's actually needed,
+ * this code is never encountered in the environment Observable provides for
+ * imports to run.
+ */
+export default function getRandomValues(buf: Uint8Array): Uint8Array {
+  if (
+    typeof window !== "undefined" &&
+    window.crypto &&
+    window.crypto.getRandomValues
+  ) {
+    return window.crypto.getRandomValues(buf);
+  }
+  if (
+    typeof window !== "undefined" &&
+    typeof window.msCrypto === "object" &&
+    typeof window.msCrypto.getRandomValues === "function"
+  ) {
+    return window.msCrypto.getRandomValues(buf);
+  }
+  const nodeCrypto = require("crypto"); // want externals here
+  if (nodeCrypto.randomBytes) {
+    if (!(buf instanceof Uint8Array)) {
+      throw new TypeError("expected Uint8Array");
+    }
+    if (buf.length > 65536) {
+      const e = new Error();
+      e.message =
+        "Failed to execute 'getRandomValues' on 'Crypto': The " +
+        "ArrayBufferView's byte length (" +
+        buf.length +
+        ") exceeds the " +
+        "number of bytes of entropy available via this API (65536).";
+      e.name = "QuotaExceededError";
+      throw e;
+    }
+    const bytes = nodeCrypto.randomBytes(buf.length);
+    buf.set(bytes);
+    return buf;
+  } else {
+    throw new Error("No secure random number generator available.");
+  }
+}

--- a/src/util/uuid.js
+++ b/src/util/uuid.js
@@ -7,7 +7,7 @@
 // the serialized form is clean for machine and human eyes.
 
 import {encode as base64Encode, decode as base64Decode} from "base-64";
-import getRandomValues from "get-random-values";
+import getRandomValues from "./getRandomValues";
 
 import * as C from "./combo";
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -4951,13 +4951,6 @@ get-caller-file@^2.0.1:
   resolved "https://registry.yarnpkg.com/get-caller-file/-/get-caller-file-2.0.5.tgz#4f94412a82db32f36e3b0b9741f8a97feb031f7e"
   integrity sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==
 
-get-random-values@^1.2.0:
-  version "1.2.2"
-  resolved "https://registry.yarnpkg.com/get-random-values/-/get-random-values-1.2.2.tgz#f1d944d0025433d53a2bd9941b9e975d98a2f7ff"
-  integrity sha512-lMyPjQyl0cNNdDf2oR+IQ/fM3itDvpoHy45Ymo2r0L1EjazeSl13SfbKZs7KtZ/3MDCeueiaJiuOEfKqRTsSgA==
-  dependencies:
-    global "^4.4.0"
-
 get-stream@^4.0.0:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/get-stream/-/get-stream-4.1.0.tgz#c1b255575f3dc21d59bfc79cd3d2b46b1c3a54b5"
@@ -5051,14 +5044,6 @@ global-prefix@^3.0.0:
     ini "^1.3.5"
     kind-of "^6.0.2"
     which "^1.3.1"
-
-global@^4.4.0:
-  version "4.4.0"
-  resolved "https://registry.yarnpkg.com/global/-/global-4.4.0.tgz#3e7b105179006a323ed71aafca3e9c57a5cc6406"
-  integrity sha512-wv/LAoHdRE3BeTGz53FAamhGlPLhlssK45usmGFThIi4XqnBmjKQ16u+RNbP7WvigRZDxUsM0J3gcQ5yicaL0w==
-  dependencies:
-    min-document "^2.19.0"
-    process "^0.11.10"
 
 global@~4.3.0:
   version "4.3.2"


### PR DESCRIPTION
getRandomValues is a random number generator. It utilizes both Node and
browser crypto libraries to securely generate a Uint8 array of specified
length that contains truly random entries.

The function takes advantage of javascript's just-in-time compilation in
order to work with Observable notebooks (https://observablehq.com). By
deferring the node crypto module import until it's actually needed,
this code is never encountered in the environment Observable provides for
imports to run.

The practical advantage of this fix over #2432 is that a single dist/api.js bundle
can be utilized in browser, node and Observable notebooks.

resolves #2351
paired with: @wchargin 

test plan:
a. importing/uploading the dist/api.js file to ObservableHQ and
requiring it should succeed:

	1. navigate to
	https://observablehq.com/@topocount/test-sourcecred in your
	modern browser of choice

	2. click on the ellipsis to the left of the "Fork" button, then
	click "File Attachments" at the top of the menu. A right sidebar
	should appear

	3. Run `yarn build:api` in the repo root. Then, click "Attach"
	in the right sidebar. Find the dist/api.js file and upload it

	4. update the require from "api@9.js" to "api.js" and execute
	both the `require` line and the line that creates an identity,
	verifying no errors are thrown

b. The same dist/api.js bundle also works in the node REPL:

	1. In repo root, run `node`

	2. in the node REPL run `const sc = require('./dist/api.js').default`

	3. Then run
	    `(new sc.ledger.ledger.Ledger()).createIdentity('USER','Bob')`

	4. Observe a random IdentityId printed out in the REPL