### PR TITLE
Allow front end to function without Cred

### DIFF
--- a/src/ui/components/AdminApp.js
+++ b/src/ui/components/AdminApp.js
@@ -52,7 +52,7 @@ const createAppLayout = ({hasBackend, currency}: LoadSuccess) => {
 };
 
 const customRoutes = (
-  credView: CredView,
+  credView: CredView | null,
   hasBackend: Boolean,
   currency: CurrencyDetails
 ) => {
@@ -61,7 +61,7 @@ const customRoutes = (
       <Explorer initialView={credView} />
     </Route>,
     <Route key="root" exact path="/">
-      <Redirect to="/explorer" />
+      <Redirect to={credView ? "/explorer" : "/accounts"} />
     </Route>,
     <Route key="accounts" exact path="/accounts">
       <AccountOverview currency={currency} />

--- a/src/ui/components/Explorer/Explorer.js
+++ b/src/ui/components/Explorer/Explorer.js
@@ -254,7 +254,11 @@ const WeightsConfigSection = ({
   );
 };
 
-export const Explorer = ({initialView}: {initialView: CredView}): ReactNode => {
+export const Explorer = ({
+  initialView,
+}: {
+  initialView: CredView | null,
+}): ReactNode => {
   const [{credView}, setCredViewState] = useState({
     credView: initialView,
   });
@@ -327,7 +331,15 @@ export const Explorer = ({initialView}: {initialView: CredView}): ReactNode => {
   const paramsUpToDate =
     deepEqual(params, currentParams) && deepEqual(weights, currentWeights);
 
-  if (!credView) return null;
+  if (!credView)
+    return (
+      <div className={css(styles.root)}>
+        <p>
+          This page is unavailable because Cred information was unable to load.
+          Calculate cred through the CLI in order to use this page.
+        </p>
+      </div>
+    );
 
   return (
     <div className={css(styles.root)}>

--- a/src/ui/components/ExplorerHome/ExplorerHome.js
+++ b/src/ui/components/ExplorerHome/ExplorerHome.js
@@ -91,10 +91,11 @@ const useStyles = makeStyles((theme) => ({
 }));
 
 type ExplorerHomeProps = {|
-  +initialView: CredView,
+  +initialView: CredView | null,
 |};
 
 export const ExplorerHome = ({initialView}: ExplorerHomeProps): ReactNode => {
+  if (!initialView) return null;
   const classes = useStyles();
   const [tab, setTab] = useState<number>(1);
   const [checkboxes, setCheckboxes] = useState({


### PR DESCRIPTION
<!-- Please read our contributor guide before submitting your PR: -->
<!-- https://github.com/sourcecred/sourcecred/blob/master/CONTRIBUTING.md -->

# Description
This change allows the front end to load successfully even if there is no `output` directory. In such a case, it simply displays the following message on the Explorer page while still allowing all other pages to be used functionally, and it uses the Accounts page as the root page instead of the Explorer page.
```
This page is unavailable because Cred information was unable to load. Calculate cred through the CLI in order to use this page.
```
By not requiring cred calculation for most of the pages, instance maintainers can use the admin portal on a fresh clone of an instance, without having to worry about doing a mock `go` or copying in files from the gh-pages branch. This will make it MUCH easier to make make identity changes and transfer grain, as well as verify such changes during PR review.
<!-- Possible prompts:
  Why is the change important?
  Did you consider and reject alternate formulations of the same idea?
  Are there relevant issues or discussions elsewhere?
-->

# Test Plan
## Manual Testing:
1. Checkout `master` branch in `cred` package
2. From sourcecred package, `yarn start --instance /Path/to/instance/cred`
3. Verify that the Accounts page loads by default.
4. Verify that the Explorer page shows only the new info message.
5. Verify that other pages are viewable/functional.
6. Verify Transfer Grain, Merge Identity, Activate Identity actions work fully.
## Manual Regression Testing:
1. Checkout `gh-pages` branch in `cred` package
2. From sourcecred package, `yarn start --instance /Path/to/instance/cred`
4. Verify that the Explorer page is loads by default.
5. Verify weight configuration can be recalculated.
6. Verify other pages work.
<!-- Possible prompts:
  How well covered by automated tests is this change?
  How did you manually test this change? How can a reviewer replicate the tests?
-->
