### PR TITLE
LedgerManager persist logic

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -7253,6 +7253,11 @@ nan@^2.12.1:
   resolved "https://registry.yarnpkg.com/nan/-/nan-2.14.1.tgz#d7be34dfa3105b91494c3147089315eff8874b01"
   integrity sha512-isWHgVjnFjh2x2yuJ/tj3JbwoHu3UC2dX5G/88Cm24yB6YopVgxvBObDY7n5xW6ExmFhJpSEQqFPvq9zaXc8Jw==
 
+nan@^2.14.0:
+  version "2.14.2"
+  resolved "https://registry.yarnpkg.com/nan/-/nan-2.14.2.tgz#f5376400695168f4cc694ac9393d0c9585eeea19"
+  integrity sha512-M2ufzIiINKCuDfBSAUr1vWQ+vuVcA9kqx8JJUsbQi6yf1uGRyb7HfpdfUr5qLXf3B/t8dPvcjhKMmlfnP47EzQ==
+
 nanoid@^3.1.16:
   version "3.1.16"
   resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-3.1.16.tgz#b21f0a7d031196faf75314d7c65d36352beeef64"


### PR DESCRIPTION
The persist method writes the local ledger changes back to the ledger storage while ensuring that there are no conflicts or inconsistencies in the ledger history as well as minimizing the potential for remote changes to get overwritten due to race conditions.

This is not super airtight or ready to be used my many people frequently updating the ledger at the same time, but it should cover the majority of sync conflicts that might arise.

Test Plan: Unit tests + test with github storage backend once that's implemented