### PR TITLE
grainConfig: take array of policies

### DIFF
--- a/src/api/grainConfig.js
+++ b/src/api/grainConfig.js
@@ -4,75 +4,42 @@ import {type DistributionPolicy} from "../core/ledger/applyDistributions";
 import * as G from "../core/ledger/grain";
 import * as C from "../util/combo";
 import * as NullUtil from "../util/null";
-import {toDiscount} from "../core/ledger/grainAllocation";
+import {
+  type AllocationPolicy,
+  allocationPolicyParser,
+} from "../core/ledger/grainAllocation";
 
 export type GrainConfig = {|
-  +immediatePerWeek: number,
-  +balancedPerWeek: number,
-  +recentPerWeek: number,
-  +recentWeeklyDecayRate?: number,
+  +allocationPolicies: $ReadOnlyArray<AllocationPolicy>,
   +maxSimultaneousDistributions?: number,
 |};
 
 export const parser: C.Parser<GrainConfig> = C.object(
   {
-    immediatePerWeek: C.number,
-    balancedPerWeek: C.number,
-    recentPerWeek: C.number,
+    allocationPolicies: C.array<AllocationPolicy>(allocationPolicyParser),
   },
   {
-    recentWeeklyDecayRate: C.number,
     maxSimultaneousDistributions: C.number,
   }
 );
 
 export function toDistributionPolicy(x: GrainConfig): DistributionPolicy {
-  if (!isNonnegativeInteger(x.immediatePerWeek)) {
-    throw new Error(
-      `immediate budget must be nonnegative integer, got ${x.immediatePerWeek}`
-    );
+  if (!x.allocationPolicies.length) {
+    throw new Error(`no valid allocation policies provided`);
   }
-  if (!isNonnegativeInteger(x.recentPerWeek)) {
-    throw new Error(
-      `recent budget must be nonnegative integer, got ${x.recentPerWeek}`
-    );
-  }
-  if (!isNonnegativeInteger(x.balancedPerWeek)) {
-    throw new Error(
-      `balanced budget must be nonnegative integer, got ${x.balancedPerWeek}`
-    );
-  }
-  const allocationPolicies = [];
-  if (x.immediatePerWeek > 0) {
-    allocationPolicies.push({
-      budget: G.fromInteger(x.immediatePerWeek),
-      policyType: "IMMEDIATE",
-    });
-  }
-  if (x.recentPerWeek > 0) {
-    const {recentWeeklyDecayRate} = x;
-    if (recentWeeklyDecayRate == null) {
-      throw new Error(`no recentWeeklyDecayRate specified for recent policy`);
+  x.allocationPolicies.map((policy) => {
+    if (!G.gt(policy.budget, G.ZERO)) {
+      throw new Error(
+        `${policy.policyType} budget must be nonnegative integer, got ${policy.budget}`
+      );
     }
-    allocationPolicies.push({
-      budget: G.fromInteger(x.recentPerWeek),
-      policyType: "RECENT",
-      discount: toDiscount(recentWeeklyDecayRate),
-    });
-  }
-  if (x.balancedPerWeek > 0) {
-    allocationPolicies.push({
-      budget: G.fromInteger(x.balancedPerWeek),
-      policyType: "BALANCED",
-    });
-  }
+  });
   const maxSimultaneousDistributions = NullUtil.orElse(
     x.maxSimultaneousDistributions,
     Infinity
   );
-  return {allocationPolicies, maxSimultaneousDistributions};
-}
-
-function isNonnegativeInteger(x: number): boolean {
-  return x >= 0 && isFinite(x) && Math.floor(x) === x;
+  return {
+    allocationPolicies: x.allocationPolicies,
+    maxSimultaneousDistributions,
+  };
 }


### PR DESCRIPTION
This commit allows users to specify an array of policies, which allows them two new advantages:
__1. Do not need to specify each policy.__
__2. Can add multiple version of the same policy (in the case that you want to use different parameters).__

Currently, users specify a budget for every valid policy in their instance's `config/grain.json` file, even if they are not using that grain allocation policy.
```js
{
  "immediatePerWeek": 0,
  "balancedPerWeek": 10,
  "recentPerWeek": 0,
  "maxSimultaneousDistributions": 100
}
```

This also forces us to handle each policy explicitly downstream, which could be a lot cleaner if we could leverage the `AllocationPolicy` type we already have.  This approach uses typing to check whether the user has specified a valid policy implicitly.

Config now looks (for example) as follows:
```js
{
  policies: [
    {
      policyType: "BALANCED",
      budget: "100"
    },
    {
      policyType: "RECENT",
      budget: "50",
      discount: 0.1
    },
    {
      policyType: "RECENT",
      budget: "100",
      discount: 0.5
    }
}
```

__Test Plan__
Unit tests are provided here for both the `parser`, and well as `toDistributionPolicy`, which serves to check the config.  Note, we can reduce this function entirely with stricter parsers and types.  For example, we have to check for negative grain values.  This calls for a new "`BudgetedGrain`" type, which I will follow up with.