### PR TITLE
Add tested support for deserializing CredGraphs

### DIFF
--- a/src/cli/common.js
+++ b/src/cli/common.js
@@ -25,6 +25,7 @@ import {
   overrideWeights,
   fromJSON as weightedGraphFromJSON,
 } from "../core/weightedGraph";
+import {CredGraph, parser as credGraphParser} from "../core/credrank/credGraph";
 import {loadFileWithDefault, loadJsonWithDefault} from "../util/disk";
 import {parser as pluginBudgetParser} from "../api/pluginBudgetConfig";
 import {applyBudget, type Budget} from "../core/mintBudget";
@@ -170,6 +171,11 @@ export async function loadWeightedGraph(
     Weights.empty
   );
   return overrideWeights(combinedGraph, weights);
+}
+
+export async function loadCredGraph(baseDir: string): Promise<CredGraph> {
+  const credGraphPath = pathJoin(baseDir, "output", "credGraph.json");
+  return await loadJson(credGraphPath, credGraphParser);
 }
 
 export async function loadLedger(baseDir: string): Promise<Ledger> {

--- a/src/core/credrank/credGraph.test.js
+++ b/src/core/credrank/credGraph.test.js
@@ -1,5 +1,6 @@
 // @flow
 
+import {CredGraph, parser as credGraphParser} from "./credGraph";
 import {markovProcessGraph, credGraph} from "./testUtils";
 
 describe("core/credrank/credGraph", () => {
@@ -47,6 +48,22 @@ describe("core/credrank/credGraph", () => {
         participantCred += cred;
       }
       expect(totalMint).toBeCloseTo(participantCred);
+    });
+  });
+
+  describe("to/fromJSON", () => {
+    it("has round trip equality", async () => {
+      const cg1 = await credGraph();
+      const cgJson1 = cg1.toJSON();
+      const cg2 = CredGraph.fromJSON(cgJson1);
+      const cgJson2 = cg2.toJSON();
+      expect(cg1).toEqual(cg2);
+      expect(cgJson1).toEqual(cgJson2);
+    });
+    it("parser works", async () => {
+      const cg = await credGraph();
+      const cgJson = cg.toJSON();
+      expect(credGraphParser.parseOrThrow(cgJson)).toEqual(cg);
     });
   });
 });

--- a/src/core/credrank/markovNode.js
+++ b/src/core/credrank/markovNode.js
@@ -1,6 +1,7 @@
 // @flow
 
-import {type NodeAddressT} from "../graph";
+import * as C from "../../util/combo";
+import {type NodeAddressT, NodeAddress} from "../graph";
 
 export type MarkovNode = {|
   // Node address, unique within a Markov process graph. This is either
@@ -12,3 +13,9 @@ export type MarkovNode = {|
   // Amount of cred to mint at this node.
   +mint: number,
 |};
+
+export const parser: C.Parser<MarkovNode> = C.object({
+  address: NodeAddress.parser,
+  description: C.string,
+  mint: C.number,
+});

--- a/src/core/credrank/markovProcessGraph.test.js
+++ b/src/core/credrank/markovProcessGraph.test.js
@@ -2,7 +2,10 @@
 
 import {sum} from "d3-array";
 import * as NullUtil from "../../util/null";
-import {MarkovProcessGraph} from "./markovProcessGraph";
+import {
+  MarkovProcessGraph,
+  parser as markovProcessGraphParser,
+} from "./markovProcessGraph";
 import {
   markovEdgeAddress,
   MarkovEdgeAddress,
@@ -356,12 +359,17 @@ describe("core/credrank/markovProcessGraph", () => {
 
   describe("to/froJSON", () => {
     it("has round trip equality", () => {
-      const mpg = markovProcessGraph();
-      const mpgJson = mpg.toJSON();
-      const mpg_ = MarkovProcessGraph.fromJSON(mpgJson);
-      const mpgJson_ = mpg_.toJSON();
-      expect(mpg).toEqual(mpg_);
-      expect(mpgJson).toEqual(mpgJson_);
+      const mpg1 = markovProcessGraph();
+      const mpgJson1 = mpg1.toJSON();
+      const mpg2 = MarkovProcessGraph.fromJSON(mpgJson1);
+      const mpgJson2 = mpg2.toJSON();
+      expect(mpg1).toEqual(mpg2);
+      expect(mpgJson1).toEqual(mpgJson2);
+    });
+    it("parser works", async () => {
+      const mpg = await markovProcessGraph();
+      const mpgJson = markovProcessGraph().toJSON();
+      expect(markovProcessGraphParser.parseOrThrow(mpgJson)).toEqual(mpg);
     });
     it("serialization does not change node/edge iteration order", () => {
       const mpg1 = markovProcessGraph();


### PR DESCRIPTION
This commit re-writes the (de)serialization pathway for CredGraph, which
was previously not functional. I've also rewritten the path to use
parsers.

I removed any usage of the compat module. The main function of the
compat module (especially when considering ephemerally-maintained data
like the CredGraph) is to ensure we get clean error messages if the
provided data is invalid. Happily, parsers do that without requiring any
extra bookkeeping on our part. The compat module makes it slightly
easier to upgrade data formats while preserving backwards compatibility,
but since cred graphs are regenerated every time the `credrank` command
is run, this is not an important consideration.

The new logic is unit tested for both the MarkovProcessGraph and the
CredGraph. I also added a helper function to `cli/common` for retrieving
the CredGraph. This doesn't have explicit unit tests, but I manually
tested it by patching the `cli/credrank` command to load the Cred Graph
from disk before reporting results.
