### PR TITLE
fix(gitcoin): cast userWhitelist str to json array

### DIFF
--- a/src/plugins/gitcoin/plugin.js
+++ b/src/plugins/gitcoin/plugin.js
@@ -53,7 +53,9 @@ export class GitcoinPlugin implements Plugin {
     const path = pathJoin(configDir, "config.json");
     const pgDatabaseUrl = process.env.GITCOIN_POSTGRES_URL;
     const gitcoinHost = process.env.GITCOIN_HOST;
-    const userWhitelist = process.env.GITCOIN_USER_WHITELIST ? JSON.parse(process.env.GITCOIN_USER_WHITELIST) : null;
+    const userWhitelist = process.env.GITCOIN_USER_WHITELIST
+      ? JSON.parse(process.env.GITCOIN_USER_WHITELIST)
+      : null;
     const task = `gitcoin: config file generating`;
 
     if (fs.existsSync(path)) {

--- a/src/plugins/gitcoin/plugin.js
+++ b/src/plugins/gitcoin/plugin.js
@@ -53,7 +53,7 @@ export class GitcoinPlugin implements Plugin {
     const path = pathJoin(configDir, "config.json");
     const pgDatabaseUrl = process.env.GITCOIN_POSTGRES_URL;
     const gitcoinHost = process.env.GITCOIN_HOST;
-    const userWhitelist = process.env.GITCOIN_USER_WHITELIST;
+    const userWhitelist = JSON.parse(process.env.GITCOIN_USER_WHITELIST);
     const task = `gitcoin: config file generating`;
 
     if (fs.existsSync(path)) {

--- a/src/plugins/gitcoin/plugin.js
+++ b/src/plugins/gitcoin/plugin.js
@@ -53,7 +53,7 @@ export class GitcoinPlugin implements Plugin {
     const path = pathJoin(configDir, "config.json");
     const pgDatabaseUrl = process.env.GITCOIN_POSTGRES_URL;
     const gitcoinHost = process.env.GITCOIN_HOST;
-    const userWhitelist = JSON.parse(process.env.GITCOIN_USER_WHITELIST);
+    const userWhitelist = process.env.GITCOIN_USER_WHITELIST ? JSON.parse(process.env.GITCOIN_USER_WHITELIST) : null;
     const task = `gitcoin: config file generating`;
 
     if (fs.existsSync(path)) {


### PR DESCRIPTION
Running `sourcecred graph` results in the error below,

```
Error: key "userWhitelist": expected array, got string
    at Parser.parseOrThrow (webpack:///./src/util/combo.js?:23:227)
    at loadJson (webpack:///./src/util/disk.js?:17:139)
    at async GitcoinPlugin.graph (webpack:///./src/plugins/gitcoin/plugin.js?:16:1876)
    at async graphCommand (webpack:///./src/cli/graph.js?:23:2480)
```

This PR fixes it by casting the str value from .env to JSON array