### PR TITLE
Implement CredGrainView

### DIFF
--- a/src/core/credGrainView.js
+++ b/src/core/credGrainView.js
@@ -7,40 +7,40 @@
  * It is useful for cases where you want to view a participant's Cred and Grain
  * data simultaneously, for example for creating summary dashboards.
  */
-import {CredGraph} from "./credrank/credGraph";
-import {type Identity, type IdentityType, type IdentityId} from "./identity";
+import deepFreeze from "deep-freeze";
+import {
+  CredGraph,
+  type Participant as GraphParticipant,
+} from "./credrank/credGraph";
+import {type Identity, type IdentityId} from "./identity";
+import * as G from "./ledger/grain";
 import {type Grain} from "./ledger/grain";
-import {Ledger} from "./ledger/ledger";
+import {Ledger, type Account} from "./ledger/ledger";
 import {type TimestampMs} from "../util/timestamp";
-import {type IntervalSequence} from "./interval";
+import findLastIndex from "lodash.findlastindex";
+import {type IntervalSequence, intervalSequence} from "./interval";
 
 /**
  * Cred and Grain data for a given participant.
  *
  * Implicitly has an associated time scope, which will
- * be the time scope of the TimeScopedCredGrainView that generated
- * this.
+ * be the time scope of the CredGrainView or TimeScopedCredGrainView that
+ * generated this.
+ *
+ * The indices of credPerInterval/grainEarnedPerInterval correspond to the
+ * same indices in the IntervalSequence of the CredGrainView or
+ * TimeScopedCredGrainView that generated this.
  */
 export type ParticipantCredGrain = {|
   +identity: Identity,
   // Total Cred earned during the time scope.
   +cred: number,
   // Cred earned in each interval within the time scope.
-  +credOverTime: $ReadOnlyArray<number>,
+  +credPerInterval: $ReadOnlyArray<number>,
   // Total Grain earned during the time scope.
   +grainEarned: Grain,
   // Grain earned in each interval within the time scope.
-  +grainEarnedOverTime: $ReadOnlyArray<Grain>,
-|};
-
-export type ParticipantSort = "BY_CRED" | "BY_GRAIN";
-export type ParticipantsOptions = {|
-  // How to sort. Always sorts from highest to lowest.
-  // Defaults to BY_CRED
-  +sort?: ParticipantSort,
-  // Which identity types should be included.
-  // Defaults to including all types.
-  +includedTypes?: Set<IdentityType>,
+  +grainEarnedPerInterval: $ReadOnlyArray<?Grain>,
 |};
 
 /**
@@ -54,77 +54,137 @@ export type ParticipantsOptions = {|
 export class CredGrainView {
   _credGraph: CredGraph;
   _ledger: Ledger;
-  _defaultTimeScope: TimeScopedCredGrainView;
+  _participants: $ReadOnlyArray<ParticipantCredGrain>;
+  _intervals: IntervalSequence;
 
   constructor(credGraph: CredGraph, ledger: Ledger) {
     this._credGraph = credGraph;
     this._ledger = ledger;
-    this._defaultTimeScope = new TimeScopedCredGrainView(
-      credGraph,
-      ledger,
-      -Infinity,
-      Infinity
+    this._intervals = deepFreeze(credGraph.intervals());
+
+    const graphParticipants = new Map<IdentityId, GraphParticipant>();
+    for (const participant of credGraph.participants()) {
+      graphParticipants.set(participant.id, participant);
+    }
+
+    this._participants = deepFreeze(
+      ledger.accounts().map((account) => {
+        const graphParticipant = graphParticipants.get(account.identity.id);
+        if (!graphParticipant)
+          throw new Error(
+            `The graph is missing account [${account.identity.name}: ${account.identity.id}] that exists in the ledger.`
+          );
+
+        return {
+          identity: account.identity,
+          cred: graphParticipant.cred,
+          credPerInterval: graphParticipant.credPerInterval,
+          grainEarned: account.paid,
+          grainEarnedPerInterval: this._calculateGrainEarnedPerInterval(
+            account
+          ),
+        };
+      })
     );
   }
 
+  _calculateGrainEarnedPerInterval(account: Account): $ReadOnlyArray<?Grain> {
+    return this._intervals.map((interval) => {
+      let grain = G.ZERO;
+      account.allocationHistory.forEach((allocationReceipt) => {
+        if (
+          interval.startTimeMs < allocationReceipt.credTimestampMs &&
+          allocationReceipt.credTimestampMs <= interval.endTimeMs
+        )
+          grain = G.add(grain, allocationReceipt.grainReceipt.amount);
+      });
+      return grain;
+    });
+  }
+
   withTimeScope(
-    startTimeMs: number,
-    endTimeMs: number
+    startTimeMs: TimestampMs,
+    endTimeMs: TimestampMs
   ): TimeScopedCredGrainView {
     return new TimeScopedCredGrainView(
-      this._credGraph,
-      this._ledger,
+      this._participants,
+      this._intervals,
       startTimeMs,
       endTimeMs
     );
   }
 
   intervals(): IntervalSequence {
-    return this._defaultTimeScope.intervals();
+    return this._intervals;
   }
 
-  participant(id: IdentityId): ParticipantCredGrain | null {
-    return this._defaultTimeScope.participant(id);
-  }
-
-  participants(
-    options: ParticipantsOptions
-  ): $ReadOnlyArray<ParticipantCredGrain> {
-    return this._defaultTimeScope.participants(options);
+  participants(): $ReadOnlyArray<ParticipantCredGrain> {
+    return this._participants;
   }
 }
 
+/**
+ * This class's contructor stores a continuous subset of the originalIntervals
+ * and participant cred/grain data where intervals are only included if their
+ * start and end times are both within the provided startTimeMs and endTimeMs,
+ * inclusively.
+ */
 export class TimeScopedCredGrainView {
-  _credGraph: CredGraph;
-  _ledger: Ledger;
-  _startTimeMs: TimestampMs;
-  _endTimeMs: TimestampMs;
+  _participants: $ReadOnlyArray<ParticipantCredGrain>;
+  _intervals: IntervalSequence;
 
   constructor(
-    credGraph: CredGraph,
-    ledger: Ledger,
+    originalParticipants: $ReadOnlyArray<ParticipantCredGrain>,
+    originalIntervals: IntervalSequence,
     startTimeMs: TimestampMs,
     endTimeMs: TimestampMs
   ) {
-    this._credGraph = credGraph;
-    this._ledger = ledger;
-    this._startTimeMs = startTimeMs;
-    this._endTimeMs = endTimeMs;
-  }
+    let inclusiveStartIndex = originalIntervals.findIndex(
+      (interval) => startTimeMs <= interval.startTimeMs
+    );
+    if (inclusiveStartIndex === -1)
+      inclusiveStartIndex = originalIntervals.length;
 
-  participants(
-    options: ParticipantsOptions
-  ): $ReadOnlyArray<ParticipantCredGrain> {
-    const _ = options;
-    throw new Error("not yet implemented");
-  }
+    const exclusiveEndIndex =
+      findLastIndex(
+        originalIntervals,
+        (interval) => interval.endTimeMs <= endTimeMs
+      ) + 1;
 
-  participant(id: IdentityId): ParticipantCredGrain | null {
-    const _ = id;
-    throw new Error("not yet implemented");
+    this._intervals = deepFreeze(
+      intervalSequence(
+        originalIntervals.slice(inclusiveStartIndex, exclusiveEndIndex)
+      )
+    );
+    this._participants = deepFreeze(
+      originalParticipants.map((participant) => {
+        const credPerInterval = participant.credPerInterval.slice(
+          inclusiveStartIndex,
+          exclusiveEndIndex
+        );
+        const grainEarnedPerInterval = participant.grainEarnedPerInterval.slice(
+          inclusiveStartIndex,
+          exclusiveEndIndex
+        );
+        return {
+          identity: participant.identity,
+          cred: credPerInterval.reduce((a, b) => a + b, 0),
+          credPerInterval,
+          grainEarned: grainEarnedPerInterval.reduce(
+            (a, b) => G.add(a, b || G.ZERO),
+            G.ZERO
+          ),
+          grainEarnedPerInterval,
+        };
+      })
+    );
   }
 
   intervals(): IntervalSequence {
-    throw new Error("not yet implemented");
+    return this._intervals;
+  }
+
+  participants(): $ReadOnlyArray<ParticipantCredGrain> {
+    return this._participants;
   }
 }

