### PR TITLE
logic for Cred budgets on Weighted Graphs

### DIFF
--- a/src/core/mintBudget.js
+++ b/src/core/mintBudget.js
@@ -1,0 +1,237 @@
+// @flow
+
+import {sum} from "d3-array";
+import * as NullUtil from "../util/null";
+import * as Weights from "./weights";
+import {type NodeAddressT, NodeAddress} from "./graph";
+import {type WeightedGraph as WeightedGraphT} from "./weightedGraph";
+import {
+  nodeWeightEvaluator,
+  type NodeWeightEvaluator,
+} from "./algorithm/weightEvaluator";
+import {partitionGraph, type GraphIntervalPartition} from "./interval";
+import type {TimestampMs} from "../util/timestamp";
+
+/**
+ * This module adds logic for imposing a Cred minting budget on a graph.
+ *
+ * Basically, we allow specifiying a budget where nodes matching a particular
+ * address may mint at most a fixed amount of Cred per period. Since every
+ * plugin writes nodes with a distinct prefix, this may be used to specify
+ * plugin-level Cred budgets. The same mechanism could also be used to
+ * implement more finely-grained budgets, e.g. for specific node types.
+ */
+
+export type IntervalLength = "WEEKLY";
+
+export type BudgetPeriod = {|
+  // When this budget policy starts
+  +startTimeMs: TimestampMs,
+  // How much Cred can be minted per interval
+  +budgetValue: number,
+|};
+
+export type BudgetEntry = {|
+  +prefix: NodeAddressT,
+  +periods: $ReadOnlyArray<BudgetPeriod>,
+|};
+
+export type Budget = {|
+  +entries: $ReadOnlyArray<BudgetEntry>,
+  +intervalLength: IntervalLength,
+|};
+
+/**
+ * Given a WeightedGraph and a budget, return a new WeightedGraph which ensures
+ * that the budget constraint is satisfied.
+ *
+ * Concretely, this means that the weights in the Graph may be reduced, as
+ * necessary, in order to bring the total minted Cred within an interval down
+ * to the budget's requirements.
+ */
+export function applyBudget(
+  wg: WeightedGraphT,
+  budget: Budget
+): WeightedGraphT {
+  // It'd be really nice to support the case where some budgets are subsets of
+  // other budgets. As an example, imagine saying: The GitHub plugin can mint
+  // at most 1000 Cred per week, and within that, this particular GitHub repo
+  // can mint at most 200, that one can mint at most 400, etc. However, I
+  // didn't want to figure out the math for solving those constraints just yet,
+  // since the initial use case of limiting minting per plugin doesn't need to
+  // worry about intersections between the budgets.
+  //
+  // So let's just throw an error if there are any overlapping prefixes for
+  // now, and we can improve the implementation later once we want to do more
+  // sophisticated budget policies.
+  if (_anyCommonPrefixes(budget.entries.map((x) => x.prefix))) {
+    throw new Error(`budget prefix conflict detected`);
+  }
+  if (budget.intervalLength !== "WEEKLY") {
+    throw new Error(`non-weekly budgets not supported`);
+  }
+
+  const reweighting = _computeReweighting(wg, budget);
+  return _reweightGraph(wg, reweighting);
+}
+
+export type AddressWeight = {|+address: NodeAddressT, +weight: number|};
+
+// Interpreted as an array of mutiplicative weight changes,
+// i.e. for each AddressWeight, the node at the address
+// should be re-weighted by the corresponding weight
+export type Reweighting = $ReadOnlyArray<AddressWeight>;
+
+/**
+ * Given the WeightedGraph and the Budget, returns an array of every {addres,
+ * weight} pair where the address needs to be re-weighted in order to satisfy
+ * the budget constraint.
+ */
+export function _computeReweighting(
+  wg: WeightedGraphT,
+  budget: Budget
+): Reweighting {
+  const evaluator = nodeWeightEvaluator(wg.weights);
+  const partition = partitionGraph(wg.graph);
+  const reweightingsForEachBudget: $ReadOnlyArray<Reweighting> = budget.entries.map(
+    (entry) => _reweightingForEntry({evaluator, partition, entry})
+  );
+  return reweightingsForEachBudget.flat();
+}
+
+/**
+ * Given a the time-partitioned graph, the weight evaluator, and a particular
+ * entry for the budget, return every {address, weight} pair where the
+ * corresponding address needs to be reweighted in order to satisfy this budget
+ * entry.
+ */
+export function _reweightingForEntry(args: {
+  evaluator: NodeWeightEvaluator,
+  partition: GraphIntervalPartition,
+  entry: BudgetEntry,
+}): Reweighting {
+  const {evaluator, partition, entry} = args;
+  const {periods, prefix} = entry;
+
+  // Check that the budget's periods are in time-sorted order.
+  if (!inSortedOrder(periods.map((x) => x.startTimeMs))) {
+    throw new Error(
+      `budget for ${NodeAddress.toString(prefix)} has periods out-of-order`
+    );
+  }
+
+  const results = [];
+  for (const {interval, nodes} of partition) {
+    const budgetValue = _findCurrentBudgetValue(periods, interval.startTimeMs);
+    const addresses = nodes.map((n) => n.address);
+    const filteredAddresses = addresses.filter((a) =>
+      NodeAddress.hasPrefix(a, prefix)
+    );
+    const addressWeights = filteredAddresses.map((a) => ({
+      address: a,
+      weight: evaluator(a),
+    }));
+    const normalizer = _computeWeightNormalizer(addressWeights, budgetValue);
+    // If the normalizer is exactly 1, no re-weighting is necessary.
+    if (normalizer !== 1) {
+      // Re-weight every address matching this budget entry
+      // equally.
+      for (const address of filteredAddresses) {
+        results.push({address, weight: normalizer});
+      }
+    }
+  }
+  return results;
+}
+
+/**
+ * Given a WeightedGraph and the reweighting, return a new WeightedGraph which
+ * has had its weights updated accordingly, without mutating the original
+ * WeightedGraph.
+ */
+export function _reweightGraph(
+  wg: WeightedGraphT,
+  reweighting: Reweighting
+): WeightedGraphT {
+  const newWeights = Weights.copy(wg.weights);
+  for (const {address, weight} of reweighting) {
+    const existingWeight = NullUtil.orElse(
+      wg.weights.nodeWeights.get(address),
+      1
+    );
+    newWeights.nodeWeights.set(address, existingWeight * weight);
+  }
+
+  return {graph: wg.graph.copy(), weights: newWeights};
+}
+
+/**
+ * Given an array of node addresses, return true if any node address is a prefix
+ * of another address.
+ *
+ * This method runs in O(n^2). This should be fine because it's intended to be
+ * run on small arrays (~one per plugin). If this becomes a performance
+ * hotpsot, we can write a more performant version.
+ */
+export function _anyCommonPrefixes(
+  addresses: $ReadOnlyArray<NodeAddressT>
+): boolean {
+  for (let i = 0; i < addresses.length; i++) {
+    for (let j = i; j < addresses.length; j++) {
+      if (i === j) {
+        continue;
+      }
+      // Check both if A is prefix of B and if B is prefix of A
+      // (not symmetrical)
+      if (NodeAddress.hasPrefix(addresses[i], addresses[j])) {
+        return true;
+      }
+      if (NodeAddress.hasPrefix(addresses[j], addresses[i])) {
+        return true;
+      }
+    }
+  }
+  return false;
+}
+
+function inSortedOrder(xs: $ReadOnlyArray<number>): boolean {
+  let last = -Infinity;
+  for (const x of xs) {
+    if (x < last) {
+      return false;
+    }
+    last = x;
+  }
+  return true;
+}
+
+// Given an array of periods, and a timestamp, choose the last period whose
+// startTimeMs is <= the timestamp, and then return its budget. Returns
+// Infinity if there is no matching budget.
+export function _findCurrentBudgetValue(
+  periods: $ReadOnlyArray<BudgetPeriod>,
+  timestamp: TimestampMs
+): number {
+  const currentPeriod = periods
+    .slice()
+    .reverse()
+    .find((period) => period.startTimeMs <= timestamp);
+  return currentPeriod ? currentPeriod.budgetValue : Infinity;
+}
+
+// For the given array of AddressWeights, and a budget that they must fit within, return
+// a normalization coefficient which can be used to reweight all of these AddressWeights
+// so that they fit within the budget. Will be a number in the range [0, 1], where 0
+// implies the budget is 0 (so everything gets set to 0) and 1 implies the AddressWeights
+// are already fitting within the budget.
+export function _computeWeightNormalizer(
+  aws: $ReadOnlyArray<AddressWeight>,
+  budgetValue: number
+): number {
+  const totalWeight = sum(aws, (aw) => aw.weight);
+  if (totalWeight <= budgetValue) {
+    return 1;
+  } else {
+    return budgetValue / totalWeight;
+  }
+}

