### PR TITLE
Weights type: uniformly import as WeightT

### DIFF
--- a/src/analysis/credView.js
+++ b/src/analysis/credView.js
@@ -1,7 +1,7 @@
 // @flow
 
 import sortedIndex from "lodash.sortedindex";
-import {type Weights, type EdgeWeight} from "../core/weights";
+import {type WeightsT, type EdgeWeight} from "../core/weights";
 import {type CredResult, compute} from "./credResult";
 import {type TimelineCredParameters} from "./timeline/params";
 import {type PluginDeclarations} from "./pluginDeclaration";
@@ -149,7 +149,7 @@ export class CredView {
     return this._credResult.weightedGraph.graph;
   }
 
-  weights(): Weights {
+  weights(): WeightsT {
     return this._credResult.weightedGraph.weights;
   }
 
@@ -298,7 +298,7 @@ export class CredView {
    * graph from this CredView.
    */
   async recompute(
-    weights: Weights,
+    weights: WeightsT,
     params: TimelineCredParameters
   ): Promise<CredView> {
     const wg = overrideWeights(this._credResult.weightedGraph, weights);

--- a/src/analysis/pluginDeclaration.js
+++ b/src/analysis/pluginDeclaration.js
@@ -3,7 +3,7 @@
 import {type NodeAddressT, type EdgeAddressT} from "../core/graph";
 import type {EdgeType, NodeType, NodeAndEdgeTypes} from "./types";
 import * as Weights from "../core/weights";
-import {type Weights as WeightsT} from "../core/weights";
+import {type WeightsT} from "../core/weights";
 import {toCompat, fromCompat, type Compatible} from "../util/compat";
 
 const COMPAT_INFO = {type: "sourcecred/pluginDeclarations", version: "0.1.0"};

--- a/src/analysis/weightsToEdgeEvaluator.js
+++ b/src/analysis/weightsToEdgeEvaluator.js
@@ -1,7 +1,7 @@
 // @flow
 
 import type {Edge} from "../core/graph";
-import type {Weights} from "../core/weights";
+import type {WeightsT} from "../core/weights";
 import type {EdgeEvaluator} from "./pagerank";
 import {
   nodeWeightEvaluator,
@@ -29,7 +29,7 @@ import {
  * cred weighting) rather than as a component of the edge weight. This method
  * will be removed when the 'legacy cred' UI is removed.
  */
-export function weightsToEdgeEvaluator(weights: Weights): EdgeEvaluator {
+export function weightsToEdgeEvaluator(weights: WeightsT): EdgeEvaluator {
   const nodeWeight = nodeWeightEvaluator(weights);
   const edgeWeight = edgeWeightEvaluator(weights);
 

--- a/src/analysis/weightsToEdgeEvaluator.test.js
+++ b/src/analysis/weightsToEdgeEvaluator.test.js
@@ -1,7 +1,7 @@
 // @flow
 
 import {NodeAddress, EdgeAddress} from "../core/graph";
-import {type Weights as WeightsT} from "../core/weights";
+import {type WeightsT} from "../core/weights";
 import * as Weights from "../core/weights";
 import {weightsToEdgeEvaluator} from "./weightsToEdgeEvaluator";
 

--- a/src/core/algorithm/weightEvaluator.js
+++ b/src/core/algorithm/weightEvaluator.js
@@ -1,7 +1,7 @@
 // @flow
 
 import type {NodeAddressT, EdgeAddressT} from "../graph";
-import type {Weights as WeightsT, EdgeWeight, NodeWeight} from "../weights";
+import type {WeightsT, EdgeWeight, NodeWeight} from "../weights";
 import {NodeTrie, EdgeTrie} from "../trie";
 
 export type NodeWeightEvaluator = (NodeAddressT) => NodeWeight;

--- a/src/core/credrank/testUtils.js
+++ b/src/core/credrank/testUtils.js
@@ -8,7 +8,7 @@ import {
   type Edge as GraphEdge,
   Graph,
 } from "../graph";
-import {type Weights as WeightsT} from "../weights";
+import {type WeightsT} from "../weights";
 import {type WeightedGraph} from "../weightedGraph";
 import {
   type NodeWeightEvaluator,

--- a/src/core/weightedGraph.js
+++ b/src/core/weightedGraph.js
@@ -1,7 +1,7 @@
 // @flow
 
 import {Graph, type GraphJSON} from "./graph";
-import {type Weights as WeightsT, type WeightsJSON} from "./weights";
+import {type WeightsT, type WeightsJSON} from "./weights";
 import * as Weights from "./weights";
 import {toCompat, fromCompat, type Compatible} from "../util/compat";
 

--- a/src/core/weights.js
+++ b/src/core/weights.js
@@ -36,7 +36,7 @@ export type EdgeOperator = (EdgeWeight, EdgeWeight) => EdgeWeight;
  * The weights are stored by address prefix, i.e. multiple weights may apply
  * to a given node or edge.
  */
-export type Weights = {|
+export type WeightsT = {|
   nodeWeights: Map<NodeAddressT, NodeWeight>,
   // Map from an edge prefix or address to a weight
   edgeWeights: Map<EdgeAddressT, EdgeWeight>,
@@ -45,14 +45,14 @@ export type Weights = {|
 /**
  * Creates new, empty weights.
  */
-export function empty(): Weights {
+export function empty(): WeightsT {
   return {
     nodeWeights: new Map(),
     edgeWeights: new Map(),
   };
 }
 
-export function copy(w: Weights): Weights {
+export function copy(w: WeightsT): WeightsT {
   return {
     nodeWeights: new Map(w.nodeWeights),
     edgeWeights: new Map(w.edgeWeights),
@@ -73,9 +73,9 @@ export function copy(w: Weights): Weights {
  * conservative "error on conflict" resolvers.
  */
 export function merge(
-  ws: $ReadOnlyArray<Weights>,
+  ws: $ReadOnlyArray<WeightsT>,
   resolvers: ?{|+nodeResolver: NodeOperator, +edgeResolver: EdgeOperator|}
-): Weights {
+): WeightsT {
   if (resolvers == null) {
     const nodeResolver = (_unused_a, _unused_b) => {
       throw new Error(
@@ -89,7 +89,7 @@ export function merge(
     };
     resolvers = {nodeResolver, edgeResolver};
   }
-  const weights: Weights = empty();
+  const weights: WeightsT = empty();
   const {nodeWeights, edgeWeights} = weights;
   const {nodeResolver, edgeResolver} = resolvers;
   for (const w of ws) {
@@ -128,14 +128,14 @@ export type SerializedWeights_0_2_0 = {|
   +edgeWeights: {[EdgeAddressT]: EdgeWeight},
 |};
 
-function serialize_0_2_0(weights: Weights): SerializedWeights_0_2_0 {
+function serialize_0_2_0(weights: WeightsT): SerializedWeights_0_2_0 {
   return {
     nodeWeights: MapUtil.toObject(weights.nodeWeights),
     edgeWeights: MapUtil.toObject(weights.edgeWeights),
   };
 }
 
-function deserialize_0_2_0(weights: SerializedWeights_0_2_0): Weights {
+function deserialize_0_2_0(weights: SerializedWeights_0_2_0): WeightsT {
   return {
     nodeWeights: MapUtil.fromObject(weights.nodeWeights),
     edgeWeights: MapUtil.fromObject(weights.edgeWeights),
@@ -152,18 +152,18 @@ const Parse_0_2_0: C.Parser<SerializedWeights_0_2_0> = (() => {
 
 const COMPAT_INFO = {type: "sourcecred/weights", version: "0.2.0"};
 
-export const parser: C.Parser<Weights> = compatibleParser(COMPAT_INFO.type, {
+export const parser: C.Parser<WeightsT> = compatibleParser(COMPAT_INFO.type, {
   "0.2.0": C.fmap(Parse_0_2_0, deserialize_0_2_0),
 });
 
 export type WeightsJSON_0_2_0 = Compatible<SerializedWeights_0_2_0>;
 export type WeightsJSON = WeightsJSON_0_2_0;
 
-export function toJSON(weights: Weights): WeightsJSON {
+export function toJSON(weights: WeightsT): WeightsJSON {
   return toCompat(COMPAT_INFO, serialize_0_2_0(weights));
 }
 
-export function fromJSON(json: WeightsJSON): Weights {
+export function fromJSON(json: WeightsJSON): WeightsT {
   return parser.parseOrThrow(json);
 }
 
@@ -186,8 +186,8 @@ export type WeightsComparison = {|
 |};
 
 export function compareWeights(
-  firstWeights: Weights,
-  secondWeights: Weights
+  firstWeights: WeightsT,
+  secondWeights: WeightsT
 ): WeightsComparison {
   const nodeWeightDiffs = [];
   const edgeWeightDiffs = [];

--- a/src/core/weights.test.js
+++ b/src/core/weights.test.js
@@ -2,7 +2,7 @@
 
 import stringify from "json-stable-stringify";
 import {NodeAddress, EdgeAddress} from "../core/graph";
-import {type Weights as WeightsT} from "./weights";
+import {type WeightsT} from "./weights";
 import * as Weights from "./weights";
 import {toCompat} from "../util/compat";
 

--- a/src/plugins/github/createGraph.js
+++ b/src/plugins/github/createGraph.js
@@ -3,7 +3,7 @@
 import * as NullUtil from "../../util/null";
 import {Graph} from "../../core/graph";
 import {type WeightedGraph} from "../../core/weightedGraph";
-import {type Weights, empty as emptyWeights} from "../../core/weights";
+import {type WeightsT, empty as emptyWeights} from "../../core/weights";
 import * as GitNode from "../git/nodes";
 import * as N from "./nodes";
 import * as R from "./relationalView";
@@ -18,7 +18,7 @@ export function createGraph(view: R.RelationalView): WeightedGraph {
 
 class GraphCreator {
   graph: Graph;
-  weights: Weights;
+  weights: WeightsT;
 
   constructor() {
     this.graph = new Graph();

--- a/src/ui/components/Explorer/Explorer.js
+++ b/src/ui/components/Explorer/Explorer.js
@@ -27,7 +27,7 @@ import sortBy from "../../../util/sortBy";
 import {type NodeAddressT} from "../../../core/graph";
 import {type PluginDeclaration} from "../../../analysis/pluginDeclaration";
 import {
-  type Weights,
+  type WeightsT,
   copy as weightsCopy,
   empty as emptyWeights,
 } from "../../../core/weights";
@@ -183,8 +183,8 @@ const FilterSelect = ({
 type WeightConfigSectionProps = {|
   show: boolean,
   credView: CredView,
-  weights: Weights,
-  setWeightsState: ({weights: Weights}) => void,
+  weights: WeightsT,
+  setWeightsState: ({weights: WeightsT}) => void,
   params: TimelineCredParameters,
   setParams: (TimelineCredParameters) => void,
 |};
@@ -207,7 +207,7 @@ const WeightsConfigSection = ({
             <Grid>
               <WeightsFileManager
                 weights={weights}
-                onWeightsChange={(weights: Weights) => {
+                onWeightsChange={(weights: WeightsT) => {
                   setWeightsState({weights});
                 }}
               />
@@ -297,7 +297,7 @@ export const Explorer = ({initialView}: {initialView: CredView}): ReactNode => {
     return sortedNodes;
   }, [filterState.filter, credView]);
 
-  const [{weights}, setWeightsState] = useState<{weights: Weights}>({
+  const [{weights}, setWeightsState] = useState<{weights: WeightsT}>({
     weights: credView ? weightsCopy(credView.weights()) : emptyWeights(),
   });
   const [params, setParams] = useState<TimelineCredParameters>({
@@ -305,7 +305,7 @@ export const Explorer = ({initialView}: {initialView: CredView}): ReactNode => {
   });
 
   const recomputeCred = async () =>
-    //weights: Weights,
+    //weights: WeightsT,
     //params: TimelineCredParameters
     {
       if (!credView) return;

--- a/src/ui/weights/WeightsFileManager.js
+++ b/src/ui/weights/WeightsFileManager.js
@@ -5,11 +5,11 @@ import stringify from "json-stable-stringify";
 import {FileUploader} from "../../util/FileUploader";
 import Link from "../../webutil/Link";
 import {MdFileDownload, MdFileUpload} from "react-icons/md";
-import {type Weights, toJSON, fromJSON} from "../../core/weights";
+import {type WeightsT, toJSON, fromJSON} from "../../core/weights";
 
 export type Props = {|
-  +weights: Weights,
-  +onWeightsChange: (Weights) => void,
+  +weights: WeightsT,
+  +onWeightsChange: (WeightsT) => void,
 |};
 export class WeightsFileManager extends React.Component<Props> {
   render(): ReactNode {


### PR DESCRIPTION
__Context__
The `Weights` type is currently imported as either `Weights` or `WeightsT`.  The latter case is
used when the type conflicts with the `core/weights.js` module which is imported as `Weights` as
well.

__Change__
This renames the `Weights` type to `WeightsT` and changes all imports/instances of the type formerly
known as `Weights`.  

__Advantages__
This gives us consistency, which has the following advantage:

(1) Searching for instances of the `Weights` (now `WeightsT`) type is much simpler as we don't need
to also sort through instances of importing the `core/weights.js` module (and vice versa).

__Test Plan__
Manually checked import instances of the `core/weights.js` module for imports, and used Flow to check
for the remaining cases within those files.

Can also search for import instances using `git grep "import \(type \)\?{.*Weights.*}"`.