### PR TITLE
grainConfig: optional budgets

### DIFF
--- a/src/api/grainConfig.js
+++ b/src/api/grainConfig.js
@@ -8,22 +8,37 @@ import {toDiscount} from "../core/ledger/policies/recent";
 
 export type GrainConfig = {|
   +immediatePerWeek: number,
-  +balancedPerWeek: number,
   +recentPerWeek: number,
+  +balancedPerWeek: number,
   +recentWeeklyDecayRate?: number,
   +maxSimultaneousDistributions?: number,
 |};
 
-export const parser: C.Parser<GrainConfig> = C.object(
-  {
-    immediatePerWeek: C.number,
-    balancedPerWeek: C.number,
-    recentPerWeek: C.number,
-  },
-  {
-    recentWeeklyDecayRate: C.number,
-    maxSimultaneousDistributions: C.number,
-  }
+/**
+ * Used by parser to zero missing budgets.
+ */
+export function zeroMissingBudgets(x: Object): GrainConfig {
+  return {
+    balancedPerWeek: NullUtil.orElse(x.balancedPerWeek, 0),
+    immediatePerWeek: NullUtil.orElse(x.immediatePerWeek, 0),
+    recentPerWeek: NullUtil.orElse(x.recentPerWeek, 0),
+    recentWeeklyDecayRate: x.recentWeeklyDecayRate,
+    maxSimultaneousDistributions: x.maxSimultaneousDistributions,
+  };
+}
+
+export const parser: C.Parser<GrainConfig> = C.fmap(
+  C.object(
+    {},
+    {
+      immediatePerWeek: C.number,
+      recentPerWeek: C.number,
+      balancedPerWeek: C.number,
+      recentWeeklyDecayRate: C.number,
+      maxSimultaneousDistributions: C.number,
+    }
+  ),
+  zeroMissingBudgets
 );
 
 export function toDistributionPolicy(x: GrainConfig): DistributionPolicy {


### PR DESCRIPTION
This commit adds support for omitted budgets in a SourceCred instance's `config/grain.json` file.

Now the parser takes all fields optionally, and maps them as an Object over the `zeroMissingBudgets` function, which zeroes missing budget parameters (`balancedPerWeek`, `immediatePerWeek`, or `recentPerWeek`).

For example, we omit the `balancedPerWeek` and `immediatePerWeek` fields here:
```js
{
  recentPerWeek: 10,
  recentWeeklyDecayRate: 0.5
}
```

__Test Plan__
Unit tests are provided here for the `zeroMissingBudgets` helper, checking that it corrently handles omitted fields and passes along the other values untouched.  I've also modified the parser tests to reflect the optional nature of these few parameters.