### PR TITLE
grainAllocation: inject optional mapping over cred scores

### DIFF
--- a/src/core/ledger/grain.js
+++ b/src/core/ledger/grain.js
@@ -60,6 +60,9 @@ export function mul(a: Grain, b: Grain): Grain {
 export function div(a: Grain, b: Grain): Grain {
   return bigInt(a).divide(bigInt(b)).toString();
 }
+export function pow(a: Grain, b: Grain): Grain {
+  return bigInt(a).pow(bigInt(b)).toString();
+}
 export function lt(a: Grain, b: Grain): boolean {
   return bigInt(a).lt(bigInt(b));
 }

--- a/src/core/ledger/grainAllocation.test.js
+++ b/src/core/ledger/grainAllocation.test.js
@@ -3,6 +3,7 @@
 import {
   computeAllocation,
   type AllocationIdentity,
+  type CredMapping,
   _validateAllocationBudget,
   toDiscount,
 } from "./grainAllocation";
@@ -18,13 +19,22 @@ describe("core/ledger/grainAllocation", () => {
   function aid(paid: number, cred: $ReadOnlyArray<number>): AllocationIdentity {
     return {id: randomUuid(), paid: ng(paid), cred};
   }
-  const immediate = (n: number) => ({policyType: "IMMEDIATE", budget: ng(n)});
-  const recent = (n: number, discount: number) => ({
+  const balanced = (n: number, credMapping?: Function) => ({
+    policyType: "BALANCED",
+    budget: ng(n),
+    credMapping,
+  });
+  const immediate = (n: number, credMapping?: Function) => ({
+    policyType: "IMMEDIATE",
+    budget: ng(n),
+    credMapping,
+  });
+  const recent = (n: number, discount: number, credMapping?: Function) => ({
     policyType: "RECENT",
     budget: ng(n),
     discount: toDiscount(discount),
+    credMapping,
   });
-  const balanced = (n: number) => ({policyType: "BALANCED", budget: ng(n)});
 
   describe("computeAllocation", () => {
     describe("validation", () => {
@@ -101,6 +111,25 @@ describe("core/ledger/grainAllocation", () => {
       });
     });
 
+    describe("quadratic immediate policy", () => {
+      const coefficient = 1;
+      const exponent = 0.5;
+      const pow = (exp) => (c) => (a) => (c * a) ** exp;
+      const quadraticMap: CredMapping = (scores) =>
+        scores.map(pow(exponent)(coefficient));
+      const policy = immediate(100, quadraticMap);
+      const i1 = aid(0, [16, 64, 25]);
+      const i2 = aid(100, [100, 100, 100]);
+      const i3 = aid(0, [100, 144, 400]);
+      const allocation = computeAllocation(policy, [i1, i2, i3]);
+      const expectedReceipts = [
+        {id: i1.id, amount: ng(14)},
+        {id: i2.id, amount: ng(28)},
+        {id: i3.id, amount: ng(58)},
+      ];
+      expect(allocation.receipts).toEqual(expectedReceipts);
+    });
+
     describe("recent policy", () => {
       it("splits based on discounted cred", () => {
         const policy = recent(100, 0.1);
@@ -173,6 +202,25 @@ describe("core/ledger/grainAllocation", () => {
       });
     });
 
+    describe("quadratic recent policy", () => {
+      const coefficient = 1;
+      const exponent = 0.5;
+      const pow = (exp) => (c) => (a) => (c * a) ** exp;
+      const quadraticMap: CredMapping = (scores) =>
+        scores.map(pow(exponent)(coefficient));
+      const policy = recent(100, 0.5, quadraticMap);
+      const i1 = aid(0, [16, 64, 100]);
+      const i2 = aid(100, [100, 100, 100]);
+      const i3 = aid(0, [100, 144, 0]);
+      const allocation = computeAllocation(policy, [i1, i2, i3]);
+      const expectedReceipts = [
+        {id: i1.id, amount: ng(33)},
+        {id: i2.id, amount: ng(38)},
+        {id: i3.id, amount: ng(29)},
+      ];
+      expect(allocation.receipts).toEqual(expectedReceipts);
+    });
+
     describe("balanced policy", () => {
       it("splits based on lifetime Cred when there's no paid amounts", () => {
         const policy = balanced(100);
@@ -222,6 +270,23 @@ describe("core/ledger/grainAllocation", () => {
         };
         expect(allocation).toEqual(expectedAllocation);
       });
+    });
+
+    describe("quadratic balanced policy", () => {
+      const coefficient = 1;
+      const exponent = 0.5;
+      const pow = (exp) => (c) => (a) => (c * a) ** exp;
+      const quadraticMap: CredMapping = (scores) =>
+        scores.map(pow(exponent)(coefficient));
+      const policy = balanced(100, quadraticMap);
+      const i1 = aid(0, [1, 1]);
+      const i2 = aid(0, [3, 0]);
+      const allocation = computeAllocation(policy, [i1, i2]);
+      const expectedReceipts = [
+        {id: i1.id, amount: ng(44)},
+        {id: i2.id, amount: ng(56)},
+      ];
+      expect(allocation.receipts).toEqual(expectedReceipts);
     });
 
     describe("special policy", () => {


### PR DESCRIPTION
This commit allows injecting an optional `CredMapping :: CredScores => CredScores` into the receipt functions for each policy type (besides special by design).  In practice, we will use this for calculating grain distributions based on quadratically weighted cred; however, it lets us add any `CredScores` garnish more generally.  This makes policy building easier as we can tweak policies and their parameters on the fly without changing the underlying types.  This should also speed up any future cryptoeconomics research.

The obvious option is to create a new policy for each, but modifying policies does not scale will in this case.  Instead, injecting a more general mapping (which defaults to `id`) allows us to use the core logic of the core `Balanced`, `Immediate`, and `Recent` policies.

__Test Plan__
Here, I've added unit tests that test this by injecting a function to quadratically weight cred.