### PR TITLE
cli: Add simulation flag to credrank cmd

### DIFF
--- a/src/cli/credrank.js
+++ b/src/cli/credrank.js
@@ -23,10 +23,15 @@ function die(std, message) {
 
 const credrankCommand: Command = async (args, std) => {
   let shouldIncludeDiff = false;
+  let isSimulation = false;
   const processedArgs = args.filter((arg) => {
     switch (arg) {
       case "-d":
         shouldIncludeDiff = true;
+        return false;
+      case "-s":
+      case "--simulate":
+        isSimulation = true;
         return false;
       default:
         return true;
@@ -73,11 +78,13 @@ const credrankCommand: Command = async (args, std) => {
     printCredSummaryTable(credGraph);
   }
 
-  taskReporter.start("write cred graph");
-  const cgJson = stringify(credGraph.toJSON());
-  const outputPath = pathJoin(baseDir, "output", "credGraph.json");
-  await fs.writeFile(outputPath, cgJson);
-  taskReporter.finish("write cred graph");
+  if (!isSimulation) {
+    taskReporter.start("write cred graph");
+    const cgJson = stringify(credGraph.toJSON());
+    const outputPath = pathJoin(baseDir, "output", "credGraph.json");
+    await fs.writeFile(outputPath, cgJson);
+    taskReporter.finish("write cred graph");
+  }
 
   taskReporter.finish("credrank");
   return 0;


### PR DESCRIPTION
<!-- Please read our contributor guide before submitting your PR: -->
<!-- https://github.com/sourcecred/sourcecred/blob/master/CONTRIBUTING.md -->

# Description
This adds a simulation flag to the `sourcecred credrank` command, which simply skips writing changes to disk when added. This allows faster iteration during development, especially when using the `-d` flag, because it is most likely that a developer will want to repeatedly diff changes against a single "original" credGraph, rather than comparing each tweak to the last tweak. This change will allow a developer to execute such an iterative workflow by simply repeating `sourcecred credrank -d -s` instead of constantly switching between branches to reset to the original credGraph.
<!-- Possible prompts:
  Why is the change important?
  Did you consider and reject alternate formulations of the same idea?
  Are there relevant issues or discussions elsewhere?
-->

# Test Plan
`scdev credrank` outputs `  GO   write cred graph
 DONE  write cred graph: 8ms` whereas `scdev credrank -s` does not.

<!-- Possible prompts:
  How well covered by automated tests is this change?
  How did you manually test this change? How can a reviewer replicate the tests?
-->
