### PR TITLE
Compare weighted graphs

### DIFF
--- a/src/core/graphTestUtil.js
+++ b/src/core/graphTestUtil.js
@@ -10,6 +10,12 @@ import {
   type NodeAddressT,
   type EdgeAddressT,
 } from "./graph";
+import {
+  type NodeWithWeight,
+  type EdgeWithWeight,
+  type WeightedGraph,
+} from "./weightedGraph";
+import {empty as emptyWeights} from "./weights";
 import type {TimestampMs} from "../util/timestamp";
 
 /**
@@ -261,4 +267,25 @@ export function advancedGraph(): {|
     fullDanglingEdge,
   };
   return {nodes, edges, graph1, graph2};
+}
+
+export function testWeightedGraph(
+  nodesWithWeights: NodeWithWeight[],
+  edgesWithWeights: EdgeWithWeight[]
+): WeightedGraph {
+  const graph = new Graph();
+  const weights = emptyWeights();
+  for (const nodeWithWeight of nodesWithWeights) {
+    const weight = nodeWithWeight.weight;
+    graph.addNode(nodeWithWeight.node);
+    if (weight == null) continue;
+    weights.nodeWeights.set(nodeWithWeight.node.address, weight);
+  }
+  for (const edgeWithWeight of edgesWithWeights) {
+    const weight = edgeWithWeight.weight;
+    graph.addEdge(edgeWithWeight.edge);
+    if (weight == null) continue;
+    weights.edgeWeights.set(edgeWithWeight.edge.address, weight);
+  }
+  return {graph, weights};
 }

--- a/src/core/weightedGraph.test.js
+++ b/src/core/weightedGraph.test.js
@@ -96,4 +96,309 @@ describe("core/weightedGraph", () => {
       expect(expected).toEqual(actual);
     });
   });
+  describe("compareWeightedGraphs", () => {
+    const src = GraphTest.node("src");
+    const dst = GraphTest.node("dst");
+    const simpleEdge = GraphTest.edge("edge", src, dst);
+    const simpleEdgeWeight = {forwards: 1, backwards: 2};
+    const getSimpleWeightedGraph = () =>
+      GraphTest.testWeightedGraph(
+        [
+          {node: src, weight: 1},
+          {node: dst, weight: 2},
+        ],
+        [{edge: simpleEdge, weight: simpleEdgeWeight}]
+      );
+
+    describe("simple graphs are equal with no differences", () => {
+      const weightedGraph1 = getSimpleWeightedGraph();
+      const weightedGraph2 = getSimpleWeightedGraph();
+
+      it("returns empty arrays", () => {
+        const expected = {
+          weightedGraphsAreEqual: true,
+          uniqueNodesInFirst: [],
+          uniqueNodesInSecond: [],
+          nodeTuplesWithDifferences: [],
+          uniqueEdgesInFirst: [],
+          uniqueEdgesInSecond: [],
+          edgeTuplesWithDifferences: [],
+        };
+        expect(
+          WeightedGraph.compareWeightedGraphs(weightedGraph1, weightedGraph2)
+        ).toEqual(expected);
+      });
+    });
+
+    describe("advanced graphs are equal with no differences", () => {
+      const advanced = GraphTest.advancedGraph();
+      const weights1 = Weights.empty();
+      weights1.nodeWeights.set(advanced.nodes.src.address, 1);
+      weights1.nodeWeights.set(advanced.nodes.dst.address, 2);
+      weights1.nodeWeights.set(advanced.nodes.isolated.address, 3);
+      weights1.nodeWeights.set(advanced.nodes.halfIsolated.address, 4);
+      weights1.nodeWeights.set(advanced.nodes.loop.address, 5);
+      weights1.edgeWeights.set(advanced.edges.hom1.address, simpleEdgeWeight);
+      weights1.edgeWeights.set(advanced.edges.hom2.address, {
+        forwards: 3,
+        backwards: 4,
+      });
+      weights1.edgeWeights.set(advanced.edges.fullDanglingEdge.address, {
+        forwards: 5,
+        backwards: 6,
+      });
+      weights1.edgeWeights.set(advanced.edges.halfDanglingEdge.address, {
+        forwards: 7,
+        backwards: 8,
+      });
+      weights1.edgeWeights.set(advanced.edges.loopLoop.address, {
+        forwards: 9,
+        backwards: 1,
+      });
+      const weights2 = Weights.copy(weights1);
+      const weightedGraph1 = {graph: advanced.graph1(), weights: weights1};
+      const weightedGraph2 = {graph: advanced.graph2(), weights: weights2};
+
+      it("returns empty arrays", () => {
+        const expected = {
+          weightedGraphsAreEqual: true,
+          uniqueNodesInFirst: [],
+          uniqueNodesInSecond: [],
+          nodeTuplesWithDifferences: [],
+          uniqueEdgesInFirst: [],
+          uniqueEdgesInSecond: [],
+          edgeTuplesWithDifferences: [],
+        };
+        expect(
+          WeightedGraph.compareWeightedGraphs(weightedGraph1, weightedGraph2)
+        ).toEqual(expected);
+      });
+    });
+
+    describe("each graph has unique full dangling edge", () => {
+      const danglingEdge = GraphTest.edge(
+        "dangling edge",
+        GraphTest.node("unknown src"),
+        GraphTest.node("unknown dst")
+      );
+      const danglingEdge2 = GraphTest.edge(
+        "dangling edge 2",
+        GraphTest.node("unknown src"),
+        GraphTest.node("unknown dst")
+      );
+      const weightedGraph1 = getSimpleWeightedGraph();
+      weightedGraph1.graph.addEdge(danglingEdge);
+      weightedGraph1.weights.edgeWeights.set(
+        danglingEdge.address,
+        simpleEdgeWeight
+      );
+      const weightedGraph2 = getSimpleWeightedGraph();
+      weightedGraph2.graph.addEdge(danglingEdge2);
+      weightedGraph2.weights.edgeWeights.set(
+        danglingEdge2.address,
+        simpleEdgeWeight
+      );
+
+      it("returns unique dangling edge", () => {
+        const expected = {
+          weightedGraphsAreEqual: false,
+          uniqueNodesInFirst: [],
+          uniqueNodesInSecond: [],
+          nodeTuplesWithDifferences: [],
+          uniqueEdgesInFirst: [{edge: danglingEdge, weight: simpleEdgeWeight}],
+          uniqueEdgesInSecond: [
+            {edge: danglingEdge2, weight: simpleEdgeWeight},
+          ],
+          edgeTuplesWithDifferences: [],
+        };
+        expect(
+          WeightedGraph.compareWeightedGraphs(weightedGraph1, weightedGraph2)
+        ).toEqual(expected);
+      });
+    });
+
+    describe("first graph has unique contents", () => {
+      const graph2 = new Graph().addNode(src);
+      const weights2 = Weights.empty();
+      weights2.nodeWeights.set(src.address, 1);
+      const weightedGraph1 = getSimpleWeightedGraph();
+      const weightedGraph2 = {graph: graph2, weights: weights2};
+
+      it("returns unique contents", () => {
+        const expected = {
+          weightedGraphsAreEqual: false,
+          uniqueNodesInFirst: [{node: dst, weight: 2}],
+          uniqueNodesInSecond: [],
+          nodeTuplesWithDifferences: [],
+          uniqueEdgesInFirst: [{edge: simpleEdge, weight: simpleEdgeWeight}],
+          uniqueEdgesInSecond: [],
+          edgeTuplesWithDifferences: [],
+        };
+        expect(
+          WeightedGraph.compareWeightedGraphs(weightedGraph1, weightedGraph2)
+        ).toEqual(expected);
+      });
+    });
+
+    describe("second graph has unique contents", () => {
+      const weightedGraph1 = GraphTest.testWeightedGraph(
+        [{node: src, weight: 1}],
+        []
+      );
+      const weightedGraph2 = getSimpleWeightedGraph();
+
+      it("returns unique contents", () => {
+        const expected = {
+          weightedGraphsAreEqual: false,
+          uniqueNodesInFirst: [],
+          uniqueNodesInSecond: [{node: dst, weight: 2}],
+          nodeTuplesWithDifferences: [],
+          uniqueEdgesInFirst: [],
+          uniqueEdgesInSecond: [{edge: simpleEdge, weight: simpleEdgeWeight}],
+          edgeTuplesWithDifferences: [],
+        };
+        expect(
+          WeightedGraph.compareWeightedGraphs(weightedGraph1, weightedGraph2)
+        ).toEqual(expected);
+      });
+    });
+
+    describe("attribute differences", () => {
+      const dst2 = {
+        address: NodeAddress.fromParts(["dst"]),
+        description: "unique description",
+        timestampMs: null,
+      };
+      const simpleEdge2 = GraphTest.edge(
+        "edge",
+        src,
+        GraphTest.node("unique dst")
+      );
+      const weightedGraph1 = getSimpleWeightedGraph();
+      const weightedGraph2 = GraphTest.testWeightedGraph(
+        [
+          {node: src, weight: 1},
+          {node: dst2, weight: 2},
+        ],
+        [{edge: simpleEdge2, weight: simpleEdgeWeight}]
+      );
+
+      it("returns tuples with differences", () => {
+        const expected = {
+          weightedGraphsAreEqual: false,
+          uniqueNodesInFirst: [],
+          uniqueNodesInSecond: [],
+          nodeTuplesWithDifferences: [
+            [
+              {node: dst, weight: 2},
+              {node: dst2, weight: 2},
+            ],
+          ],
+          uniqueEdgesInFirst: [],
+          uniqueEdgesInSecond: [],
+          edgeTuplesWithDifferences: [
+            [
+              {edge: simpleEdge, weight: simpleEdgeWeight},
+              {edge: simpleEdge2, weight: simpleEdgeWeight},
+            ],
+          ],
+        };
+        expect(
+          WeightedGraph.compareWeightedGraphs(weightedGraph1, weightedGraph2)
+        ).toEqual(expected);
+      });
+    });
+
+    describe("weight differences", () => {
+      const weightedGraph1 = getSimpleWeightedGraph();
+      const weightedGraph2 = GraphTest.testWeightedGraph(
+        [
+          {node: src, weight: 1},
+          {node: dst, weight: 22},
+        ],
+        [{edge: simpleEdge, weight: {forwards: 6, backwards: 8}}]
+      );
+
+      it("returns tuples with differences", () => {
+        const expected = {
+          weightedGraphsAreEqual: false,
+          uniqueNodesInFirst: [],
+          uniqueNodesInSecond: [],
+          nodeTuplesWithDifferences: [
+            [
+              {node: dst, weight: 2},
+              {node: dst, weight: 22},
+            ],
+          ],
+          uniqueEdgesInFirst: [],
+          uniqueEdgesInSecond: [],
+          edgeTuplesWithDifferences: [
+            [
+              {edge: simpleEdge, weight: simpleEdgeWeight},
+              {edge: simpleEdge, weight: {forwards: 6, backwards: 8}},
+            ],
+          ],
+        };
+        expect(
+          WeightedGraph.compareWeightedGraphs(weightedGraph1, weightedGraph2)
+        ).toEqual(expected);
+      });
+    });
+
+    describe("equal graphs have missing weights", () => {
+      const weightedGraph1 = getSimpleWeightedGraph();
+      const weightedGraph2 = getSimpleWeightedGraph();
+      weightedGraph1.graph.addNode(GraphTest.node("noWeightN"));
+      weightedGraph2.graph.addNode(GraphTest.node("noWeightN"));
+      weightedGraph1.graph.addEdge(GraphTest.edge("noWeightE", src, dst));
+      weightedGraph2.graph.addEdge(GraphTest.edge("noWeightE", src, dst));
+
+      it("returns empty arrays", () => {
+        const expected = {
+          weightedGraphsAreEqual: true,
+          uniqueNodesInFirst: [],
+          uniqueNodesInSecond: [],
+          nodeTuplesWithDifferences: [],
+          uniqueEdgesInFirst: [],
+          uniqueEdgesInSecond: [],
+          edgeTuplesWithDifferences: [],
+        };
+        expect(
+          WeightedGraph.compareWeightedGraphs(weightedGraph1, weightedGraph2)
+        ).toEqual(expected);
+      });
+    });
+
+    describe("first graph has missing weights", () => {
+      const weightedGraph1 = getSimpleWeightedGraph();
+      const weightedGraph2 = getSimpleWeightedGraph();
+      weightedGraph1.weights.nodeWeights.delete(dst.address);
+      weightedGraph1.weights.edgeWeights.delete(simpleEdge.address);
+
+      it("returns tuples with differences", () => {
+        const expected = {
+          weightedGraphsAreEqual: false,
+          uniqueNodesInFirst: [],
+          uniqueNodesInSecond: [],
+          nodeTuplesWithDifferences: [
+            [
+              {node: dst, weight: undefined},
+              {node: dst, weight: 2},
+            ],
+          ],
+          uniqueEdgesInFirst: [],
+          uniqueEdgesInSecond: [],
+          edgeTuplesWithDifferences: [
+            [
+              {edge: simpleEdge, weight: undefined},
+              {edge: simpleEdge, weight: simpleEdgeWeight},
+            ],
+          ],
+        };
+        expect(
+          WeightedGraph.compareWeightedGraphs(weightedGraph1, weightedGraph2)
+        ).toEqual(expected);
+      });
+    });
+  });
 });


### PR DESCRIPTION
# Notes
This adds a comparator for the WeightedGraph type. This will be used for the `sourcecred graph -d` diff flag instead of the other two comparators I was working on. I intend to keep the other two, though, and maybe experiment with adding more granular options to the flag.

# Automated Tests
`yarn test`

# Manual Tests
Tried it in WIP cli