### PR TITLE
Refactor computeCredAccounts to function in the empty case

### DIFF
--- a/src/core/ledger/credAccounts.js
+++ b/src/core/ledger/credAccounts.js
@@ -47,15 +47,19 @@ export function computeCredAccounts(
 ): CredAccountData {
   const grainAccounts = ledger.accounts();
   const userlikeInfo = new Map();
+  const intervals = credView.intervals();
+  const noIntervals = intervals.length === 0;
   for (const {address, credOverTime, description} of credView.userNodes()) {
-    if (credOverTime == null) {
+    if (noIntervals) {
+      userlikeInfo.set(address, {cred: [], description});
+    } else if (credOverTime === null) {
       throw new Error(
         `userlike ${NodeAddress.toString(address)} does not have detailed cred`
       );
+    } else {
+      userlikeInfo.set(address, {cred: credOverTime.cred, description});
     }
-    userlikeInfo.set(address, {cred: credOverTime.cred, description});
   }
-  const intervals = credView.intervals();
   return _computeCredAccounts(grainAccounts, userlikeInfo, intervals);
 }
 

--- a/src/core/ledger/credAccounts.test.js
+++ b/src/core/ledger/credAccounts.test.js
@@ -7,6 +7,11 @@ import {intervalSequence} from "../interval";
 
 describe("core/ledger/credAccounts", () => {
   describe("_computeCredAccounts", () => {
+    it("works in an empty case", () => {
+      expect(
+        _computeCredAccounts([], new Map(), intervalSequence([]))
+      ).toEqual({"accounts": [], "intervals": [], unclaimedAliases: []});
+    });
     it("works in a simple case", () => {
       const ledger = new Ledger();
       ledger.createIdentity("USER", "sourcecred");
@@ -43,6 +48,42 @@ describe("core/ledger/credAccounts", () => {
       expect(_computeCredAccounts([account], info, intervals)).toEqual(
         expectedData
       );
+    });
+    it("returns credAccountData even if no intervals have passed", () => {
+      // note: this is the default case in our template intance
+      // By default, we mean:
+      // 1. single identity exists and
+      // 2. no cred intervals have been computed
+      const ledger = new Ledger();
+      ledger.createIdentity("USER", "sourcecred");
+      const userAddress = NodeAddress.empty;
+      const emptyCred = [];
+      const account = ledger.accounts()[0];
+      const intervals = intervalSequence([]);
+      const info = new Map([
+        [
+          account.identity.address,
+          {cred: emptyCred, description: "irrelevant"},
+        ],
+        [userAddress, {cred: emptyCred, description: "Little lost user"}],
+      ]);
+
+      const expectedCredAccount = {cred: emptyCred, account, totalCred: 0};
+      const expectedUnclaimedAccount = {
+        alias: {
+          address: userAddress,
+          description: "Little lost user",
+        },
+        cred: emptyCred,
+        totalCred: 0,
+      };
+      const expectedData = {
+        accounts: [expectedCredAccount],
+        unclaimedAliases: [expectedUnclaimedAccount],
+        intervals,
+      };
+      const result = _computeCredAccounts([account], info, intervals);
+      expect(result).toEqual(expectedData);
     });
     it("errors if an alias address is in the cred scores", () => {
       const ledger = new Ledger();


### PR DESCRIPTION
The public computeCredAccounts command would fail if no intervals had
been computed yet, because userNodes were always assumed to contain some
cred values. This refactoring allows for computeCredAccounts to succeed
without any credIntervals needing to be created.

This is needed to allow the template instance to successfully run `yarn
go` out of the box (even if it doesn't do anything substantial without
plugins)

test plan: The outer function is untested, but the inner function has
been updated to demonstrate support for both the empty case and the
"default case", meaning the case in the template instance