### PR TITLE
Discord: Support "props channels"

### DIFF
--- a/src/plugins/experimental-discord/config.js
+++ b/src/plugins/experimental-discord/config.js
@@ -58,6 +58,12 @@ export type DiscordConfigJson = {|
   // Note that channels use a snowflake id only.
   // defaultWeight is used to set weights for channels that don't have a specified weight
   +channelWeightConfig?: ChannelWeightConfig,
+  // List of channels which are considered "props channels".
+  // In a props channel, we have an extra rule: if someone is mentioned in a message,
+  // we create a "props" edge to the mentioned user instead of a regular "mentions" edge.
+  // We can set a higher weight on these props edges, which allows us to flow Cred in a props
+  // mostly to the people getting propsed, rather than to the author of the props message.
+  +propsChannels?: $ReadOnlyArray<Model.Snowflake>,
 |};
 
 const parserJson: C.Parser<DiscordConfigJson> = C.object(
@@ -74,12 +80,14 @@ const parserJson: C.Parser<DiscordConfigJson> = C.object(
       defaultWeight: C.number,
       weights: C.dict(C.number),
     }),
+    propsChannels: C.array(C.string),
   }
 );
 
 export type DiscordConfig = {|
   +guildId: Model.Snowflake,
   +weights: WeightConfig,
+  +propsChannels: $ReadOnlyArray<Model.Snowflake>,
 |};
 
 /**
@@ -106,6 +114,7 @@ export function _upgrade(json: DiscordConfigJson): DiscordConfig {
         defaultWeight: 1,
       },
     },
+    propsChannels: json.propsChannels || [],
   };
 }
 

--- a/src/plugins/experimental-discord/config.js
+++ b/src/plugins/experimental-discord/config.js
@@ -62,7 +62,7 @@ export type DiscordConfigJson = {|
   // In a props channel, we have an extra rule: if someone is mentioned in a message,
   // we create a "props" edge to the mentioned user instead of a regular "mentions" edge.
   // We can set a higher weight on these props edges, which allows us to flow Cred in a props
-  // mostly to the people getting propsed, rather than to the author of the props message.
+  // mostly to the people receiving props, rather than to the author of the props message.
   +propsChannels?: $ReadOnlyArray<Model.Snowflake>,
 |};
 

--- a/src/plugins/experimental-discord/createGraph.js
+++ b/src/plugins/experimental-discord/createGraph.js
@@ -222,7 +222,7 @@ export type GraphMessage = {|
   +reactions: $ReadOnlyArray<GraphReaction>,
   +mentions: $ReadOnlyArray<Model.GuildMember>,
   // Included so we can apply any channel-based rules (e.g. creating props
-  // edges intsead of mentions edges) at graph construction time.
+  // edges instead of mentions edges) at graph construction time.
   +channelId: Model.Snowflake,
   // Included because we want the channel name in the node description.
   +channelName: string,

--- a/src/plugins/experimental-discord/declaration.js
+++ b/src/plugins/experimental-discord/declaration.js
@@ -77,7 +77,7 @@ export const mentionsEdgeType: EdgeType = deepFreeze({
 
 export const propsEdgeType: EdgeType = deepFreeze({
   forwardName: "gives props to",
-  backwardName: "recevies props from",
+  backwardName: "recieves props from",
   prefix: EdgeAddress.append(edgePrefix, "PROPS"),
   defaultWeight: {forwards: 19, backwards: 1 / 16},
   description: "Connects a props message to the person getting props",

--- a/src/plugins/experimental-discord/declaration.js
+++ b/src/plugins/experimental-discord/declaration.js
@@ -79,6 +79,10 @@ export const propsEdgeType: EdgeType = deepFreeze({
   forwardName: "gives props to",
   backwardName: "recieves props from",
   prefix: EdgeAddress.append(edgePrefix, "PROPS"),
+  // We set the default forward weight to 19x because message authors get a
+  // 1x weight by default, so in the most common case of a props with a
+  // single recipient, the props author will get 5% of the Cred and the
+  // props-ee will get 95%.
   defaultWeight: {forwards: 19, backwards: 1 / 16},
   description: "Connects a props message to the person getting props",
 });

--- a/src/plugins/experimental-discord/declaration.js
+++ b/src/plugins/experimental-discord/declaration.js
@@ -75,6 +75,14 @@ export const mentionsEdgeType: EdgeType = deepFreeze({
   description: "Connects a message to the member being mentioned.",
 });
 
+export const propsEdgeType: EdgeType = deepFreeze({
+  forwardName: "gives props to",
+  backwardName: "recevies props from",
+  prefix: EdgeAddress.append(edgePrefix, "PROPS"),
+  defaultWeight: {forwards: 19, backwards: 1 / 16},
+  description: "Connects a props message to the person getting props",
+});
+
 export const declaration: PluginDeclaration = deepFreeze({
   name: "Discord",
   nodePrefix,
@@ -85,6 +93,7 @@ export const declaration: PluginDeclaration = deepFreeze({
     addsReactionEdgeType,
     reactsToEdgeType,
     mentionsEdgeType,
+    propsEdgeType,
   ],
   userTypes: [memberNodeType],
 });

--- a/src/plugins/experimental-discord/plugin.js
+++ b/src/plugins/experimental-discord/plugin.js
@@ -67,10 +67,10 @@ export class DiscordPlugin implements Plugin {
     rd: ReferenceDetector
   ): Promise<WeightedGraph> {
     const _ = rd; // TODO(#1808): not yet used
-    const {guildId, weights} = await loadConfig(ctx);
-    const repo = await repository(ctx, guildId);
+    const config = await loadConfig(ctx);
+    const repo = await repository(ctx, config.guildId);
 
-    const weightedGraph = await createGraph(guildId, repo, weights);
+    const weightedGraph = await createGraph(config, repo);
 
     const declarationWeights = weightsForDeclaration(declaration);
     // Add in the type-level weights from the plugin spec


### PR DESCRIPTION
On our Discord instance, we have a "props" channel where people are
encouraged to give props to other members of the community. Ideally, the
person getting props should receive a very large fraction of the Cred
flow from the props. However, with our current Cred semantics, the
person making the props splits Cred evenly with the person receiving
props.

This commit fixes that by adding a special, optional field to the
discord config where you can specify which channel(s) are props
channels. When a user is mentioned in one of those channels, they get a
"props" edge instead of a "mentions" edge. By default, the props edge
has a weight of 19x, so a message with a single props will flow 95% of
the Cred to the person getting props, and 5% to the person creating the
props as a small incentive for recognizing others.

In principle, we might not want to add this special case logic directly
into the Discord plugin; we might instead want to support adding
"micro plugins" to cover this kind of use case.

In practice, this doesn't add much complexity and is something we really
want, so I think hacking it in is justified.

Test plan: There isn't any automated testing covering the Discord graph
creation, but I manually tested this and am confident it works.
Specifically, I re-ran our own cred scores using this change and am
seeing reasonable diffs in Cred (see below). Also, inspecting the Cred
explorer shows that people who authored props messages are now getting
less Cred, and people who received props are now getting more Cred.

| Name | Before | After | Change % |
| ---- | ------ | ----- | -------- |
| decentralion | 24756 | 24102 | −3% |
| wchargin | 11403 | 11416 | 0% |
| beanow | 5692 | 5649 | −1% |
| s-ben | 5101 | 5015 | −2% |
| lbstrobbe | 4856 | 4841 | 0% |
| hammad | 3642 | 3702 | 2% |
| topocount | 1790 | 1799 | 1% |
| burrrata | 1735 | 1737 | 0% |
| KuraFire | 1649 | 1731 | 5% |
| bex | 1586 | 1616 | 2% |
| sourcecred | 1396 | 1396 | 0% |
| mzargham | 1261 | 1280 | 2% |
| sandpiper | 1113 | 1262 | 13% |
| dependabot | 1255 | 1257 | 0% |
| panchomiguel | 904 | 970 | 7% |
| vsoch | 910 | 913 | 0% |
| brianlitwin | 889 | 895 | 1% |
| evan | 642 | 703 | 10% |
| greenkeeper | 667 | 666 | 0% |
| joiecousins | 552 | 630 | 14% |
| yalor | 481 | 561 | 16% |
| Thena | 426 | 466 | 9% |
| youngkidwarrior | 463 | 437 | −6% |
| benoxmo | 443 | 432 | −2% |
| flyingzumwalt | 362 | 398 | 10% |
| amico | 259 | 273 | 5% |
| rpp | 239 | 251 | 5% |
| doctorrobinson | 290 | 233 | −19% |
| github-actions | 223 | 223 | 0% |
| owocki | 210 | 208 | −1% |
| deltafreq | 205 | 204 | −1% |
| ian | 129 | 199 | 54% |
| cortanav | 105 | 148 | 41% |
| protocol | 140 | 140 | 0% |
| Louisgrx | 139 | 139 | 0% |
| samkuhlmann | 132 | 132 | 0% |
| sriche | 129 | 128 | −1% |
| peth | 166 | 125 | −25% |
| coopahtroopa | 125 | 123 | −1% |
| JavierCanovas | 109 | 121 | 11% |