### PR TITLE
credrank: Add intervals getter to CredGraph, rename credPerEpoch to c…

### DIFF
--- a/src/core/credrank/credGraph.js
+++ b/src/core/credrank/credGraph.js
@@ -11,6 +11,7 @@ import {
 } from "./markovProcessGraph";
 import {type MarkovEdge, type TransitionProbability} from "./markovEdge";
 import {payoutGadget} from "./edgeGadgets";
+import {type IntervalSequence} from "../interval";
 
 export type Node = {|
   +address: NodeAddressT,
@@ -32,7 +33,7 @@ export type Participant = {|
   +address: NodeAddressT,
   +description: string,
   +cred: number,
-  +credPerEpoch: $ReadOnlyArray<number>,
+  +credPerInterval: $ReadOnlyArray<number>,
   +id: Uuid,
 |};
 
@@ -90,15 +91,19 @@ export class CredGraph {
         epochStart,
       }));
       let totalCred = 0;
-      const credPerEpoch = epochs.map((e) => {
+      const credPerInterval = epochs.map((e) => {
         const payoutAddress = payoutGadget.toRaw(e);
         const payoutMarkovEdge = NullUtil.get(this._mpg.edge(payoutAddress));
         const cred = this._credFlow(payoutMarkovEdge);
         totalCred += cred;
         return cred;
       });
-      yield {address, description, credPerEpoch, cred: totalCred, id};
+      yield {address, description, credPerInterval, cred: totalCred, id};
     }
+  }
+
+  intervals(): IntervalSequence {
+    return this._mpg.intervals();
   }
 
   *inNeighbors(addr: NodeAddressT): Iterator<Edge> {

--- a/src/core/credrank/credGraph.test.js
+++ b/src/core/credrank/credGraph.test.js
@@ -31,7 +31,7 @@ describe("core/credrank/credGraph", () => {
       const mpgParticipants = Array.from(mpg.participants());
       const expectedParticipants = mpgParticipants.map((p) => ({
         ...p,
-        credPerEpoch: expect.anything(),
+        credPerInterval: expect.anything(),
         cred: expect.anything(),
       }));
       const actualParticipants = Array.from(cg.participants());
@@ -48,6 +48,11 @@ describe("core/credrank/credGraph", () => {
         participantCred += cred;
       }
       expect(totalMint).toBeCloseTo(participantCred);
+    });
+    it("exposes the mpg intervals", async () => {
+      const mpg = markovProcessGraph();
+      const cg = await credGraph();
+      expect(cg.intervals()).toEqual(mpg.intervals());
     });
   });
 


### PR DESCRIPTION


<!-- Please read our contributor guide before submitting your PR: -->
<!-- https://github.com/sourcecred/sourcecred/blob/master/CONTRIBUTING.md -->

# Description
This adds a passthrough `intervals()` getter on the CredGraph, which will allow consumers like the CredGrainView to access the intervals, which is important for contextualizing the Participant credPerInterval array in time.

It also renames the credPerEpoch array to credPerInterval. They are ultimately the same, but I think credPerInterval is more semantically intuitive, especially now that we are exposing the intervals and not the epochs.
"How much cred is associated with a given time period" instead of "how much cred is associated with a startTime timestamp"
In my opinion, the idea of epochs should not be exposed outside of the CredGraph internal logic, in preference of intervals.
<!-- Possible prompts:
  Why is the change important?
  Did you consider and reject alternate formulations of the same idea?
  Are there relevant issues or discussions elsewhere?
-->

# Test Plan
Added a basic unit test.
CI passes.
<!-- Possible prompts:
  How well covered by automated tests is this change?
  How did you manually test this change? How can a reviewer replicate the tests?
-->
