### PR TITLE
Refactor compareGraphs to match compareWeights

### DIFF
--- a/src/core/graph.js
+++ b/src/core/graph.js
@@ -1213,69 +1213,59 @@ export function edgeToParts(
   return {addressParts, srcParts, dstParts, timestampMs};
 }
 
+export type NodeDiff = {|
+  +first: ?Node,
+  +second: ?Node,
+|};
+
+export type EdgeDiff = {|
+  +first: ?Edge,
+  +second: ?Edge,
+|};
+
 export type GraphComparison = {|
   +graphsAreEqual: boolean,
-  +uniqueNodesInFirst: $ReadOnlyArray<Node>,
-  +uniqueNodesInSecond: $ReadOnlyArray<Node>,
-  +nodeTuplesWithDifferences: $ReadOnlyArray<[Node, Node]>,
-  +uniqueEdgesInFirst: $ReadOnlyArray<Edge>,
-  +uniqueEdgesInSecond: $ReadOnlyArray<Edge>,
-  +edgeTuplesWithDifferences: $ReadOnlyArray<[Edge, Edge]>,
+  +nodeDiffs: $ReadOnlyArray<NodeDiff>,
+  +edgeDiffs: $ReadOnlyArray<EdgeDiff>,
 |};
 
 export function compareGraphs(
   firstGraph: Graph,
   secondGraph: Graph
 ): GraphComparison {
-  const uniqueNodesInFirst = [];
-  const uniqueNodesInSecond = [];
-  const nodeTuplesWithDifferences = [];
-  const uniqueEdgesInFirst = [];
-  const uniqueEdgesInSecond = [];
-  const edgeTuplesWithDifferences = [];
+  const nodeDiffs = [];
+  const edgeDiffs = [];
   const graphsAreEqual = firstGraph.equals(secondGraph);
 
   if (!graphsAreEqual) {
     for (const firstNode of firstGraph.nodes()) {
       const secondNode = secondGraph.node(firstNode.address);
-      if (secondNode) {
-        if (!deepEqual(firstNode, secondNode))
-          nodeTuplesWithDifferences.push([firstNode, secondNode]);
-      } else {
-        uniqueNodesInFirst.push(firstNode);
-      }
+      if (!deepEqual(firstNode, secondNode))
+        nodeDiffs.push({first: firstNode, second: secondNode});
     }
     for (const secondNode of secondGraph.nodes()) {
       const firstNode = firstGraph.node(secondNode.address);
       if (!firstNode) {
-        uniqueNodesInSecond.push(secondNode);
+        nodeDiffs.push({first: firstNode, second: secondNode});
       }
     }
 
     for (const firstEdge of firstGraph.edges({showDangling: true})) {
       const secondEdge = secondGraph.edge(firstEdge.address);
-      if (secondEdge) {
-        if (!deepEqual(firstEdge, secondEdge))
-          edgeTuplesWithDifferences.push([firstEdge, secondEdge]);
-      } else {
-        uniqueEdgesInFirst.push(firstEdge);
-      }
+      if (!deepEqual(firstEdge, secondEdge))
+        edgeDiffs.push({first: firstEdge, second: secondEdge});
     }
     for (const secondEdge of secondGraph.edges({showDangling: true})) {
       const firstEdge = firstGraph.edge(secondEdge.address);
       if (!firstEdge) {
-        uniqueEdgesInSecond.push(secondEdge);
+        edgeDiffs.push({first: firstEdge, second: secondEdge});
       }
     }
   }
 
   return {
     graphsAreEqual,
-    uniqueNodesInFirst,
-    uniqueNodesInSecond,
-    nodeTuplesWithDifferences,
-    uniqueEdgesInFirst,
-    uniqueEdgesInSecond,
-    edgeTuplesWithDifferences,
+    nodeDiffs,
+    edgeDiffs,
   };
 }

