### PR TITLE
rename `dependencyMintPolicy` to `bonusMinting`

### DIFF
--- a/src/analysis/credData.js
+++ b/src/analysis/credData.js
@@ -1,10 +1,7 @@
 // @flow
 
 import type {TimelineCredScores} from "../core/algorithm/distributionToCred";
-import {
-  type DependencyMintPolicy,
-  processMintPolicy,
-} from "../core/dependenciesMintPolicy";
+import {type BonusPolicy, processBonusPolicy} from "../core/bonusMinting";
 import {type NodeAddressT, NodeAddress} from "../core/graph";
 import {IDENTITY_PREFIX} from "../core/identity";
 import {type IntervalSequence, intervalSequence} from "../core/interval";
@@ -74,7 +71,7 @@ export type EdgeCredOverTime = {|
 export function computeCredData(
   scores: TimelineCredScores,
   nodeOrder: $ReadOnlyArray<NodeAddressT>,
-  dependencyPolicies: $ReadOnlyArray<DependencyMintPolicy>
+  bonusPolicies: $ReadOnlyArray<BonusPolicy>
 ): CredData {
   const numIntervals = scores.length;
   if (numIntervals === 0) {
@@ -87,8 +84,8 @@ export function computeCredData(
     };
   }
   const intervals = intervalSequence(scores.map((d) => d.interval));
-  const processedDependencyPolicies = dependencyPolicies.map((p) =>
-    processMintPolicy(p, nodeOrder, intervals)
+  const processedBonusPolicies = bonusPolicies.map((p) =>
+    processBonusPolicy(p, nodeOrder, intervals)
   );
   const numNodes = scores[0].cred.length;
   const numEdges = scores[0].forwardFlow.length;
@@ -148,7 +145,7 @@ export function computeCredData(
       // Pre-fill with 0 to ensure a value for every node
       nodeOverTime[n].dependencyMintedCred[i] = 0;
     }
-    for (const {nodeIndex, intervalWeights} of processedDependencyPolicies) {
+    for (const {nodeIndex, intervalWeights} of processedBonusPolicies) {
       const weight = intervalWeights[i];
       const mintedCred = weight * intervalTotalParticipantCred;
       nodeSummaries[nodeIndex].cred += mintedCred;

--- a/src/analysis/credData.test.js
+++ b/src/analysis/credData.test.js
@@ -2,7 +2,7 @@
 
 import {computeCredData, compressByThreshold} from "./credData";
 import type {TimelineCredScores} from "../core/algorithm/distributionToCred";
-import type {DependencyMintPolicy} from "../core/dependenciesMintPolicy";
+import type {BonusPolicy} from "../core/bonusMinting";
 import {NodeAddress} from "../core/graph";
 import {IDENTITY_PREFIX} from "../core/identity";
 import {intervalSequence} from "../core/interval";
@@ -97,7 +97,7 @@ describe("src/analysis/credData", () => {
         syntheticLoopFlow: new Float64Array([0.1, 0]),
       },
     ];
-    const mintPolicies: DependencyMintPolicy[] = [
+    const bonusPolicies: BonusPolicy[] = [
       {
         address: IDENTITY_PREFIX,
         periods: [{weight: 0.5, startTimeMs: -Infinity}],
@@ -143,7 +143,7 @@ describe("src/analysis/credData", () => {
     // Only the first node address is a participant, so we mint
     // based on its Cred alone.
     const nodeOrder = [IDENTITY_PREFIX, NodeAddress.empty];
-    expect(computeCredData(scores, nodeOrder, mintPolicies)).toEqual(expected);
+    expect(computeCredData(scores, nodeOrder, bonusPolicies)).toEqual(expected);
   });
   it("compresses by threshold correctly", () => {
     const intervals = intervalSequence([

--- a/src/analysis/credView.js
+++ b/src/analysis/credView.js
@@ -306,7 +306,7 @@ export class CredView {
       wg,
       params,
       this.plugins(),
-      this._credResult.dependencyPolicies
+      this._credResult.bonusPolicies
     );
     return new CredView(credResult);
   }

--- a/src/api/dependenciesConfig.js
+++ b/src/api/dependenciesConfig.js
@@ -5,7 +5,7 @@
  * which allows a project to mint excess Cred for its dependencies.
  *
  * To learn about the semantics of the dependencies system, read the module
- * docstring for core/dependenciesMintPolicy.js
+ * docstring for core/bonusMinting.js
  *
  * At a high level, this config type allows the instance maintainer to specify
  * identities (usually PROJECT-type identities) to mint extra Cred over time,
@@ -52,7 +52,7 @@ import {
 } from "../util/timestamp";
 import {type IdentityId, type Name, nameParser} from "../core/identity";
 import {parser as uuidParser} from "../util/uuid";
-import {type DependencyMintPolicy} from "../core/dependenciesMintPolicy";
+import {type BonusPolicy} from "../core/bonusMinting";
 
 // A finite nonnegative value (usually in range [0, 1]) which specifies how
 // much extra Cred to mint for a given dependency, as a proportion of the raw
@@ -175,10 +175,10 @@ export function ensureIdentityExists(
   }
 }
 
-export function toDependencyPolicy(
+export function toBonusPolicy(
   config: DependencyConfig,
   ledger: Ledger
-): DependencyMintPolicy {
+): BonusPolicy {
   const {id} = config;
   if (id == null) {
     throw new Error(

--- a/src/api/dependenciesConfig.test.js
+++ b/src/api/dependenciesConfig.test.js
@@ -1,7 +1,7 @@
 // @flow
 
 import {Ledger} from "../core/ledger/ledger";
-import {toDependencyPolicy, ensureIdentityExists} from "./dependenciesConfig";
+import {toBonusPolicy, ensureIdentityExists} from "./dependenciesConfig";
 import {nameFromString as n} from "../core/identity";
 import {random as randomUuid} from "../util/uuid";
 import {fromISO, toISO, validateTimestampISO} from "../util/timestamp";
@@ -173,7 +173,7 @@ describe("api/dependenciesConfig", () => {
     });
   });
 
-  describe("toDependencyPolicy", () => {
+  describe("toBonusPolicy", () => {
     it("creates a policy with the right address", () => {
       const ledger = new Ledger();
       const id = ledger.createIdentity("USER", "foo");
@@ -182,7 +182,7 @@ describe("api/dependenciesConfig", () => {
         {name: n("foo"), periods: []},
         ledger
       );
-      const policy = toDependencyPolicy(config, ledger);
+      const policy = toBonusPolicy(config, ledger);
       expect(policy.address).toEqual(address);
     });
     it("creates a policy with specified periods", () => {
@@ -197,7 +197,7 @@ describe("api/dependenciesConfig", () => {
         },
         ledger
       );
-      const policy = toDependencyPolicy(config, ledger);
+      const policy = toBonusPolicy(config, ledger);
       expect(policy.periods).toEqual([{startTimeMs: timestampMs, weight: 0.1}]);
     });
     it("creates a policy with empty periods", () => {
@@ -210,13 +210,13 @@ describe("api/dependenciesConfig", () => {
         },
         ledger
       );
-      const policy = toDependencyPolicy(config, ledger);
+      const policy = toBonusPolicy(config, ledger);
       expect(policy.periods).toEqual([]);
     });
     it("errors if the config is missing an id", () => {
       const config = {name: n("foo"), periods: []};
       const ledger = new Ledger();
-      const thunk = () => toDependencyPolicy(config, ledger);
+      const thunk = () => toBonusPolicy(config, ledger);
       expect(thunk).toThrowError(
         "cannot convert config to policy before it has an id"
       );
@@ -225,7 +225,7 @@ describe("api/dependenciesConfig", () => {
       const id = randomUuid();
       const config = {id, name: n("foo"), periods: []};
       const ledger = new Ledger();
-      const thunk = () => toDependencyPolicy(config, ledger);
+      const thunk = () => toBonusPolicy(config, ledger);
       expect(thunk).toThrowError("no Account for identity");
     });
   });

--- a/src/cli/common.js
+++ b/src/cli/common.js
@@ -6,7 +6,7 @@ import {loadJson, mkdirx} from "../util/disk";
 import deepEqual from "lodash.isequal";
 import stringify from "json-stable-stringify";
 
-import {type DependencyMintPolicy} from "../core/dependenciesMintPolicy";
+import {type BonusPolicy} from "../core/bonusMinting";
 import type {PluginDirectoryContext} from "../api/plugin";
 import {
   parser as configParser,
@@ -17,7 +17,7 @@ import {contractions as identityContractions} from "../core/identity";
 import {
   parser as dependenciesParser,
   ensureIdentityExists,
-  toDependencyPolicy,
+  toBonusPolicy,
 } from "../api/dependenciesConfig";
 import {
   type WeightedGraph,
@@ -85,7 +85,7 @@ export async function prepareCredData(
 ): Promise<{|
   weightedGraph: WeightedGraph,
   ledger: Ledger,
-  dependencies: $ReadOnlyArray<DependencyMintPolicy>,
+  dependencies: $ReadOnlyArray<BonusPolicy>,
 |}> {
   const [weightedGraph, ledger] = await Promise.all([
     await loadWeightedGraph(baseDir, config),
@@ -110,7 +110,7 @@ export async function prepareCredData(
 async function loadDependenciesAndWriteChanges(
   baseDir: string,
   ledger: Ledger
-): Promise<$ReadOnlyArray<DependencyMintPolicy>> {
+): Promise<$ReadOnlyArray<BonusPolicy>> {
   const dependenciesPath = pathJoin(baseDir, "config", "dependencies.json");
   const dependencies = await loadJsonWithDefault(
     dependenciesPath,
@@ -131,7 +131,7 @@ async function loadDependenciesAndWriteChanges(
     await saveLedger(baseDir, ledger);
   }
 
-  return dependenciesWithIds.map((d) => toDependencyPolicy(d, ledger));
+  return dependenciesWithIds.map((d) => toBonusPolicy(d, ledger));
 }
 
 export async function loadWeightedGraph(

--- a/src/core/bonusMinting.js
+++ b/src/core/bonusMinting.js
@@ -1,23 +1,16 @@
 // @flow
 
 /**
- * This module adds a core type for specifying "Dependency Mint" policies.
- * The Dependency Minting system is how we intend to allow projects to
- * flow Cred to their dependencies; e.g. it is how a user of SourceCred may
- * flow Cred to SourceCred itself. We want to make this easily configured at
- * the whole-project level, so that e.g. we can make projects flow ~5% of their
- * Cred to SourceCred by default.
+ * This module adds a system for specifying "bonus minting" policies. The core
+ * idea for bonus minting is that extra Cred is conjured out of thin air (as a
+ * "bonus") and distributed to a chosen recipient. This system is intended to
+ * be used for minting Cred for project-level dependencies. For example, we
+ * would like users of SourceCred to mint some extra Cred and flow it to the
+ * SourceCred project.
  *
- * It's not obvious how to embed this information directly into the Contribution
- * Graph in a way that's elegant and computationally efficient. E.g. we could add
- * an edge from every individual contribution to each dependency, but that
- * greatly increases the size and max degree of the Graph, which is
- * undesirable. After some discussion and consideration of alternatives,
- * @decentralion and @wchargin decided it would be cleanest to handle this
- * outside of the normal Graph abstraction. Thus, the Dependency Mint Policy was
- * born. These policies specify that after normal, Graph-based Cred computation is
- * finished, some nodes will recieve "extra" Cred minting which is proportional
- * to the total pre-dependencies Cred.
+ * In CredRank, we handle this by creating extra nodes in the graph which mint
+ * the bonus Cred, and it flows directly from those nodes to the intended
+ * recipients.
  *
  * The total amount of Cred that may be minted is unbounded; for example, if
  * the dependencies have a total weight of 0.2, then the total Cred will be
@@ -25,38 +18,24 @@
  * the total Cred would be double the base Cred. This was a deliberate design
  * decision so that dependency minting would feel "non-rival", i.e. there is
  * not a fixed budget of dependency cred that must be split between the
- * dependencies. In many cases, it may be very reasonable for the total Cred
- * flowing to a project's dependencies to be larger than the total Cred flowing
+ * dependencies. In some cases, it may be reasonable for the total Cred flowing
+ * to a project's dependencies to be larger than the total Cred flowing
  * directly to the project's contributors; consider that the total amount of
  * time/effort invested in building all the dependencies may be orders of
  * magnitude larger than investment in the project itself.
- *
- * In the future, we may develop more elegant approaches that integrate
- * dependencies more naturally into the contribution graph itself, in which
- * case we could phase out this system. But for now, it seems like a
- * sufficiently useful and flexible abstraction to merit inclusion in core/.
- *
- * Note that there's nothing in the implementation or data types that imply
- * that this is only used for dependencies; one could imagine using it for
- * other purposes, e.g. minting extra Cred for moderators of a forum, or for
- * maintainers of a project. However, we have a prior that all contributors to
- * a project should be paid via CredRank and the graph-based system, rather
- * than "out-of-band" fiat/configuration like the mint policies in this module.
- * Thus, we're naming it the dependencyMintPolicy to communicate that
- * intention.
  */
 import {type NodeAddressT, NodeAddress} from "./graph";
 import {type TimestampMs} from "../util/timestamp";
 import {type IntervalSequence} from "./interval";
 
-export type DependencyMintPolicy = {|
+export type BonusPolicy = {|
   // The node address that will receieve the extra minted Cred
   +address: NodeAddressT,
   // Information on how the Cred minting weight varies in time.
-  +periods: $ReadOnlyArray<DependencyMintPeriod>,
+  +periods: $ReadOnlyArray<BonusPeriod>,
 |};
 
-export type DependencyMintPeriod = {|
+export type BonusPeriod = {|
   // What proportion of the project's raw Cred should be minted to this
   // dependency during this period. For example, if the weight is 0.05, and the
   // project has a pre-dependencies total Cred of 1000 in a given interval,
@@ -68,23 +47,27 @@ export type DependencyMintPeriod = {|
   +startTimeMs: TimestampMs | number,
 |};
 
+// ========================= DEPRECATED =========================
+// Everything below this line has TimelineCred specific logic, and will be
+// removed when we switch to CredRank.
+
 /**
- * The ProcessedDependencyMintPolicy is a DependencyMintPolicy which has
+ * The ProcessedBonusPolicy is a BonusPolicy which has
  * been transformed so that it matches the abstractions available when
  * we're doing raw cred computation: instead of an address, we track an index
  * into the canonical node order, and rather than arbitrary client-provided
  * periods, we compute the weight for each Interval.
  */
-export type ProcessedDependencyMintPolicy = {|
+export type ProcessedBonusPolicy = {|
   +nodeIndex: number,
   +intervalWeights: $ReadOnlyArray<number>,
 |};
 
-export function processMintPolicy(
-  policy: DependencyMintPolicy,
+export function processBonusPolicy(
+  policy: BonusPolicy,
   nodeOrder: $ReadOnlyArray<NodeAddressT>,
   intervals: IntervalSequence
-): ProcessedDependencyMintPolicy {
+): ProcessedBonusPolicy {
   const {address, periods} = policy;
   const nodeIndex = nodeOrder.indexOf(address);
   if (nodeIndex === -1) {
@@ -98,7 +81,7 @@ export function processMintPolicy(
 }
 
 export function _alignPeriodsToIntervals(
-  periods: $ReadOnlyArray<DependencyMintPeriod>,
+  periods: $ReadOnlyArray<BonusPeriod>,
   intervalStarts: $ReadOnlyArray<TimestampMs>
 ): $ReadOnlyArray<number> {
   if (periods.length === 0) {

--- a/src/core/bonusMinting.test.js
+++ b/src/core/bonusMinting.test.js
@@ -2,13 +2,10 @@
 
 import deepFreeze from "deep-freeze";
 import {NodeAddress} from "./graph";
-import {
-  _alignPeriodsToIntervals,
-  processMintPolicy,
-} from "./dependenciesMintPolicy";
+import {_alignPeriodsToIntervals, processBonusPolicy} from "./bonusMinting";
 import {intervalSequence} from "./interval";
 
-describe("core/dependenciesMintPolicy", () => {
+describe("core/bonusMinting", () => {
   describe("_alignPeriodsToIntervals", () => {
     it("handles a case with no periods and no intervals", () => {
       expect(_alignPeriodsToIntervals([], [])).toEqual([]);
@@ -85,7 +82,7 @@ describe("core/dependenciesMintPolicy", () => {
     });
   });
 
-  describe("processMintPolicy", () => {
+  describe("processBonusPolicy", () => {
     const n1 = NodeAddress.fromParts(["1"]);
     const n2 = NodeAddress.fromParts(["2"]);
     const n3 = NodeAddress.fromParts(["3"]);
@@ -104,13 +101,13 @@ describe("core/dependenciesMintPolicy", () => {
       const policy = {address: n2, periods};
       const intervalStarts = intervals.map((i) => i.startTimeMs);
       const intervalWeights = _alignPeriodsToIntervals(periods, intervalStarts);
-      const actual = processMintPolicy(policy, nodeOrder, intervals);
+      const actual = processBonusPolicy(policy, nodeOrder, intervals);
       const expected = {nodeIndex: 1, intervalWeights};
       expect(actual).toEqual(expected);
     });
     it("errors if the node address isn't in the ordering", () => {
       const policy = {address: nx, periods};
-      const thunk = () => processMintPolicy(policy, nodeOrder, intervals);
+      const thunk = () => processBonusPolicy(policy, nodeOrder, intervals);
       expect(thunk).toThrowError("address not in nodeOrder");
     });
   });


### PR DESCRIPTION
This commit renames the dependencyMintPolicy module to bonusMinting, and
changes typenames and downstream usage accordingly. This is motivated,
most proximately, by my need to re-write this system to output a bonus
minting subgraph as part of the CredRank integration. (We want to have
dependency minting occur directly within the Graph, rather than adding
extra logic to the whole score computation pipeline.)

While writing the graph module, I found that the naming became a big
mess. The problem, I think, is that "DependencyMint" is a confusing
name: it describes the intended use case (paying dependencies) but not
the mechanism at hand (minting a bonus %age of total Cred that flows to
a particular recipient). I think renaming the mechanism to better
reflect its behavior will make the core logic more readable.

I've left the config API un-renamed, i.e. the config file is still
called dependnecies.json. That makes sense, since the intended use case
is still for minting Cred for dependencies.

Test plan: All existing tests pass. It's just a bunch of renames so that
suffices.