### PR TITLE
grainConfig: optional budgets (alternative to #2522)

### DIFF
--- a/src/api/grainConfig.test.js
+++ b/src/api/grainConfig.test.js
@@ -7,11 +7,8 @@ import {fromInteger} from "../core/ledger/grain";
 
 describe("api/grainConfig", () => {
   describe("parser", () => {
-    it("errors if missing params", () => {
-      const grainConfig = {};
-      expect(() => parser.parseOrThrow(grainConfig)).toThrowError(
-        "missing key"
-      );
+    it("does not throw with no params", () => {
+      expect(parser.parseOrThrow({})).toEqual({});
     });
 
     it("errors if malformed params", () => {
@@ -27,15 +24,11 @@ describe("api/grainConfig", () => {
 
     it("ignores extra params", () => {
       const grainConfig = {
-        balancedPerWeek: 10,
-        immediatePerWeek: 20,
         recentPerWeek: 30,
         EXTRA: 30,
       };
 
       const to = {
-        balancedPerWeek: 10,
-        immediatePerWeek: 20,
         recentPerWeek: 30,
       };
 
@@ -66,7 +59,20 @@ describe("api/grainConfig", () => {
   });
 
   describe("toDistributionPolicy", () => {
-    it("errors on missing discount", () => {
+    it("can handle missing policies", () => {
+      const x: GrainConfig = {
+        maxSimultaneousDistributions: 100,
+      };
+
+      const expected: DistributionPolicy = {
+        allocationPolicies: [],
+        maxSimultaneousDistributions: 100,
+      };
+
+      expect(toDistributionPolicy(x)).toEqual(expected);
+    });
+
+    it("errors on missing discount for recent policy", () => {
       const x: GrainConfig = {
         balancedPerWeek: 10,
         immediatePerWeek: 20,


### PR DESCRIPTION
This commit adds support for omitted budgets in a SourceCred instance's `config/grain.json` file.

Here, the `GrainConfig` type takes the policy budgets optionally, and passes the responsibilty to handle null values to `toDistributionPolicy`.
```js
export type GrainConfig = {|
  +immediatePerWeek?: number,
  +balancedPerWeek?: number,
  +recentPerWeek?: number,
  +recentWeeklyDecayRate?: number,
  +maxSimultaneousDistributions?: number,
|};
```
```js
export function toDistributionPolicy(x: GrainConfig): DistributionPolicy {
  const immediatePerWeek = NullUtil.orElse(x.immediatePerWeek, 0);
  const recentPerWeek = NullUtil.orElse(x.recentPerWeek, 0);
  const balancedPerWeek = NullUtil.orElse(x.balancedPerWeek, 0);
  // ...
```
This is an alternative implementation to sourcecred#2522.  The advantage here is that we consolidate all the configuration checks on the data in `toDistributionPolicy`, as opposed to splitting its responsibilities with the parser.

__Test Plan__
I've modified the parser's unit tests to allow missing budget fields.  In addition, I've modified unit tests for `toDistributionPolicy` to test that missing parameters are handled properly.