### PR TITLE
credrank: provide cleaner interface

### DIFF
--- a/src/cli/credrank.js
+++ b/src/cli/credrank.js
@@ -9,15 +9,8 @@ import sortBy from "../util/sortBy";
 import {credrank} from "../core/credrank/compute";
 import {CredGraph} from "../core/credrank/credGraph";
 import {LoggingTaskReporter} from "../util/taskReporter";
-import {MarkovProcessGraph} from "../core/credrank/markovProcessGraph";
 import type {Command} from "./command";
 import {loadInstanceConfig, prepareCredData} from "./common";
-import {graphIntervals} from "../core/interval";
-
-const DEFAULT_ALPHA = 0.1;
-const DEFAULT_BETA = 0.4;
-const DEFAULT_GAMMA_FORWARD = 0.1;
-const DEFAULT_GAMMA_BACKWARD = 0.1;
 
 function die(std, message) {
   std.err("fatal: " + message);
@@ -38,30 +31,8 @@ const credrankCommand: Command = async (args, std) => {
   const {weightedGraph, ledger} = await prepareCredData(baseDir, config);
   taskReporter.finish("load data");
 
-  taskReporter.start("create Markov process graph");
-  // TODO: Support loading params from config.
-  const parameters = {
-    beta: DEFAULT_BETA,
-    gammaForward: DEFAULT_GAMMA_FORWARD,
-    gammaBackward: DEFAULT_GAMMA_BACKWARD,
-    alpha: DEFAULT_ALPHA,
-  };
-  const participants = ledger.accounts().map(({identity}) => ({
-    description: identity.name,
-    address: identity.address,
-    id: identity.id,
-  }));
-  const intervals = graphIntervals(weightedGraph.graph);
-  const mpg = MarkovProcessGraph.new({
-    weightedGraph,
-    participants,
-    parameters,
-    intervals,
-  });
-  taskReporter.finish("create Markov process graph");
-
   taskReporter.start("run CredRank");
-  const credGraph = await credrank(mpg);
+  const credGraph = await credrank(weightedGraph, ledger);
   taskReporter.finish("run CredRank");
 
   taskReporter.start("write cred graph");


### PR DESCRIPTION
This refactors the interface in `credrank/compute.js`. Now, the caller
provides a `WeightedGraph` and a `Ledger`, instead of providing a
`MarkovProcessGraph`. This is appropriate because the
`MarkovProcessGraph` is an internal concept to the credrank
implementation, whereas the `WeightedGraph` and `Ledger` are
broadly-available concepts.

This is immediately motivated by wanting to write tests for
`credgraph.js` without needing to manually construct a
`MarkovProcessGraph`. Producing a `WeightedGraph` and `Ledger` so as to
construct a test case will be cleaner. Also, this allows a cleanup of
the `cli/credrank` command.

Test plan:
The `credrank/compute` module is untested, because it is the kind of
data-pipelining module that tends to be annoying to unit test, but is
also very unlikely to be broken in ways that flow doesn't catch. As a
precaution, I ran the credrank command and verified that scores are
still as expected.