### PR TITLE
add description and timestamp to nodeToString

### DIFF
--- a/src/core/graph.js
+++ b/src/core/graph.js
@@ -1162,7 +1162,9 @@ export class Graph {
  */
 export function nodeToString(node: Node): string {
   const address = NodeAddress.toString(node.address);
-  return `{address: ${address}}`;
+  const timestamp =
+    node.timestampMs == null ? "null" : String(node.timestampMs);
+  return `{address: ${address}, description: ${node.description}, timestampMs: ${timestamp}}`;
 }
 
 /**

--- a/src/core/graph.test.js
+++ b/src/core/graph.test.js
@@ -1623,8 +1623,16 @@ describe("core/graph", () => {
   describe("nodeToString", () => {
     it("works", () => {
       const string = nodeToString(node("foo"));
+      const string2 = nodeToString({
+        address: NodeAddress.fromParts(["bar"]),
+        description: "test",
+        timestampMs: 123,
+      });
       expect(string).toMatchInlineSnapshot(
-        `"{address: NodeAddress[\\"foo\\"]}"`
+        `"{address: NodeAddress[\\"foo\\"], description: foo, timestampMs: null}"`
+      );
+      expect(string2).toMatchInlineSnapshot(
+        `"{address: NodeAddress[\\"bar\\"], description: test, timestampMs: 123}"`
       );
     });
   });


### PR DESCRIPTION
As a part of the `graph -d` diff flag project, I am updating the nodeToStirng method to include all attributes.

## Testing
yarn test
used it in my WIP cli branch and worked as expected.