### PR TITLE
util: Add findLast and findLastIndex util functions

### DIFF
--- a/src/core/mintBudget.js
+++ b/src/core/mintBudget.js
@@ -2,6 +2,7 @@
 
 import {sum} from "d3-array";
 import * as NullUtil from "../util/null";
+import {findLast} from "../util/findLast";
 import * as Weights from "./weights";
 import * as C from "../util/combo";
 import {type NodeAddressT, NodeAddress} from "./graph";
@@ -217,10 +218,10 @@ export function _findCurrentBudgetValue(
   periods: $ReadOnlyArray<BudgetPeriod>,
   timestamp: TimestampMs
 ): number {
-  const currentPeriod = periods
-    .slice()
-    .reverse()
-    .find((period) => period.startTimeMs <= timestamp);
+  const currentPeriod = findLast(
+    periods,
+    (period) => period.startTimeMs <= timestamp
+  );
   return currentPeriod ? currentPeriod.budgetValue : Infinity;
 }
 

--- a/src/util/findLast.js
+++ b/src/util/findLast.js
@@ -1,0 +1,25 @@
+// @flow
+
+// This is simply a reverse-order version of Array.prototype.find()
+// Returns the last element in the array that satisfies the provided
+// testing function.
+// Otherwise, it returns undefined, indicating that no element passed the test.
+export function findLast<T>(
+  array: $ReadOnlyArray<T>,
+  testingFunction: (obj: T) => boolean
+): ?T {
+  return array[findLastIndex(array, testingFunction)];
+}
+
+// This is simply a reverse-order version of Array.prototype.findIndex()
+// Returns the index of the last element in the array that satisfies the
+// provided testing function.
+// Otherwise, it returns -1, indicating that no element passed the test.
+export function findLastIndex<T>(
+  array: $ReadOnlyArray<T>,
+  testingFunction: (obj: T) => boolean
+): number {
+  let index = array.length - 1;
+  while (index >= 0 && !testingFunction(array[index])) index--;
+  return index;
+}

--- a/src/util/findLast.test.js
+++ b/src/util/findLast.test.js
@@ -1,0 +1,59 @@
+// @flow
+
+import {findLast, findLastIndex} from "./findLast";
+
+describe("util/findLast", () => {
+  it("should work when the last object satisfies the condition", () => {
+    const input = [4, 5, 6, 9];
+    const testingFunction = (n) => n === 9;
+    expect(findLast(input, testingFunction)).toEqual(9);
+  });
+  it("should work when the first object satisfies the condition", () => {
+    const input = [4, 5, 6, 9];
+    const testingFunction = (n) => n === 4;
+    expect(findLast(input, testingFunction)).toEqual(4);
+  });
+  it("should return the last viable object when multiple objects satisfy the condition", () => {
+    const input = [4, 5, 6, 9];
+    const testingFunction = (n) => n < 7;
+    expect(findLast(input, testingFunction)).toEqual(6);
+  });
+  it("should return undefined when no objects satisfy the condition", () => {
+    const input = [4, 5, 6, 9];
+    const testingFunction = (n) => n === 22;
+    expect(findLast(input, testingFunction)).toEqual(undefined);
+  });
+  it("should return undefined when the array is empty", () => {
+    const input = [];
+    const testingFunction = (n) => n === 22;
+    expect(findLast(input, testingFunction)).toEqual(undefined);
+  });
+});
+
+describe("util/findLastIndex", () => {
+  it("should work when the last object satisfies the condition", () => {
+    const input = [4, 1, 1, 9];
+    const testingFunction = (n) => n === 9;
+    expect(findLastIndex(input, testingFunction)).toEqual(3);
+  });
+  it("should work when the first object satisfies the condition", () => {
+    const input = [4, 1, 1, 9];
+    const testingFunction = (n) => n === 4;
+    expect(findLastIndex(input, testingFunction)).toEqual(0);
+  });
+  it("should return the last viable index when multiple objects satisfy the condition", () => {
+    const input = [4, 1, 1, 9];
+    const testingFunction = (n) => n === 1;
+    expect(findLastIndex(input, testingFunction)).toEqual(2);
+  });
+  it("should return -1 when no objects satisfy the condition", () => {
+    const input = [4, 1, 1, 9];
+    const testingFunction = (n) => n === 22;
+    expect(findLastIndex(input, testingFunction)).toEqual(-1);
+  });
+  it("should return -1 when the array is empty", () => {
+    const input = [];
+    const testingFunction = (n) => n === 22;
+    expect(findLastIndex(input, testingFunction)).toEqual(-1);
+  });
+});


### PR DESCRIPTION
<!-- Please read our contributor guide before submitting your PR: -->
<!-- https://github.com/sourcecred/sourcecred/blob/master/CONTRIBUTING.md -->

# Description
I found it annoying that JS doesn't provide reverse-order versions of Array.find and Array.findIndex so I wrote my own. Without this method, there is a trade off between readability (slice.reverse.find) and efficiency (index-based loop). Now, these can be used to provide the efficiency of an index loop with better readability.

These do not technically have all of the functionality of Array.find and Array.findIndex (namely the optional callback params), but they can be updated to include that later if needed. Most cases do not need it.
<!-- Possible prompts:
  Why is the change important?
  Did you consider and reject alternate formulations of the same idea?
  Are there relevant issues or discussions elsewhere?
-->

# Test Plan
Unit tests added for the util methods.
The `_findCurrentBudgetValue` example is well-covered by unit tests.
<!-- Possible prompts:
  How well covered by automated tests is this change?
  How did you manually test this change? How can a reviewer replicate the tests?
-->
