### PR TITLE
Support `sourcecred go` out of the box

### DIFF
--- a/src/cli/common.js
+++ b/src/cli/common.js
@@ -34,12 +34,6 @@ export async function loadInstanceConfig(
 ): Promise<InstanceConfig> {
   const projectFilePath = pathJoin(baseDir, "sourcecred.json");
   const config = await loadJson(projectFilePath, configParser);
-  if (config.bundledPlugins.size === 0) {
-    throw new Error(
-      "No plugins configured; Please set up at least one plugin: " +
-        "https://github.com/sourcecred/template-instance#supported-plugins"
-    );
-  }
   return config;
 }
 

--- a/src/cli/common.js
+++ b/src/cli/common.js
@@ -29,9 +29,18 @@ import {loadFileWithDefault, loadJsonWithDefault} from "../util/disk";
 
 import * as Weights from "../core/weights";
 
-export function loadInstanceConfig(baseDir: string): Promise<InstanceConfig> {
+export async function loadInstanceConfig(
+  baseDir: string
+): Promise<InstanceConfig> {
   const projectFilePath = pathJoin(baseDir, "sourcecred.json");
-  return loadJson(projectFilePath, configParser);
+  const config = await loadJson(projectFilePath, configParser);
+  if (config.bundledPlugins.size === 0) {
+    throw new Error(
+      "No plugins configured; Please set up at least one plugin: " +
+        "https://github.com/sourcecred/template-instance#supported-plugins"
+    );
+  }
+  return config;
 }
 
 export function makePluginDir(

--- a/src/cli/load.js
+++ b/src/cli/load.js
@@ -31,6 +31,12 @@ const loadCommand: Command = async (args, std) => {
   const config = await loadInstanceConfig(baseDir);
   if (args.length === 0) {
     pluginsToLoad = Array.from(config.bundledPlugins.keys());
+    if (pluginsToLoad.length === 0) {
+      std.err(
+        "No plugins configured; Please set up at least one plugin: " +
+          "https://github.com/sourcecred/template-instance#supported-plugins"
+      );
+    }
   } else {
     for (const arg of args) {
       const id = pluginIdParser.parseOrThrow(arg);

--- a/src/cli/score.js
+++ b/src/cli/score.js
@@ -6,7 +6,7 @@ import stringify from "json-stable-stringify";
 
 import type {Command} from "./command";
 import {loadInstanceConfig, prepareCredData} from "./common";
-import {loadJsonWithDefault} from "../util/disk";
+import {loadJsonWithDefault, mkdirx} from "../util/disk";
 import dedent from "../util/dedent";
 import {LoggingTaskReporter} from "../util/taskReporter";
 import {
@@ -58,7 +58,9 @@ const scoreCommand: Command = async (args, std) => {
   // information available once we merge CredRank, anyway.
   const stripped = stripOverTimeDataForNonUsers(credResult);
   const credJSON = stringify(credResultToJSON(stripped));
-  const outputPath = pathJoin(baseDir, "output", "credResult.json");
+  const outputDir = pathJoin(baseDir, "output");
+  mkdirx(outputDir);
+  const outputPath = pathJoin(outputDir, "credResult.json");
   await fs.writeFile(outputPath, credJSON);
 
   // Write out the account data for convenient usage.

--- a/src/core/ledger/credAccounts.js
+++ b/src/core/ledger/credAccounts.js
@@ -47,15 +47,19 @@ export function computeCredAccounts(
 ): CredAccountData {
   const grainAccounts = ledger.accounts();
   const userlikeInfo = new Map();
+  const intervals = credView.intervals();
+  const noIntervals = intervals.length === 0;
   for (const {address, credOverTime, description} of credView.userNodes()) {
-    if (credOverTime == null) {
+    if (noIntervals) {
+      userlikeInfo.set(address, {cred: [], description});
+    } else if (credOverTime == null) {
       throw new Error(
         `userlike ${NodeAddress.toString(address)} does not have detailed cred`
       );
+    } else {
+      userlikeInfo.set(address, {cred: credOverTime.cred || null, description});
     }
-    userlikeInfo.set(address, {cred: credOverTime.cred, description});
   }
-  const intervals = credView.intervals();
   return _computeCredAccounts(grainAccounts, userlikeInfo, intervals);
 }
 

--- a/src/core/ledger/credAccounts.test.js
+++ b/src/core/ledger/credAccounts.test.js
@@ -7,6 +7,11 @@ import {intervalSequence} from "../interval";
 
 describe("core/ledger/credAccounts", () => {
   describe("_computeCredAccounts", () => {
+    it("works in an empty case", () => {
+      expect(
+        _computeCredAccounts([], new Map(), intervalSequence([]))
+      ).toEqual({"accounts": [], "intervals": [], unclaimedAliases: []});
+    });
     it("works in a simple case", () => {
       const ledger = new Ledger();
       ledger.createIdentity("USER", "sourcecred");
@@ -43,6 +48,42 @@ describe("core/ledger/credAccounts", () => {
       expect(_computeCredAccounts([account], info, intervals)).toEqual(
         expectedData
       );
+    });
+    it("returns credAccountData even if no intervals have passed", () => {
+      // note: this is the default case in our template intance
+      // By default, we mean:
+      // 1. single identity exists and
+      // 2. no cred intervals have been computed
+      const ledger = new Ledger();
+      ledger.createIdentity("USER", "sourcecred");
+      const userAddress = NodeAddress.empty;
+      const emptyCred = [];
+      const account = ledger.accounts()[0];
+      const intervals = intervalSequence([]);
+      const info = new Map([
+        [
+          account.identity.address,
+          {cred: emptyCred, description: "irrelevant"},
+        ],
+        [userAddress, {cred: emptyCred, description: "Little lost user"}],
+      ]);
+
+      const expectedCredAccount = {cred: emptyCred, account, totalCred: 0};
+      const expectedUnclaimedAccount = {
+        alias: {
+          address: userAddress,
+          description: "Little lost user",
+        },
+        cred: emptyCred,
+        totalCred: 0,
+      };
+      const expectedData = {
+        accounts: [expectedCredAccount],
+        unclaimedAliases: [expectedUnclaimedAccount],
+        intervals,
+      };
+      const result = _computeCredAccounts([account], info, intervals);
+      expect(result).toEqual(expectedData);
     });
     it("errors if an alias address is in the cred scores", () => {
       const ledger = new Ledger();

--- a/src/util/jsonLog.js
+++ b/src/util/jsonLog.js
@@ -74,6 +74,10 @@ function _extractLogLines(log: string): string[] {
   // format, all automatically written ledgers include a trailing LF.
   // Strip it, if present, for ease of `split("\n")`.
   log = log.trimRight();
+  // If the file is empty, return no entries to parse
+  if (log.length === 0) {
+    return [];
+  }
   if (log.startsWith("[")) {
     // Temporarily compatibility measure for raw JSON arrays (not NDJSON),
     // in the specific form written by previous versions of this module.

--- a/src/util/jsonLog.test.js
+++ b/src/util/jsonLog.test.js
@@ -33,6 +33,9 @@ describe("util/jsonLog", () => {
     expect(emptyLogString).toEqual("");
   });
   it("parses an empty string as an empty log", () => {
+    expect(JsonLog.fromString("", C.number)).toEqual(new JsonLog());
+  });
+  it("parses an empty array as an empty log", () => {
     expect(JsonLog.fromString("[]", C.number)).toEqual(new JsonLog());
   });
 


### PR DESCRIPTION
This PR allows `sourcecred go` to succeed out of the box in the template instance. Each small bugfix and refactor needed to make this happen is contained in its own semantically atomic commit. 

test plan:
1. yarn build
2. run `scdev go` in the template-instance repo