### PR TITLE
cli/common: rename loadWeightedGraph to mergePluginWeightedGraphs

### DIFF
--- a/src/cli/common.js
+++ b/src/cli/common.js
@@ -91,7 +91,7 @@ export async function prepareCredData(
   dependencies: $ReadOnlyArray<BonusPolicy>,
 |}> {
   const [weightedGraph, ledger] = await Promise.all([
-    await loadWeightedGraph(baseDir, config),
+    await loadAndMergePluginWeigtedGraphs(baseDir, config),
     await loadLedger(baseDir),
   ]);
 
@@ -152,7 +152,11 @@ export async function loadWeightedGraphForPlugin(
   return weightedGraphFromJSON(graphJSON);
 }
 
-export async function loadWeightedGraph(
+/**
+ * Loads a weighted graph of all plugins' weighted graphs
+ * merged together.
+ */
+export async function loadAndMergePluginWeigtedGraphs(
   baseDir: string,
   config: InstanceConfig
 ): Promise<WeightedGraph> {


### PR DESCRIPTION
This is a simple renaming to make clear which weighted graph we're
loading, and also the fact that we're merging the plugin weighted
graphs into *the* graph.

__Test Plan__
Trivial rename, unit tests pass, manually checked for all potential
import instances.