### PR TITLE
Add prompt if no plugins are configured

### DIFF
--- a/src/cli/load.js
+++ b/src/cli/load.js
@@ -31,6 +31,12 @@ const loadCommand: Command = async (args, std) => {
   const config = await loadInstanceConfig(baseDir);
   if (args.length === 0) {
     pluginsToLoad = Array.from(config.bundledPlugins.keys());
+    if (pluginsToLoad.length === 0) {
+      std.err(
+        "No plugins configured; Please set up at least one plugin: " +
+          "https://github.com/sourcecred/template-instance#supported-plugins"
+      );
+    }
   } else {
     for (const arg of args) {
       const id = pluginIdParser.parseOrThrow(arg);


### PR DESCRIPTION
We can provide a better UX for community leads interested in testing out SourceCred and simultaneously minimize our support load with a prompt to get people who just dive right into the template instance. Based on support requests I've been fielding, I've gotten the idea that a non-trivial quantity of people start toying with the instance before reading much, and this message will be an actionable nudge in the right direction.

Test plan: in template instance run `scdev load` and observe the
message. Test on a configured instance to ensure the message does not
display