--- a/src/core/mintBudget.test.js
+++ b/src/core/mintBudget.test.js
@@ -1,0 +1,246 @@
+// @flow
+
+import cloneDeep from "lodash.clonedeep";
+import {utcWeek} from "d3-time";
+import {type TimestampMs} from "../util/timestamp";
+import {NodeAddress} from "./graph";
+import {Graph, type NodeAddressT} from "./graph";
+import * as WG from "./weightedGraph";
+import {empty as emptyWeights} from "./weights";
+import {type WeightedGraph as WeightedGraphT} from "./weightedGraph";
+import {nodeWeightEvaluator} from "./algorithm/weightEvaluator";
+
+import {
+  _anyCommonPrefixes,
+  applyBudget,
+  _findCurrentBudgetValue,
+} from "./mintBudget";
+
+describe("core/mintBudget", () => {
+  describe("applyBudget", () => {
+    it("errors if there are prefix conflicts", () => {
+      const entry1 = {prefix: NodeAddress.empty, periods: []};
+      const entry2 = {prefix: NodeAddress.fromParts(["foo"]), periods: []};
+      const badBudget = {intervalLength: "WEEKLY", entries: [entry1, entry2]};
+      const fail = () => applyBudget(WG.empty(), badBudget);
+      expect(fail).toThrow("budget prefix conflict detected");
+    });
+    it("errors if the intervalLength is not weekly", () => {
+      const badBudget = {intervalLength: "DAILY", entries: []};
+      // $FlowExpectedError[incompatible-call]
+      const fail = () => applyBudget(WG.empty(), badBudget);
+      expect(fail).toThrow("non-weekly budgets not supported");
+    });
+    it("errors if the periods are out-of-order", () => {
+      const p1 = {budgetValue: 100, startTimeMs: 50};
+      const p2 = {budgetValue: 50, startTimeMs: 25};
+      const entry = {prefix: NodeAddress.empty, periods: [p1, p2]};
+      const budget = {intervalLength: "WEEKLY", entries: [entry]};
+      const fail = () => applyBudget(WG.empty(), budget);
+      expect(fail).toThrow("periods out-of-order");
+    });
+    describe("end-to-end testing with weighted graphs", () => {
+      class TestWeightedGraph {
+        wg: WeightedGraphT;
+        constructor() {
+          this.wg = {weights: emptyWeights(), graph: new Graph()};
+        }
+        addNode(opts: {|
+          +id: number,
+          +timestampMs: TimestampMs,
+          +mint: number,
+          +prefix?: string,
+        |}): TestWeightedGraph {
+          const {id, timestampMs, mint} = opts;
+          const prefix = opts.prefix == null ? "" : opts.prefix;
+          const address = this.addressForId(id, prefix);
+          this.wg.weights.nodeWeights.set(address, mint);
+          this.wg.graph.addNode({
+            address,
+            description: prefix + "/" + String(id),
+            timestampMs,
+          });
+          return this;
+        }
+        addressForId(id: number, prefix: string = ""): NodeAddressT {
+          return NodeAddress.fromParts([prefix, String(id)]);
+        }
+      }
+      // Since we are hardcoded to week-based time partitioning, generate some
+      // week-spaced timestamps
+      const w1 = +utcWeek.floor(0);
+      const w2 = +utcWeek.ceil(0);
+      const w3 = +utcWeek.ceil(w2 + 1);
+      const w4 = +utcWeek.ceil(w3 + 1);
+      expect(w4).toBeGreaterThan(w3);
+      expect(w3).toBeGreaterThan(w2);
+      expect(w2).toBeGreaterThan(w1);
+
+      it("works in a sample case where weights must be reduced", () => {
+        const testWeightedGraph = new TestWeightedGraph()
+          .addNode({id: 1, timestampMs: w1, mint: 100})
+          .addNode({id: 2, timestampMs: w2, mint: 200});
+        const period = {startTimeMs: -Infinity, budgetValue: 50};
+        const entry = {prefix: NodeAddress.empty, periods: [period]};
+        const budget = {intervalLength: "WEEKLY", entries: [entry]};
+        const reweightedGraph = applyBudget(testWeightedGraph.wg, budget);
+        const reweightEvaluator = nodeWeightEvaluator(reweightedGraph.weights);
+        const a1 = testWeightedGraph.addressForId(1);
+        expect(reweightEvaluator(a1)).toEqual(50); // w1 conforms to budget
+        const a2 = testWeightedGraph.addressForId(2);
+        expect(reweightEvaluator(a2)).toEqual(50); // w2 conforms to budget
+      });
+      it("works in a case where multiple weights are in contention", () => {
+        const testWeightedGraph = new TestWeightedGraph()
+          .addNode({id: 1, timestampMs: w1, mint: 10})
+          .addNode({id: 2, timestampMs: w1, mint: 90});
+        const period = {startTimeMs: -Infinity, budgetValue: 10};
+        const entry = {prefix: NodeAddress.empty, periods: [period]};
+        const budget = {intervalLength: "WEEKLY", entries: [entry]};
+        const reweightedGraph = applyBudget(testWeightedGraph.wg, budget);
+        const reweightEvaluator = nodeWeightEvaluator(reweightedGraph.weights);
+        const a1 = testWeightedGraph.addressForId(1);
+        expect(reweightEvaluator(a1)).toEqual(1);
+        const a2 = testWeightedGraph.addressForId(2);
+        expect(reweightEvaluator(a2)).toEqual(9);
+      });
+      it("does not modify periods that are under budget", () => {
+        const testWeightedGraph = new TestWeightedGraph()
+          .addNode({id: 1, timestampMs: w1, mint: 5})
+          .addNode({id: 2, timestampMs: w2, mint: 15});
+        const period = {startTimeMs: -Infinity, budgetValue: 10};
+        const entry = {prefix: NodeAddress.empty, periods: [period]};
+        const budget = {intervalLength: "WEEKLY", entries: [entry]};
+        const reweightedGraph = applyBudget(testWeightedGraph.wg, budget);
+        const reweightEvaluator = nodeWeightEvaluator(reweightedGraph.weights);
+        const a1 = testWeightedGraph.addressForId(1);
+        expect(reweightEvaluator(a1)).toEqual(5);
+        const a2 = testWeightedGraph.addressForId(2);
+        expect(reweightEvaluator(a2)).toEqual(10);
+      });
+      it("only re-weights nodes matching the prefix", () => {
+        const testWeightedGraph = new TestWeightedGraph()
+          .addNode({id: 1, timestampMs: w1, mint: 5, prefix: "foo"})
+          .addNode({id: 2, timestampMs: w1, mint: 10, prefix: "foo"})
+          .addNode({id: 3, timestampMs: w1, mint: 15});
+        const period = {startTimeMs: -Infinity, budgetValue: 3};
+        const entry = {
+          prefix: NodeAddress.fromParts(["foo"]),
+          periods: [period],
+        };
+        const budget = {intervalLength: "WEEKLY", entries: [entry]};
+        const reweightedGraph = applyBudget(testWeightedGraph.wg, budget);
+        const reweightEvaluator = nodeWeightEvaluator(reweightedGraph.weights);
+        const a1 = testWeightedGraph.addressForId(1, "foo");
+        expect(reweightEvaluator(a1)).toEqual(1);
+        const a2 = testWeightedGraph.addressForId(2, "foo");
+        expect(reweightEvaluator(a2)).toEqual(2);
+        const a3 = testWeightedGraph.addressForId(3);
+        expect(reweightEvaluator(a3)).toEqual(15);
+      });
+      it("does not re-weight if there are no periods", () => {
+        const testWeightedGraph = new TestWeightedGraph()
+          .addNode({id: 1, timestampMs: w1, mint: 5})
+          .addNode({id: 2, timestampMs: w1, mint: 5});
+        const entry = {
+          prefix: NodeAddress.empty,
+          periods: [],
+        };
+        const budget = {intervalLength: "WEEKLY", entries: [entry]};
+        const reweightedGraph = applyBudget(testWeightedGraph.wg, budget);
+        const reweightEvaluator = nodeWeightEvaluator(reweightedGraph.weights);
+        const a1 = testWeightedGraph.addressForId(1);
+        expect(reweightEvaluator(a1)).toEqual(5);
+        const a2 = testWeightedGraph.addressForId(2);
+        expect(reweightEvaluator(a2)).toEqual(5);
+      });
+      it("only reweights nodes when the period is active", () => {
+        const testWeightedGraph = new TestWeightedGraph()
+          .addNode({id: 1, timestampMs: w1, mint: 5})
+          .addNode({id: 2, timestampMs: w2, mint: 5});
+        const period = {startTimeMs: w2, budgetValue: 1};
+        const entry = {
+          prefix: NodeAddress.empty,
+          periods: [period],
+        };
+        const budget = {intervalLength: "WEEKLY", entries: [entry]};
+        const reweightedGraph = applyBudget(testWeightedGraph.wg, budget);
+        const reweightEvaluator = nodeWeightEvaluator(reweightedGraph.weights);
+        const a1 = testWeightedGraph.addressForId(1);
+        expect(reweightEvaluator(a1)).toEqual(5);
+        const a2 = testWeightedGraph.addressForId(2);
+        expect(reweightEvaluator(a2)).toEqual(1);
+      });
+      it("re-weighting does not mutate the input graph", () => {
+        const testWeightedGraph = new TestWeightedGraph()
+          .addNode({id: 1, timestampMs: w1, mint: 5})
+          .addNode({id: 2, timestampMs: w2, mint: 5});
+        const before = cloneDeep(testWeightedGraph.wg);
+        const period = {startTimeMs: w2, budgetValue: 1};
+        const entry = {
+          prefix: NodeAddress.empty,
+          periods: [period],
+        };
+        const budget = {intervalLength: "WEEKLY", entries: [entry]};
+        const reweightedGraph = applyBudget(testWeightedGraph.wg, budget);
+        const after = testWeightedGraph.wg;
+        expect(before.weights).toEqual(after.weights);
+        expect(before.graph.equals(after.graph)).toBe(true);
+        expect(reweightedGraph.weights).not.toEqual(before.weights);
+        expect(reweightedGraph.graph.equals(before.graph)).toBe(true);
+      });
+    });
+  });
+
+  describe("_anyCommonPrefixes", () => {
+    it("returns true if there are common prefixes", () => {
+      // Empty address is prefix of everything
+      const empty = NodeAddress.empty;
+      const foo = NodeAddress.fromParts(["foo"]);
+      // Order of arguments must not matter.
+      expect(_anyCommonPrefixes([empty, foo])).toBe(true);
+      expect(_anyCommonPrefixes([foo, empty])).toBe(true);
+    });
+    it("returns true if the same prefix is present multiple times", () => {
+      const empty = NodeAddress.empty;
+      // Order of arguments must not matter.
+      expect(_anyCommonPrefixes([empty, empty])).toBe(true);
+    });
+    it("returns false for no common prefixes", () => {
+      expect(
+        _anyCommonPrefixes([
+          NodeAddress.fromParts(["bar"]),
+          NodeAddress.fromParts(["foo"]),
+        ])
+      ).toBe(false);
+    });
+    it("returns false in the empty case", () => {
+      expect(_anyCommonPrefixes([])).toBe(false);
+    });
+  });
+
+  describe("_findCurrentBudgetValue", () => {
+    it("returns infinity if there are no periods", () => {
+      expect(_findCurrentBudgetValue([], 0)).toEqual(Infinity);
+    });
+    it("returns infinity if no periods are yet active", () => {
+      expect(
+        _findCurrentBudgetValue([{startTimeMs: 1, budgetValue: 100}], 0)
+      ).toEqual(Infinity);
+    });
+    it("returns the latest period whose startTimeMs is <= current time", () => {
+      const p1 = {startTimeMs: 0, budgetValue: 1};
+      const p2 = {startTimeMs: 1, budgetValue: 2};
+      const p3 = {startTimeMs: 1, budgetValue: 3};
+      const p4 = {startTimeMs: 2, budgetValue: 4};
+      expect(_findCurrentBudgetValue([p1, p2, p3, p4], 1)).toEqual(3);
+    });
+    it("returns the last period if necessary", () => {
+      const p1 = {startTimeMs: 0, budgetValue: 1};
+      const p2 = {startTimeMs: 1, budgetValue: 2};
+      const p3 = {startTimeMs: 1, budgetValue: 3};
+      const p4 = {startTimeMs: 2, budgetValue: 4};
+      expect(_findCurrentBudgetValue([p1, p2, p3, p4], 9)).toEqual(4);
+    });
+  });
+});


### PR DESCRIPTION
This commit adds core logic for applying a CredBudget to a
WeightedGraph. The idea is the budget sets constraints on how much Cred
nodes matching a given address can mint each interval. If the budget
constraint is violated in a particular period, all of the nodes created
in that period will be re-weighted to enforce the budget.

Test plan: Has some end-to-end unit tests and some helper unit tests,
but may still merit more testing as the logic is somewhat complex.