### PR TITLE
Utilize ES6 concat syntax instead of ES2019 flat method

### DIFF
--- a/src/core/mintBudget.js
+++ b/src/core/mintBudget.js
@@ -101,7 +101,7 @@ export function _computeReweighting(
   const reweightingsForEachBudget: $ReadOnlyArray<Reweighting> = budget.entries.map(
     (entry) => _reweightingForEntry({evaluator, partition, entry})
   );
-  return reweightingsForEachBudget.flat();
+  return [].concat(...reweightingsForEachBudget);
 }
 
 /**


### PR DESCRIPTION
Node V10 does not support ES2019 Array.prototype.flat() syntax. This
causes issues with unit tests. Since @wchargin and sometimes I utilize
Node V10 I've created this PR.

While the build succeeds without this change still, unit tests with jest fail.

test plan: nvm use 10 && yarn unit # assumes the use of nvm to access node V10