--- a/src/core/credGrainView.test.js
+++ b/src/core/credGrainView.test.js
@@ -1,0 +1,452 @@
+// @flow
+
+import {CredGrainView} from "./credGrainView";
+import * as GraphUtil from "./credrank/testUtils";
+import {createTestLedgerFixture} from "./ledger/testUtils";
+import {g} from "./ledger/testUtils";
+import {Ledger} from "./ledger/ledger";
+import * as uuid from "../util/uuid";
+
+describe("core/credGrainView", () => {
+  const {
+    identity1,
+    identity2,
+    ledgerWithActiveIdentities,
+  } = createTestLedgerFixture();
+  const allocationId1 = uuid.random();
+  const allocationId2 = uuid.random();
+
+  describe("when two identities have grain across two intervals", () => {
+    let credGraph;
+    let ledger;
+    let credGrainView;
+    const id1 = GraphUtil.participant1.id;
+    const id2 = GraphUtil.participant2.id;
+    const allocation1 = {
+      policy: {policyType: "IMMEDIATE", budget: g("10")},
+      id: allocationId1,
+      receipts: [
+        {amount: g("3"), id: id1},
+        {amount: g("7"), id: id2},
+      ],
+    };
+    const allocation2 = {
+      id: allocationId2,
+      policy: {policyType: "BALANCED", budget: g("20")},
+      receipts: [
+        {amount: g("10"), id: id1},
+        {amount: g("10"), id: id2},
+      ],
+    };
+    const distribution1 = {
+      credTimestamp: 1,
+      allocations: [allocation1],
+      id: uuid.random(),
+    };
+    const distribution2 = {
+      credTimestamp: 3,
+      allocations: [allocation2],
+      id: uuid.random(),
+    };
+
+    beforeEach(async (done) => {
+      credGraph = await GraphUtil.credGraph();
+      ledger = ledgerWithActiveIdentities(id1, id2);
+      ledger.distributeGrain(distribution1);
+      ledger.distributeGrain(distribution2);
+      credGrainView = new CredGrainView(credGraph, ledger);
+      done();
+    });
+
+    it("should have participant data for all intervals", () => {
+      const expectedIntervals = GraphUtil.intervals;
+      const expectedParticipants = [
+        {
+          identity: identity1(id1),
+          cred: GraphUtil.expectedParticipant1.cred,
+          credPerInterval: GraphUtil.expectedParticipant1.credPerInterval,
+          grainEarned: g("13"),
+          grainEarnedPerInterval: [g("3"), g("10")],
+        },
+        {
+          identity: identity2(id2),
+          cred: GraphUtil.expectedParticipant2.cred,
+          credPerInterval: GraphUtil.expectedParticipant2.credPerInterval,
+          grainEarned: g("17"),
+          grainEarnedPerInterval: [g("7"), g("10")],
+        },
+      ];
+
+      expect(credGrainView.intervals()).toEqual(expectedIntervals);
+      expect(credGrainView.participants()).toEqual(expectedParticipants);
+    });
+
+    describe("when time scoped to exactly the last interval", () => {
+      it("should have participant data for the last interval", () => {
+        const timeScopedCredGrainView = credGrainView.withTimeScope(
+          GraphUtil.intervals[GraphUtil.intervals.length - 1].startTimeMs,
+          GraphUtil.intervals[GraphUtil.intervals.length - 1].endTimeMs
+        );
+        const expectedIntervals = [
+          GraphUtil.intervals[GraphUtil.intervals.length - 1],
+        ];
+        const expectedParticipants = [
+          {
+            identity: identity1(id1),
+            cred: GraphUtil.expectedParticipant1.credPerInterval[1],
+            credPerInterval: [
+              GraphUtil.expectedParticipant1.credPerInterval[1],
+            ],
+            grainEarned: g("10"),
+            grainEarnedPerInterval: [g("10")],
+          },
+          {
+            identity: identity2(id2),
+            cred: GraphUtil.expectedParticipant2.credPerInterval[1],
+            credPerInterval: [
+              GraphUtil.expectedParticipant2.credPerInterval[1],
+            ],
+            grainEarned: g("10"),
+            grainEarnedPerInterval: [g("10")],
+          },
+        ];
+
+        expect(timeScopedCredGrainView.intervals()).toEqual(expectedIntervals);
+        expect(timeScopedCredGrainView.participants()).toEqual(
+          expectedParticipants
+        );
+      });
+    });
+
+    describe("when time scoped to exactly the first interval", () => {
+      it("should have participant data for the first interval", () => {
+        const timeScopedCredGrainView = credGrainView.withTimeScope(
+          GraphUtil.intervals[0].startTimeMs,
+          GraphUtil.intervals[0].endTimeMs
+        );
+        const expectedIntervals = [GraphUtil.intervals[0]];
+        const expectedParticipants = [
+          {
+            identity: identity1(id1),
+            cred: GraphUtil.expectedParticipant1.credPerInterval[0],
+            credPerInterval: [
+              GraphUtil.expectedParticipant1.credPerInterval[0],
+            ],
+            grainEarned: g("3"),
+            grainEarnedPerInterval: [g("3")],
+          },
+          {
+            identity: identity2(id2),
+            cred: GraphUtil.expectedParticipant2.credPerInterval[0],
+            credPerInterval: [
+              GraphUtil.expectedParticipant2.credPerInterval[0],
+            ],
+            grainEarned: g("7"),
+            grainEarnedPerInterval: [g("7")],
+          },
+        ];
+
+        expect(timeScopedCredGrainView.intervals()).toEqual(expectedIntervals);
+        expect(timeScopedCredGrainView.participants()).toEqual(
+          expectedParticipants
+        );
+      });
+    });
+
+    describe("when time scoped around the first interval", () => {
+      it("should have participant data for the first interval", () => {
+        const timeScopedCredGrainView = credGrainView.withTimeScope(
+          GraphUtil.intervals[0].startTimeMs - 1,
+          GraphUtil.intervals[0].endTimeMs + 1
+        );
+        const expectedIntervals = [GraphUtil.intervals[0]];
+        const expectedParticipants = [
+          {
+            identity: identity1(id1),
+            cred: GraphUtil.expectedParticipant1.credPerInterval[0],
+            credPerInterval: [
+              GraphUtil.expectedParticipant1.credPerInterval[0],
+            ],
+            grainEarned: g("3"),
+            grainEarnedPerInterval: [g("3")],
+          },
+          {
+            identity: identity2(id2),
+            cred: GraphUtil.expectedParticipant2.credPerInterval[0],
+            credPerInterval: [
+              GraphUtil.expectedParticipant2.credPerInterval[0],
+            ],
+            grainEarned: g("7"),
+            grainEarnedPerInterval: [g("7")],
+          },
+        ];
+
+        expect(timeScopedCredGrainView.intervals()).toEqual(expectedIntervals);
+        expect(timeScopedCredGrainView.participants()).toEqual(
+          expectedParticipants
+        );
+      });
+    });
+
+    describe("when time scoped after all intervals", () => {
+      it("should have participant data for no intervals", () => {
+        const timeScopedCredGrainView = credGrainView.withTimeScope(
+          9999,
+          99999
+        );
+        const expectedIntervals = [];
+        const expectedParticipants = [
+          {
+            identity: identity1(id1),
+            cred: 0,
+            credPerInterval: [],
+            grainEarned: g("0"),
+            grainEarnedPerInterval: [],
+          },
+          {
+            identity: identity2(id2),
+            cred: 0,
+            credPerInterval: [],
+            grainEarned: g("0"),
+            grainEarnedPerInterval: [],
+          },
+        ];
+
+        expect(timeScopedCredGrainView.intervals()).toEqual(expectedIntervals);
+        expect(timeScopedCredGrainView.participants()).toEqual(
+          expectedParticipants
+        );
+      });
+    });
+
+    describe("when time scoped for the partial beginning of an interval", () => {
+      it("should have participant data for no intervals", () => {
+        const timeScopedCredGrainView = credGrainView.withTimeScope(
+          GraphUtil.intervals[0].startTimeMs,
+          GraphUtil.intervals[0].startTimeMs + 1
+        );
+        const expectedIntervals = [];
+        const expectedParticipants = [
+          {
+            identity: identity1(id1),
+            cred: 0,
+            credPerInterval: [],
+            grainEarned: g("0"),
+            grainEarnedPerInterval: [],
+          },
+          {
+            identity: identity2(id2),
+            cred: 0,
+            credPerInterval: [],
+            grainEarned: g("0"),
+            grainEarnedPerInterval: [],
+          },
+        ];
+
+        expect(timeScopedCredGrainView.intervals()).toEqual(expectedIntervals);
+        expect(timeScopedCredGrainView.participants()).toEqual(
+          expectedParticipants
+        );
+      });
+    });
+
+    describe("when time scoped for the partial end of an interval", () => {
+      it("should have participant data for no intervals", () => {
+        const timeScopedCredGrainView = credGrainView.withTimeScope(
+          GraphUtil.intervals[0].startTimeMs + 1,
+          GraphUtil.intervals[0].endTimeMs
+        );
+        const expectedIntervals = [];
+        const expectedParticipants = [
+          {
+            identity: identity1(id1),
+            cred: 0,
+            credPerInterval: [],
+            grainEarned: g("0"),
+            grainEarnedPerInterval: [],
+          },
+          {
+            identity: identity2(id2),
+            cred: 0,
+            credPerInterval: [],
+            grainEarned: g("0"),
+            grainEarnedPerInterval: [],
+          },
+        ];
+
+        expect(timeScopedCredGrainView.intervals()).toEqual(expectedIntervals);
+        expect(timeScopedCredGrainView.participants()).toEqual(
+          expectedParticipants
+        );
+      });
+    });
+  });
+
+  describe("when two identities have grain in only the first interval", () => {
+    let credGraph;
+    let ledger;
+    let credGrainView;
+    const id1 = GraphUtil.participant1.id;
+    const id2 = GraphUtil.participant2.id;
+    const allocation1 = {
+      policy: {policyType: "IMMEDIATE", budget: g("10")},
+      id: allocationId1,
+      receipts: [
+        {amount: g("3"), id: id1},
+        {amount: g("7"), id: id2},
+      ],
+    };
+    const distribution1 = {
+      credTimestamp: 1,
+      allocations: [allocation1],
+      id: uuid.random(),
+    };
+
+    beforeEach(async (done) => {
+      credGraph = await GraphUtil.credGraph();
+      ledger = ledgerWithActiveIdentities(id1, id2);
+      ledger.distributeGrain(distribution1);
+      credGrainView = new CredGrainView(credGraph, ledger);
+      done();
+    });
+
+    it("should have correct participant data for all intervals", () => {
+      const expectedIntervals = GraphUtil.intervals;
+      const expectedParticipants = [
+        {
+          identity: identity1(id1),
+          cred: GraphUtil.expectedParticipant1.cred,
+          credPerInterval: GraphUtil.expectedParticipant1.credPerInterval,
+          grainEarned: g("3"),
+          grainEarnedPerInterval: [g("3"), g("0")],
+        },
+        {
+          identity: identity2(id2),
+          cred: GraphUtil.expectedParticipant2.cred,
+          credPerInterval: GraphUtil.expectedParticipant2.credPerInterval,
+          grainEarned: g("7"),
+          grainEarnedPerInterval: [g("7"), g("0")],
+        },
+      ];
+
+      expect(credGrainView.intervals()).toEqual(expectedIntervals);
+      expect(credGrainView.participants()).toEqual(expectedParticipants);
+    });
+
+    describe("when time scoped to exactly the last interval", () => {
+      it("should have participant data for the last interval", () => {
+        const timeScopedCredGrainView = credGrainView.withTimeScope(
+          GraphUtil.intervals[GraphUtil.intervals.length - 1].startTimeMs,
+          GraphUtil.intervals[GraphUtil.intervals.length - 1].endTimeMs
+        );
+        const expectedIntervals = [
+          GraphUtil.intervals[GraphUtil.intervals.length - 1],
+        ];
+        const expectedParticipants = [
+          {
+            identity: identity1(id1),
+            cred: GraphUtil.expectedParticipant1.credPerInterval[1],
+            credPerInterval: [
+              GraphUtil.expectedParticipant1.credPerInterval[1],
+            ],
+            grainEarned: g("0"),
+            grainEarnedPerInterval: [g("0")],
+          },
+          {
+            identity: identity2(id2),
+            cred: GraphUtil.expectedParticipant2.credPerInterval[1],
+            credPerInterval: [
+              GraphUtil.expectedParticipant2.credPerInterval[1],
+            ],
+            grainEarned: g("0"),
+            grainEarnedPerInterval: [g("0")],
+          },
+        ];
+
+        expect(timeScopedCredGrainView.intervals()).toEqual(expectedIntervals);
+        expect(timeScopedCredGrainView.participants()).toEqual(
+          expectedParticipants
+        );
+      });
+    });
+  });
+
+  describe("when two identities have no grain distribution", () => {
+    let credGraph;
+    let ledger;
+    let credGrainView;
+    const id1 = GraphUtil.participant1.id;
+    const id2 = GraphUtil.participant2.id;
+
+    beforeEach(async (done) => {
+      credGraph = await GraphUtil.credGraph();
+      ledger = ledgerWithActiveIdentities(id1, id2);
+      credGrainView = new CredGrainView(credGraph, ledger);
+      done();
+    });
+
+    it("should have correct participant data for all intervals", () => {
+      const expectedIntervals = GraphUtil.intervals;
+      const expectedParticipants = [
+        {
+          identity: identity1(id1),
+          cred: GraphUtil.expectedParticipant1.cred,
+          credPerInterval: GraphUtil.expectedParticipant1.credPerInterval,
+          grainEarned: g("0"),
+          grainEarnedPerInterval: [g("0"), g("0")],
+        },
+        {
+          identity: identity2(id2),
+          cred: GraphUtil.expectedParticipant2.cred,
+          credPerInterval: GraphUtil.expectedParticipant2.credPerInterval,
+          grainEarned: g("0"),
+          grainEarnedPerInterval: [g("0"), g("0")],
+        },
+      ];
+
+      expect(credGrainView.intervals()).toEqual(expectedIntervals);
+      expect(credGrainView.participants()).toEqual(expectedParticipants);
+    });
+  });
+
+  describe("when the graph has participants but the ledger has no accounts", () => {
+    let credGraph;
+    let ledger;
+    let credGrainView;
+
+    beforeEach(async (done) => {
+      credGraph = await GraphUtil.credGraph();
+      ledger = new Ledger();
+      credGrainView = new CredGrainView(credGraph, ledger);
+      done();
+    });
+
+    it("should have no CredGrainView participants", () => {
+      const expectedIntervals = GraphUtil.intervals;
+      const expectedParticipants = [];
+
+      expect(credGrainView.intervals()).toEqual(expectedIntervals);
+      expect(credGrainView.participants()).toEqual(expectedParticipants);
+    });
+  });
+
+  describe("when the ledger has an account that the graph does not have", () => {
+    let credGraph;
+    let ledger;
+    const id1 = GraphUtil.participant1.id;
+    const id2 = GraphUtil.participant2.id;
+
+    beforeEach(async (done) => {
+      credGraph = await GraphUtil.credGraph();
+      ledger = ledgerWithActiveIdentities(id1, id2);
+      ledger.createIdentity("USER", "credless");
+      done();
+    });
+
+    it("should throw", () => {
+      expect(() => new CredGrainView(credGraph, ledger)).toThrow(
+        "The graph is missing account"
+      );
+    });
+  });
+});

