### PR TITLE
Pin commonmark to 0.29.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "big-integer": "^1.6.48",
     "bottleneck": "^2.19.5",
     "chalk": "^4.0.0",
-    "commonmark": "^0.29.1",
+    "commonmark": "0.29.1",
     "d3-array": "^2.4.0",
     "d3-format": "^2.0.0",
     "d3-scale": "^3.2.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2915,7 +2915,7 @@ commondir@^1.0.1:
   resolved "https://registry.yarnpkg.com/commondir/-/commondir-1.0.1.tgz#ddd800da0c66127393cca5950ea968a3aaf1253b"
   integrity sha1-3dgA2gxmEnOTzKWVDqloo6rxJTs=
 
-commonmark@^0.29.1:
+commonmark@0.29.1:
   version "0.29.1"
   resolved "https://registry.yarnpkg.com/commonmark/-/commonmark-0.29.1.tgz#fdbf5970ca23600f4a27487e30eed43b66b83ef5"
   integrity sha512-DafPdNYFXoEhsSiR4O+dJ45UJBfDL4cBTks4B+agKiaWt7qjG0bIhg5xuCE0RqU71ikJcBIf4/sRHh9vYQVF8Q==


### PR DESCRIPTION
Commonmark 0.29.2 is a breaking change for us since it scopes the exports
and strictly privatizes the contents of its lib/common and thus they cannot
be consumed directly in our code.

pinning this dependency is necessary because instance administrators may
wipe their yarn.lock files for some reason and re-install, then build
with the 0.29.2 release, which breaks some things from their end.

I understand that this is technically user error, but it's still
something of a Quality-of-Life concern.

test plan: N/A