### PR TITLE
Don't reset page on # of results per page change for Ledger Viewer

### DIFF
--- a/src/ui/components/LedgerViewer.js
+++ b/src/ui/components/LedgerViewer.js
@@ -75,8 +75,13 @@ export const LedgerViewer = ({
   };
 
   const handleChangeRowsPerPage = (event) => {
-    setRowsPerPage(parseInt(event.target.value, 10));
-    setPage(0);
+    // Keep the user from losing their place when changing # of results per page
+    const newRowsPerPage = parseInt(event.target.value, 10);
+    const currentFirstVisibleRow = page * rowsPerPage;
+    const newPage = Math.floor(currentFirstVisibleRow / newRowsPerPage);
+
+    setRowsPerPage(newRowsPerPage);
+    setPage(newPage);
   };
 
   const events = useMemo(() => [...ledger.eventLog()].reverse(), [ledger]);


### PR DESCRIPTION
In reviewing the changes for the recent update to the Ledger Viewer page from PR #2389 I noticed that when changing the number of results to show per page, the user would automatically be reset to the first page. For a more seamless user experience, I've made some small changes so that the user continues to be in (at least approximately) the same place in the result set, even after changing the number of results per page. Because the resulting page size may be larger or smaller than the previous size, I defaulting to ensuring the new page number includes the first row of the results the user was viewing (as opposed to, say, the middle or final row). The intention of this more conservative choice is to make sure the user is never moved further down in the result set, thereby unintentionally skipping results.

**Test Plan**
I launched my local template-instance and tried every combination of result size changes (25->50, 50->100, 100->25, etc). All resulted in the expect change of remaining on the page number that contained the first row of the previous result page.