### PR TITLE
MarkovProcessGraph bugfix: epochs should include each interval

### DIFF
--- a/src/core/credrank/markovProcessGraph.js
+++ b/src/core/credrank/markovProcessGraph.js
@@ -266,6 +266,7 @@ export class MarkovProcessGraph {
     const timeBoundaries = [
       -Infinity,
       ...intervals.map((x) => x.startTimeMs),
+      intervals[intervals.length - 1].endTimeMs,
       Infinity,
     ];
 

--- a/src/core/credrank/markovProcessGraph.test.js
+++ b/src/core/credrank/markovProcessGraph.test.js
@@ -183,6 +183,14 @@ describe("core/credrank/markovProcessGraph", () => {
             )
             // .2 -- because this has incident organic edges
             .set(2, parameters.alpha)
+            // .55 -- because this one has no incident organic edges
+            .set(
+              4,
+              1 -
+                parameters.gammaForward -
+                parameters.gammaBackward -
+                parameters.beta
+            )
             // 0.7 -- because this has no incident organic edges, and no forward webbing
             .set(Infinity, 1 - parameters.gammaBackward - parameters.beta)
             .get(boundary)
@@ -346,7 +354,7 @@ describe("core/credrank/markovProcessGraph", () => {
       });
     });
     it("has the correct epoch boundaries for the given intervals", () => {
-      const expected = [-Infinity, 0, 2, Infinity];
+      const expected = [-Infinity, 0, 2, 4, Infinity];
       expect(markovProcessGraph().epochBoundaries()).toEqual(expected);
     });
     it("has the right participants", () => {


### PR DESCRIPTION
<!-- Please read our contributor guide before submitting your PR: -->
<!-- https://github.com/sourcecred/sourcecred/blob/master/CONTRIBUTING.md -->

# Description
This addresses a fence post bug in the way epoch boundaries are created. Epoch boundaries should include the start AND end times of each interval in the interval sequence, so that the original intervals can be reconstructed from the epoch boundaries faithfully. This will be important for features like Explorer Home that want to associate cred with intervals.
<!-- Possible prompts:
  Why is the change important?
  Did you consider and reject alternate formulations of the same idea?
  Are there relevant issues or discussions elsewhere?
-->

# Test Plan
Change is sufficiently covered by updated unit tests.
I ran `credrank` without the change and then `credrank -d` with the change. As expected, cred changed, but trivially.
```
┌─────────┬───────────────────────┬────────────┬──────────┬──────────┐
│ (index) │         Name          │ Prior Cred │ New Cred │ % Change │
├─────────┼───────────────────────┼────────────┼──────────┼──────────┤
│    0    │       'hammadj'       │   '55.4'   │  '55.4'  │  '0.0%'  │
│    1    │       'Beanow'        │   '48.7'   │  '48.7'  │  '0.0%'  │
│    2    │ 'decentralion-github' │   '23.7'   │  '23.7'  │  '0.0%'  │
│    3    │        'Thena'        │   '13.8'   │  '13.8'  │  '0.0%'  │
│    4    │  'topocount-github'   │   '12.2'   │  '12.2'  │  '0.1%'  │
│    5    │     'blueridger'      │   '10.5'   │  '10.5'  │  '0.0%'  │
│    6    │        's-ben'        │   '4.4'    │  '4.4'   │  '0.0%'  │
│    7    │      'KuraFire'       │   '3.8'    │  '3.8'   │  '0.0%'  │
│    8    │    'Brian-Litwin'     │   '3.0'    │  '3.0'   │  '0.0%'  │
│    9    │   'pablomendezroyo'   │   '3.0'    │  '3.0'   │  '0.0%'  │
│   10    │      'wchargin'       │   '1.3'    │  '1.3'   │  '0.0%'  │
│   11    │     'SourceCred'      │   '1.2'    │  '1.2'   │  '0.0%'  │
│   12    │   'BrianBelhumeur'    │   '0.9'    │  '0.9'   │  '0.0%'  │
│   13    │     'dependabot'      │   '0.9'    │  '0.9'   │  '0.9%'  │
│   14    │   'scottrepreneur'    │   '0.9'    │  '0.9'   │  '0.0%'  │
│   15    │   'befitsandpiper'    │   '0.8'    │  '0.8'   │  '0.0%'  │
│   16    │      'topocount'      │   '0.0'    │  '0.0'   │  '0.8%'  │
│   17    │      'sandpiper'      │   '0.0'    │  '0.0'   │  '0.8%'  │
│   18    │   'CredBot-Beanow'    │   '0.0'    │  '0.0'   │  '0.8%'  │
│   19    │     'sts-credbot'     │   '0.0'    │  '0.0'   │  '0.8%'  │
└─────────┴───────────────────────┴────────────┴──────────┴──────────┘
```
<!-- Possible prompts:
  How well covered by automated tests is this change?
  How did you manually test this change? How can a reviewer replicate the tests?
-->
