### PR TITLE
grain: move defaults to api/currencyConfig

### DIFF
--- a/src/api/currencyConfig.js
+++ b/src/api/currencyConfig.js
@@ -1,6 +1,5 @@
 // @flow
 
-import {DEFAULT_SUFFIX} from "../core/ledger/grain";
 import * as C from "../util/combo";
 import * as NullUtil from "../util/null";
 
@@ -21,6 +20,7 @@ export type CurrencyDetails = {|
 |};
 
 export const DEFAULT_NAME = "Grain";
+export const DEFAULT_SUFFIX = "g";
 
 /**
  * Utilized by combo.fmap to enforce default currency values

--- a/src/core/ledger/grain.js
+++ b/src/core/ledger/grain.js
@@ -2,6 +2,7 @@
 
 import * as P from "../../util/combo";
 import bigInt from "big-integer";
+import {DEFAULT_SUFFIX} from "../../api/currencyConfig";
 
 /**
  * This module contains the types for tracking Grain, which is the native
@@ -79,8 +80,6 @@ export function eq(a: Grain, b: Grain): boolean {
 export function fromString(s: string): Grain {
   return bigInt(s).toString();
 }
-
-export const DEFAULT_SUFFIX = "g";
 
 /**
  * Formats a grain balance as a human-readable number, dividing the


### PR DESCRIPTION
This commit passes currency default responsibilities to `api/currencyConfig`.  Previously, the `DEFAULT_NAME` was handled in `api/currencyConfig` and `DEFAULT_SUFFIX` was held in `core/ledger/grain`.  Now we can treat `currencyConfig` as the source of truth for currency details.