### PR TITLE
grainConfig: take array of policies

### DIFF
--- a/src/api/grainConfig.js
+++ b/src/api/grainConfig.js
@@ -1,33 +1,44 @@
 // @flow
 
 import {type DistributionPolicy} from "../core/ledger/applyDistributions";
-import * as G from "../core/ledger/grain";
 import * as C from "../util/combo";
 import * as NullUtil from "../util/null";
+import {
+  type AllocationPolicy,
+  policyConfigParser,
+} from "../core/ledger/policies";
+import {fromInteger as toNonnegativeGrain} from "../core/ledger/policies/nonnegativeGrain";
 import {toDiscount} from "../core/ledger/policies/recent";
 
 export type GrainConfig = {|
-  +immediatePerWeek?: number,
-  +balancedPerWeek?: number,
-  +recentPerWeek?: number,
-  +recentWeeklyDecayRate?: number,
+  +immediatePerWeek?: number, // (deprecated)
+  +balancedPerWeek?: number, // (deprecated)
+  +recentPerWeek?: number, // (deprecated)
+  +recentWeeklyDecayRate?: number, // (deprecated)
+  +allocationPolicies: $ReadOnlyArray<AllocationPolicy>,
   +maxSimultaneousDistributions?: number,
 |};
 
 export const parser: C.Parser<GrainConfig> = C.object(
-  {},
   {
+    allocationPolicies: C.array<AllocationPolicy>(policyConfigParser),
+  },
+  {
+    maxSimultaneousDistributions: C.number,
     immediatePerWeek: C.number,
     balancedPerWeek: C.number,
     recentPerWeek: C.number,
     recentWeeklyDecayRate: C.number,
-    maxSimultaneousDistributions: C.number,
   }
 );
 
 /**
  * Create a DistributionPolicy from GrainConfig, checking that config
  * fields can form valid policies.
+ *
+ * Moving forward, policies will need to be passed in the `allocationPolicies`
+ * parameter; however to avoid backcompatability issues, we optionally allow
+ * the deprecated fields for the time being.
  */
 export function toDistributionPolicy(x: GrainConfig): DistributionPolicy {
   const immediatePerWeek = NullUtil.orElse(x.immediatePerWeek, 0);
@@ -49,10 +60,11 @@ export function toDistributionPolicy(x: GrainConfig): DistributionPolicy {
       `balanced budget must be nonnegative integer, got ${balancedPerWeek}`
     );
   }
