### PR TITLE
grain cli: distribution + allocation markdown tables

### DIFF
--- a/src/core/ledger/distributionSummary/allocationSummary.js
+++ b/src/core/ledger/distributionSummary/allocationSummary.js
@@ -1,0 +1,60 @@
+// @flow
+
+import sortBy from "../../../util/sortBy";
+import * as NullUtil from "../../../util/null";
+import {type IdentityId} from "../../identity";
+import {type Distribution} from "../distribution";
+import * as G from "../grain";
+import {type Allocation, type GrainReceipt} from "../grainAllocation";
+import {Ledger} from "../ledger";
+import {toString} from "../policies";
+import {formatCenter} from "./distributionSummary";
+
+export function allocationMarkdownSummary(
+  distribution: Distribution,
+  allocation: Allocation,
+  ledger: Ledger
+): string {
+  const {receipts} = allocation;
+  const totalDistributed: G.Grain = getTotalDistributed(receipts);
+
+  const columnHeaders = `|          name          |    total    |     %     |`;
+  const divider = `| ---------------------- | ----------- | --------- |`;
+
+  return [
+    toString(allocation.policy),
+    columnHeaders,
+    divider,
+    sortedReceipts(receipts)
+      .map(({amount, id}) => row(amount, id))
+      .join(`\n`),
+  ].join(`\n`);
+
+  function row(amount: G.Grain, id: IdentityId) {
+    const {name} = ledger.account(id).identity;
+    const nameFormatted = formatCenter(name, 22);
+
+    const total = NullUtil.orElse(amount, G.ZERO);
+    const totalFormatted = formatCenter(G.format(total, 3, ""), 11);
+
+    const percentage = 100 * G.toFloatRatio(total, totalDistributed);
+    const percentageFormatted = formatCenter(percentage.toFixed(2) + "%", 9);
+
+    return `| ${nameFormatted} | ${totalFormatted} | ${percentageFormatted} |`;
+  }
+}
+
+/**
+ * Given {allocationBalances}, return the total Grain distributed across ids.
+ */
+export function getTotalDistributed(
+  receipts: $ReadOnlyArray<GrainReceipt>
+): G.Grain {
+  return receipts.reduce((sum, {amount}) => G.add(sum, amount), G.ZERO);
+}
+
+function sortedReceipts(
+  receipts: $ReadOnlyArray<GrainReceipt>
+): $ReadOnlyArray<GrainReceipt> {
+  return sortBy(receipts, (receipt) => -Number(receipt.amount));
+}

