### PR TITLE
cli/common: loadCurrencyDetails

### DIFF
--- a/src/api/currencyConfig.js
+++ b/src/api/currencyConfig.js
@@ -35,6 +35,13 @@ function upgrade(c: SerializedCurrencyDetails): CurrencyDetails {
   };
 }
 
+export function defaultCurrencyConfig(): CurrencyDetails {
+  return {
+    name: DEFAULT_NAME,
+    suffix: DEFAULT_SUFFIX,
+  };
+}
+
 export const parser: C.Parser<CurrencyDetails> = C.fmap(
   C.object({}, {currencyName: C.string, currencySuffix: C.string}),
   upgrade

--- a/src/cli/common.js
+++ b/src/cli/common.js
@@ -29,6 +29,11 @@ import {CredGraph, parser as credGraphParser} from "../core/credrank/credGraph";
 import {loadFileWithDefault, loadJsonWithDefault} from "../util/disk";
 import {parser as pluginBudgetParser} from "../api/pluginBudgetConfig";
 import {applyBudget, type Budget} from "../core/mintBudget";
+import {
+  parser as currencyConfigParser,
+  type CurrencyDetails,
+} from "../api/currencyConfig";
+import {defaultCurrencyConfig} from "../api/currencyConfig";
 
 import * as Weights from "../core/weights";
 
@@ -200,4 +205,18 @@ export async function saveLedger(
 function loadPluginBudget(baseDir: string): Promise<Budget | null> {
   const budgetPath = pathJoin(baseDir, "config", "pluginBudgets.json");
   return loadJsonWithDefault(budgetPath, pluginBudgetParser, () => null);
+}
+
+/**
+ * Load the currency details from config, falling back on defaults
+ * if need be.
+ */
+export async function loadCurrencyDetails(
+  currencyDetailsPath: string
+): Promise<CurrencyDetails> {
+  return await loadJsonWithDefault(
+    currencyDetailsPath,
+    currencyConfigParser,
+    defaultCurrencyConfig
+  );
 }

--- a/src/cli/common.test.js
+++ b/src/cli/common.test.js
@@ -1,0 +1,16 @@
+// @flow
+
+import {loadCurrencyDetails} from "./common";
+import {DEFAULT_NAME, DEFAULT_SUFFIX} from "../api/currencyConfig";
+
+describe("cli/common", () => {
+  describe("loadCurrencyDetails", () => {
+    it("returns default CurrencyDetails on missing config path", async () => {
+      const {name, suffix} = await loadCurrencyDetails("");
+      expect({name, suffix}).toEqual({
+        name: DEFAULT_NAME,
+        suffix: DEFAULT_SUFFIX,
+      });
+    });
+  });
+});


### PR DESCRIPTION
<!-- Please read our contributor guide before submitting your PR: -->
<!-- https://github.com/sourcecred/sourcecred/blob/master/CONTRIBUTING.md -->

### Description
Loads custom currency config, falling back on defaults if necessary.

__Related__
- Used by #2571
- Uses #2572 

<!-- Possible prompts:
  Why is the change important?
  Did you consider and reject alternate formulations of the same idea?
  Are there relevant issues or discussions elsewhere?
-->

### Test Plan
Unit test to check fallback to defaults on bad path to currency config.  Manually tested on 1Hive's instance to check success case with custom configs.

<!-- Possible prompts:
  How well covered by automated tests is this change?
  How did you manually test this change? How can a reviewer replicate the tests?
-->
