### PR TITLE
Bugfix: support empty JsonLog files

### DIFF
--- a/src/util/jsonLog.js
+++ b/src/util/jsonLog.js
@@ -74,6 +74,10 @@ function _extractLogLines(log: string): string[] {
   // format, all automatically written ledgers include a trailing LF.
   // Strip it, if present, for ease of `split("\n")`.
   log = log.trimRight();
+  // If the file is empty, return no entries to parse
+  if (log.length === 0) {
+    return [];
+  }
   if (log.startsWith("[")) {
     // Temporarily compatibility measure for raw JSON arrays (not NDJSON),
     // in the specific form written by previous versions of this module.

--- a/src/util/jsonLog.test.js
+++ b/src/util/jsonLog.test.js
@@ -33,6 +33,9 @@ describe("util/jsonLog", () => {
     expect(emptyLogString).toEqual("");
   });
   it("parses an empty string as an empty log", () => {
+    expect(JsonLog.fromString("", C.number)).toEqual(new JsonLog());
+  });
+  it("parses an empty array as an empty log", () => {
     expect(JsonLog.fromString("[]", C.number)).toEqual(new JsonLog());
   });
 


### PR DESCRIPTION
We support legacy empty-case formats, but we technically don't support
the empty-case for NDjson. This change fixes that, by adding support for
when the serialized logfile contains no entries.

It's technically a bug because when an empty JSONlog is serialized it
returns an empty file and there was no way to parse it again. This case
presented itself when running `yarn graph` and `yarn score` in a clean
template instance

test plan: unit tests have been updated to demonstrate support for this
case.