### PR TITLE
add support for limiting Cred minting by plugin

### DIFF
--- a/src/api/pluginBudgetConfig.js
+++ b/src/api/pluginBudgetConfig.js
@@ -1,0 +1,81 @@
+// @flow
+
+import {
+  type IntervalLength,
+  type Budget,
+  type BudgetPeriod,
+  intervalLengthParser,
+} from "../core/mintBudget";
+import {
+  type PluginId,
+  parser as pluginIdParser,
+  fromString as pluginIdFromString,
+} from "./pluginId";
+import {
+  type TimestampISO,
+  fromISO,
+  timestampISOParser,
+} from "../util/timestamp";
+import * as C from "../util/combo";
+import {bundledPlugins} from "./bundledPlugins";
+
+/**
+ * This module contains logic for setting Cred minting budgets over time on a per-plugin basis.
+ * As an example, suppose we want to limit the GitHub plugin to mint only 200 Cred per week,
+ * and we want the Discord plugin to mint 100 Cred per Week until Jan 1, 2020 and 200 Cred per
+ * week thereafter. We could do so with the following config:
+ * ```json
+ * {
+ *   "intervalLength": "WEEKLY",
+ *   "plugins": {
+ *     "sourcecred/github": [
+ *        {"startTime": "2018-01-01", "budget": 200}
+ *     ],
+ *     "sourcecred/discord": [
+ *       {"startTime": "2018-01-01", "budget": 100},
+ *       {"startTime": "2020-01-01", "budget": 200},
+ *     ],
+ *   }
+ * }
+ * ```
+ */
+
+type RawPluginBudgetConfig = {|
+  +intervalLength: IntervalLength,
+  +plugins: {[PluginId]: $ReadOnlyArray<RawBudgetPeriod>},
+|};
+
+type RawBudgetPeriod = {|
+  +startTime: TimestampISO,
+  +budget: number,
+|};
+
+const rawPeriodParser: C.Parser<RawBudgetPeriod> = C.object({
+  startTime: timestampISOParser,
+  budget: C.number,
+});
+
+const rawParser: C.Parser<RawPluginBudgetConfig> = C.object({
+  intervalLength: intervalLengthParser,
+  plugins: C.dict(C.array(rawPeriodParser), pluginIdParser),
+});
+
+function upgradeRawPeriod(p: RawBudgetPeriod): BudgetPeriod {
+  return {budgetValue: p.budget, startTimeMs: fromISO(p.startTime)};
+}
+
+function upgrade(config: RawPluginBudgetConfig): Budget {
+  const entries = Object.keys(config.plugins).map((key) => {
+    const id = pluginIdFromString(key);
+    const plugin = bundledPlugins()[id];
+    if (id == null) {
+      throw new Error(`No available plugin with id ${id}`);
+    }
+    const prefix = plugin.declaration().nodePrefix;
+    const periods = config.plugins[id].map(upgradeRawPeriod);
+    return {prefix, periods};
+  });
+  return {entries, intervalLength: config.intervalLength};
+}
+
+export const parser: C.Parser<Budget> = C.fmap(rawParser, upgrade);

--- a/src/core/mintBudget.js
+++ b/src/core/mintBudget.js
@@ -3,6 +3,7 @@
 import {sum} from "d3-array";
 import * as NullUtil from "../util/null";
 import * as Weights from "./weights";
+import * as C from "../util/combo";
 import {type NodeAddressT, NodeAddress} from "./graph";
 import {type WeightedGraph as WeightedGraphT} from "./weightedGraph";
 import {
@@ -23,6 +24,10 @@ import type {TimestampMs} from "../util/timestamp";
  */
 
 export type IntervalLength = "WEEKLY";
+
+export const intervalLengthParser: C.Parser<IntervalLength> = C.exactly([
+  "WEEKLY",
+]);
 
 export type BudgetPeriod = {|
   // When this budget policy starts


### PR DESCRIPTION
This commit builds on #2512 to allow instances to limit the rate of Cred
minting on a per-plugin basis. For example, an instance maintainer could
set a rule where the GitHub plugin can only mint up to 100 Cred per
week. The budgets may also vary over time; for example, the budget could
be 100 Cred per week in the year 2019, but 200 Cred per week in 2020.

This change is motivated in part by 1Hive's experience using SourceCred,
where the activity level on the Discord plugin grew much faster than
activity on other plugins, and threatened to drown out other Cred
minting.

To activate this feature, simply add a `config/pluginBudgets.json` file.
Here's an example:

```json
{
  "intervalLength": "WEEKLY",
  "plugins": {
    "sourcecred/github": [
      {"startTime": "2018-01-01", "budget": 10}
    ],
    "sourcecred/discord": [
      {"startTime": "2018-01-01", "budget": 10}
    ],
    "sourcecred/discourse": [
      {"startTime": "2018-01-01", "budget": 10}
    ],
    "sourcecred/initiatives": [
      {"startTime": "2018-01-01", "budget": 10}
    ]
  }
}
```

Note that the budget limitation is a _maximum_, i.e. a plugin might
still mint less than the stated amount in a given period. This means
that it's not possible to write strict invariants like "GitHub mints
half and Discord mints half". If there's a week with very little GitHub
activity, the GitHub plugin is likely to come in under-budget, in which
case the GitHub plugin will mint less than half of the total Cred.

Test plan: The code does not have any unit tests. This is typical of
"plumbing" type code where the logic basically amounts to deserializing
a config file and then piping it into the core logic: it's hard to get
things "subtly wrong" where it breaks in surprising ways. Flow passes,
which suggests things are wired correclty. I've also manually tested
this by imposing a variety of budget constraints on the real SourceCred
instance, and can confirm that things work as intended. For example,
here's the `credrank` output when applying a limitation on the SC
instance that each plugin may mint at most 10 Cred per week:

| Description | Cred | % |
| --- | --- | --- |
| decentralion | 1111.2 | 34.0% |
| wchargin | 413.5 | 12.6% |
| beanow | 257.2 | 7.9% |
| s-ben | 214.3 | 6.6% |
| lbstrobbe | 141.4 | 4.3% |
| mzargham | 107.4 | 3.3% |
| hammad | 96.1 | 2.9% |
| brianlitwin | 71.3 | 2.2% |
| burrrata | 67.8 | 2.1% |
| topocount | 62.3 | 1.9% |
| bex | 55.2 | 1.7% |
| KuraFire | 50.3 | 1.5% |
| dependabot | 36.3 | 1.1% |
| greenkeeper | 32.2 | 1.0% |
| panchomiguel | 31.6 | 1.0% |
| vsoch | 31.5 | 1.0% |
| sourcecred | 29.3 | 0.9% |
| evan | 29.3 | 0.9% |
| sandpiper | 24.9 | 0.8% |
| benoxmo | 19.3 | 0.6% |