### PR TITLE
Create Generic CurrencyId type

### DIFF
--- a/src/core/ledger/currency.js
+++ b/src/core/ledger/currency.js
@@ -1,0 +1,84 @@
+// @flow
+
+import {
+  ethAddressParser,
+  type EthAddress,
+} from "../../plugins/ethereum/ethAddress";
+import * as C from "../../util/combo";
+
+/**
+ * EvmChainId is represented in the form of a stringified integer for all
+ * EVM-based chains, including mainnet (1), and xDai (100).
+ * The reason for this is that ethereum's client configuration utilizes
+ * a number to represent chainId, and this way we can just transpose that
+ * chainId here as a component of the currency Id, since the web3 client will
+ * return a stringified integer when the chainId is requested.
+ */
+export opaque type EvmChainId: string = string;
+
+export function parseEvmChainId(id: string): EvmChainId {
+  const result = parseInt(id, 10).toString();
+  if (Number.isNaN(result) || result !== id) {
+    throw new Error(`Invalid EVM chainId value: ${id}`);
+  }
+  return id;
+}
+
+export type EvmId = {|
+  +type: "EVM",
+  +chainId: EvmChainId,
+  /**
+   * CurrencyAddress is a subset of all available EthAddresses.
+   *
+   * A currency address is the address of the token contract for an ERC20 token,
+   * or the 20 byte-length equivalent of 0x0, which is the conventional address
+   * used to represent ETH on the ethereum mainnet, or the native currency on an
+   * EVM-based sidechain see here for more details on these semantics:
+   * https://ethereum.org/en/developers/docs/intro-to-ethereum/#eth
+   */
+  +currencyAddress: EthAddress,
+|};
+
+/**
+ * Example protocol symbols: "BTC" for bitcoin and "FIL" for Filecoin
+ */
+export opaque type ProtocolSymbol: string = string;
+
+const protocolSymbolParser: C.Parser<ProtocolSymbol> = C.exactly([
+  "BTC",
+  "FIL",
+]);
+
+/**
+ * Chains like Bitcoin and Filecoin do not have "production" sidechains so
+ * we represent them as a string, as specified in the ProtocolSymbol type
+ */
+export type ProtocolId = {|
+  +type: "PROTOCOL",
+  +chainId: ProtocolSymbol,
+|};
+
+export type ChainId = EvmChainId | ProtocolSymbol;
+export type CurrencyId = EvmId | ProtocolId;
+
+export const evmChainParser: C.Parser<EvmChainId> = C.fmap(
+  C.string,
+  parseEvmChainId
+);
+
+export const evmIdParser: C.Parser<EvmId> = C.object({
+  type: C.exactly(["EVM"]),
+  chainId: evmChainParser,
+  currencyAddress: ethAddressParser,
+});
+
+export const protocolIdParser: C.Parser<ProtocolId> = C.object({
+  type: C.exactly(["PROTOCOL"]),
+  chainId: protocolSymbolParser,
+});
+
+// @topocount TODO: enable protocolIdParser once we support its address types
+export const currencyIdParser: C.Parser<CurrencyId> = C.orElse([
+  evmIdParser,
+  protocolIdParser,
+]);

--- a/src/core/ledger/currency.test.js
+++ b/src/core/ledger/currency.test.js
@@ -1,0 +1,25 @@
+// @flow
+
+import {parseEvmChainId} from "./currency";
+
+describe("core/ledger/currency", () => {
+  describe("parseEvmChainId", () => {
+    it("can parse integer strings", () => {
+      const ARRAY_LENGTH = 50;
+      const chainIds = Array.from(Array(ARRAY_LENGTH)).map((_unused_x, idx) =>
+        (idx - ARRAY_LENGTH / 2).toString()
+      );
+      chainIds.forEach((id) => {
+        const result = parseEvmChainId(id);
+        expect(result).toBe(id);
+      });
+    });
+    it("fails on non-integer values", () => {
+      [5.5, Infinity, -Infinity, "Bob"].forEach((x) => {
+        expect(() => parseEvmChainId(x.toString())).toThrow(
+          `Invalid EVM chainId value: ${x}`
+        );
+      });
+    });
+  });
+});

--- a/src/plugins/ethereum/ethAddress.js
+++ b/src/plugins/ethereum/ethAddress.js
@@ -7,6 +7,9 @@ import {compatibleParser} from "../../util/compat";
 
 export opaque type EthAddress: string = string;
 
+export const ETH_CURRENCY_ADDRESS: EthAddress =
+  "0x0000000000000000000000000000000000000000";
+
 /**
  * parseAddress will accept any 20-byte hexadecimal ethereum address encoded as
  * a string, optionally prefixed with `0x`.


### PR DESCRIPTION
A generic CurrencyId will provide support for non-evm protocols once we
support their address formats. For EVM-based blockchains, the numeric
chainId is stored as part of the key, along with the address of the
currency paid out as grain.

Prerequisite for #2429 

test plan: unit tests have been included for parsing logic