### PR TITLE
grain cli: generate markdown tables for grain distributions

### DIFF
--- a/src/cli/grain.js
+++ b/src/cli/grain.js
@@ -2,12 +2,17 @@
 
 import fs from "fs-extra";
 import {join} from "path";
+
+import {fromString as uuidFromString} from "../util/uuid";
+import sortBy from "../util/sortBy";
 import {loadFileWithDefault, loadJson} from "../util/disk";
 import {fromJSON as credResultFromJson} from "../analysis/credResult";
 import {CredView} from "../analysis/credView";
 import {Ledger} from "../core/ledger/ledger";
 import {applyDistributions} from "../core/ledger/applyDistributions";
 import {computeCredAccounts} from "../core/ledger/credAccounts";
+import {type GrainReceipt} from "../core/ledger/grainAllocation";
+import {type Distribution} from "../core/ledger/distribution";
 import stringify from "json-stable-stringify";
 import * as G from "../core/ledger/grain";
 import dedent from "../util/dedent";
@@ -47,21 +52,21 @@ const grainCommand: Command = async (args, std) => {
     +Date.now()
   );
 
-  let totalDistributed = G.ZERO;
-  const recipientIdentities = new Set();
-  for (const {allocations} of distributions) {
-    for (const {receipts} of allocations) {
-      for (const {amount, id} of receipts) {
-        totalDistributed = G.add(amount, totalDistributed);
-        recipientIdentities.add(id);
-      }
-    }
-  }
+  // Print MD table for each policy.
+  distributions.map(({allocations}) =>
+    allocations.map(({policy, receipts}) =>
+      printAllocationMarkdownTable(
+        receipts,
+        ledger,
+        `${policy.policyType} Grain Allocation`
+      )
+    )
+  );
 
-  console.log(
-    `Distributed ${G.format(totalDistributed)} to ${
-      recipientIdentities.size
-    } identities in ${distributions.length} distributions`
+  printAllocationMarkdownTable(
+    mergeReceipts(distributions),
+    ledger,
+    `Aggregate Grain Distribution`
   );
 
   await fs.writeFile(ledgerPath, ledger.serialize());
@@ -72,6 +77,64 @@ const grainCommand: Command = async (args, std) => {
 
   return 0;
 };
+
+/**
+ * Merge receipts under the same name into one.
+ */
+function mergeReceipts(
+  distributions: $ReadOnlyArray<Distribution>
+): $ReadOnlyArray<GrainReceipt> {
+  const mergedBalances: {[string]: G.Grain} = {};
+  for (const {allocations} of distributions) {
+    for (const {receipts} of allocations) {
+      for (const {amount, id} of receipts) {
+        if (!mergedBalances[id.toString()]) {
+          mergedBalances[id.toString()] = amount;
+        } else {
+          const existingBalance = mergedBalances[id.toString()];
+          mergedBalances[id.toString()] = G.add(amount, existingBalance);
+        }
+      }
+    }
+  }
+
+  return Object.keys(mergedBalances).map((id) => ({
+    amount: mergedBalances[id],
+    id: uuidFromString(id),
+  }));
+}
+
+function printAllocationMarkdownTable(
+  receipts: $ReadOnlyArray<GrainReceipt>,
+  ledger: Ledger,
+  title: string
+) {
+  const totalDistributed = receipts.reduce((sum, {amount}) => {
+    return G.add(amount, sum);
+  }, G.ZERO);
+
+  console.log(`# ${title}`);
+  console.log(
+    `### ${G.toFloatRatio(totalDistributed, G.ONE).toFixed(0)} grain budget`
+  );
+  console.log();
+  console.log(`| % | grain | name |`);
+  console.log(`| --- | --- | --- |`);
+  const sorted = sortBy(receipts, ({amount}) => -Number(amount));
+  sorted.map((n) => console.log(row(n)));
+  console.log();
+
+  function row({amount, id}) {
+    const percentage = 100 * G.toFloatRatio(amount, totalDistributed);
+
+    // get alias from ledger
+    const {name} = ledger.account(id).identity;
+    return `| ${percentage.toFixed(2)}% | ${G.toFloatRatio(
+      amount,
+      G.ONE
+    ).toFixed(2)} | ${name} |`;
+  }
+}
 
 export const grainHelp: Command = async (args, std) => {
   std.out(


### PR DESCRIPTION
This adds support for generating markdown table of distributions given an instance's config/grain.json. Users can now view the grain allocated to each recipient across individual policies and also collectively.

On yarn grain, users will receive md tables which they can share or archive.

Note that I had to delete the most recent distribution, which was too recent to allow for another distribution. In the future, we can add support for speculative distributions.
To replicate in the meantime, you can delete the most recent distribution from the ledger (as well as any grain sales after).

Test Plan
I didn't write any unit tests here to check the markdown table. Instead, I tested this using different policy configs on my local instance, and sanity checked them myself. That being said, this module doesn't have any unit tests so I can work on that when I add more functionality next.