### PR TITLE
cli: Add -d diff flag to graph command

### DIFF
--- a/src/core/weights.js
+++ b/src/core/weights.js
@@ -196,14 +196,14 @@ export function compareWeights(
     ...firstWeights.nodeWeights.keys(),
     ...secondWeights.nodeWeights.keys(),
   ]);
-  for (const a of nodeAddresses) {
-    const first = firstWeights.nodeWeights.get(a);
-    const second = secondWeights.nodeWeights.get(a);
+  for (const address of nodeAddresses) {
+    const first = firstWeights.nodeWeights.get(address);
+    const second = secondWeights.nodeWeights.get(address);
     if (!deepEqual(first, second)) {
       nodeWeightDiffs.push({
-        address: a,
-        first: first,
-        second: second,
+        address,
+        first,
+        second,
       });
     }
   }
@@ -211,14 +211,14 @@ export function compareWeights(
     ...firstWeights.edgeWeights.keys(),
     ...secondWeights.edgeWeights.keys(),
   ]);
-  for (const a of edgeAddresses) {
-    const first = firstWeights.edgeWeights.get(a);
-    const second = secondWeights.edgeWeights.get(a);
+  for (const address of edgeAddresses) {
+    const first = firstWeights.edgeWeights.get(address);
+    const second = secondWeights.edgeWeights.get(address);
     if (!deepEqual(first, second)) {
       edgeWeightDiffs.push({
-        address: a,
-        first: first,
-        second: second,
+        address,
+        first,
+        second,
       });
     }
   }


### PR DESCRIPTION
This adds a `-d` flag to the `graph` command that loads the existing graph an outputs a comparison. It currently only compares the Graphs and not the Weights, which I will add next.

## Automated Testing
`yarn test` (though this code is not covered by unit tests)

## Manual Testing
I tested this extensively including the following cases:
- Without the flag (regression testing)
  - Verified with and without plugin name args
- With the flag
  - Verified with and without plugin name args
  - verified arg order doesn't matter
  - verified it works with one plugin and with multiple
  - made changes in the test discord and verified output was as expected

## Test Outputs
Note: markdown isn't word wrapping, so the below looks a little different than it actually does in terminal, where word wrap occurs.
### When a graph.json does not exist yet:
```
  GO   sourcecred/discord: generating graph
  GO   sourcecred/discord: diffing with existing graph
Could not find or compare existing graph.json for sourcecred/discord. Error: ENOENT: no such file or directory, open '/Users/thena/workspace/template-instance/output/graphs/sourcecred/discord/graph.json'
 DONE  sourcecred/discord: diffing with existing graph: 0ms
 DONE  sourcecred/discord: generating graph: 19ms
```

### When there are no changes (also demo of multi-plugin format):
```
  GO   sourcecred/discord: generating graph
  GO   sourcecred/discord: diffing with existing graph
=============================================================
  sourcecred/discord - Unchanged
=============================================================
 DONE  sourcecred/discord: diffing with existing graph: 12ms
 DONE  sourcecred/discord: generating graph: 33ms
  GO   sourcecred/github: generating graph
  GO   sourcecred/github: diffing with existing graph
=============================================================
  sourcecred/github - Unchanged
=============================================================
 DONE  sourcecred/github: diffing with existing graph: 6ms
 DONE  sourcecred/github: generating graph: 484ms
```

### When a new liked message is created:
```
  GO   sourcecred/discord: generating graph
  GO   sourcecred/discord: diffing with existing graph
=============================================================
  sourcecred/discord - Node Diffs
=============================================================
Old:	No matching address
New:	{address: NodeAddress["sourcecred","discord","MEMBER","user","258786206387666944"], description: discord/Thena#2630, timestampMs: null}

Old:	No matching address
New:	{address: NodeAddress["sourcecred","discord","MESSAGE","678348980849213472","775902529178435655"], description: #general message ["testaa..."](https://discordapp.com/channels/678348980639498428/678348980849213472/775902529178435655), timestampMs: 1605059978528}

Old:	No matching address
New:	{address: NodeAddress["sourcecred","discord","REACTION","678348980849213472","👍","258786206387666944","775902529178435655"], description: Reacted `👍` to message [775902529178435655](https://discordapp.com/channels/678348980639498428/678348980849213472/775902529178435655), timestampMs: 1605059978528}

=============================================================
  sourcecred/discord - Node Weight Diffs
=============================================================
NodeAddress["sourcecred","discord","REACTION","678348980849213472","👍","258786206387666944","775902529178435655"]
Old:	No matching address
New:	0

=============================================================
  sourcecred/discord - Edge Diffs
=============================================================
Old:	No matching address
New:	{address: EdgeAddress["sourcecred","discord","ADDS_REACTION","user","258786206387666944","👍","678348980849213472","775902529178435655"], src: NodeAddress["sourcecred","discord","MEMBER","user","258786206387666944"], dst: NodeAddress["sourcecred","discord","REACTION","678348980849213472","👍","258786206387666944","775902529178435655"], timestampMs: 1605059978528}

Old:	No matching address
New:	{address: EdgeAddress["sourcecred","discord","AUTHORS","MESSAGE","user","258786206387666944","678348980849213472","775902529178435655"], src: NodeAddress["sourcecred","discord","MEMBER","user","258786206387666944"], dst: NodeAddress["sourcecred","discord","MESSAGE","678348980849213472","775902529178435655"], timestampMs: 1605059978528}

Old:	No matching address
New:	{address: EdgeAddress["sourcecred","discord","REACTS_TO","👍","258786206387666944","678348980849213472","775902529178435655"], src: NodeAddress["sourcecred","discord","REACTION","678348980849213472","👍","258786206387666944","775902529178435655"], dst: NodeAddress["sourcecred","discord","MESSAGE","678348980849213472","775902529178435655"], timestampMs: 1605059978528}

=============================================================
  sourcecred/discord - Summary of Changes
=============================================================
Node Diffs: 3
Node Weight Diffs: 1
Edge Diffs: 3
Edge Weight Diffs: 0
 DONE  sourcecred/discord: diffing with existing graph: 4ms
 DONE  sourcecred/discord: generating graph: 23ms
```

### When a liked message is deleted:
```
  GO   sourcecred/discord: generating graph
  GO   sourcecred/discord: diffing with existing graph
=============================================================
  sourcecred/discord - Node Diffs
=============================================================
Old:	{address: NodeAddress["sourcecred","discord","MEMBER","user","258786206387666944"], description: discord/Thena#2630, timestampMs: null}
New:	No matching address

Old:	{address: NodeAddress["sourcecred","discord","MESSAGE","678348980849213472","775902529178435655"], description: #general message ["testaa..."](https://discordapp.com/channels/678348980639498428/678348980849213472/775902529178435655), timestampMs: 1605059978528}
New:	No matching address

Old:	{address: NodeAddress["sourcecred","discord","REACTION","678348980849213472","👍","258786206387666944","775902529178435655"], description: Reacted `👍` to message [775902529178435655](https://discordapp.com/channels/678348980639498428/678348980849213472/775902529178435655), timestampMs: 1605059978528}
New:	No matching address

=============================================================
  sourcecred/discord - Node Weight Diffs
=============================================================
NodeAddress["sourcecred","discord","REACTION","678348980849213472","👍","258786206387666944","775902529178435655"]
Old:	0
New:	No matching address

=============================================================
  sourcecred/discord - Edge Diffs
=============================================================
Old:	{address: EdgeAddress["sourcecred","discord","ADDS_REACTION","user","258786206387666944","👍","678348980849213472","775902529178435655"], src: NodeAddress["sourcecred","discord","MEMBER","user","258786206387666944"], dst: NodeAddress["sourcecred","discord","REACTION","678348980849213472","👍","258786206387666944","775902529178435655"], timestampMs: 1605059978528}
New:	No matching address

Old:	{address: EdgeAddress["sourcecred","discord","AUTHORS","MESSAGE","user","258786206387666944","678348980849213472","775902529178435655"], src: NodeAddress["sourcecred","discord","MEMBER","user","258786206387666944"], dst: NodeAddress["sourcecred","discord","MESSAGE","678348980849213472","775902529178435655"], timestampMs: 1605059978528}
New:	No matching address

Old:	{address: EdgeAddress["sourcecred","discord","REACTS_TO","👍","258786206387666944","678348980849213472","775902529178435655"], src: NodeAddress["sourcecred","discord","REACTION","678348980849213472","👍","258786206387666944","775902529178435655"], dst: NodeAddress["sourcecred","discord","MESSAGE","678348980849213472","775902529178435655"], timestampMs: 1605059978528}
New:	No matching address

=============================================================
  sourcecred/discord - Summary of Changes
=============================================================
Node Diffs: 3
Node Weight Diffs: 1
Edge Diffs: 3
Edge Weight Diffs: 0
 DONE  sourcecred/discord: diffing with existing graph: 4ms
 DONE  sourcecred/discord: generating graph: 22ms
```

### When a liked message's text is edited:
```
  GO   sourcecred/discord: generating graph
  GO   sourcecred/discord: diffing with existing graph
=============================================================
  sourcecred/discord - Node Diffs
=============================================================
Old:	{address: NodeAddress["sourcecred","discord","MESSAGE","678348980849213472","775902529178435655"], description: #general message ["testaa..."](https://discordapp.com/channels/678348980639498428/678348980849213472/775902529178435655), timestampMs: 1605059978528}
New:	{address: NodeAddress["sourcecred","discord","MESSAGE","678348980849213472","775902529178435655"], description: #general message ["test..."](https://discordapp.com/channels/678348980639498428/678348980849213472/775902529178435655), timestampMs: 1605059978528}

=============================================================
  sourcecred/discord - Summary of Changes
=============================================================
Node Diffs: 1
Node Weight Diffs: 0
Edge Diffs: 0
Edge Weight Diffs: 0
 DONE  sourcecred/discord: diffing with existing graph: 5ms
 DONE  sourcecred/discord: generating graph: 24ms
```

### When default weight declarations are changed
```
  GO   sourcecred/discord: generating graph
  GO   sourcecred/discord: diffing with existing graph
=============================================================
  sourcecred/discord - Node Weight Diffs
=============================================================
NodeAddress["sourcecred","discord","MEMBER"]
Old:	1
New:	0

=============================================================
  sourcecred/discord - Edge Weight Diffs
=============================================================
EdgeAddress["sourcecred","discord","ADDS_REACTION"]
Old:	{"backwards":0.0625,"forwards":2}
New:	{"backwards":0.0625,"forwards":1}

=============================================================
  sourcecred/discord - Summary of Changes
=============================================================
Node Diffs: 0
Node Weight Diffs: 1
Edge Diffs: 0
Edge Weight Diffs: 1
 DONE  sourcecred/discord: diffing with existing graph: 12ms
 DONE  sourcecred/discord: generating graph: 32ms
```