### PR TITLE
Sketch a CredLedger interface

### DIFF
--- a/src/core/credGrainView.js
+++ b/src/core/credGrainView.js
@@ -18,10 +18,10 @@ import {type IntervalSequence} from "./interval";
  * Cred and Grain data for a given participant.
  *
  * Implicitly has an associated time scope, which will
- * be the time scope of the TimeScopedCredLedger that generated
+ * be the time scope of the TimeScopedCredGrainView that generated
  * this.
  */
-export type ParticipantData = {|
+export type ParticipantCredGrain = {|
   +identity: Identity,
   // Total Cred earned during the time scope.
   +cred: number,
@@ -35,36 +35,31 @@ export type ParticipantData = {|
 
 export type ParticipantSort = "BY_CRED" | "BY_GRAIN";
 export type ParticipantsOptions = {|
+  // How to sort. Always sorts from highest to lowest.
+  // Defaults to BY_CRED
   +sort?: ParticipantSort,
   // Which identity types should be included.
   // Defaults to including all types.
   +includedTypes?: Set<IdentityType>,
-  // Minimum Cred required to be included in the results.
-  // Defaults to including all participants regardless of
-  // Cred.
-  +minCred?: number,
-  // Minimum Grain earnings required to be included in results.
-  // Defaults to including all participants regardless of Grain.
-  +minGrain?: Grain,
 |};
 
 /**
  * Aggregates data across a CredGraph and Ledger.
  *
  * By default, it includes data across all time present in the instance.
- * Callers can call `withTimeScope` to get a `TimeScopedCredLedger` which
+ * Callers can call `withTimeScope` to get a `TimeScopedCredGrainView` which
  * returns data that only includes a continuous subset of cred and grain data
  * across time.
  */
-export class CredLedger {
+export class CredGrainView {
   _credGraph: CredGraph;
   _ledger: Ledger;
-  _defaultTimeScope: TimeScopedCredLedger;
+  _defaultTimeScope: TimeScopedCredGrainView;
 
   constructor(credGraph: CredGraph, ledger: Ledger) {
     this._credGraph = credGraph;
     this._ledger = ledger;
-    this._defaultTimeScope = new TimeScopedCredLedger(
+    this._defaultTimeScope = new TimeScopedCredGrainView(
       credGraph,
       ledger,
       -Infinity,
@@ -72,8 +67,11 @@ export class CredLedger {
     );
   }
 
-  withTimeScope(startTimeMs: number, endTimeMs: number): TimeScopedCredLedger {
-    return new TimeScopedCredLedger(
+  withTimeScope(
+    startTimeMs: number,
+    endTimeMs: number
+  ): TimeScopedCredGrainView {
+    return new TimeScopedCredGrainView(
       this._credGraph,
       this._ledger,
       startTimeMs,
@@ -85,16 +83,18 @@ export class CredLedger {
     return this._defaultTimeScope.intervals();
   }
 
-  participant(id: IdentityId): ParticipantData | null {
+  participant(id: IdentityId): ParticipantCredGrain | null {
     return this._defaultTimeScope.participant(id);
   }
 
-  participants(options: ParticipantsOptions): $ReadOnlyArray<ParticipantData> {
+  participants(
+    options: ParticipantsOptions
+  ): $ReadOnlyArray<ParticipantCredGrain> {
     return this._defaultTimeScope.participants(options);
   }
 }
 
-export class TimeScopedCredLedger {
+export class TimeScopedCredGrainView {
   _credGraph: CredGraph;
   _ledger: Ledger;
   _startTimeMs: TimestampMs;
@@ -112,12 +112,14 @@ export class TimeScopedCredLedger {
     this._endTimeMs = endTimeMs;
   }
 
-  participants(options: ParticipantsOptions): $ReadOnlyArray<ParticipantData> {
+  participants(
+    options: ParticipantsOptions
+  ): $ReadOnlyArray<ParticipantCredGrain> {
     const _ = options;
     throw new Error("not yet implemented");
   }
 
-  participant(id: IdentityId): ParticipantData | null {
+  participant(id: IdentityId): ParticipantCredGrain | null {
     const _ = id;
     throw new Error("not yet implemented");
   }

--- a/src/core/credLedger.js
+++ b/src/core/credLedger.js
@@ -1,0 +1,128 @@
+// @flow
+
+/**
+ * This module exposes a class that accesses participant data, aggregating
+ * between a CredGraph and a Ledger.
+ *
+ * It is useful for cases where you want to view a participant's Cred and Grain
+ * data simultaneously, for example for creating summary dashboards.
+ */
+import {CredGraph} from "./credrank/credGraph";
+import {type Identity, type IdentityType, type IdentityId} from "./identity";
+import {type Grain} from "./ledger/grain";
+import {Ledger} from "./ledger/ledger";
+import {type TimestampMs} from "../util/timestamp";
+import {type IntervalSequence} from "./interval";
+
+/**
+ * Cred and Grain data for a given participant.
+ *
+ * Implicitly has an associated time scope, which will
+ * be the time scope of the TimeScopedCredLedger that generated
+ * this.
+ */
+export type ParticipantData = {|
+  +identity: Identity,
+  // Total Cred earned during the time scope.
+  +cred: number,
+  // Cred earned in each interval within the time scope.
+  +credOverTime: $ReadOnlyArray<number>,
+  // Total Grain earned during the time scope.
+  +grainEarned: Grain,
+  // Grain earned in each interval within the time scope.
+  +grainEarnedOverTime: $ReadOnlyArray<Grain>,
+|};
+
+export type ParticipantSort = "BY_CRED" | "BY_GRAIN";
+export type ParticipantsOptions = {|
+  +sort?: ParticipantSort,
+  // Which identity types should be included.
+  // Defaults to including all types.
+  +includedTypes?: Set<IdentityType>,
+  // Minimum Cred required to be included in the results.
+  // Defaults to including all participants regardless of
+  // Cred.
+  +minCred?: number,
+  // Minimum Grain earnings required to be included in results.
+  // Defaults to including all participants regardless of Grain.
+  +minGrain?: Grain,
+|};
+
+/**
+ * Aggregates data across a CredGraph and Ledger.
+ *
+ * By default, it includes data across all time present in the instance.
+ * Callers can call `withTimeScope` to get a `TimeScopedCredLedger` which
+ * returns data that only includes a continuous subset of cred and grain data
+ * across time.
+ */
+export class CredLedger {
+  _credGraph: CredGraph;
+  _ledger: Ledger;
+  _defaultTimeScope: TimeScopedCredLedger;
+
+  constructor(credGraph: CredGraph, ledger: Ledger) {
+    this._credGraph = credGraph;
+    this._ledger = ledger;
+    this._defaultTimeScope = new TimeScopedCredLedger(
+      credGraph,
+      ledger,
+      -Infinity,
+      Infinity
+    );
+  }
+
+  withTimeScope(startTimeMs: number, endTimeMs: number): TimeScopedCredLedger {
+    return new TimeScopedCredLedger(
+      this._credGraph,
+      this._ledger,
+      startTimeMs,
+      endTimeMs
+    );
+  }
+
+  intervals(): IntervalSequence {
+    return this._defaultTimeScope.intervals();
+  }
+
+  participant(id: IdentityId): ParticipantData | null {
+    return this._defaultTimeScope.participant(id);
+  }
+
+  participants(options: ParticipantsOptions): $ReadOnlyArray<ParticipantData> {
+    return this._defaultTimeScope.participants(options);
+  }
+}
+
+export class TimeScopedCredLedger {
+  _credGraph: CredGraph;
+  _ledger: Ledger;
+  _startTimeMs: TimestampMs;
+  _endTimeMs: TimestampMs;
+
+  constructor(
+    credGraph: CredGraph,
+    ledger: Ledger,
+    startTimeMs: TimestampMs,
+    endTimeMs: TimestampMs
+  ) {
+    this._credGraph = credGraph;
+    this._ledger = ledger;
+    this._startTimeMs = startTimeMs;
+    this._endTimeMs = endTimeMs;
+  }
+
+  participants(options: ParticipantsOptions): $ReadOnlyArray<ParticipantData> {
+    const _ = options;
+    throw new Error("not yet implemented");
+  }
+
+  participant(id: IdentityId): ParticipantData | null {
+    const _ = id;
+    throw new Error("not yet implemented");
+  }
+
+  intervals(): IntervalSequence {
+    throw new Error("not yet implemented");
+  }
+}


### PR DESCRIPTION
This is a sketch of a data interface for accessing aggregated data from
a CredGraph and a Ledger, i.e. wrapping Cred scores and Grain earnings
together.

This is based on @blueridger's work in #2521.

Main differences:
- Different naming, specifically the names build "up" from the underlying domain (a wrapper around CredGraph and Ledger exposing enhanced participant data) rather than "down" from the intended use case (rows in an explorer table)
- I used the `Identity` type which includes id, name, and identity type
- The "builder" class implicitly wraps a view-across-all-time for convenience.
- Elaborated on the APIs for retrieving data (sorting, filtering, retrieving just one participant, etc)

Test plan: It's just an interface; flow and lint pass.