### PR TITLE
CLI: Add -d diff flag to credrank command

### DIFF
--- a/src/cli/credrank.js
+++ b/src/cli/credrank.js
@@ -4,15 +4,17 @@ import fs from "fs-extra";
 import stringify from "json-stable-stringify";
 import {join as pathJoin} from "path";
 import {sum} from "d3-array";
+import {format} from "d3-format";
 
 import sortBy from "../util/sortBy";
 import {credrank} from "../core/credrank/compute";
-import {CredGraph} from "../core/credrank/credGraph";
+import {CredGraph, type Participant} from "../core/credrank/credGraph";
 import {LoggingTaskReporter} from "../util/taskReporter";
 import {computeBonusMinting, createBonusGraph} from "../core/bonusMinting";
 import type {Command} from "./command";
-import {loadInstanceConfig, prepareCredData} from "./common";
+import {loadInstanceConfig, prepareCredData, loadCredGraph} from "./common";
 import {merge} from "../core/weightedGraph";
+import {type Uuid} from "../util/uuid";
 
 function die(std, message) {
   std.err("fatal: " + message);
@@ -20,8 +22,19 @@ function die(std, message) {
 }
 
 const credrankCommand: Command = async (args, std) => {
-  if (args.length !== 0) {
-    return die(std, "usage: sourcecred credrank");
+  let shouldIncludeDiff = false;
+  const processedArgs = args.filter((arg) => {
+    switch (arg) {
+      case "-d":
+        shouldIncludeDiff = true;
+        return false;
+      default:
+        return true;
+    }
+  });
+
+  if (processedArgs.length !== 0) {
+    return die(std, "usage: sourcecred credrank [-d]");
   }
   const taskReporter = new LoggingTaskReporter();
   taskReporter.start("credrank");
@@ -44,13 +57,27 @@ const credrankCommand: Command = async (args, std) => {
   const credGraph = await credrank(combinedWeightedGraph, ledger);
   taskReporter.finish("run CredRank");
 
+  if (shouldIncludeDiff) {
+    taskReporter.start("load prior graph");
+    try {
+      const priorCredGraph = await loadCredGraph(baseDir);
+      printCredDiffTable(credGraph, priorCredGraph);
+    } catch (e) {
+      console.log(
+        `Could not load or compare existing credGraph.json. Skipping diff. Error: ${e.message}`
+      );
+      printCredSummaryTable(credGraph);
+    }
+    taskReporter.finish("load prior graph");
+  } else {
+    printCredSummaryTable(credGraph);
+  }
+
   taskReporter.start("write cred graph");
   const cgJson = stringify(credGraph.toJSON());
   const outputPath = pathJoin(baseDir, "output", "credGraph.json");
   await fs.writeFile(outputPath, cgJson);
   taskReporter.finish("write cred graph");
-
-  printCredSummaryTable(credGraph);
 
   taskReporter.finish("credrank");
   return 0;
@@ -71,6 +98,37 @@ function printCredSummaryTable(credGraph: CredGraph) {
     )}% |`;
   }
   sortedParticipants.slice(0, 20).forEach((n) => console.log(row(n)));
+}
+
+function printCredDiffTable(credGraph: CredGraph, priorCredGraph: CredGraph) {
+  console.log(`# Top Participants By New Cred`);
+  const priorParticipants: Map<Uuid, Participant> = new Map();
+  for (const participant of priorCredGraph.participants())
+    priorParticipants.set(participant.id, participant);
+
+  const credParticipants = Array.from(credGraph.participants());
+  const sortedParticipants = sortBy(credParticipants, (p) => -p.cred);
+  if (credParticipants.length !== Array.from(priorParticipants.keys()).length)
+    throw Error(
+      `Number of participants has changed. Rerun without -d to refresh.`
+    );
+  function row({cred, description, id}) {
+    const prior = priorParticipants.get(id);
+    if (!prior)
+      throw Error(
+        `Participant [${description}, ${id}] exists in the new scores but not in the old. Rerun without -d to refresh.`
+      );
+    const changeFactor = (cred - prior.cred) / prior.cred;
+    const percentageChangeStr =
+      changeFactor > 100 ? ">10,000%" : format(",.1%")(changeFactor);
+    return {
+      "Name": description,
+      "Prior Cred": prior.cred.toFixed(1),
+      "New Cred": cred.toFixed(1),
+      "% Change": percentageChangeStr,
+    };
+  }
+  console.table(sortedParticipants.slice(0, 20).map((n) => row(n)));
 }
 
 export default credrankCommand;


### PR DESCRIPTION
<!-- Please read our contributor guide before submitting your PR: -->
<!-- https://github.com/sourcecred/sourcecred/blob/master/CONTRIBUTING.md -->

# Description
Adds a `-d` flag to the `credrank` command that outputs a table showing the diff between the existing credgraph as read from json and the new credgraph. This will allow developers to easily see if/how their code changes affect credrank scores.

I chose to use `console.table` instead of the existing line-by-line method because the table is the primary product of the command when the flag is included, and readability (specifically, scanning the % Change column) is most important. Although this makes the table wider, it still seems like it should fit fine for 80-char terminal users in most cases.

<!-- Possible prompts:
  Why is the change important?
  Did you consider and reject alternate formulations of the same idea?
  Are there relevant issues or discussions elsewhere?
-->

# Test Plan
Not tested by automated tests.

To create cred diffs, I added `+1` to the end of line 107 or 104 in `core/credrank/compute.js`

Used `scdev credrank -d`

### Negative change:
<img width="509" alt="Screen Shot 2020-11-26 at 11 13 13 AM" src="https://user-images.githubusercontent.com/11550396/100386037-2def5380-2fd9-11eb-8a4f-727054f18f08.png">

### Positive change:
<img width="507" alt="Screen Shot 2020-11-26 at 11 14 24 AM" src="https://user-images.githubusercontent.com/11550396/100386044-3051ad80-2fd9-11eb-81d4-7f3983e1347f.png">

### When there is no existing json
<img width="437" alt="Screen Shot 2020-11-26 at 11 26 34 AM" src="https://user-images.githubusercontent.com/11550396/100386465-4613a280-2fda-11eb-9e68-3915d8e6dd99.png">

### With a few lines of context:
<img width="513" alt="Screen Shot 2020-11-26 at 11 00 45 AM" src="https://user-images.githubusercontent.com/11550396/100386024-23cd5500-2fd9-11eb-966d-6b7784c694c3.png">

### 80-char terminal with long cred scores:
<img width="589" alt="Screen Shot 2020-11-26 at 11 43 03 AM" src="https://user-images.githubusercontent.com/11550396/100387291-9b50b380-2fdc-11eb-83bd-38e9b9d17a48.png">



### Also copies and pastes well:

│    0    │       'hammadj'       │   '55.4'   │  '73.0'  │  '+31.8%'  │
│    1    │       'Beanow'        │   '48.7'   │  '66.3'  │  '+36.2%'  │
│    2    │ 'decentralion-github' │   '23.7'   │  '41.3'  │  '+74.3%'  │
│    3    │        'Thena'        │   '13.8'   │  '31.4'  │ '+127.8%'  │
│    4    │  'topocount-github'   │   '12.2'   │  '29.8'  │ '+144.8%'  │
```
│    0    │       'hammadj'       │   '55.4'   │  '73.0'  │  '+31.8%'  │
│    1    │       'Beanow'        │   '48.7'   │  '66.3'  │  '+36.2%'  │
│    2    │ 'decentralion-github' │   '23.7'   │  '41.3'  │  '+74.3%'  │
│    3    │        'Thena'        │   '13.8'   │  '31.4'  │ '+127.8%'  │
│    4    │  'topocount-github'   │   '12.2'   │  '29.8'  │ '+144.8%'  │
```

<!-- Possible prompts:
  How well covered by automated tests is this change?
  How did you manually test this change? How can a reviewer replicate the tests?
-->
