### PR TITLE
grainAllocation: move policies to modules

### DIFF
--- a/src/api/grainConfig.js
+++ b/src/api/grainConfig.js
@@ -4,7 +4,7 @@ import {type DistributionPolicy} from "../core/ledger/applyDistributions";
 import * as G from "../core/ledger/grain";
 import * as C from "../util/combo";
 import * as NullUtil from "../util/null";
-import {toDiscount} from "../core/ledger/grainAllocation";
+import {toDiscount} from "../core/ledger/policies/recent";
 
 export type GrainConfig = {|
   +immediatePerWeek: number,

--- a/src/api/grainConfig.test.js
+++ b/src/api/grainConfig.test.js
@@ -2,7 +2,7 @@
 
 import {parser, toDistributionPolicy, type GrainConfig} from "./grainConfig";
 import {type DistributionPolicy} from "../core/ledger/applyDistributions";
-import {toDiscount} from "../core/ledger/grainAllocation";
+import {toDiscount} from "../core/ledger/policies/recent";
 import {fromInteger} from "../core/ledger/grain";
 
 describe("api/grainConfig", () => {

--- a/src/core/ledger/applyDistributions.js
+++ b/src/core/ledger/applyDistributions.js
@@ -3,7 +3,7 @@
 import {type TimestampMs} from "../../util/timestamp";
 import {type IntervalSequence, intervalSequence} from "../interval";
 import {Ledger} from "./ledger";
-import {type AllocationPolicy} from "./grainAllocation";
+import {type AllocationPolicy} from "./policies";
 import {CredView} from "../../analysis/credView";
 import {computeCredAccounts} from "./credAccounts";
 import {computeDistribution} from "./computeDistribution";

--- a/src/core/ledger/computeDistribution.js
+++ b/src/core/ledger/computeDistribution.js
@@ -2,11 +2,8 @@
 
 import * as uuid from "../../util/uuid";
 import {type TimestampMs} from "../../util/timestamp";
-import {
-  type AllocationPolicy,
-  type AllocationIdentity,
-  computeAllocation,
-} from "./grainAllocation";
+import {type AllocationIdentity, computeAllocation} from "./grainAllocation";
+import {type AllocationPolicy} from "./policies";
 import {type CredAccountData} from "./credAccounts";
 import {type Distribution} from "./distribution";
 

--- a/src/core/ledger/grainAllocation.js
+++ b/src/core/ledger/grainAllocation.js
@@ -5,7 +5,6 @@
  * their Cred scores. This is called a "Distribution". This module contains the
  * logic for computing distributions.
  */
-import {sum} from "d3-array";
 import * as G from "./grain";
 import * as P from "../../util/combo";
 import {
@@ -14,88 +13,18 @@ import {
   parser as uuidParser,
 } from "../../util/uuid";
 import {type IdentityId} from "../identity";
-
-/**
- * The Balanced policy attempts to pay Grain to everyone so that their
- * lifetime Grain payouts are consistent with their lifetime Cred scores.
- *
- * We recommend use of the Balanced strategy as it takes new information into
- * account-- for example, if a user's contributions earned little Cred in the
- * past, but are now seen as more valuable, the Balanced policy will take this
- * into account and pay them more, to fully appreciate their past
- * contributions.
- */
-export type Balanced = "BALANCED";
-
-/**
- * The Immediate policy evenly distributes its Grain budget
- * across users based on their Cred in the most recent interval.
- *
- * It's used when you want to ensure that everyone gets some consistent reward
- * for participating (even if they may be "overpaid" in a lifetime sense).
- * We recommend using a smaller budget for the Immediate policy.
- */
-export type Immediate = "IMMEDIATE";
-
-/**
- * The Recent policy distributes cred using a time discount factor, weighing
- * recent contributions higher. The policy takes a history of cred scores, progressively
- * discounting past cred scores, and then taking the sum over the discounted scores.
- *
- * A cred score at time t reads as follows: "The discounted cred c' at a timestep which is
- * n timesteps back from the most recent one is its cred score c multiplied by the discount
- * factor to the nth power."
- *
- * c' =  c * (1 - discount) ** n
- *
- * Discounts range from 0 to 1, with a higher discount weighing recent contribution
- * higher.
- *
- * Note that this is a generalization of the Immediate policy, where Immediate
- * is the same as Recent with a full discount, i.e. a discount factor 1 (100%).
- *
- */
-export type Recent = "RECENT";
-
-/**
- * The Special policy is a power-maintainer tool for directly paying Grain
- * to a target identity. I'm including it because we will use it to create
- * "initialization" payouts to contributors with prior Grain balances in our old
- * ledger.
- *
- * This has potential for abuse, I don't recommend making it easy to make special
- * payouts from the UI, since it subverts the "Grain comes from Cred" model.
- */
-export type Special = "SPECIAL";
-
-export type AllocationPolicy =
-  | BalancedPolicy
-  | ImmediatePolicy
-  | RecentPolicy
-  | SpecialPolicy;
-
-export type BalancedPolicy = {|
-  +policyType: Balanced,
-  +budget: G.Grain,
-|};
-
-export type ImmediatePolicy = {|
-  +policyType: Immediate,
-  +budget: G.Grain,
-|};
-
-export type RecentPolicy = {|
-  +policyType: Recent,
-  +budget: G.Grain,
-  +discount: Discount,
-|};
-
-export type SpecialPolicy = {|
-  +policyType: Special,
-  +budget: G.Grain,
-  +memo: string,
-  +recipient: IdentityId,
-|};
+import {
+  type AllocationPolicy,
+  allocationPolicyParser,
+  balancedReceipts,
+  immediateReceipts,
+  recentReceipts,
+  specialReceipts,
+} from "./policies";
+import {
+  type ProcessedIdentities,
+  processIdentities,
+} from "./processedIdentities";
 
 export type GrainReceipt = {|
   +id: IdentityId,
@@ -119,66 +48,12 @@ export function computeAllocation(
   identities: $ReadOnlyArray<AllocationIdentity>
 ): Allocation {
   const validatedPolicy = _validatePolicy(policy);
-  const processedIdentities = _processIdentities(identities);
+  const processedIdentities = processIdentities(identities);
   return _validateAllocationBudget({
     policy,
     receipts: receipts(validatedPolicy, processedIdentities),
     id: randomUuid(),
   });
-}
-
-// ProcessedIdentities type has the following guarantees:
-// - no Cred is negative
-// - no Paid is negative
-// - total Cred is positive
-// - all cred arrays have same length
-opaque type ProcessedIdentities = $ReadOnlyArray<{|
-  +paid: G.Grain,
-  +id: IdentityId,
-  +cred: $ReadOnlyArray<number>,
-  +lifetimeCred: number,
-  +mostRecentCred: number,
-|}>;
-function _processIdentities(
-  items: $ReadOnlyArray<AllocationIdentity>
-): ProcessedIdentities {
-  if (items.length === 0) {
-    throw new Error(`must have at least one identity to allocate grain to`);
-  }
-  let hasPositiveCred = false;
-  const credLength = items[0].cred.length;
-  const results = items.map((i) => {
-    const {cred, id, paid} = i;
-    if (G.lt(paid, G.ZERO)) {
-      throw new Error(`negative paid: ${paid}`);
-    }
-    if (credLength !== cred.length) {
-      throw new Error(
-        `inconsistent cred length: ${credLength} vs ${cred.length}`
-      );
-    }
-    let lifetimeCred = 0;
-    for (const c of cred) {
-      if (c < 0 || !isFinite(c)) {
-        throw new Error(`invalid cred: ${c}`);
-      }
-      if (c > 0) {
-        hasPositiveCred = true;
-      }
-      lifetimeCred += c;
-    }
-    return {
-      id,
-      paid,
-      cred,
-      lifetimeCred,
-      mostRecentCred: cred[cred.length - 1],
-    };
-  });
-  if (!hasPositiveCred) {
-    throw new Error("cred is zero");
-  }
-  return results;
 }
 
 function _validatePolicy(p: AllocationPolicy) {
@@ -219,133 +94,6 @@ function receipts(
   }
 }
 
-/**
- * Split a grain budget in proportion to the cred scores in
- * the most recent time interval.
- */
-function immediateReceipts(
-  budget: G.Grain,
-  identities: ProcessedIdentities
-): $ReadOnlyArray<GrainReceipt> {
-  const amounts = G.splitBudget(
-    budget,
-    identities.map((i) => i.mostRecentCred)
-  );
-  return identities.map(({id}, i) => ({id, amount: amounts[i]}));
-}
-
-/**
- * Split a grain budget based on exponentially weighted recent
- * cred.
- */
-function recentReceipts(
-  budget: G.Grain,
-  identities: ProcessedIdentities,
-  discount: Discount
-): $ReadOnlyArray<GrainReceipt> {
-  const computeDecayedCred = (i) =>
-    i.cred.reduce((acc, cred) => acc * (1 - discount) + cred, 0);
-  const decayedCredPerIdentity = identities.map(computeDecayedCred);
-  const amounts = G.splitBudget(budget, decayedCredPerIdentity);
-
-  return identities.map(({id}, i) => ({id, amount: amounts[i]}));
-}
-
-/**
- * Allocate a fixed budget of Grain to the users who were "most underpaid".
- *
- * We consider a user underpaid if they have received a smaller proportion of
- * past earnings than their share of score. They are balanced paid if their
- * proportion of earnings is equal to their score share, and they are overpaid
- * if their proportion of earnings is higher than their share of the score.
- *
- * We start by imagining a hypothetical world, where the entire grain supply of
- * the project (including this allocation) was allocated according to the
- * current scores. Based on this, we can calculate the "balanced" lifetime earnings
- * for each participant. Usually, some will be "underpaid" (they received less
- * than this amount) and others are "overpaid".
- *
- * We can sum across all users who were underpaid to find the "total
- * underpayment".
- *
- * Now that we've calculated each actor's underpayment, and the total
- * underpayment, we divide the allocation's grain budget across users in
- * proportion to their underpayment.
- *
- * You should use this allocation when you want to divide a fixed budget of grain
- * across participants in a way that aligns long-term payment with total cred
- * scores.
- */
-function balancedReceipts(
-  budget: G.Grain,
-  identities: ProcessedIdentities
-): $ReadOnlyArray<GrainReceipt> {
-  const totalCred = sum(identities.map((x) => x.lifetimeCred));
-  const totalEverPaid = G.sum(identities.map((i) => i.paid));
-
-  const targetTotalDistributed = G.add(totalEverPaid, budget);
-  const targetGrainPerCred = G.multiplyFloat(
-    targetTotalDistributed,
-    1 / totalCred
-  );
-
-  const userUnderpayment = identities.map(({paid, lifetimeCred}) => {
-    const target = G.multiplyFloat(targetGrainPerCred, lifetimeCred);
-    if (G.gt(target, paid)) {
-      return G.sub(target, paid);
-    } else {
-      return G.ZERO;
-    }
-  });
-
-  const floatUnderpayment = userUnderpayment.map((x) => Number(x));
-
-  const grainAmounts = G.splitBudget(budget, floatUnderpayment);
-  return identities.map(({id}, i) => ({id, amount: grainAmounts[i]}));
-}
-
-function specialReceipts(
-  policy: SpecialPolicy,
-  identities: ProcessedIdentities
-): $ReadOnlyArray<GrainReceipt> {
-  for (const {id} of identities) {
-    if (id === policy.recipient) {
-      return [{id, amount: policy.budget}];
-    }
-  }
-  throw new Error(`no active grain account for identity: ${policy.recipient}`);
-}
-
-const balancedPolicyParser: P.Parser<BalancedPolicy> = P.object({
-  policyType: P.exactly(["BALANCED"]),
-  budget: G.parser,
-});
-
-const immediatePolicyParser: P.Parser<ImmediatePolicy> = P.object({
-  policyType: P.exactly(["IMMEDIATE"]),
-  budget: G.parser,
-});
-
-const recentPolicyParser: P.Parser<RecentPolicy> = P.object({
-  policyType: P.exactly(["RECENT"]),
-  budget: G.parser,
-  discount: P.fmap(P.number, toDiscount),
-});
-
-const specialPolicyParser: P.Parser<SpecialPolicy> = P.object({
-  policyType: P.exactly(["SPECIAL"]),
-  budget: G.parser,
-  memo: P.string,
-  recipient: uuidParser,
-});
-
-export const allocationPolicyParser: P.Parser<AllocationPolicy> = P.orElse([
-  balancedPolicyParser,
-  immediatePolicyParser,
-  recentPolicyParser,
-  specialPolicyParser,
-]);
-
 const grainReceiptParser: P.Parser<GrainReceipt> = P.object({
   id: uuidParser,
   amount: G.parser,
@@ -355,12 +103,3 @@ export const allocationParser: P.Parser<Allocation> = P.object({
   id: uuidParser,
   receipts: P.array(grainReceiptParser),
 });
-
-export opaque type Discount: number = number;
-export function toDiscount(n: number): Discount {
-  if (n < 0 || n > 1) {
-    throw new Error(`Discount must be in range [0,1]`);
-  }
-
-  return n;
-}

--- a/src/core/ledger/grainAllocation.test.js
+++ b/src/core/ledger/grainAllocation.test.js
@@ -1,13 +1,13 @@
 // @flow
 
+import * as G from "./grain";
+import {random as randomUuid, parser as uuidParser} from "../../util/uuid";
 import {
   computeAllocation,
   type AllocationIdentity,
   _validateAllocationBudget,
-  toDiscount,
 } from "./grainAllocation";
-import * as G from "./grain";
-import {random as randomUuid, parser as uuidParser} from "../../util/uuid";
+import {toDiscount} from "./policies/recent";
 
 describe("core/ledger/grainAllocation", () => {
   // concise helper for grain from a string

--- a/src/core/ledger/policies/balanced.js
+++ b/src/core/ledger/policies/balanced.js
@@ -1,0 +1,82 @@
+// @flow
+
+import {sum} from "d3-array";
+import * as G from "../grain";
+import * as P from "../../../util/combo";
+import {type GrainReceipt} from "../grainAllocation";
+import {type ProcessedIdentities} from "../processedIdentities";
+
+/**
+ * The Balanced policy attempts to pay Grain to everyone so that their
+ * lifetime Grain payouts are consistent with their lifetime Cred scores.
+ *
+ * We recommend use of the Balanced strategy as it takes new information into
+ * account-- for example, if a user's contributions earned little Cred in the
+ * past, but are now seen as more valuable, the Balanced policy will take this
+ * into account and pay them more, to fully appreciate their past
+ * contributions.
+ */
+export type Balanced = "BALANCED";
+
+export type BalancedPolicy = {|
+  +policyType: Balanced,
+  +budget: G.Grain,
+|};
+
+/**
+ * Allocate a fixed budget of Grain to the users who were "most underpaid".
+ *
+ * We consider a user underpaid if they have received a smaller proportion of
+ * past earnings than their share of score. They are balanced paid if their
+ * proportion of earnings is equal to their score share, and they are overpaid
+ * if their proportion of earnings is higher than their share of the score.
+ *
+ * We start by imagining a hypothetical world, where the entire grain supply of
+ * the project (including this allocation) was allocated according to the
+ * current scores. Based on this, we can calculate the "balanced" lifetime earnings
+ * for each participant. Usually, some will be "underpaid" (they received less
+ * than this amount) and others are "overpaid".
+ *
+ * We can sum across all users who were underpaid to find the "total
+ * underpayment".
+ *
+ * Now that we've calculated each actor's underpayment, and the total
+ * underpayment, we divide the allocation's grain budget across users in
+ * proportion to their underpayment.
+ *
+ * You should use this allocation when you want to divide a fixed budget of grain
+ * across participants in a way that aligns long-term payment with total cred
+ * scores.
+ */
+export function balancedReceipts(
+  budget: G.Grain,
+  identities: ProcessedIdentities
+): $ReadOnlyArray<GrainReceipt> {
+  const totalCred = sum(identities.map((x) => x.lifetimeCred));
+  const totalEverPaid = G.sum(identities.map((i) => i.paid));
+
+  const targetTotalDistributed = G.add(totalEverPaid, budget);
+  const targetGrainPerCred = G.multiplyFloat(
+    targetTotalDistributed,
+    1 / totalCred
+  );
+
+  const userUnderpayment = identities.map(({paid, lifetimeCred}) => {
+    const target = G.multiplyFloat(targetGrainPerCred, lifetimeCred);
+    if (G.gt(target, paid)) {
+      return G.sub(target, paid);
+    } else {
+      return G.ZERO;
+    }
+  });
+
+  const floatUnderpayment = userUnderpayment.map((x) => Number(x));
+
+  const grainAmounts = G.splitBudget(budget, floatUnderpayment);
+  return identities.map(({id}, i) => ({id, amount: grainAmounts[i]}));
+}
+
+export const balancedPolicyParser: P.Parser<BalancedPolicy> = P.object({
+  policyType: P.exactly(["BALANCED"]),
+  budget: G.parser,
+});

--- a/src/core/ledger/policies/immediate.js
+++ b/src/core/ledger/policies/immediate.js
@@ -1,0 +1,41 @@
+// @flow
+
+import * as G from "../grain";
+import * as P from "../../../util/combo";
+import {type GrainReceipt} from "../grainAllocation";
+import {type ProcessedIdentities} from "../processedIdentities";
+
+/**
+ * The Immediate policy evenly distributes its Grain budget
+ * across users based on their Cred in the most recent interval.
+ *
+ * It's used when you want to ensure that everyone gets some consistent reward
+ * for participating (even if they may be "overpaid" in a lifetime sense).
+ * We recommend using a smaller budget for the Immediate policy.
+ */
+export type Immediate = "IMMEDIATE";
+
+export type ImmediatePolicy = {|
+  +policyType: Immediate,
+  +budget: G.Grain,
+|};
+
+/**
+ * Split a grain budget in proportion to the cred scores in
+ * the most recent time interval.
+ */
+export function immediateReceipts(
+  budget: G.Grain,
+  identities: ProcessedIdentities
+): $ReadOnlyArray<GrainReceipt> {
+  const amounts = G.splitBudget(
+    budget,
+    identities.map((i) => i.mostRecentCred)
+  );
+  return identities.map(({id}, i) => ({id, amount: amounts[i]}));
+}
+
+export const immediatePolicyParser: P.Parser<ImmediatePolicy> = P.object({
+  policyType: P.exactly(["IMMEDIATE"]),
+  budget: G.parser,
+});

--- a/src/core/ledger/policies/index.js
+++ b/src/core/ledger/policies/index.js
@@ -1,0 +1,37 @@
+// @flow
+
+import * as P from "../../../util/combo";
+import {
+  type BalancedPolicy,
+  balancedReceipts,
+  balancedPolicyParser,
+} from "./balanced";
+import {
+  type ImmediatePolicy,
+  immediateReceipts,
+  immediatePolicyParser,
+} from "./immediate";
+import {type RecentPolicy, recentReceipts, recentPolicyParser} from "./recent";
+import {
+  type SpecialPolicy,
+  specialReceipts,
+  specialPolicyParser,
+} from "./special";
+
+export {balancedReceipts, balancedPolicyParser};
+export {immediateReceipts, immediatePolicyParser};
+export {recentReceipts, recentPolicyParser};
+export {specialReceipts, specialPolicyParser};
+
+export type AllocationPolicy =
+  | BalancedPolicy
+  | ImmediatePolicy
+  | RecentPolicy
+  | SpecialPolicy;
+
+export const allocationPolicyParser: P.Parser<AllocationPolicy> = P.orElse([
+  balancedPolicyParser,
+  immediatePolicyParser,
+  recentPolicyParser,
+  specialPolicyParser,
+]);

--- a/src/core/ledger/policies/recent.js
+++ b/src/core/ledger/policies/recent.js
@@ -1,0 +1,64 @@
+// @flow
+
+import * as G from "../grain";
+import * as P from "../../../util/combo";
+import {type GrainReceipt} from "../grainAllocation";
+import {type ProcessedIdentities} from "../processedIdentities";
+
+/**
+ * The Recent policy distributes cred using a time discount factor, weighing
+ * recent contributions higher. The policy takes a history of cred scores, progressively
+ * discounting past cred scores, and then taking the sum over the discounted scores.
+ *
+ * A cred score at time t reads as follows: "The discounted cred c' at a timestep which is
+ * n timesteps back from the most recent one is its cred score c multiplied by the discount
+ * factor to the nth power."
+ *
+ * c' =  c * (1 - discount) ** n
+ *
+ * Discounts range from 0 to 1, with a higher discount weighing recent contribution
+ * higher.
+ *
+ * Note that this is a generalization of the Immediate policy, where Immediate
+ * is the same as Recent with a full discount, i.e. a discount factor 1 (100%).
+ *
+ */
+export type Recent = "RECENT";
+
+export type RecentPolicy = {|
+  +policyType: Recent,
+  +budget: G.Grain,
+  +discount: Discount,
+|};
+
+/**
+ * Split a grain budget based on exponentially weighted recent
+ * cred.
+ */
+export function recentReceipts(
+  budget: G.Grain,
+  identities: ProcessedIdentities,
+  discount: Discount
+): $ReadOnlyArray<GrainReceipt> {
+  const computeDecayedCred = (i) =>
+    i.cred.reduce((acc, cred) => acc * (1 - discount) + cred, 0);
+  const decayedCredPerIdentity = identities.map(computeDecayedCred);
+  const amounts = G.splitBudget(budget, decayedCredPerIdentity);
+
+  return identities.map(({id}, i) => ({id, amount: amounts[i]}));
+}
+
+export const recentPolicyParser: P.Parser<RecentPolicy> = P.object({
+  policyType: P.exactly(["RECENT"]),
+  budget: G.parser,
+  discount: P.fmap(P.number, toDiscount),
+});
+
+export opaque type Discount: number = number;
+export function toDiscount(n: number): Discount {
+  if (n < 0 || n > 1) {
+    throw new Error(`Discount must be in range [0,1]`);
+  }
+
+  return n;
+}

--- a/src/core/ledger/policies/special.js
+++ b/src/core/ledger/policies/special.js
@@ -1,0 +1,45 @@
+// @flow
+
+import {parser as uuidParser} from "../../../util/uuid";
+import * as P from "../../../util/combo";
+import {type IdentityId} from "../../identity";
+import {type GrainReceipt} from "../grainAllocation";
+import {type ProcessedIdentities} from "../processedIdentities";
+import * as G from "../grain";
+
+/**
+ * The Special policy is a power-maintainer tool for directly paying Grain
+ * to a target identity. I'm including it because we will use it to create
+ * "initialization" payouts to contributors with prior Grain balances in our old
+ * ledger.
+ *
+ * This has potential for abuse, I don't recommend making it easy to make special
+ * payouts from the UI, since it subverts the "Grain comes from Cred" model.
+ */
+export type Special = "SPECIAL";
+
+export type SpecialPolicy = {|
+  +policyType: Special,
+  +budget: G.Grain,
+  +memo: string,
+  +recipient: IdentityId,
+|};
+
+export function specialReceipts(
+  policy: SpecialPolicy,
+  identities: ProcessedIdentities
+): $ReadOnlyArray<GrainReceipt> {
+  for (const {id} of identities) {
+    if (id === policy.recipient) {
+      return [{id, amount: policy.budget}];
+    }
+  }
+  throw new Error(`no active grain account for identity: ${policy.recipient}`);
+}
+
+export const specialPolicyParser: P.Parser<SpecialPolicy> = P.object({
+  policyType: P.exactly(["SPECIAL"]),
+  budget: G.parser,
+  memo: P.string,
+  recipient: uuidParser,
+});

--- a/src/core/ledger/processedIdentities.js
+++ b/src/core/ledger/processedIdentities.js
@@ -1,0 +1,65 @@
+// @flow
+
+import {type IdentityId} from "../identity";
+import * as G from "./grain";
+import {type AllocationIdentity} from "./grainAllocation";
+
+// ProcessedIdentities type has the following guarantees:
+// - no Cred is negative
+// - no Paid is negative
+// - total Cred is positive
+// - all cred arrays have same length
+export opaque type ProcessedIdentities: $ReadOnlyArray<{|
+  +paid: G.Grain,
+  +id: IdentityId,
+  +cred: $ReadOnlyArray<number>,
+  +lifetimeCred: number,
+  +mostRecentCred: number,
+|}> = $ReadOnlyArray<{|
+  +paid: G.Grain,
+  +id: IdentityId,
+  +cred: $ReadOnlyArray<number>,
+  +lifetimeCred: number,
+  +mostRecentCred: number,
+|}>;
+export function processIdentities(
+  items: $ReadOnlyArray<AllocationIdentity>
+): ProcessedIdentities {
+  if (items.length === 0) {
+    throw new Error(`must have at least one identity to allocate grain to`);
+  }
+  let hasPositiveCred = false;
+  const credLength = items[0].cred.length;
+  const results = items.map((i) => {
+    const {cred, id, paid} = i;
+    if (G.lt(paid, G.ZERO)) {
+      throw new Error(`negative paid: ${paid}`);
+    }
+    if (credLength !== cred.length) {
+      throw new Error(
+        `inconsistent cred length: ${credLength} vs ${cred.length}`
+      );
+    }
+    let lifetimeCred = 0;
+    for (const c of cred) {
+      if (c < 0 || !isFinite(c)) {
+        throw new Error(`invalid cred: ${c}`);
+      }
+      if (c > 0) {
+        hasPositiveCred = true;
+      }
+      lifetimeCred += c;
+    }
+    return {
+      id,
+      paid,
+      cred,
+      lifetimeCred,
+      mostRecentCred: cred[cred.length - 1],
+    };
+  });
+  if (!hasPositiveCred) {
+    throw new Error("cred is zero");
+  }
+  return results;
+}


### PR DESCRIPTION
Currently, each grain allocation policy is located in the `grainAllocation` module.  This commit seeks to simplify that module by moving policies into their own modules.  This has the added benefit of being able to quickly view each policy.

__Test Plan__
Testing here should be trivial, as existing flow and unit tests should cover any potential errors caused from reorganizing modules.