### PR TITLE
credrank: add "bonus minting" in the Graph

### DIFF
--- a/src/core/bonusMinting.js
+++ b/src/core/bonusMinting.js
@@ -24,9 +24,20 @@
  * time/effort invested in building all the dependencies may be orders of
  * magnitude larger than investment in the project itself.
  */
-import {type NodeAddressT, NodeAddress} from "./graph";
+import {
+  type NodeAddressT,
+  NodeAddress,
+  type Node as GraphNode,
+  type Edge as GraphEdge,
+  type EdgeAddressT,
+  EdgeAddress,
+  Graph,
+} from "./graph";
+import {type WeightedGraph as WeightedGraphT} from "./weightedGraph";
+import {empty as emptyWeights, type EdgeWeight} from "./weights";
 import {type TimestampMs} from "../util/timestamp";
-import {type IntervalSequence} from "./interval";
+import {type IntervalSequence, type Interval, partitionGraph} from "./interval";
+import {nodeWeightEvaluator} from "./algorithm/weightEvaluator";
 
 export type BonusPolicy = {|
   // The node address that will receieve the extra minted Cred
@@ -47,6 +58,161 @@ export type BonusPeriod = {|
   +startTimeMs: TimestampMs | number,
 |};
 
+export type ComputedBonusMinting = $ReadOnlyArray<BonusMintOverTime>;
+
+export type BonusMintOverTime = {|
+  +recipient: GraphNode,
+  // Recipient's bonus minting in each interval.
+  +bonusIntervals: $ReadOnlyArray<BonusInterval>,
+|};
+
+export type BonusInterval = {|
+  +interval: Interval,
+  // The amount of bonus Cred to mint in this interval.
+  +amount: number,
+|};
+
+export function computeBonusMinting(
+  wg: WeightedGraphT,
+  policies: $ReadOnlyArray<BonusPolicy>
+): ComputedBonusMinting {
+  const mintIntervals = _computeMintIntervals(wg);
+  return policies.map((policy) => {
+    const recipient = wg.graph.node(policy.address);
+    if (recipient == null) {
+      throw new Error(
+        `bonus recipient not in graph: ${NodeAddress.toString(policy.address)}`
+      );
+    }
+    return {
+      recipient,
+      bonusIntervals: _bonusIntervals(mintIntervals, policy.periods),
+    };
+  });
+}
+
+export function _bonusIntervals(
+  mintIntervals: $ReadOnlyArray<MintInterval>,
+  periods: $ReadOnlyArray<BonusPeriod>
+): $ReadOnlyArray<BonusInterval> {
+  let nextIndex = 0;
+  let weight = 0;
+
+  return mintIntervals.map(({interval, totalMint}) => {
+    while (
+      nextIndex < periods.length &&
+      periods[nextIndex].startTimeMs <= interval.startTimeMs
+    ) {
+      weight = periods[nextIndex].weight;
+      nextIndex++;
+    }
+    return {
+      interval,
+      amount: totalMint * weight,
+    };
+  });
+}
+
+export function createBonusGraph(
+  bonusMints: ComputedBonusMinting
+): WeightedGraphT {
+  const graph = new Graph();
+  const weights = emptyWeights();
+  for (const {recipient, bonusIntervals} of bonusMints) {
+    graph.addNode(recipient);
+    for (const {interval, amount} of bonusIntervals) {
+      if (amount === 0) {
+        continue;
+      }
+      graph.addNode(bonusNode(recipient, interval));
+      graph.addEdge(bonusEdge(recipient, interval));
+      weights.nodeWeights.set(bonusNodeAddress(recipient, interval), amount);
+    }
+  }
+  weights.edgeWeights.set(BONUS_EDGE_PREFIX, BONUS_EDGE_WEIGHT);
+  return {graph, weights};
+}
+
+export const BONUS_NODE_PREFIX: NodeAddressT = NodeAddress.fromParts([
+  "sourcecred",
+  "core",
+  "BONUS",
+]);
+
+export function bonusNodeAddress(
+  recipient: GraphNode,
+  interval: Interval
+): NodeAddressT {
+  return NodeAddress.append(
+    BONUS_NODE_PREFIX,
+    String(interval.startTimeMs),
+    ...NodeAddress.toParts(recipient.address)
+  );
+}
+
+export function bonusNode(recipient: GraphNode, interval: Interval): GraphNode {
+  return {
+    address: bonusNodeAddress(recipient, interval),
+    timestampMs: interval.startTimeMs,
+    description: `bonus minting for ${recipient.description} starting ${interval.startTimeMs}`,
+  };
+}
+
+export const BONUS_EDGE_PREFIX: EdgeAddressT = EdgeAddress.fromParts([
+  "sourcecred",
+  "core",
+  "BONUS",
+]);
+
+export const BONUS_EDGE_WEIGHT: EdgeWeight = Object.freeze({
+  forwards: 1,
+  // setting the backward weight to non-zero has a material effect on the
+  // resultant Cred scores, since it means that the bonus minting node acts as
+  // a mini Cred accumulator in a tight loop with the recipient. Setting this
+  // to 0 results in somewhat lower Cred for the mint recipient, and I like
+  // biasing conservatively here.
+  backwards: 0,
+});
+
+export function bonusEdgeAddress(
+  recipient: GraphNode,
+  interval: Interval
+): EdgeAddressT {
+  return EdgeAddress.append(
+    BONUS_EDGE_PREFIX,
+    String(interval.startTimeMs),
+    ...NodeAddress.toParts(recipient.address)
+  );
+}
+
+export function bonusEdge(recipient: GraphNode, interval: Interval): GraphEdge {
+  return {
+    src: bonusNodeAddress(recipient, interval),
+    dst: recipient.address,
+    address: bonusEdgeAddress(recipient, interval),
+    timestampMs: interval.startTimeMs,
+  };
+}
+
+// How much total Cred minting occured in a particular interval, for a particular graph?
+export type MintInterval = {|
+  +interval: Interval,
+  +totalMint: number,
+|};
+export function _computeMintIntervals(
+  wg: WeightedGraphT
+): $ReadOnlyArray<MintInterval> {
+  const nwe = nodeWeightEvaluator(wg.weights);
+  const partition = partitionGraph(wg.graph);
+  return partition.map(({interval, nodes}) => {
+    let totalMint = 0;
+    for (const {address} of nodes) {
+      totalMint += nwe(address);
+    }
+    return {interval, totalMint};
+  });
+}
+
 // ========================= DEPRECATED =========================
 // Everything below this line has TimelineCred specific logic, and will be
 // removed when we switch to CredRank.
@@ -57,6 +223,8 @@ export type BonusPeriod = {|
  * we're doing raw cred computation: instead of an address, we track an index
  * into the canonical node order, and rather than arbitrary client-provided
  * periods, we compute the weight for each Interval.
+ *
+ * TODO(#1686, @decentralion): Remove this once we switch to CredRank.
  */
 export type ProcessedBonusPolicy = {|
   +nodeIndex: number,

--- a/src/core/bonusMinting.test.js
+++ b/src/core/bonusMinting.test.js
@@ -1,11 +1,293 @@
 // @flow
 
+import {type TimestampMs} from "../util/timestamp";
 import deepFreeze from "deep-freeze";
-import {NodeAddress} from "./graph";
-import {_alignPeriodsToIntervals, processBonusPolicy} from "./bonusMinting";
+import {Graph, NodeAddress} from "./graph";
 import {intervalSequence} from "./interval";
+import {type WeightedGraph as WeightedGraphT} from "./weightedGraph";
+import {empty as emptyWeights} from "./weights";
+import {utcWeek} from "d3-time";
+import {
+  _alignPeriodsToIntervals,
+  processBonusPolicy,
+  computeBonusMinting,
+  createBonusGraph,
+  _computeMintIntervals,
+  _bonusIntervals,
+  BONUS_EDGE_PREFIX,
+  BONUS_EDGE_WEIGHT,
+  bonusNode,
+  bonusNodeAddress,
+  bonusEdge,
+} from "./bonusMinting";
 
 describe("core/bonusMinting", () => {
+  describe("createBonusGraph", () => {
+    it("adds no nodes or node weights if there is no minting", () => {
+      const wg = createBonusGraph([]);
+      expect(wg.graph.equals(new Graph())).toBe(true);
+      expect(wg.weights.nodeWeights).toEqual(new Map());
+    });
+    it("adds the bonus edge prefix weight even without minting", () => {
+      const {weights} = createBonusGraph([]);
+      const expectedEdgeWeights = new Map().set(
+        BONUS_EDGE_PREFIX,
+        BONUS_EDGE_WEIGHT
+      );
+      expect(weights.edgeWeights).toEqual(expectedEdgeWeights);
+    });
+    it("only contains recipient if there is no minting", () => {
+      const recipient = {
+        address: NodeAddress.fromParts(["recipient"]),
+        description: "recipient",
+        timestampMs: null,
+      };
+      const mint = {recipient, bonusIntervals: []};
+
+      const expectedGraph = new Graph().addNode(recipient);
+      const expectedWeights = emptyWeights();
+      expectedWeights.edgeWeights.set(BONUS_EDGE_PREFIX, BONUS_EDGE_WEIGHT);
+
+      const wg = createBonusGraph([mint]);
+      expect(wg.graph.equals(expectedGraph)).toBe(true);
+      expect(wg.weights).toEqual(expectedWeights);
+    });
+    it("adds nodes, edges, and weights when there is minting", () => {
+      const recipient = {
+        address: NodeAddress.fromParts(["recipient"]),
+        description: "recipient",
+        timestampMs: null,
+      };
+      const interval = {startTimeMs: 101, endTimeMs: 102};
+      const bonusInterval = {
+        interval,
+        amount: 10,
+      };
+      const mint = {recipient, bonusIntervals: [bonusInterval]};
+
+      const expectedGraph = new Graph()
+        .addNode(recipient)
+        .addNode(bonusNode(recipient, interval))
+        .addEdge(bonusEdge(recipient, interval));
+      const expectedWeights = emptyWeights();
+      expectedWeights.nodeWeights.set(
+        bonusNodeAddress(recipient, interval),
+        10
+      );
+      expectedWeights.edgeWeights.set(BONUS_EDGE_PREFIX, BONUS_EDGE_WEIGHT);
+
+      const wg = createBonusGraph([mint]);
+      expect(wg.graph.equals(expectedGraph)).toBe(true);
+      expect(wg.weights).toEqual(expectedWeights);
+    });
+  });
+
+  describe("node and edge methods", () => {
+    const recipient = deepFreeze({
+      address: NodeAddress.fromParts(["1"]),
+      timestampMs: null,
+      description: "recipient",
+    });
+    const interval = deepFreeze({startTimeMs: 1, endTimeMs: 2});
+    const expectedAddress = bonusNodeAddress(recipient, interval);
+    it("bonusNode works", () => {
+      const node = bonusNode(recipient, interval);
+      expect(node.address).toEqual(expectedAddress);
+      expect(node.timestampMs).toEqual(interval.startTimeMs);
+      expect(node.description).toMatchInlineSnapshot(
+        `"bonus minting for recipient starting 1"`
+      );
+    });
+    it("bonusEdge works", () => {
+      const edge = bonusEdge(recipient, interval);
+      expect(edge.timestampMs).toEqual(interval.startTimeMs);
+      expect(edge.dst).toEqual(recipient.address);
+      expect(edge.src).toEqual(expectedAddress);
+    });
+  });
+
+  describe("methods operating on weighted graphs", () => {
+    class TestWeightedGraph {
+      wg: WeightedGraphT;
+      constructor() {
+        this.wg = {weights: emptyWeights(), graph: new Graph()};
+      }
+      addNode(opts: {|
+        +id: number,
+        +timestampMs: TimestampMs,
+        +mint: number,
+      |}): TestWeightedGraph {
+        const {id, timestampMs, mint} = opts;
+        const address = NodeAddress.fromParts([String(id)]);
+        this.wg.weights.nodeWeights.set(address, mint);
+        this.wg.graph.addNode({address, description: String(id), timestampMs});
+        return this;
+      }
+    }
+    // Since we are hardcoded to week-based time partitioning, generate some
+    // week-spaced timestamps
+    const w1 = +utcWeek.floor(0);
+    const w2 = +utcWeek.ceil(0);
+    const w3 = +utcWeek.ceil(w2 + 1);
+    const w4 = +utcWeek.ceil(w3 + 1);
+    expect(w4).toBeGreaterThan(w3);
+    expect(w3).toBeGreaterThan(w2);
+    expect(w2).toBeGreaterThan(w1);
+
+    describe("computeBonusMinting", () => {
+      // This method is a wrapper around methods which are individually well tested,
+      // so a smoke/integration test here is fine.
+      it("works on a representative case", () => {
+        const wg = new TestWeightedGraph()
+          .addNode({id: 1, mint: 3, timestampMs: w1})
+          .addNode({id: 2, mint: 4, timestampMs: w2}).wg;
+        const recipient = {
+          address: NodeAddress.fromParts(["recipient"]),
+          description: "recipient",
+          timestampMs: null,
+        };
+        wg.graph.addNode(recipient);
+        wg.weights.nodeWeights.set(recipient.address, 0);
+        const policy = {
+          address: recipient.address,
+          periods: [{startTimeMs: w1, weight: 0.5}],
+        };
+        const minting = computeBonusMinting(wg, [policy]);
+        const expected = [
+          {
+            recipient,
+            bonusIntervals: [
+              {interval: {startTimeMs: w1, endTimeMs: w2}, amount: 1.5},
+              {interval: {startTimeMs: w2, endTimeMs: w3}, amount: 2},
+            ],
+          },
+        ];
+        expect(minting).toEqual(expected);
+      });
+      it("errors if the recipient is not in the graph", () => {
+        const wg = new TestWeightedGraph()
+          .addNode({id: 1, mint: 3, timestampMs: w1})
+          .addNode({id: 2, mint: 4, timestampMs: w2}).wg;
+        const recipient = {
+          address: NodeAddress.fromParts(["recipient"]),
+          description: "recipient",
+          timestampMs: null,
+        };
+        const policy = {
+          address: recipient.address,
+          periods: [{startTimeMs: w1, weight: 0.5}],
+        };
+        const fail = () => computeBonusMinting(wg, [policy]);
+        expect(fail).toThrowError("bonus recipient not in graph");
+      });
+    });
+
+    describe("_computeMintIntervals", () => {
+      it("handles an empty graph", () => {
+        const wg = new TestWeightedGraph().wg;
+        expect(_computeMintIntervals(wg)).toEqual([]);
+      });
+      it("handles a graph with no minting", () => {
+        const wg = new TestWeightedGraph()
+          .addNode({id: 0, mint: 0, timestampMs: w1})
+          .addNode({id: 1, mint: 0, timestampMs: w2}).wg;
+        expect(_computeMintIntervals(wg)).toEqual([
+          {interval: {startTimeMs: w1, endTimeMs: w2}, totalMint: 0},
+          {interval: {startTimeMs: w2, endTimeMs: w3}, totalMint: 0},
+        ]);
+      });
+      it("handles a graph with minting", () => {
+        const wg = new TestWeightedGraph()
+          .addNode({id: 0, mint: 1, timestampMs: w1})
+          .addNode({id: 1, mint: 3, timestampMs: w3}).wg;
+        expect(_computeMintIntervals(wg)).toEqual([
+          {interval: {startTimeMs: w1, endTimeMs: w2}, totalMint: 1},
+          {interval: {startTimeMs: w2, endTimeMs: w3}, totalMint: 0},
+          {interval: {startTimeMs: w3, endTimeMs: w4}, totalMint: 3},
+        ]);
+      });
+    });
+
+    describe("_bonusIntervals", () => {
+      it("yields 0 weight if there are no periods", () => {
+        const mintIntervals = [
+          {interval: {startTimeMs: w1, endTimeMs: w2}, totalMint: 1},
+          {interval: {startTimeMs: w2, endTimeMs: w3}, totalMint: 2},
+        ];
+        const periods = [];
+        const expected = mintIntervals.map((mintInterval) => ({
+          interval: mintInterval.interval,
+          amount: 0,
+        }));
+        expect(Array.from(_bonusIntervals(mintIntervals, periods))).toEqual(
+          expected
+        );
+      });
+      it("handles a simple case of interval-aligned periods", () => {
+        const mintIntervals = [
+          {interval: {startTimeMs: w1, endTimeMs: w2}, totalMint: 1},
+          {interval: {startTimeMs: w2, endTimeMs: w3}, totalMint: 2},
+        ];
+        const periods = [
+          {startTimeMs: w1, weight: 0.5},
+          {startTimeMs: w2, weight: 0.8},
+        ];
+        const expected = [
+          {interval: {startTimeMs: w1, endTimeMs: w2}, amount: 0.5},
+          {interval: {startTimeMs: w2, endTimeMs: w3}, amount: 1.6},
+        ];
+        expect(Array.from(_bonusIntervals(mintIntervals, periods))).toEqual(
+          expected
+        );
+      });
+      it("handles a starting period at -Infinity", () => {
+        const mintIntervals = [
+          {interval: {startTimeMs: w1, endTimeMs: w2}, totalMint: 1},
+          {interval: {startTimeMs: w2, endTimeMs: w3}, totalMint: 2},
+        ];
+        const periods = [{startTimeMs: -Infinity, weight: 0.5}];
+        const expected = [
+          {interval: {startTimeMs: w1, endTimeMs: w2}, amount: 0.5},
+          {interval: {startTimeMs: w2, endTimeMs: w3}, amount: 1},
+        ];
+        expect(Array.from(_bonusIntervals(mintIntervals, periods))).toEqual(
+          expected
+        );
+      });
+      it("handles offset periods", () => {
+        const mintIntervals = [
+          {interval: {startTimeMs: w1, endTimeMs: w2}, totalMint: 1},
+          {interval: {startTimeMs: w2, endTimeMs: w3}, totalMint: 2},
+        ];
+        const periods = [{startTimeMs: w1 + 1, weight: 0.5}];
+        const expected = [
+          {interval: {startTimeMs: w1, endTimeMs: w2}, amount: 0},
+          {interval: {startTimeMs: w2, endTimeMs: w3}, amount: 1},
+        ];
+        expect(Array.from(_bonusIntervals(mintIntervals, periods))).toEqual(
+          expected
+        );
+      });
+      it("skips periods that are sandwiched", () => {
+        const mintIntervals = [
+          {interval: {startTimeMs: w1, endTimeMs: w2}, totalMint: 1},
+          {interval: {startTimeMs: w2, endTimeMs: w3}, totalMint: 2},
+        ];
+        const periods = [
+          {startTimeMs: w1 + 1, weight: 0.5},
+          {startTimeMs: w1 + 1, weight: 0.9},
+        ];
+        const expected = [
+          {interval: {startTimeMs: w1, endTimeMs: w2}, amount: 0},
+          {interval: {startTimeMs: w2, endTimeMs: w3}, amount: 1.8},
+        ];
+        expect(Array.from(_bonusIntervals(mintIntervals, periods))).toEqual(
+          expected
+        );
+      });
+    });
+  });
+
   describe("_alignPeriodsToIntervals", () => {
     it("handles a case with no periods and no intervals", () => {
       expect(_alignPeriodsToIntervals([], [])).toEqual([]);


### PR DESCRIPTION
This commit adds new logic to the bonus minting module so that we can
embed bonus minting directly in to the graph. That is to say, if we mint
bonus Cred for a particular recipient, there will be an explicit Graph
node that mints Cred and flows it to that recipient.

This is intended as a way to add bonus minting to CredRank, without
needing to special-case bonus minting outside of the usual Graph
abstraction. We considered a few approaches here, including embedding
complicated graph gadgets without minting any additional Cred, but this
approach is by far easier to implement.

The downside to this approach is that the amount of bonus-minted Cred
will not exactly match the intended specification. For example, if we
have a single bonus account and we want it to get 10% of the total Cred
(after bonus minting), we would set weight = 0.1111111. In practice,
using SC's own instance as a reference case, it winds up getting
8.6% of the Cred. It's impossible to get exact correctness using this
approach because of nuances in how much raw (PageRank) transition
probability accumulates at nodes based on the path between the seed node
and the recipient.

We could continue getting exact results (as in TimelineCred) if we
entirely special-case the bonus minting, rather than using the usual
Cred computation pipeline. However, I think it's preferrable to keep the
core algorithm as consistent as possible. I also see this kind of bonus
minting as a temporary solution to the general question of "how should
projects value their dependences". Therefore, I don't mind if it has a
few rough edges.

Note: This commit doesn't change behavior for TimelineCred at all. Since
we're planning to deprecate it, no sense upgrading it.

Test plan:
Run the `credrank` command on an instance that has dependencies
specified. You'll see that the dependency now gets Cred, and it's
generally similar to the intended minting amount. Also, unit tests
added.