### PR TITLE
grainConfig: implement Recent configuration

### DIFF
--- a/src/api/grainConfig.test.js
+++ b/src/api/grainConfig.test.js
@@ -1,0 +1,122 @@
+// @flow
+
+import {parser, toDistributionPolicy, type GrainConfig} from "./grainConfig";
+import {type DistributionPolicy} from "../core/ledger/applyDistributions";
+import {toDiscount} from "../core/ledger/grainAllocation";
+import {fromInteger} from "../core/ledger/grain";
+
+describe("api/grainConfig", () => {
+  describe("parser", () => {
+    it("errors if missing params", () => {
+      const grainConfig = {};
+      expect(() => parser.parseOrThrow(grainConfig)).toThrowError(
+        "missing key"
+      );
+    });
+
+    it("errors if malformed params", () => {
+      const grainConfig = {
+        balancedPerWeek: {},
+        immediatePerWeek: 10,
+        recentPerWeek: 10,
+      };
+      expect(() => parser.parseOrThrow(grainConfig)).toThrowError(
+        "expected number"
+      );
+    });
+
+    it("ignores extra params", () => {
+      const grainConfig = {
+        balancedPerWeek: 10,
+        immediatePerWeek: 20,
+        recentPerWeek: 30,
+        EXTRA: 30,
+      };
+
+      const to = {
+        balancedPerWeek: 10,
+        immediatePerWeek: 20,
+        recentPerWeek: 30,
+      };
+
+      expect(parser.parseOrThrow(grainConfig)).toEqual(to);
+    });
+
+    it("does not throw on negative or zero budgets", () => {
+      const grainConfig = {
+        balancedPerWeek: -1,
+        immediatePerWeek: 0,
+        recentPerWeek: -100,
+        recentWeeklyDecayRate: 0.5,
+      };
+
+      expect(parser.parseOrThrow(grainConfig)).toEqual(grainConfig);
+    });
+
+    it("works on well formed object", () => {
+      const grainConfig = {
+        balancedPerWeek: 10,
+        immediatePerWeek: 20,
+        recentPerWeek: 30,
+        recentWeeklyDecayRate: 0.5,
+      };
+
+      expect(parser.parseOrThrow(grainConfig)).toEqual(grainConfig);
+    });
+  });
+
+  describe("toDistributionPolicy", () => {
+    it("errors on missing discount", () => {
+      const x: GrainConfig = {
+        balancedPerWeek: 10,
+        immediatePerWeek: 20,
+        recentPerWeek: 10,
+      };
+
+      expect(() => toDistributionPolicy(x)).toThrowError(
+        "no recentWeeklyDecayRate specified"
+      );
+    });
+
+    it("does not error for missing recentWeeklyDecayRate if 0 recent budget", () => {
+      const x: GrainConfig = {
+        balancedPerWeek: 10,
+        immediatePerWeek: 20,
+        recentPerWeek: 0,
+      };
+
+      expect(() => toDistributionPolicy(x)).not.toThrow();
+    });
+
+    it("creates DistributionPolicy from valid GrainConfig", () => {
+      const x: GrainConfig = {
+        balancedPerWeek: 10,
+        immediatePerWeek: 20,
+        recentPerWeek: 30,
+        recentWeeklyDecayRate: 0.1,
+        maxSimultaneousDistributions: 2,
+      };
+
+      const expectedDistributionPolicy: DistributionPolicy = {
+        allocationPolicies: [
+          {
+            budget: fromInteger(20),
+            policyType: "IMMEDIATE",
+          },
+          {
+            budget: fromInteger(30),
+            policyType: "RECENT",
+            discount: toDiscount(0.1),
+          },
+          {
+            budget: fromInteger(10),
+            policyType: "BALANCED",
+          },
+        ],
+        maxSimultaneousDistributions: 2,
+      };
+
+      expect(toDistributionPolicy(x)).toEqual(expectedDistributionPolicy);
+    });
+  });
+});

--- a/src/core/ledger/grainAllocation.js
+++ b/src/core/ledger/grainAllocation.js
@@ -39,10 +39,21 @@ export type Immediate = "IMMEDIATE";
 
 /**
  * The Recent policy distributes cred using a time discount factor, weighing
- * recent contributions higher.
+ * recent contributions higher. The policy takes a history of cred scores, progressively
+ * discounting past cred scores, and then taking the sum over the discounted scores.
+ *
+ * A cred score at time t reads as follows: "The discounted cred c' at a timestep which is
+ * n timesteps back from the most recent one is its cred score c multiplied by the discount
+ * factor to the nth power."
+ *
+ * c' =  c * (1 - discount) ** n
+ *
+ * Discounts range from 0 to 1, with a higher discount weighing recent contribution
+ * higher.
  *
  * Note that this is a generalization of the Immediate policy, where Immediate
- * is the same as Recent with a discount factor 1 (100%).
+ * is the same as Recent with a full discount, i.e. a discount factor 1 (100%).
+ *
  */
 export type Recent = "RECENT";
 


### PR DESCRIPTION
This adds configuration logic for the Recent policy to read from an instance's `config/grain.json` file.  Here, we add an optional `discount` parameter to the `GrainConfig` type, which checked for if there is a non-zero Recent policy.

This is followup to #2447

__Test Plan__
I've added some unit tests covering the `GrainConfig` parser.  I also added tests to cover errors related to missing a missing `discount`.

__Next__
I'd like to remove the hardcoding of policy names from this module.  Ideally, the `grainConfig` would read any valid policy that exist in `core/ledger/grainAllocation`.