--- a/src/core/ledger/distributionSummary/distributionSummary.js
+++ b/src/core/ledger/distributionSummary/distributionSummary.js
@@ -1,0 +1,129 @@
+// @flow
+
+import {type CurrencyDetails} from "../../../api/currencyConfig";
+import * as NullUtil from "../../../util/null";
+import sortBy from "../../../util/sortBy";
+import {toISO, type TimestampMs} from "../../../util/timestamp";
+import {type IdentityId} from "../../identity";
+import {type Distribution} from "../distribution";
+import * as G from "../grain";
+import {Ledger} from "../ledger";
+
+export function distributionMarkdownSummary(
+  distribution: Distribution,
+  ledger: Ledger,
+  currencyDetails: CurrencyDetails
+): string {
+  const {name: currencyName, suffix: currencySuffix} = currencyDetails;
+  const distributionBalances: DistributionBalances = getDistributionBalances(
+    distribution
+  );
+  const totalDistributed: G.Grain = getTotalDistributed(distributionBalances);
+
+  const columnHeaders = `|          name          |    total    |     %     |`;
+  const divider = `| ---------------------- | ----------- | --------- |`;
+
+  return [
+    title(currencyName),
+    timeStamp(distribution.credTimestamp),
+    total(totalDistributed, currencySuffix),
+    policyAmounts(distribution, currencySuffix),
+    columnHeaders,
+    divider,
+    sortedIds(distributionBalances).map(row).join(`\n`),
+  ].join(`\n`);
+
+  function row(id: IdentityId) {
+    const {name} = ledger.account(id).identity;
+    const nameFormatted = formatCenter(name, 22);
+
+    const total = NullUtil.orElse(distributionBalances.get(id), G.ZERO);
+    const totalFormatted = formatCenter(G.format(total, 3, ""), 11);
+
+    const percentage = 100 * G.toFloatRatio(total, totalDistributed);
+    const percentageFormatted = formatCenter(percentage.toFixed(2) + "%", 9);
+
+    return `| ${nameFormatted} | ${totalFormatted} | ${percentageFormatted} |`;
+  }
+}
+
+function title(currencyName: string): string {
+  return `## ${currencyName.toUpperCase()} Distribution`;
+}
+
+function timeStamp(credTimeStamp: TimestampMs): string {
+  return `### ${toISO(credTimeStamp)}`;
+}
+
+function total(total: G.Grain, currencySuffix: string): string {
+  return `#### Total Distributed: ${G.format(total, 0, currencySuffix)}`;
+}
+
+function policyAmounts(
+  distribution: Distribution,
+  currencySuffix: string
+): string {
+  return distribution.allocations
+    .map(({policy}) => {
+      const {policyType, budget} = policy;
+      return `#### ${policyType}: ${G.format(budget, 0, currencySuffix)}`;
+    })
+    .join(`\n`);
+}
+
+/**
+ * Return ids sorted by balance.
+ */
+function sortedIds(
+  distributionBalances: DistributionBalances
+): $ReadOnlyArray<IdentityId> {
+  return sortBy(
+    Array.from(distributionBalances.keys()),
+    (id) => -Number(distributionBalances.get(id))
+  );
+}
+
+/**
+ * Center string in some whitespace for total length {len}.
+ */
+export function formatCenter(str: string, len: number): string {
+  return str.length >= len
+    ? str
+    : str.length < len - 1
+    ? formatCenter(` ${str} `, len)
+    : formatCenter(`${str} `, len);
+}
+
+/**
+ * Given some distribution, return the total allocated to id across
+ * all allocation policies.
+ */
+export type DistributionBalances = Map<IdentityId, G.Grain>;
+export function getDistributionBalances(
+  distribution: Distribution
+): DistributionBalances {
+  const distributionBalances = new Map<IdentityId, G.Grain>();
+
+  distribution.allocations.map(({receipts}) => {
+    receipts.map(({amount, id}) => {
+      const existing = NullUtil.orElse(distributionBalances.get(id), G.ZERO);
+      distributionBalances.set(id, G.add(amount, existing));
+    });
+  });
+
+  return distributionBalances;
+}
+
+/**
+ * Given DistributionBalances, return total grain distributed
+ * across participants.
+ */
+export function getTotalDistributed(
+  distributionBalances: DistributionBalances
+): G.Grain {
+  let total: G.Grain = G.ZERO;
+  distributionBalances.forEach((amount) => {
+    total = G.add(total, amount);
+  });
+  return total;
+}

--- a/src/core/ledger/distributionSummary/distributionSummary.test.js
+++ b/src/core/ledger/distributionSummary/distributionSummary.test.js
@@ -1,0 +1,45 @@
+// @flow
+
+import {random as randomUuid} from "../../../util/uuid";
+import type {IdentityId} from "../../identity";
+import * as G from "../grain";
+import {
+  formatCenter,
+  getTotalDistributed,
+  type DistributionBalances,
+} from "./distributionSummary";
+
+describe("core/ledger/distributionSummary/distributionSummary", () => {
+  describe("formatCenter", () => {
+    it("returns the same string when len == str.length", () => {
+      expect(formatCenter("test", 4)).toEqual("test");
+    });
+
+    it("returns the same string when len < str.length", () => {
+      expect(formatCenter("test", 0)).toEqual("test");
+    });
+
+    it("adds whitespace right if cannot evenly wrap on both sides", () => {
+      expect(formatCenter("test", 5)).toEqual("test ");
+    });
+
+    it("wraps evenly on both sides when len - str.length is even", () => {
+      expect(formatCenter("test", 8)).toEqual("  test  ");
+    });
+  });
+
+  describe("getTotalDistributed", () => {
+    it("sums balances correctly", () => {
+      const distributionBalances: DistributionBalances = new Map<
+        IdentityId,
+        G.Grain
+      >();
+      distributionBalances.set(randomUuid(), G.fromInteger(15));
+      distributionBalances.set(randomUuid(), G.fromFloatString("30.002"));
+      distributionBalances.set(randomUuid(), G.fromFloatString("100.002"));
+      expect(getTotalDistributed(distributionBalances)).toEqual(
+        G.fromFloatString("145.004")
+      );
+    });
+  });
+});

