### PR TITLE
Discourse: Refactor like weight logic

### DIFF
--- a/src/plugins/discourse/weights.js
+++ b/src/plugins/discourse/weights.js
@@ -1,0 +1,30 @@
+// @flow
+
+import {type NodeWeight} from "../../core/weights";
+import {DEFAULT_TRUST_LEVEL_TO_WEIGHT} from "./createGraph";
+import {type User} from "./fetch";
+
+export function likeWeight(user: ?User): NodeWeight {
+  if (user == null) {
+    return 0;
+  }
+  return _trustLevelWeight(user.trustLevel);
+}
+
+export function _trustLevelWeight(trustLevel: number | null): NodeWeight {
+  if (trustLevel == null) {
+    // The null trust level shouldn't happen in practice, right now users who
+    // only like but never post will have null trust level (will be fixed by #2045).
+    // This means they could have trust level 1. But to be conservative, we treat anyone
+    // with a null trust level as if they have trust level 0.
+    // Possibly this could come up with deleted users too.
+    return DEFAULT_TRUST_LEVEL_TO_WEIGHT["0"];
+  }
+
+  const key = String(trustLevel);
+  const weight = DEFAULT_TRUST_LEVEL_TO_WEIGHT[key];
+  if (weight == null) {
+    throw new Error(`invalid trust level: ${String(key)}`);
+  }
+  return weight;
+}

--- a/src/plugins/discourse/weights.test.js
+++ b/src/plugins/discourse/weights.test.js
@@ -1,0 +1,28 @@
+// @flow
+
+import {_trustLevelWeight, likeWeight} from "./weights";
+import {DEFAULT_TRUST_LEVEL_TO_WEIGHT as weights} from "./createGraph";
+
+describe("plugins/discourse/weights", () => {
+  describe("likeWeight", () => {
+    it("has a weight of 0 for a null or undefined User", () => {
+      expect(likeWeight(null)).toEqual(0);
+      expect(likeWeight()).toEqual(0);
+    });
+  });
+
+  describe("_trustLevelWeight", () => {
+    it("throws an error for an invalid trustLevel", () => {
+      const thunk = () => _trustLevelWeight(-1);
+      expect(thunk).toThrowError("invalid trust level");
+    });
+    it("works as expected for a regular user", () => {
+      expect(_trustLevelWeight(null)).toEqual(weights[0]);
+      [0, 1, 2, 3, 4].forEach((trustLevel) => {
+        expect(_trustLevelWeight(trustLevel)).toEqual(
+          weights[trustLevel.toString()]
+        );
+      });
+    });
+  });
+});


### PR DESCRIPTION
In preparation for adding more weight calculations for likes, weight
calculations are moved to their own file. This builds towards the
completion of #2455.

n.b. This is similar to how the experimental discord reaction weight
calculations are organized.

test plan: yarn unit