### PR TITLE
Add AllocationId and DistributionId types

### DIFF
--- a/src/core/ledger/distribution.js
+++ b/src/core/ledger/distribution.js
@@ -5,8 +5,10 @@ import * as Uuid from "../../util/uuid";
 import {type TimestampMs} from "../../util/timestamp";
 import {type Allocation, allocationParser} from "./grainAllocation";
 
+export type DistributionId = Uuid.Uuid;
+
 export type Distribution = {|
-  +id: Uuid.Uuid,
+  +id: DistributionId,
   +allocations: $ReadOnlyArray<Allocation>,
   +credTimestamp: TimestampMs,
 |};

--- a/src/core/ledger/grainAllocation.js
+++ b/src/core/ledger/grainAllocation.js
@@ -26,13 +26,15 @@ import {
   processIdentities,
 } from "./processedIdentities";
 
+export type AllocationId = Uuid;
+
 export type GrainReceipt = {|
   +id: IdentityId,
   +amount: G.Grain,
 |};
 
 export type Allocation = {|
-  +id: Uuid,
+  +id: AllocationId,
   +policy: AllocationPolicy,
   +receipts: $ReadOnlyArray<GrainReceipt>,
 |};


### PR DESCRIPTION
This commit adds `AllocationId` and `DistributionId` as types. Much like
`IdentityId`, they are just aliases for `Uuid`. While they don't have
semantic significance at present, I think their presence makes code and
type signatures more informative.

We can consider making them opaque subtypes of Uuid, in which case all
instances would need to be created from within the respective modules,
but since we can't do any meaningful runtime verification, I think this
would be extra boilerplate without any real benefit.

Test plan: Typing only change; `yarn flow` passes.