--- a/src/core/ledger/policies/balanced.js
+++ b/src/core/ledger/policies/balanced.js
@@ -90,3 +90,10 @@ export const balancedPolicyParser: P.Parser<BalancedPolicy> = P.object({
   policyType: P.exactly(["BALANCED"]),
   budget: grainParser,
 });
+
+export function toString(policy: BalancedPolicy): string {
+  return [
+    policy.policyType + " Policy",
+    "Budget " + G.format(policy.budget, 3),
+  ].join(`\n`);
+}

--- a/src/core/ledger/policies/immediate.js
+++ b/src/core/ledger/policies/immediate.js
@@ -49,3 +49,10 @@ export const immediatePolicyParser: P.Parser<ImmediatePolicy> = P.object({
   policyType: P.exactly(["IMMEDIATE"]),
   budget: grainParser,
 });
+
+export function toString(policy: ImmediatePolicy): string {
+  return [
+    policy.policyType + " Policy",
+    "Budget " + G.format(policy.budget, 3),
+  ].join(`\n`);
+}

--- a/src/core/ledger/policies/index.js
+++ b/src/core/ledger/policies/index.js
@@ -6,24 +6,28 @@ import {
   balancedReceipts,
   balancedPolicyParser,
   balancedConfigParser,
+  toString as toStringBalanced,
 } from "./balanced";
 import {
   type ImmediatePolicy,
   immediateReceipts,
   immediatePolicyParser,
   immediateConfigParser,
+  toString as toStringImmediate,
 } from "./immediate";
 import {
   type RecentPolicy,
   recentReceipts,
   recentPolicyParser,
   recentConfigParser,
+  toString as toStringRecent,
 } from "./recent";
 import {
   type SpecialPolicy,
   specialReceipts,
   specialPolicyParser,
   specialConfigParser,
+  toString as toStringSpecial,
 } from "./special";
 
 export {balancedReceipts, balancedPolicyParser};
@@ -43,6 +47,19 @@ export const policyConfigParser: P.Parser<AllocationPolicy> = P.orElse([
   recentConfigParser,
   specialConfigParser,
 ]);
+
+export function toString(policy: AllocationPolicy): string {
+  switch (policy.policyType) {
+    case "BALANCED":
+      return toStringBalanced(policy);
+    case "IMMEDIATE":
+      return toStringImmediate(policy);
+    case "RECENT":
+      return toStringRecent(policy);
+    case "SPECIAL":
+      return toStringSpecial(policy);
+  }
+}
 
 export const allocationPolicyParser: P.Parser<AllocationPolicy> = P.orElse([
   balancedPolicyParser,

--- a/src/core/ledger/policies/recent.js
+++ b/src/core/ledger/policies/recent.js
@@ -73,3 +73,11 @@ export function toDiscount(n: number): Discount {
 
   return n;
 }
+
+export function toString(policy: RecentPolicy): string {
+  return [
+    policy.policyType + " Policy",
+    "Budget " + G.format(policy.budget, 3),
+    "Discount: " + policy.discount,
+  ].join(`\n`);
+}

--- a/src/core/ledger/policies/special.js
+++ b/src/core/ledger/policies/special.js
@@ -3,6 +3,7 @@
 import {parser as uuidParser} from "../../../util/uuid";
 import * as P from "../../../util/combo";
 import {type IdentityId} from "../../identity";
+import * as G from "../grain";
 import {type GrainReceipt} from "../grainAllocation";
 import {type ProcessedIdentities} from "../processedIdentities";
 import {
@@ -54,3 +55,12 @@ export const specialPolicyParser: P.Parser<SpecialPolicy> = P.object({
   memo: P.string,
   recipient: uuidParser,
 });
+
+export function toString(policy: SpecialPolicy): string {
+  return [
+    policy.policyType + " Policy",
+    "Budget " + G.format(policy.budget, 3),
+    "Memo: " + policy.memo,
+    "Recepient: " + policy.recipient,
+  ].join(`\n`);
+}


### PR DESCRIPTION
### Description
This adds support for generating markdown tables of distributions given an instance's `config/grain.json`. Users can now view the grain distributed to each recipient across individual policies and also collectively. Each distribution generates a table showing the aggregate distribution to users across policies along with their percentage share.  For each allocation policy in the distribution, we also provide tables with the amount distributed to each user.

__Related__
- Uses #2570 (which uses #2572)

### Test Plan
I tested this using different policy configs on my local instance, and sanity checked the format
ting myself. In addition I ran this with 1Hive's instance to make sure the currency logic worked in
practice. Wrote unit test for formatting helper function.