### PR TITLE
Bugfix: create output directory in score command

### DIFF
--- a/src/cli/score.js
+++ b/src/cli/score.js
@@ -6,7 +6,7 @@ import stringify from "json-stable-stringify";
 
 import type {Command} from "./command";
 import {loadInstanceConfig, prepareCredData} from "./common";
-import {loadJsonWithDefault} from "../util/disk";
+import {loadJsonWithDefault, mkdirx} from "../util/disk";
 import dedent from "../util/dedent";
 import {LoggingTaskReporter} from "../util/taskReporter";
 import {
@@ -58,7 +58,9 @@ const scoreCommand: Command = async (args, std) => {
   // information available once we merge CredRank, anyway.
   const stripped = stripOverTimeDataForNonUsers(credResult);
   const credJSON = stringify(credResultToJSON(stripped));
-  const outputPath = pathJoin(baseDir, "output", "credResult.json");
+  const outputDir = pathJoin(baseDir, "output");
+  mkdirx(outputDir);
+  const outputPath = pathJoin(outputDir, "credResult.json");
   await fs.writeFile(outputPath, credJSON);
 
   // Write out the account data for convenient usage.


### PR DESCRIPTION
In the template instance, no prior commands yield anything in the output
directory. This yields a bug in the score command because there is no
allowance for it not to exist at this point. Adding a `mkdirx` command
here fixes that.

test plan: run `scdev go` in a clean template instance and verify the
folder is created without and filesystem-level errors throwing