-  const allocationPolicies = [];
+
+  const allocationPoliciesDeprecated: Array<AllocationPolicy> = [];
   if (immediatePerWeek > 0) {
-    allocationPolicies.push({
-      budget: G.fromInteger(immediatePerWeek),
+    allocationPoliciesDeprecated.push({
+      budget: toNonnegativeGrain(immediatePerWeek),
       policyType: "IMMEDIATE",
     });
   }
@@ -61,23 +73,29 @@ export function toDistributionPolicy(x: GrainConfig): DistributionPolicy {
     if (recentWeeklyDecayRate == null) {
       throw new Error(`no recentWeeklyDecayRate specified for recent policy`);
     }
-    allocationPolicies.push({
-      budget: G.fromInteger(recentPerWeek),
+    allocationPoliciesDeprecated.push({
+      budget: toNonnegativeGrain(recentPerWeek),
       policyType: "RECENT",
       discount: toDiscount(recentWeeklyDecayRate),
     });
   }
   if (balancedPerWeek > 0) {
-    allocationPolicies.push({
-      budget: G.fromInteger(balancedPerWeek),
+    allocationPoliciesDeprecated.push({
+      budget: toNonnegativeGrain(balancedPerWeek),
       policyType: "BALANCED",
     });
   }
+
   const maxSimultaneousDistributions = NullUtil.orElse(
     x.maxSimultaneousDistributions,
     Infinity
   );
-  return {allocationPolicies, maxSimultaneousDistributions};
+  return {
+    allocationPolicies: x.allocationPolicies.concat(
+      allocationPoliciesDeprecated
+    ),
+    maxSimultaneousDistributions,
+  };
 }
 
 function isNonnegativeInteger(x: number): boolean {

--- a/src/api/grainConfig.test.js
+++ b/src/api/grainConfig.test.js
@@ -3,122 +3,240 @@
 import {parser, toDistributionPolicy, type GrainConfig} from "./grainConfig";
 import {type DistributionPolicy} from "../core/ledger/applyDistributions";
 import {toDiscount} from "../core/ledger/policies/recent";
-import {fromInteger} from "../core/ledger/grain";
+import {type Uuid, random as randomUuid} from "../util/uuid";
+import {fromInteger as toNonnegativeGrain} from "../core/ledger/policies/nonnegativeGrain";
+import {type BalancedPolicy} from "../core/ledger/policies/balanced";
+import {type ImmediatePolicy} from "../core/ledger/policies/immediate";
+import {type RecentPolicy} from "../core/ledger/policies/recent";
+import {type SpecialPolicy} from "../core/ledger/policies/special";
+
+const balanced = (budget: number): BalancedPolicy => ({
+  policyType: "BALANCED",
+  budget: toNonnegativeGrain(budget),
+});
+const immediate = (budget: number): ImmediatePolicy => ({
+  policyType: "IMMEDIATE",
+  budget: toNonnegativeGrain(budget),
+});
+const recent = (budget: number, discount: number): RecentPolicy => ({
+  policyType: "RECENT",
+  budget: toNonnegativeGrain(budget),
+  discount: toDiscount(discount),
+});
+const special = (
+  budget: number,
+  memo: string,
+  recipient: Uuid
+): SpecialPolicy => ({
+  policyType: "SPECIAL",
+  budget: toNonnegativeGrain(budget),
+  memo,
+  recipient,
+});
 
 describe("api/grainConfig", () => {
   describe("parser", () => {
-    it("does not throw with no params", () => {
-      expect(parser.parseOrThrow({})).toEqual({});
+    it("errors if missing allocationPolicies key", () => {
+      expect(() => parser.parseOrThrow({})).toThrowError(`missing key`);
     });
 
-    it("errors if malformed params", () => {
-      const grainConfig = {
-        balancedPerWeek: {},
-        immediatePerWeek: 10,
-        recentPerWeek: 10,
-      };
-      expect(() => parser.parseOrThrow(grainConfig)).toThrowError(
-        "expected number"
-      );
+    describe("errors if malformed params", () => {
+      it("errors on malformed allocationPolicies", () => {
+        const grainConfig = {
+          allocationPolicies: {},
+          maxSimultaneousDistributions: 2,
+        };
+        expect(() => parser.parseOrThrow(grainConfig)).toThrowError(
+          "expected array, got object"
+        );
+      });
+
+      it("errors on malformed maxSimultaneousDistributions", () => {
+        const grainConfig = {
+          allocationPolicies: [],
+          maxSimultaneousDistributions: [],
+        };
+        expect(() => parser.parseOrThrow(grainConfig)).toThrowError(
+          "expected number, got array"
+        );
+      });
     });
 
     it("ignores extra params", () => {
       const grainConfig = {
-        recentPerWeek: 30,
+        allocationPolicies: [],
         EXTRA: 30,
       };
 
       const to = {
-        recentPerWeek: 30,
+        allocationPolicies: [],
       };
 
       expect(parser.parseOrThrow(grainConfig)).toEqual(to);
     });
 
-    it("does not throw on negative or zero budgets", () => {
+    it("does not throw on negative maxSimultaneousDistributions", () => {
       const grainConfig = {
-        balancedPerWeek: -1,
-        immediatePerWeek: 0,
-        recentPerWeek: -100,
-        recentWeeklyDecayRate: 0.5,
+        allocationPolicies: [],
+        maxSimultaneousDistributions: -5,
       };
 
       expect(parser.parseOrThrow(grainConfig)).toEqual(grainConfig);
     });
 
-    it("works on well formed object", () => {
+    it("rejects improperly formatted allocation policies", () => {
       const grainConfig = {
+        allocationPolicies: [
+          {
+            policyType: "RECENT",
+            budget: 20,
+            discount: 1.5,
+          },
+        ],
+        maxSimultaneousDistributions: 2,
+      };
+
+      expect(() => parser.parseOrThrow(grainConfig)).toThrowError(
+        `Discount must be in range [0,1]`
+      );
+    });
+
+    it("works on well formed config", () => {
+      const uuid = randomUuid();
+      const grainConfig = {
+        allocationPolicies: [
+          {
+            policyType: "BALANCED",
+            budget: 50,
+          },
+          {
+            policyType: "IMMEDIATE",
+            budget: 10,
+          },
+          {
+            policyType: "RECENT",
+            budget: 20,
+            discount: 0.5,
+          },
+          {
+            policyType: "SPECIAL",
+            budget: 100,
+            memo: "howdy",
+            recipient: uuid,
+          },
+        ],
+        maxSimultaneousDistributions: 2,
+      };
+
+      const expected: GrainConfig = {
+        allocationPolicies: [
+          balanced(50),
+          immediate(10),
+          recent(20, 0.5),
+          special(100, "howdy", uuid),
+        ],
+        maxSimultaneousDistributions: 2,
+      };
+
+      expect(parser.parseOrThrow(grainConfig)).toEqual(expected);
+    });
+
+    it("can take multiple of the same policy", () => {
+      const config = {
+        allocationPolicies: [
+          {
+            policyType: "RECENT",
+            budget: 20,
+            discount: 0.1,
+          },
+          {
+            policyType: "RECENT",
+            budget: 20,
+            discount: 0.1,
+          },
+        ],
+        maxSimultaneousDistributions: 2,
+      };
+
+      const expected: GrainConfig = {
+        allocationPolicies: [recent(20, 0.1), recent(20, 0.1)],
+        maxSimultaneousDistributions: 2,
+      };
+
+      expect(parser.parseOrThrow(config)).toEqual(expected);
+    });
+
+    it("parses deprecated policy config", () => {
+      const config = {
         balancedPerWeek: 10,
         immediatePerWeek: 20,
         recentPerWeek: 30,
-        recentWeeklyDecayRate: 0.5,
+        allocationPolicies: [],
       };
 
-      expect(parser.parseOrThrow(grainConfig)).toEqual(grainConfig);
+      expect(parser.parseOrThrow(config)).toEqual(config);
     });
   });
 
   describe("toDistributionPolicy", () => {
+    it("deprecated policy config works alongside new config", () => {
+      const x: GrainConfig = {
+        allocationPolicies: [recent(50, 0.1)],
+        recentPerWeek: 30,
+        recentWeeklyDecayRate: 0.5,
+        maxSimultaneousDistributions: 10,
+      };
+      const expected: DistributionPolicy = {
+        allocationPolicies: [recent(50, 0.1), recent(30, 0.5)],
+        maxSimultaneousDistributions: 10,
+      };
+      expect(toDistributionPolicy(x)).toEqual(expected);
+    });
+
+    it("errors on deprecated allocation policy with negative budget", () => {
+      const x: GrainConfig = {
+        balancedPerWeek: -1,
+        allocationPolicies: [],
+      };
+
+      expect(() => toDistributionPolicy(x)).toThrowError(
+        `budget must be nonnegative integer`
+      );
+    });
+
+    it("deprecated recent policy with no discount errors", () => {
+      const x: GrainConfig = {
+        recentPerWeek: 10,
+        allocationPolicies: [],
+      };
+
+      expect(() => toDistributionPolicy(x)).toThrowError(
+        `no recentWeeklyDecayRate specified for recent policy`
+      );
+    });
+
     it("can handle missing policies", () => {
       const x: GrainConfig = {
+        allocationPolicies: [balanced(50)],
         maxSimultaneousDistributions: 100,
       };
 
       const expected: DistributionPolicy = {
-        allocationPolicies: [],
+        allocationPolicies: [balanced(50)],
         maxSimultaneousDistributions: 100,
       };
 
       expect(toDistributionPolicy(x)).toEqual(expected);
     });
 
-    it("errors on missing discount for recent policy", () => {
+    it("creates DistributionPolicy with at least 1 allocation policy with positive budgets", () => {
       const x: GrainConfig = {
-        balancedPerWeek: 10,
-        immediatePerWeek: 20,
-        recentPerWeek: 10,
-      };
-
-      expect(() => toDistributionPolicy(x)).toThrowError(
-        "no recentWeeklyDecayRate specified"
-      );
-    });
-
-    it("does not error for missing recentWeeklyDecayRate if 0 recent budget", () => {
-      const x: GrainConfig = {
-        balancedPerWeek: 10,
-        immediatePerWeek: 20,
-        recentPerWeek: 0,
-      };
-
-      expect(() => toDistributionPolicy(x)).not.toThrow();
-    });
-
-    it("creates DistributionPolicy from valid GrainConfig", () => {
-      const x: GrainConfig = {
-        balancedPerWeek: 10,
-        immediatePerWeek: 20,
-        recentPerWeek: 30,
-        recentWeeklyDecayRate: 0.1,
+        allocationPolicies: [immediate(20), recent(30, 0.1), balanced(10)],
         maxSimultaneousDistributions: 2,
       };
 
       const expectedDistributionPolicy: DistributionPolicy = {
-        allocationPolicies: [
-          {
-            budget: fromInteger(20),
-            policyType: "IMMEDIATE",
-          },
-          {
-            budget: fromInteger(30),
-            policyType: "RECENT",
-            discount: toDiscount(0.1),
-          },
-          {
-            budget: fromInteger(10),
-            policyType: "BALANCED",
-          },
-        ],
+        allocationPolicies: [immediate(20), recent(30, 0.1), balanced(10)],
         maxSimultaneousDistributions: 2,
       };
 

--- a/src/api/ledgerManager.test.js
+++ b/src/api/ledgerManager.test.js
@@ -4,13 +4,10 @@ import {Ledger} from "../core/ledger/ledger";
 import * as uuid from "../util/uuid";
 import {LedgerManager} from "./ledgerManager";
 import type {LedgerLog} from "../core/ledger/ledger";
-import * as G from "../core/ledger/grain";
 import {createUuidMock} from "../core/ledger/testUtils";
+import {fromString as g} from "../core/ledger/policies/nonnegativeGrain";
 
 describe("api/ledgerManager", () => {
-  // Helper for constructing Grain values.
-  const g = (s) => G.fromString(s);
-
   const {resetFakeUuid, setNextUuid} = createUuidMock();
 
   const id1 = uuid.fromString("YVZhbGlkVXVpZEF0TGFzdA");

--- a/src/core/ledger/grainAllocation.test.js
+++ b/src/core/ledger/grainAllocation.test.js
@@ -1,17 +1,15 @@
 // @flow
 
-import * as G from "./grain";
 import {random as randomUuid, parser as uuidParser} from "../../util/uuid";
 import {
   computeAllocation,
   type AllocationIdentity,
   _validateAllocationBudget,
 } from "./grainAllocation";
+import {fromString as g} from "./policies/nonnegativeGrain";
 import {toDiscount} from "./policies/recent";
 
 describe("core/ledger/grainAllocation", () => {
-  // concise helper for grain from a string
-  const g = (x: string) => G.fromString(x);
   // concise helper for grain from a number
   const ng = (x: number) => g(x.toString());
   // concise helper for an allocation identity
@@ -32,18 +30,9 @@ describe("core/ledger/grainAllocation", () => {
         const thunk = () => computeAllocation(immediate(5), []);
         expect(thunk).toThrowError("must have at least one identity");
       });
-      it("errors if the budget is negative", () => {
-        const id = aid(5, [1]);
-        const thunk = () => computeAllocation(immediate(-5), [id]);
-        expect(thunk).toThrowError("invalid budget");
-      });
       it("errors if the total cred is zero", () => {
         const thunk = () => computeAllocation(immediate(5), [aid(0, [0])]);
         expect(thunk).toThrowError("cred is zero");
-      });
-      it("errors if there's negative paid", () => {
-        const thunk = () => computeAllocation(immediate(5), [aid(-1, [0])]);
-        expect(thunk).toThrowError("negative paid");
       });
       it("errors if there's NaN or Infinity in Cred", () => {
         const thunk = () => computeAllocation(immediate(5), [aid(0, [NaN])]);

--- a/src/core/ledger/ledger.test.js
+++ b/src/core/ledger/ledger.test.js
@@ -7,11 +7,9 @@ import {newIdentity} from "../identity";
 import * as G from "./grain";
 import * as uuid from "../../util/uuid";
 import {createUuidMock} from "./testUtils"; // for spy purposes
+import {fromString as g} from "./policies/nonnegativeGrain";
 
 describe("core/ledger/ledger", () => {
-  // Helper for constructing Grain values.
-  const g = (s) => G.fromString(s);
-
   let nextFakeDate = 0;
   function resetFakeDate() {
     nextFakeDate = 0;
@@ -1145,7 +1143,7 @@ describe("core/ledger/ledger", () => {
           id: uuid.random(),
           receipts: [
             {id: id1, amount: g("3")},
-            {id: id2, amount: g("-4")},
+            {id: id2, amount: G.fromString("-4")},
           ],
         };
         const distribution = {
@@ -1357,7 +1355,7 @@ describe("core/ledger/ledger", () => {
           ledger.transferGrain({
             from: id1,
             to: id2,
-            amount: g("-3"),
+            amount: G.fromString("-3"),
             memo: "test",
           });
         failsWithoutMutation(

--- a/src/core/ledger/policies/balanced.js
+++ b/src/core/ledger/policies/balanced.js
@@ -5,6 +5,11 @@ import * as G from "../grain";
 import * as P from "../../../util/combo";
 import {type GrainReceipt} from "../grainAllocation";
 import {type ProcessedIdentities} from "../processedIdentities";
+import {
+  type NonnegativeGrain,
+  numberParser,
+  grainParser,
+} from "./nonnegativeGrain";
 
 /**
  * The Balanced policy attempts to pay Grain to everyone so that their
@@ -20,7 +25,7 @@ export type Balanced = "BALANCED";
 
 export type BalancedPolicy = {|
   +policyType: Balanced,
-  +budget: G.Grain,
+  +budget: NonnegativeGrain,
 |};
 
 /**
@@ -76,7 +81,12 @@ export function balancedReceipts(
   return identities.map(({id}, i) => ({id, amount: grainAmounts[i]}));
 }
 
+export const balancedConfigParser: P.Parser<BalancedPolicy> = P.object({
+  policyType: P.exactly(["BALANCED"]),
+  budget: numberParser,
+});
+
 export const balancedPolicyParser: P.Parser<BalancedPolicy> = P.object({
   policyType: P.exactly(["BALANCED"]),
-  budget: G.parser,
+  budget: grainParser,
 });

--- a/src/core/ledger/policies/immediate.js
+++ b/src/core/ledger/policies/immediate.js
@@ -4,6 +4,11 @@ import * as G from "../grain";
 import * as P from "../../../util/combo";
 import {type GrainReceipt} from "../grainAllocation";
 import {type ProcessedIdentities} from "../processedIdentities";
+import {
+  type NonnegativeGrain,
+  numberParser,
+  grainParser,
+} from "./nonnegativeGrain";
 
 /**
  * The Immediate policy evenly distributes its Grain budget
@@ -17,7 +22,7 @@ export type Immediate = "IMMEDIATE";
 
 export type ImmediatePolicy = {|
   +policyType: Immediate,
-  +budget: G.Grain,
+  +budget: NonnegativeGrain,
 |};
 
 /**
@@ -35,7 +40,12 @@ export function immediateReceipts(
   return identities.map(({id}, i) => ({id, amount: amounts[i]}));
 }
 
+export const immediateConfigParser: P.Parser<ImmediatePolicy> = P.object({
+  policyType: P.exactly(["IMMEDIATE"]),
+  budget: numberParser,
+});
+
 export const immediatePolicyParser: P.Parser<ImmediatePolicy> = P.object({
   policyType: P.exactly(["IMMEDIATE"]),
-  budget: G.parser,
+  budget: grainParser,
 });

--- a/src/core/ledger/policies/index.js
+++ b/src/core/ledger/policies/index.js
@@ -5,17 +5,25 @@ import {
   type BalancedPolicy,
   balancedReceipts,
   balancedPolicyParser,
+  balancedConfigParser,
 } from "./balanced";
 import {
   type ImmediatePolicy,
   immediateReceipts,
   immediatePolicyParser,
+  immediateConfigParser,
 } from "./immediate";
-import {type RecentPolicy, recentReceipts, recentPolicyParser} from "./recent";
+import {
+  type RecentPolicy,
+  recentReceipts,
+  recentPolicyParser,
+  recentConfigParser,
+} from "./recent";
 import {
   type SpecialPolicy,
   specialReceipts,
   specialPolicyParser,
+  specialConfigParser,
 } from "./special";
 
 export {balancedReceipts, balancedPolicyParser};
@@ -28,6 +36,13 @@ export type AllocationPolicy =
   | ImmediatePolicy
   | RecentPolicy
   | SpecialPolicy;
+
+export const policyConfigParser: P.Parser<AllocationPolicy> = P.orElse([
+  balancedConfigParser,
+  immediateConfigParser,
+  recentConfigParser,
+  specialConfigParser,
+]);
 
 export const allocationPolicyParser: P.Parser<AllocationPolicy> = P.orElse([
   balancedPolicyParser,

--- a/src/core/ledger/policies/nonnegativeGrain.js
+++ b/src/core/ledger/policies/nonnegativeGrain.js
@@ -1,0 +1,39 @@
+// @flow
+
+import * as G from "../grain";
+import * as P from "../../../util/combo";
+
+/**
+ * The NonnegativeGrain type ensures Grain amount is >= 0,
+ * which is particularly useful in the case of policy budgets
+ * or grain transfers.
+ */
+export opaque type NonnegativeGrain: G.Grain = G.Grain;
+
+export function fromGrain(g: G.Grain): NonnegativeGrain {
+  if (G.lt(g, G.ZERO)) {
+    throw new Error(`Grain must be in nonnegative, got ${g}`);
+  }
+  return g;
+}
+
+export function fromInteger(n: number): NonnegativeGrain {
+  return fromGrain(G.fromInteger(n));
+}
+
+export function fromString(s: string): NonnegativeGrain {
+  return fromGrain(G.fromString(s));
+}
+
+export const grainParser: P.Parser<NonnegativeGrain> = P.fmap(
+  G.parser,
+  fromGrain
+);
+export const numberParser: P.Parser<NonnegativeGrain> = P.fmap(
+  P.number,
+  fromInteger
+);
+export const stringParser: P.Parser<NonnegativeGrain> = P.fmap(
+  P.string,
+  fromString
+);

--- a/src/core/ledger/policies/recent.js
+++ b/src/core/ledger/policies/recent.js
@@ -4,6 +4,11 @@ import * as G from "../grain";
 import * as P from "../../../util/combo";
 import {type GrainReceipt} from "../grainAllocation";
 import {type ProcessedIdentities} from "../processedIdentities";
+import {
+  type NonnegativeGrain,
+  numberParser,
+  grainParser,
+} from "./nonnegativeGrain";
 
 /**
  * The Recent policy distributes cred using a time discount factor, weighing
@@ -27,7 +32,7 @@ export type Recent = "RECENT";
 
 export type RecentPolicy = {|
   +policyType: Recent,
-  +budget: G.Grain,
+  +budget: NonnegativeGrain,
   +discount: Discount,
 |};
 
@@ -48,9 +53,15 @@ export function recentReceipts(
   return identities.map(({id}, i) => ({id, amount: amounts[i]}));
 }
 
+export const recentConfigParser: P.Parser<RecentPolicy> = P.object({
+  policyType: P.exactly(["RECENT"]),
+  budget: numberParser,
+  discount: P.fmap(P.number, toDiscount),
+});
+
 export const recentPolicyParser: P.Parser<RecentPolicy> = P.object({
   policyType: P.exactly(["RECENT"]),
-  budget: G.parser,
+  budget: grainParser,
   discount: P.fmap(P.number, toDiscount),
 });
 

--- a/src/core/ledger/policies/special.js
+++ b/src/core/ledger/policies/special.js
@@ -5,7 +5,11 @@ import * as P from "../../../util/combo";
 import {type IdentityId} from "../../identity";
 import {type GrainReceipt} from "../grainAllocation";
 import {type ProcessedIdentities} from "../processedIdentities";
-import * as G from "../grain";
+import {
+  type NonnegativeGrain,
+  numberParser,
+  grainParser,
+} from "./nonnegativeGrain";
 
 /**
  * The Special policy is a power-maintainer tool for directly paying Grain
@@ -20,7 +24,7 @@ export type Special = "SPECIAL";
 
 export type SpecialPolicy = {|
   +policyType: Special,
-  +budget: G.Grain,
+  +budget: NonnegativeGrain,
   +memo: string,
   +recipient: IdentityId,
 |};
@@ -37,9 +41,16 @@ export function specialReceipts(
   throw new Error(`no active grain account for identity: ${policy.recipient}`);
 }
 
+export const specialConfigParser: P.Parser<SpecialPolicy> = P.object({
+  policyType: P.exactly(["SPECIAL"]),
+  budget: numberParser,
+  memo: P.string,
+  recipient: uuidParser,
+});
+
 export const specialPolicyParser: P.Parser<SpecialPolicy> = P.object({
   policyType: P.exactly(["SPECIAL"]),
-  budget: G.parser,
+  budget: grainParser,
   memo: P.string,
   recipient: uuidParser,
 });

--- a/src/ui/components/SpecialDistribution.js
+++ b/src/ui/components/SpecialDistribution.js
@@ -11,6 +11,7 @@ import {computeAllocation} from "../../core/ledger/grainAllocation";
 import * as uuid from "../../util/uuid";
 import type {TimestampMs} from "../../util/timestamp";
 import {useLedger} from "../utils/LedgerContext";
+import {fromGrain as nonnegative} from "../../core/ledger/policies/nonnegativeGrain";
 
 const useStyles = makeStyles((theme) => ({
   root: {
@@ -67,7 +68,7 @@ export const SpecialDistribution = ({
     if (recipient && amount && amount !== ZERO) {
       const policy = {
         policyType: "SPECIAL",
-        budget: fromFloatString(amount),
+        budget: nonnegative(fromFloatString(amount)),
         memo,
         recipient: recipient.identity.id,
       };


### PR DESCRIPTION
__Context__
After implementing the `Recent` policy and a variant of `Balanced` (#2584), we can see that adding policy parameters for new policies is both tedious on from our perspective as well as for the user.

More specifically, on the user side, their config is a flat object with parameters from different policies sitting side by side.  Here, we implement more structure by taking an array of policies.

Right now, an example `config/grain.json` might look as follows:
```js
{
  "balancedPerWeek": 30
  "immediatePerWeek": 50,
  "recentPerWeek": 20,
  "maxSimultaneousDistributions": 2,
  "discount": 0.5
}
```

This also forced us to check each policy explicitly downstream in `toDistributionPolicy`, which could be a lot cleaner if we could leverage the `AllocationPolicy` type we already have.  Now, we only need to check that at least one policy is provided and budgets are positive.

Config now looks (for example) as follows:
```js
{
  allocationPolicies: [
    {
      policyType: "BALANCED",
      budget: "100"
    },
    {
      policyType: "RECENT",
      budget: "50",
      discount: 0.1
    },
    {
      policyType: "RECENT",
      budget: "100",
      discount: 0.5
    }
}
```

This also lets us take multiple versions of the same policies.  This allows us to create richer ensembles of policies.  For instance, I might want to run a `Recent` policy with a 90% discount, and another one with a 5% discount.

__Test Plan__
Unit tests are provided here for both the parser, and well as `toDistributionPolicy`, which serves to check the config.