--- a/src/core/credrank/testUtils.js
+++ b/src/core/credrank/testUtils.js
@@ -17,7 +17,7 @@ import {
   edgeWeightEvaluator,
 } from "../algorithm/weightEvaluator";
 import {
-  type Participant,
+  type Participant as MarkovProcessParticipant,
   type Parameters as MarkovProcessGraphParameters,
   type Arguments as MarkovProcessGraphArguments,
   MarkovProcessGraph,
@@ -25,7 +25,7 @@ import {
 import * as uuid from "../../util/uuid"; // for spy purposes
 import {type IntervalSequence, intervalSequence} from "../interval";
 import {markovProcessGraphPagerank} from "./compute";
-import {CredGraph} from "./credGraph";
+import {CredGraph, type Participant} from "./credGraph";
 
 /**
  * This module contains test helpers for working with CredRank data,
@@ -47,23 +47,37 @@ export const participantNode2: GraphNode = {
 };
 deepFreeze([participantNode1, participantNode2]);
 
-export const participant1: Participant = {
+export const participant1: MarkovProcessParticipant = {
   description: participantNode1.description,
   address: participantNode1.address,
   id: uuid.fromString("YVZhbGlkVXVpZEF0TGFzdA"),
 };
-export const participant2: Participant = {
+export const participant2: MarkovProcessParticipant = {
   description: participantNode2.description,
   address: participantNode2.address,
-  id: uuid.fromString("YVZhbGlkVXVpZE20TGFzdA"),
+  id: uuid.fromString("URgLrCxgvjHxtGJ9PgmckQ"),
 };
 
-export const participants: $ReadOnlyArray<Participant> = deepFreeze([
-  participant1,
-  participant2,
-]);
+export const expectedParticipant1: Participant = {
+  description: participantNode1.description,
+  address: participantNode1.address,
+  id: uuid.fromString("YVZhbGlkVXVpZEF0TGFzdA"),
+  cred: 2.999999337965189,
+  credPerInterval: [0.9479471812187605, 2.0520521567464285],
+};
+export const expectedParticipant2: Participant = {
+  description: participantNode2.description,
+  address: participantNode2.address,
+  id: uuid.fromString("URgLrCxgvjHxtGJ9PgmckQ"),
+  cred: 1.286615549244117e-19,
+  credPerInterval: [5.146462196976468e-20, 7.719693295464702e-20],
+};
 
-const intervals: IntervalSequence = deepFreeze(
+export const participants: $ReadOnlyArray<MarkovProcessParticipant> = deepFreeze(
+  [participant1, participant2]
+);
+
+export const intervals: IntervalSequence = deepFreeze(
   intervalSequence([
     {startTimeMs: 0, endTimeMs: 2},
     {startTimeMs: 2, endTimeMs: 4},

--- a/src/core/ledger/testUtils.js
+++ b/src/core/ledger/testUtils.js
@@ -17,10 +17,13 @@ export interface DateMock {
 }
 
 export interface LedgerMock {
-  identity1(): Identity;
-  identity2(): Identity;
-  ledgerWithIdentities(): Ledger;
-  ledgerWithActiveIdentities(): Ledger;
+  identity1(id?: IdentityId): Identity;
+  identity2(id?: IdentityId): Identity;
+  ledgerWithIdentities(firstId?: IdentityId, secondId?: IdentityId): Ledger;
+  ledgerWithActiveIdentities(
+    firstId?: IdentityId,
+    secondId?: IdentityId
+  ): Ledger;
 }
 
 export const createUuidMock = (): UuidMock => {
@@ -66,30 +69,36 @@ export const createTestLedgerFixture = (
   uuidMock: UuidMock = createUuidMock(),
   dateMock: DateMock = createDateMock()
 ): LedgerMock => {
-  const identity1 = (): Identity => {
-    uuidMock.setNextUuid(id1);
+  const identity1 = (id?: IdentityId = id1): Identity => {
+    uuidMock.setNextUuid(id);
     return newIdentity("USER", "steven");
   };
-  const identity2 = (): Identity => {
-    uuidMock.setNextUuid(id2);
+  const identity2 = (id?: IdentityId = id2): Identity => {
+    uuidMock.setNextUuid(id);
     return newIdentity("ORGANIZATION", "crystal-gems");
   };
 
-  const ledgerWithIdentities = (): Ledger => {
+  const ledgerWithIdentities = (
+    firstId: IdentityId = id1,
+    secondId: IdentityId = id2
+  ): Ledger => {
     uuidMock.resetFakeUuid();
     dateMock.resetFakeDate();
     const ledger = new Ledger();
-    uuidMock.setNextUuid(id1);
+    uuidMock.setNextUuid(firstId);
     ledger.createIdentity("USER", "steven");
-    uuidMock.setNextUuid(id2);
+    uuidMock.setNextUuid(secondId);
     ledger.createIdentity("ORGANIZATION", "crystal-gems");
     return ledger;
   };
 
-  const ledgerWithActiveIdentities = (): Ledger => {
+  const ledgerWithActiveIdentities = (
+    firstId: IdentityId = id1,
+    secondId: IdentityId = id2
+  ): Ledger => {
     const ledger = ledgerWithIdentities();
-    ledger.activate(id1);
-    ledger.activate(id2);
+    ledger.activate(firstId);
+    ledger.activate(secondId);
     return ledger;
   };
 


### PR DESCRIPTION
<!-- Please read our contributor guide before submitting your PR: -->
<!-- https://github.com/sourcecred/sourcecred/blob/master/CONTRIBUTING.md -->

# Description
This is an implementation for the CredGrainView, which is responsible for aligning cred and grain data in time using intervals. It will be used initially by the Explorer UI and the credrank-based Grain distributions.

# Design decisions
I decided to do most of the processing in the CredGrainView instead of the TimeScopedCredGrainView. This should be more efficient for high-frequency time scoping, as long as time scoping the processed data is faster than time scoping graph/ledger data, which it is for now. This may become more controversial if we add a bunch more data caches to this class, but I hope we will not in favor of creating more atomic classes.

I decided to remove the filter and sort options from the originally sketched interface, as most of that is probably better done downstream. If there is sorting or filtering that we need in the future that would be more appropriate to have in this module (such as filtering by allocation type), we can add that in later as needed.
<!-- Possible prompts:
  Why is the change important?
  Did you consider and reject alternate formulations of the same idea?
  Are there relevant issues or discussions elsewhere?
-->

# Test Plan
I added super thorough unit tests. They cover the grain logic extremely well, however the cred logic is tested only somewhat well. It only tests against a credGraph in which both participants have cred in both intervals. I accept this because the cred logic is far less complex and more expensive to create test data for.

No manual testing. (manual testing will come in future work using this module)
<!-- Possible prompts:
  How well covered by automated tests is this change?
  How did you manually test this change? How can a reviewer replicate the tests?
-->
