### PR TITLE
grain allocation: Underpaid Policy

### DIFF
--- a/src/api/grainConfig.js
+++ b/src/api/grainConfig.js
@@ -9,9 +9,12 @@ import {toDiscount} from "../core/ledger/policies/recent";
 export type GrainConfig = {|
   +immediatePerWeek?: number,
   +balancedPerWeek?: number,
+  +underpaidPerWeek?: number,
   +recentPerWeek?: number,
   +recentWeeklyDecayRate?: number,
   +maxSimultaneousDistributions?: number,
+  +underpaidThreshold?: number,
+  +underpaidExponent?: number,
 |};
 
 export const parser: C.Parser<GrainConfig> = C.object(
@@ -19,8 +22,11 @@ export const parser: C.Parser<GrainConfig> = C.object(
   {
     immediatePerWeek: C.number,
     balancedPerWeek: C.number,
+    underpaidPerWeek: C.number,
     recentPerWeek: C.number,
     recentWeeklyDecayRate: C.number,
+    underpaidThreshold: C.number,
+    underpaidExponent: C.number,
     maxSimultaneousDistributions: C.number,
   }
 );
@@ -33,6 +39,7 @@ export function toDistributionPolicy(x: GrainConfig): DistributionPolicy {
   const immediatePerWeek = NullUtil.orElse(x.immediatePerWeek, 0);
   const recentPerWeek = NullUtil.orElse(x.recentPerWeek, 0);
   const balancedPerWeek = NullUtil.orElse(x.balancedPerWeek, 0);
+  const underpaidPerWeek = NullUtil.orElse(x.underpaidPerWeek, 0);
 
   if (!isNonnegativeInteger(immediatePerWeek)) {
     throw new Error(
@@ -47,6 +54,11 @@ export function toDistributionPolicy(x: GrainConfig): DistributionPolicy {
   if (!isNonnegativeInteger(balancedPerWeek)) {
     throw new Error(
       `balanced budget must be nonnegative integer, got ${balancedPerWeek}`
+    );
+  }
+  if (!isNonnegativeInteger(underpaidPerWeek)) {
+    throw new Error(
+      `underpaid budget must be nonnegative integer, got ${balancedPerWeek}`
     );
   }
   const allocationPolicies = [];
@@ -71,6 +83,23 @@ export function toDistributionPolicy(x: GrainConfig): DistributionPolicy {
     allocationPolicies.push({
       budget: G.fromInteger(balancedPerWeek),
       policyType: "BALANCED",
+    });
+  }
+  if (underpaidPerWeek > 0) {
+    const {underpaidThreshold, underpaidExponent: exponent} = x;
+    if (underpaidThreshold == null) {
+      throw new Error(`no threshold specified for underpaid policy`);
+    }
+
+    if (exponent == null) {
+      throw new Error(`no exponent specified for underpaid policy`);
+    }
+
+    allocationPolicies.push({
+      budget: G.fromInteger(underpaidPerWeek),
+      policyType: "UNDERPAID",
+      threshold: G.fromApproximateFloat(underpaidThreshold),
+      exponent,
     });
   }
   const maxSimultaneousDistributions = NullUtil.orElse(

--- a/src/core/ledger/grainAllocation.js
+++ b/src/core/ledger/grainAllocation.js
@@ -20,6 +20,7 @@ import {
   immediateReceipts,
   recentReceipts,
   specialReceipts,
+  underpaidReceipts,
 } from "./policies";
 import {
   type ProcessedIdentities,
@@ -88,6 +89,13 @@ function receipts(
       return recentReceipts(policy.budget, identities, policy.discount);
     case "BALANCED":
       return balancedReceipts(policy.budget, identities);
+    case "UNDERPAID":
+      return underpaidReceipts(
+        policy.budget,
+        identities,
+        policy.threshold,
+        policy.exponent
+      );
     case "SPECIAL":
       return specialReceipts(policy, identities);
     // istanbul ignore next: unreachable per Flow

--- a/src/core/ledger/policies/index.js
+++ b/src/core/ledger/policies/index.js
@@ -7,6 +7,11 @@ import {
   balancedPolicyParser,
 } from "./balanced";
 import {
+  type UnderpaidPolicy,
+  underpaidReceipts,
+  underpaidPolicyParser,
+} from "./underpaid";
+import {
   type ImmediatePolicy,
   immediateReceipts,
   immediatePolicyParser,
@@ -19,18 +24,21 @@ import {
 } from "./special";
 
 export {balancedReceipts, balancedPolicyParser};
+export {underpaidReceipts, underpaidPolicyParser};
 export {immediateReceipts, immediatePolicyParser};
 export {recentReceipts, recentPolicyParser};
 export {specialReceipts, specialPolicyParser};
 
 export type AllocationPolicy =
   | BalancedPolicy
+  | UnderpaidPolicy
   | ImmediatePolicy
   | RecentPolicy
   | SpecialPolicy;
 
 export const allocationPolicyParser: P.Parser<AllocationPolicy> = P.orElse([
   balancedPolicyParser,
+  underpaidPolicyParser,
   immediatePolicyParser,
   recentPolicyParser,
   specialPolicyParser,

--- a/src/core/ledger/policies/underpaid.js
+++ b/src/core/ledger/policies/underpaid.js
@@ -1,0 +1,112 @@
+// @flow
+
+import {sum} from "d3-array";
+import * as G from "../grain";
+import * as P from "../../../util/combo";
+import {type GrainReceipt} from "../grainAllocation";
+import {type ProcessedIdentities} from "../processedIdentities";
+
+/**
+ * The Underpaid policy attempts to get users below some threshold of underpayment
+ * as quickly and fairly as possible by reducing the speed at which major
+ * contributors get paid.  As the amount of underpayment increases, the marginal
+ * increase in their payment will taper off.
+ *
+ * Underpaid uses Balanced to calculate lifetime underpayment, and expands on it
+ * in two ways. First, it allows quadratic scaling of allocated Grain amounts.
+ * This avoids massively underpaid contributors from being paid right away at
+ * the expense of others.
+ *
+ * Second, Underpaid has a threshold parameter which sets the minimum amount a
+ * contributor must be underpaid in order to qualify for a payment.  When using
+ * quadratic scaling, small amounts allocated to many users can potentially
+ * eat an undesirably larger proportion of the budget.
+ *
+ * Note, Underpaid with a threshold of 0 and an exponent of 1 is equivalent to
+ * the Balanced policy.
+ */
+export type Underpaid = "UNDERPAID";
+
+export type UnderpaidPolicy = {|
+  +policyType: Underpaid,
+  +budget: G.Grain,
+  +threshold: G.Grain,
+  +exponent: number,
+|};
+
+/**
+ * Allocate a fixed budget of Grain to the users who were "most underpaid" owed
+ * at least {threshold} grain.
+ *
+ * We consider a user underpaid if they have received a smaller proportion of
+ * past earnings than their share of score. They are balanced paid if their
+ * proportion of earnings is equal to their score share, and they are overpaid
+ * if their proportion of earnings is higher than their share of the score.
+ *
+ * We start by imagining a hypothetical world, where the entire grain supply of
+ * the project (including this allocation) was allocated according to the
+ * current scores. Based on this, we can calculate the "balanced" lifetime earnings
+ * for each participant. Usually, some will be "underpaid" (they received less
+ * than this amount) and others are "overpaid".
+ *
+ * We can sum across all users who were underpaid to find the "total
+ * underpayment".
+ *
+ * Now that we've calculated each actor's underpayment, and the total
+ * underpayment, we:
+ * 1. Filter out users whose underpayment < {threshold}.
+ * 2. Quadratically scale underpayments to the power of {exponent}.
+ *
+ * Finally we divide the allocation's grain budget across users in
+ * proportion to their adjusted underpayment.
+ *
+ * You should use this allocation when you want to divide a fixed budget of grain
+ * across participants in order to keep them below a reasonable threshold of
+ * underpayment with respect to total cred, and/or when large contributors have
+ * the potential to monopolize a Balanced allocation.
+ */
+export function underpaidReceipts(
+  budget: G.Grain,
+  identities: ProcessedIdentities,
+  threshold: G.Grain,
+  exponent: number
+): $ReadOnlyArray<GrainReceipt> {
+  if (G.lt(threshold, G.ZERO)) {
+    throw new Error(`threshold must be >= 0, got ${threshold}`);
+  }
+  if (exponent <= 0 || exponent > 1) {
+    throw new Error(`exponent must be in range (0, 1], got ${exponent}`);
+  }
+
+  const totalCred = sum(identities.map((x) => x.lifetimeCred));
+  const totalEverPaid = G.sum(identities.map((i) => i.paid));
+
+  const targetTotalDistributed = G.add(totalEverPaid, budget);
+  const targetGrainPerCred = G.multiplyFloat(
+    targetTotalDistributed,
+    1 / totalCred
+  );
+
+  const userUnderpayment = identities.map(({paid, lifetimeCred}) => {
+    const target = G.multiplyFloat(targetGrainPerCred, lifetimeCred);
+    return G.gt(target, G.add(paid, threshold)) ? G.sub(target, paid) : G.ZERO;
+  });
+
+  const floatUnderpayment = userUnderpayment.map(Number);
+  const quadraticUnderPayment = floatUnderpayment.map((x) =>
+    Math.pow(x, exponent)
+  );
+
+  if (sum(quadraticUnderPayment) === 0)
+    return identities.map(({id}) => ({id, amount: G.ZERO}));
+
+  const grainAmounts = G.splitBudget(budget, quadraticUnderPayment);
+  return identities.map(({id}, i) => ({id, amount: grainAmounts[i]}));
+}
+
+export const underpaidPolicyParser: P.Parser<UnderpaidPolicy> = P.object({
+  policyType: P.exactly(["UNDERPAID"]),
+  budget: G.parser,
+  threshold: G.parser,
+  exponent: P.number,
+});


### PR DESCRIPTION
## Description
The current `Balanced` policy is prone to prioritizing paying users with
large underpayments at the expense of others.  This `Underpaid` policy
attempts to provide another option that communities can use alongside the
`Balanced` policy to dampen the impact of this undesirable property.

In English: "`Underpaid` tries to get everyone below some threshold of
underpayment by delaying the speed at which the most underpaid
people are paid out."

__How It Works__
The `Underpaid` policy pays contributors who are owed at least N grain as
specified in the policy's config, quadratically weighing the qualifying
underpayment amounts, using a configurable exponent in range (0, 1].

## __Test Plan__
- Unit tests provided for `Underpaid` in `core/ledger/grainAllocation` tests.
- Grain config unit tests provided in `api/grainConfig` tests.

__Other Considerations__
- In practice, `Underpaid` is a simple fork of `Balanced`.  Next, I plan
on refactoring the policy modules so that we can share component functions
across them.
- As followup, I plan on splitting policy tests into their own test modules.