### PR TITLE
cli: Add simulation flag to graph cmd

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,8 +154,9 @@ cd $MY_SC_INSTANCE
 scdev go
 ```
 
-While making backend changes, you may find it useful to view a diff between the last generated graph and
-a newly generated graph by running `scdev graph -d`  
+While making backend changes, you may find it useful to view a diff between
+the last generated graph and a newly generated graph by running `scdev graph -d`
+and/or running a no-write simulation by running `scdev graph -s`
 The graph.json is stored in the instance, so you can easily compare results across backend branches.
 
 ### Using a Modified Frontend


### PR DESCRIPTION
<!-- Please read our contributor guide before submitting your PR: -->
<!-- https://github.com/sourcecred/sourcecred/blob/master/CONTRIBUTING.md -->

# Description

<!-- Possible prompts:
  Why is the change important?
  Did you consider and reject alternate formulations of the same idea?
  Are there relevant issues or discussions elsewhere?
-->
This adds a simulation flag to the `sourcecred graph` command, which simply skips writing changes to disk when added. This allows faster iteration during development, especially when using the `-d` flag, because it is most likely that a developer will want to repeatedly diff changes against a single "original" graph, rather than comparing each tweak to the last tweak. This change will allow a developer to execute such an iterative workflow by simply repeating `sourcecred graph -d -s` instead of constantly switching between branches to reset to the original graph.

I considered combining these semantics into the existing `-d` command since I would generally expect the two flags to be used together, but I opted to give the user finer grained control just in case.

# Test Plan
- confirmed that the order of params like `sourcecred/github --simulation -d` doesn't matter
- confirmed that both `-s` and `--simulation` work
- confirmed that ledger is changed iff `-s` is absent
- confirmed that the taskReporter output is as expected for each combination of flags:

## both -s and -d
```
  GO   sourcecred/discord: generating graph
 DONE  sourcecred/discord: generating graph: 17ms
  GO   sourcecred/discord: diffing with existing graph
=============================================================
  sourcecred/discord - Unchanged
=============================================================
 DONE  sourcecred/discord: diffing with existing graph: 13ms
```

## -d only
```
  GO   sourcecred/discord: generating graph
 DONE  sourcecred/discord: generating graph: 23ms
  GO   sourcecred/discord: diffing with existing graph
=============================================================
  sourcecred/discord - Unchanged
=============================================================
 DONE  sourcecred/discord: diffing with existing graph: 13ms
  GO   sourcecred/discord: writing graph
 DONE  sourcecred/discord: writing graph: 4ms
```

## -s only
```
  GO   sourcecred/discord: generating graph
 DONE  sourcecred/discord: generating graph: 16ms
```

## neither flag
```
  GO   sourcecred/discord: generating graph
 DONE  sourcecred/discord: generating graph: 17ms
  GO   sourcecred/discord: writing graph
 DONE  sourcecred/discord: writing graph: 4ms
```
<!-- Possible prompts:
  How well covered by automated tests is this change?
  How did you manually test this change? How can a reviewer replicate the tests?
-->
