### PR TITLE
Update WeightConfig.js to use grid xs=6

### DIFF
--- a/src/ui/weights/WeightConfig.js
+++ b/src/ui/weights/WeightConfig.js
@@ -71,7 +71,7 @@ export class WeightConfig extends React.Component<Props> {
     const nodeConfigs = nonUserTypes.map((t) => this._nodeConfig(t));
     const edgeConfigs = edgeTypes.map((t) => this._edgeConfig(t));
     return (
-      <Grid item xs={4} key={name}>
+      <Grid item xs={6} key={name}>
         <h3>{name}</h3>
         <h4 style={{marginBottom: "0.3em"}}>Node weights</h4>
         {nodeConfigs}


### PR DESCRIPTION
This changes the 12-column weight configuration Grid to use a two-column layout per plugin, instead of three columns.

Related to #2510 