### PR TITLE
Reorganize CredRank gadget address structure

### DIFF
--- a/src/core/credrank/edgeGadgets.js
+++ b/src/core/credrank/edgeGadgets.js
@@ -69,15 +69,21 @@ function makeSeedGadget<T>({
   return Object.freeze({prefix, toRaw, fromRaw, markovEdge});
 }
 
+export const GADGET_EDGE_PREFIX: EdgeAddressT = EdgeAddress.fromParts([
+  "sourcecred",
+  "core",
+  "gadget",
+]);
+
 export const radiationGadget: EdgeGadget<NodeAddressT> = makeSeedGadget({
-  edgePrefix: EdgeAddress.fromParts(["sourcecred", "core", "RADIATION"]),
+  edgePrefix: EdgeAddress.append(GADGET_EDGE_PREFIX, "RADIATION"),
   seedIsSrc: false,
   toParts: (x) => NodeAddress.toParts(x),
   fromParts: (x) => NodeAddress.fromParts(x),
 });
 
 export const seedMintGadget: EdgeGadget<NodeAddressT> = makeSeedGadget({
-  edgePrefix: EdgeAddress.fromParts(["sourcecred", "core", "SEED_MINT"]),
+  edgePrefix: EdgeAddress.append(GADGET_EDGE_PREFIX, "SEED_MINT"),
   seedIsSrc: true,
   toParts: (x) => NodeAddress.toParts(x),
   fromParts: (x) => NodeAddress.fromParts(x),
@@ -93,7 +99,7 @@ export const seedMintGadget: EdgeGadget<NodeAddressT> = makeSeedGadget({
  * nodes, etc.)
  */
 export const payoutGadget: EdgeGadget<ParticipantEpochAddress> = (() => {
-  const edgePrefix = EdgeAddress.fromParts(["sourcecred", "core", "PAYOUT"]);
+  const edgePrefix = EdgeAddress.append(GADGET_EDGE_PREFIX, "PAYOUT");
   const prefix = markovEdgeAddress(edgePrefix, "F");
   const prefixLength = MarkovEdgeAddress.toParts(prefix).length;
   const toRaw = ({epochStart, owner}) =>
@@ -119,11 +125,10 @@ export type WebbingAddress = {|
   +lastStart: TimestampMs,
   +owner: Uuid,
 |};
-const webbingEdgePrefix = EdgeAddress.fromParts([
-  "sourcecred",
-  "core",
-  "EPOCH_WEBBING",
-]);
+const webbingEdgePrefix = EdgeAddress.append(
+  GADGET_EDGE_PREFIX,
+  "EPOCH_WEBBING"
+);
 
 /**
  * The forward webbing edges flow Cred forwards from participant epoch nodes to

--- a/src/core/credrank/markovProcessGraph.js
+++ b/src/core/credrank/markovProcessGraph.js
@@ -83,7 +83,7 @@ import {
   seedGadget,
   accumulatorGadget,
   epochGadget,
-  CORE_NODE_PREFIX,
+  GADGET_NODE_PREFIX,
 } from "./nodeGadgets";
 
 import {
@@ -285,7 +285,7 @@ export class MarkovProcessGraph {
         const name = NodeAddress.toString(node.address);
         throw new Error(`Bad node weight for ${name}: ${weight}`);
       }
-      if (NodeAddress.hasPrefix(node.address, CORE_NODE_PREFIX)) {
+      if (NodeAddress.hasPrefix(node.address, GADGET_NODE_PREFIX)) {
         throw new Error(
           "Unexpected core node in underlying graph: " +
             NodeAddress.toString(node.address)

--- a/src/core/credrank/nodeGadgets.js
+++ b/src/core/credrank/nodeGadgets.js
@@ -10,9 +10,10 @@ import type {TimestampMs} from "../../util/timestamp";
 import type {MarkovNode} from "./markovNode";
 import stringify from "json-stable-stringify";
 
-export const CORE_NODE_PREFIX: NodeAddressT = NodeAddress.fromParts([
+export const GADGET_NODE_PREFIX: NodeAddressT = NodeAddress.fromParts([
   "sourcecred",
   "core",
+  "gadget",
 ]);
 
 export interface NodeGadget<T> {
@@ -29,7 +30,7 @@ export interface NodeGadget<T> {
 
 export const seedGadget: NodeGadget<void> = (() => {
   const description: string = "\u{1f331}"; // U+1F331 SEEDLING
-  const prefix = NodeAddress.append(CORE_NODE_PREFIX, "SEED");
+  const prefix = NodeAddress.append(GADGET_NODE_PREFIX, "SEED");
   const toRaw = () => prefix;
   const fromRaw = (address) => {
     if (address !== prefix) {
@@ -45,7 +46,7 @@ export type EpochAccumulatorAddress = {|
   +epochStart: TimestampMs,
 |};
 export const accumulatorGadget: NodeGadget<EpochAccumulatorAddress> = (() => {
-  const prefix = NodeAddress.append(CORE_NODE_PREFIX, "EPOCH_ACCUMULATOR");
+  const prefix = NodeAddress.append(GADGET_NODE_PREFIX, "EPOCH_ACCUMULATOR");
   const prefixLength = NodeAddress.toParts(prefix).length;
   function toRaw(addr) {
     return NodeAddress.append(prefix, String(addr.epochStart));
@@ -83,7 +84,7 @@ export type ParticipantEpochAddress = {|
   +epochStart: TimestampMs,
 |};
 export const epochGadget: NodeGadget<ParticipantEpochAddress> = (() => {
-  const prefix = NodeAddress.append(CORE_NODE_PREFIX, "USER_EPOCH");
+  const prefix = NodeAddress.append(GADGET_NODE_PREFIX, "USER_EPOCH");
   const epochPrefixLength = NodeAddress.toParts(prefix).length;
   function toRaw(addr: ParticipantEpochAddress): NodeAddressT {
     return NodeAddress.append(prefix, String(addr.epochStart), addr.owner);


### PR DESCRIPTION
The CredRank markov process graph has a concept of "gadgets", which are
nodes that are added specifically for the logic of CredRank. These nodes
are "virtual", in that they are not serialized in the underlying graph.

Heretofore, all of these gadgets have been nested in the
`sourcecred/core` address scope, and we've written an assumption that
every node in that scope is a gadget. However, this will cease holding
as we start adding other nodes in the core scope (e.g. dependency cred
minting nodes). Therefore, we should refine the gadget scope to
`sourcecred/core/gadget`.

Test plan: Existing tests pass, also code inspection. The node gadgets
were already organized around a common prefix (exported as variable)
which I modified and renamed. For the edge gadgets, I added that common
prefix here, and `git grep EdgeAddress.fromParts` in `edgeGadgets.js`
shows that no addresses are being constructed raw (other than the
prefix). Other addresses are all constructed by appending to the prefix.