--- a/src/core/graph.test.js
+++ b/src/core/graph.test.js
@@ -1673,12 +1673,8 @@ describe("core/graph", () => {
       it("returns empty arrays", () => {
         const expected = {
           graphsAreEqual: true,
-          uniqueNodesInFirst: [],
-          uniqueNodesInSecond: [],
-          nodeTuplesWithDifferences: [],
-          uniqueEdgesInFirst: [],
-          uniqueEdgesInSecond: [],
-          edgeTuplesWithDifferences: [],
+          nodeDiffs: [],
+          edgeDiffs: [],
         };
         expect(compareGraphs(graph1, graph2)).toEqual(expected);
       });
@@ -1690,12 +1686,8 @@ describe("core/graph", () => {
       it("returns empty arrays", () => {
         const expected = {
           graphsAreEqual: true,
-          uniqueNodesInFirst: [],
-          uniqueNodesInSecond: [],
-          nodeTuplesWithDifferences: [],
-          uniqueEdgesInFirst: [],
-          uniqueEdgesInSecond: [],
-          edgeTuplesWithDifferences: [],
+          nodeDiffs: [],
+          edgeDiffs: [],
         };
         expect(compareGraphs(advanced.graph1(), advanced.graph2())).toEqual(
           expected
@@ -1728,12 +1720,11 @@ describe("core/graph", () => {
       it("returns unique dangling edge", () => {
         const expected = {
           graphsAreEqual: false,
-          uniqueNodesInFirst: [],
-          uniqueNodesInSecond: [],
-          nodeTuplesWithDifferences: [],
-          uniqueEdgesInFirst: [danglingEdge],
-          uniqueEdgesInSecond: [danglingEdge2],
-          edgeTuplesWithDifferences: [],
+          nodeDiffs: [],
+          edgeDiffs: [
+            {first: danglingEdge, second: undefined},
+            {first: undefined, second: danglingEdge2},
+          ],
         };
         expect(compareGraphs(graph1, graph2)).toEqual(expected);
       });
@@ -1746,12 +1737,8 @@ describe("core/graph", () => {
       it("returns unique contents", () => {
         const expected = {
           graphsAreEqual: false,
-          uniqueNodesInFirst: [dst],
-          uniqueNodesInSecond: [],
-          nodeTuplesWithDifferences: [],
-          uniqueEdgesInFirst: [simpleEdge],
-          uniqueEdgesInSecond: [],
-          edgeTuplesWithDifferences: [],
+          nodeDiffs: [{first: dst, second: undefined}],
+          edgeDiffs: [{first: simpleEdge, second: undefined}],
         };
         expect(compareGraphs(graph1, graph2)).toEqual(expected);
       });
@@ -1764,12 +1751,8 @@ describe("core/graph", () => {
       it("returns unique contents", () => {
         const expected = {
           graphsAreEqual: false,
-          uniqueNodesInFirst: [],
-          uniqueNodesInSecond: [dst],
-          nodeTuplesWithDifferences: [],
-          uniqueEdgesInFirst: [],
-          uniqueEdgesInSecond: [simpleEdge],
-          edgeTuplesWithDifferences: [],
+          nodeDiffs: [{first: undefined, second: dst}],
+          edgeDiffs: [{first: undefined, second: simpleEdge}],
         };
         expect(compareGraphs(graph1, graph2)).toEqual(expected);
       });
@@ -1791,12 +1774,8 @@ describe("core/graph", () => {
       it("returns tuples with differences", () => {
         const expected = {
           graphsAreEqual: false,
-          uniqueNodesInFirst: [],
-          uniqueNodesInSecond: [],
-          nodeTuplesWithDifferences: [[dst, dst2]],
-          uniqueEdgesInFirst: [],
-          uniqueEdgesInSecond: [],
-          edgeTuplesWithDifferences: [[simpleEdge, simpleEdge2]],
+          nodeDiffs: [{first: dst, second: dst2}],
+          edgeDiffs: [{first: simpleEdge, second: simpleEdge2}],
         };
         expect(compareGraphs(graph1, graph2)).toEqual(expected);
       });


### PR DESCRIPTION
# Notes 
I didn't use the fancy Set union strategy because Nodes/Edges aren't primitives, so Set would allow duplicates, and this seemed sufficiently understandable and efficient.

# Automated Testing
<!-- test -->
yarn test

# Manual Testing
none