### PR TITLE
api: fix Observable compatibility

### DIFF
--- a/config/webpack.config.api.js
+++ b/config/webpack.config.api.js
@@ -47,9 +47,6 @@ module.exports = ({
       new ModuleScopePlugin(paths.appSrc, [paths.appPackageJson]),
     ],
   },
-  externals: {
-    "crypto": "crypto",
-  },
   module: {
     strictExportPresence: true,
     rules: [

--- a/package.json
+++ b/package.json
@@ -25,7 +25,6 @@
     "deep-freeze": "^0.0.1",
     "express": "^4.17.1",
     "fs-extra": "^9.0.0",
-    "get-random-values": "^1.2.0",
     "globby": "^11.0.0",
     "history": "^5.0.0",
     "htmlparser2": "^4.1.0",

--- a/src/util/getRandomValues.js
+++ b/src/util/getRandomValues.js
@@ -29,14 +29,15 @@ function getRandomValues(buf: Uint8Array): Uint8Array {
     // Late-import `crypto` to avoid `require` in Observable notebooks,
     // and avoid using a literal `require(...)` to prevent Webpack from
     // rewriting this. (Getting Webpack externals to work properly is .)
+    //
+    /* eslint-disable camelcase */
+    /* eslint-disable no-undef */
     const realRequire =
       // $FlowExpectedError[cannot-resolve-name]
       typeof __non_webpack_require__ !== "undefined"
         ? __non_webpack_require__
         : require; /* needed for Jest */
     const nodeCrypto = realRequire("crypto");
-    if (!nodeCrypto.randomBytes) {
-    }
     if (buf.length > 65536) {
       const e = new Error();
       (e: any).code = 22;

--- a/src/util/getRandomValues.js
+++ b/src/util/getRandomValues.js
@@ -1,0 +1,54 @@
+// @flow
+
+/*
+ * API shim for `window.crypto.getRandomValues` in the browser, for
+ * compatibility with browser, Node, Jest, and Observable.
+ *
+ * Forked from NPM `get-random-bytes` by Kenan Yildirim, which is
+ * released under the MIT License.
+ */
+
+/**
+ * Fill the given buffer with cryptographically secure random bytes. The
+ * buffer length must not exceed 65536.
+ */
+function getRandomValues(buf: Uint8Array): Uint8Array {
+  if (typeof window !== "undefined") {
+    if (window.crypto && window.crypto.getRandomValues) {
+      return window.crypto.getRandomValues(buf);
+    }
+    if (
+      typeof window.msCrypto === "object" &&
+      typeof window.msCrypto.getRandomValues === "function"
+    ) {
+      return window.msCrypto.getRandomValues(buf);
+    }
+  }
+
+  if (typeof require !== "undefined") {
+    // Late-import `crypto` to avoid `require` in Observable notebooks,
+    // and avoid using a literal `require(...)` to prevent Webpack from
+    // rewriting this. (Getting Webpack externals to work properly is .)
+    const realRequire =
+      // $FlowExpectedError[cannot-resolve-name]
+      typeof __non_webpack_require__ !== "undefined"
+        ? __non_webpack_require__
+        : require; /* needed for Jest */
+    const nodeCrypto = realRequire("crypto");
+    if (!nodeCrypto.randomBytes) {
+    }
+    if (buf.length > 65536) {
+      const e = new Error();
+      (e: any).code = 22;
+      e.message = `Quota exceeded: requested ${buf.length} > 65536 bytes`;
+      e.name = "QuotaExceededError";
+      throw e;
+    }
+    const bytes = nodeCrypto.randomBytes(buf.length);
+    buf.set(bytes);
+    return buf;
+  }
+  throw new Error("No secure random number generator available.");
+}
+
+module.exports = getRandomValues;

--- a/src/util/getRandomValues.js
+++ b/src/util/getRandomValues.js
@@ -12,7 +12,7 @@
  * Fill the given buffer with cryptographically secure random bytes. The
  * buffer length must not exceed 65536.
  */
-function getRandomValues(buf: Uint8Array): Uint8Array {
+export default function getRandomValues(buf: Uint8Array): Uint8Array {
   if (typeof window !== "undefined") {
     if (window.crypto && window.crypto.getRandomValues) {
       return window.crypto.getRandomValues(buf);
@@ -28,7 +28,8 @@ function getRandomValues(buf: Uint8Array): Uint8Array {
   if (typeof require !== "undefined") {
     // Late-import `crypto` to avoid `require` in Observable notebooks,
     // and avoid using a literal `require(...)` to prevent Webpack from
-    // rewriting this. (Getting Webpack externals to work properly is .)
+    // rewriting this. (Getting Webpack externals to work properly is
+    // daunting.)
     //
     /* eslint-disable camelcase */
     /* eslint-disable no-undef */
@@ -51,5 +52,3 @@ function getRandomValues(buf: Uint8Array): Uint8Array {
   }
   throw new Error("No secure random number generator available.");
 }
-
-module.exports = getRandomValues;

--- a/src/util/getRandomValues.test.js
+++ b/src/util/getRandomValues.test.js
@@ -1,0 +1,15 @@
+// @flow
+
+import getRandomValues from "./getRandomValues";
+
+describe("util/getRandomValues", () => {
+  it("populates a buffer", () => {
+    const buf = new Uint8Array(1024);
+    getRandomValues(buf);
+    expect(buf.every((x) => x === 0)).toBe(false);
+  });
+  it("complains if buffer.length > 65536", () => {
+    const buf = new Uint8Array(65537);
+    expect(() => void getRandomValues(buf)).toThrow(/Quota exceeded/);
+  });
+});

--- a/src/util/uuid.js
+++ b/src/util/uuid.js
@@ -7,7 +7,7 @@
 // the serialized form is clean for machine and human eyes.
 
 import {encode as base64Encode, decode as base64Decode} from "base-64";
-import getRandomValues from "get-random-values";
+import getRandomValues from "./getRandomValues";
 
 import * as C from "./combo";
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -4951,13 +4951,6 @@ get-caller-file@^2.0.1:
   resolved "https://registry.yarnpkg.com/get-caller-file/-/get-caller-file-2.0.5.tgz#4f94412a82db32f36e3b0b9741f8a97feb031f7e"
   integrity sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==
 
-get-random-values@^1.2.0:
-  version "1.2.2"
-  resolved "https://registry.yarnpkg.com/get-random-values/-/get-random-values-1.2.2.tgz#f1d944d0025433d53a2bd9941b9e975d98a2f7ff"
-  integrity sha512-lMyPjQyl0cNNdDf2oR+IQ/fM3itDvpoHy45Ymo2r0L1EjazeSl13SfbKZs7KtZ/3MDCeueiaJiuOEfKqRTsSgA==
-  dependencies:
-    global "^4.4.0"
-
 get-stream@^4.0.0:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/get-stream/-/get-stream-4.1.0.tgz#c1b255575f3dc21d59bfc79cd3d2b46b1c3a54b5"
@@ -5051,14 +5044,6 @@ global-prefix@^3.0.0:
     ini "^1.3.5"
     kind-of "^6.0.2"
     which "^1.3.1"
-
-global@^4.4.0:
-  version "4.4.0"
-  resolved "https://registry.yarnpkg.com/global/-/global-4.4.0.tgz#3e7b105179006a323ed71aafca3e9c57a5cc6406"
-  integrity sha512-wv/LAoHdRE3BeTGz53FAamhGlPLhlssK45usmGFThIi4XqnBmjKQ16u+RNbP7WvigRZDxUsM0J3gcQ5yicaL0w==
-  dependencies:
-    min-document "^2.19.0"
-    process "^0.11.10"
 
 global@~4.3.0:
   version "4.3.2"


### PR DESCRIPTION
Summary:
This patch replaces our `getRandomValues` polyfill with a fork that
works in the browser, in Node, in Jest, and in Observable. It’s slightly
hacky because we can’t figure out how to get Webpack’s externs to play
nicely, but the hackiness is entirely contained in this file.

Paired with @topocount.

Fixes #2351.

Test Plan:
Run `yarn build:api`. Test in Node:

```
$ node
> (new (require("./dist/api").default.ledger.ledger.Ledger)()).createIdentity("USER", "z")
'GtJslqp9kl7J8Dr869xGKw'
```

Test in Observable:

 1. Visit <https://observablehq.com/new> and make any change to the
    notebook contents.
 2. Click the “Notebook actions” horizontal ellipsis button to the left
    of the “Publish” button in the top of the screen.
 3. Select “File attachments”.
 4. Click “Upload”, and select `dist/api.js` under your repo.
 5. This will upload `api.js`, or `api@N.js` for some value of `N` if
    you’ve done this before. If you see `api@N.js`, adjust accordingly
    in the following steps.
 6. In an Observable cell, run:

    ```javascript
    {
      const sc = (await require(await FileAttachment("api.js").url()));
      return new sc.default.ledger.ledger.Ledger().createIdentity("USER", "z");
    }
    ```

 7. Observe that it spits out a UUID without crashing.

wchargin-branch: api-observable-build

