### PR TITLE
Bug/explorer mobile responsive fix

### DIFF
--- a/src/ui/components/AdminApp.js
+++ b/src/ui/components/AdminApp.js
@@ -5,6 +5,7 @@ import {Redirect, Route, useHistory} from "react-router-dom";
 import {Admin, Resource, Layout, Loading} from "react-admin";
 import {createMuiTheme} from "@material-ui/core/styles";
 import pink from "@material-ui/core/colors/pink";
+import {makeStyles} from "@material-ui/core/styles";
 import fakeDataProvider from "ra-data-fakerest";
 import {Explorer} from "./Explorer/Explorer";
 import {ExplorerHome} from "./ExplorerHome/ExplorerHome";
@@ -40,14 +41,26 @@ const theme = createMuiTheme({
   },
 });
 
+const useLayoutStyles = makeStyles(
+  (theme) => ({
+    layout: {
+     overflowX: 'hidden',
+    },
+  }),
+  {name: "RaLayout"}
+);
 const createAppLayout = ({hasBackend, currency}: LoadSuccess) => {
-  const AppLayout = (props) => (
-    <Layout
-      {...props}
-      appBar={AppBar}
-      menu={withRouter(createMenu(hasBackend, currency))}
-    />
-  );
+  const AppLayout = (props) => {
+    const classes = useLayoutStyles(props);
+    return (
+      <Layout
+        className={classes.layout}
+        {...props}
+        appBar={AppBar}
+        menu={withRouter(createMenu(hasBackend, currency))}
+      />
+    );
+  }
   return AppLayout;
 };
 

--- a/src/ui/components/AdminApp.js
+++ b/src/ui/components/AdminApp.js
@@ -42,9 +42,9 @@ const theme = createMuiTheme({
 });
 
 const useLayoutStyles = makeStyles(
-  (theme) => ({
+  () => ({
     layout: {
-     overflowX: 'hidden',
+      overflowX: "hidden",
     },
   }),
   {name: "RaLayout"}
@@ -60,7 +60,7 @@ const createAppLayout = ({hasBackend, currency}: LoadSuccess) => {
         menu={withRouter(createMenu(hasBackend, currency))}
       />
     );
-  }
+  };
   return AppLayout;
 };
 

--- a/src/ui/components/Explorer/CredTimeline.js
+++ b/src/ui/components/Explorer/CredTimeline.js
@@ -23,7 +23,7 @@ const CredTimeline = ({
     .y((d) => yScale(d));
 
   return (
-    <svg width={width} height={height}>
+    <svg viewBox={`0 0 ${width} ${height}`}>
       <path d={gen(data)} stroke="cyan" fill="none" stokewidth={1} />
     </svg>
   );


### PR DESCRIPTION
# Description
Currently, in the explorer view, the D3 sparkline charts break screen width responsitivity. This simple fix allows the SVG chart to scale and thus allows this page to be more responsive.

# Test
Run the site locally (`yarn start`) and go to the Explorer view. (which is also the default route).
Resize your screen or check it out in the chrome inspector and note that scrolling right in the mobile view no longer has the whitespace it did before.

Current:
![explorer-mobile-before](https://user-images.githubusercontent.com/5613706/101261978-e3b05580-36ef-11eb-8834-c64f3cd821c0.gif)

Proposed PR:
![explorer-mobile-after](https://user-images.githubusercontent.com/5613706/101261976-e01cce80-36ef-11eb-84ad-a803fae77997.gif)

