### PR TITLE
Add tag and category parsing to DiscourseConfig

### DIFF
--- a/src/plugins/discourse/config.js
+++ b/src/plugins/discourse/config.js
@@ -3,54 +3,21 @@
 import * as Combo from "../../util/combo";
 import {optionsShapeParser, type MirrorOptions} from "./mirror";
 import {
-  type TagConfig,
-  type CategoryConfig,
-  tagConfigParser,
-  categoryConfigParser,
+  type WeightsConfig,
+  weightsConfigParser,
+  type SerializedWeightsConfig,
 } from "./weights";
+
+export type SerializedDiscourseConfig = {|
+  +serverUrl: string,
+  +mirrorOptions?: $Shape<MirrorOptions>,
+  +weights: SerializedWeightsConfig,
+|};
 
 export type DiscourseConfig = {|
   +serverUrl: string,
   +mirrorOptions?: $Shape<MirrorOptions>,
-  /**
-   * Categories can be configured to confer specific like-weight multipliers
-   * when added to a Topic.
-   * If a category does not have a configured weight, the deafaultWeight is applied.
-   * An example configuration might look like:
-   * "categoryWeights": {
-   *   "defaultWeight": 1,
-   *   "weights": {
-   *     "5": 0,
-   *     "36": 1.25
-   *   }
-   * }
-   * where "5" and "36" are the categoryIds in discourse.
-   *
-   * An easy way to find the categoryId for a given category is to browse to the
-   * categories section in discourse
-   * (e.g. https://discourse.sourcecred.io/categories).
-   * Then mousing over or clicking on a category will bring you to a url that
-   * has the shape https://exampleUrl.com/c/<category name>/<categoryId>
-   * Clicking on the community category in sourcecred navigates to
-   * https://discourse.sourcecred.io/c/community/26 for example, where the
-   * categoryId is 26
-   */
-  +categoryWeights?: CategoryConfig,
-  /**
-   * Tags can be configured to confer specific like-weight multipliers when
-   * added to a Topic.
-   * If a tag does not have a configured weight, the defaultWeight is applied.
-   * An example configuration might look like:
-   * "tagWeights": {
-   *   "defaultWeight": 1,
-   *   "weights": {
-   *     "foo": 0,
-   *     "bar": 1.25
-   *   }
-   * }
-   * where foo and bar are the names of tags used in discourse.
-   */
-  +tagWeights?: TagConfig,
+  +weights: WeightsConfig,
 |};
 
 export const parser: Combo.Parser<DiscourseConfig> = (() => {
@@ -69,8 +36,7 @@ export const parser: Combo.Parser<DiscourseConfig> = (() => {
     },
     {
       mirrorOptions: optionsShapeParser,
-      tagWeights: tagConfigParser,
-      categoryWeights: categoryConfigParser,
+      weights: weightsConfigParser,
     }
   );
 })();

--- a/src/plugins/discourse/config.js
+++ b/src/plugins/discourse/config.js
@@ -2,10 +2,55 @@
 
 import * as Combo from "../../util/combo";
 import {optionsShapeParser, type MirrorOptions} from "./mirror";
+import {
+  type TagConfig,
+  type CategoryConfig,
+  tagConfigParser,
+  categoryConfigParser,
+} from "./weights";
 
 export type DiscourseConfig = {|
   +serverUrl: string,
   +mirrorOptions?: $Shape<MirrorOptions>,
+  /**
+   * Categories can be configured to confer specific like-weight multipliers
+   * when added to a Topic.
+   * If a category does not have a configured weight, the deafaultWeight is applied.
+   * An example configuration might look like:
+   * "categoryWeights": {
+   *   "defaultWeight": 1,
+   *   "weights": {
+   *     "5": 0,
+   *     "36": 1.25
+   *   }
+   * }
+   * where "5" and "36" are the categoryIds in discourse.
+   *
+   * An easy way to find the categoryId for a given category is to browse to the
+   * categories section in discourse
+   * (e.g. https://discourse.sourcecred.io/categories).
+   * Then mousing over or clicking on a category will bring you to a url that
+   * has the shape https://exampleUrl.com/c/<category name>/<categoryId>
+   * Clicking on the community category in sourcecred navigates to
+   * https://discourse.sourcecred.io/c/community/26 for example, where the
+   * categoryId is 26
+   */
+  +categoryWeights?: CategoryConfig,
+  /**
+   * Tags can be configured to confer specific like-weight multipliers when
+   * added to a Topic.
+   * If a tag does not have a configured weight, the defaultWeight is applied.
+   * An example configuration might look like:
+   * "tagWeights": {
+   *   "defaultWeight": 1,
+   *   "weights": {
+   *     "foo": 0,
+   *     "bar": 1.25
+   *   }
+   * }
+   * where foo and bar are the names of tags used in discourse.
+   */
+  +tagWeights?: TagConfig,
 |};
 
 export const parser: Combo.Parser<DiscourseConfig> = (() => {
@@ -24,6 +69,8 @@ export const parser: Combo.Parser<DiscourseConfig> = (() => {
     },
     {
       mirrorOptions: optionsShapeParser,
+      tagWeights: tagConfigParser,
+      categoryWeights: categoryConfigParser,
     }
   );
 })();

--- a/src/plugins/discourse/config.js
+++ b/src/plugins/discourse/config.js
@@ -1,6 +1,6 @@
 // @flow
 
-import * as Combo from "../../util/combo";
+import * as C from "../../util/combo";
 import {optionsShapeParser, type MirrorOptions} from "./mirror";
 import {
   type WeightsConfig,
@@ -17,26 +17,23 @@ export type SerializedDiscourseConfig = {|
 export type DiscourseConfig = {|
   +serverUrl: string,
   +mirrorOptions?: $Shape<MirrorOptions>,
-  +weights: WeightsConfig,
+  +weights?: WeightsConfig,
 |};
 
-export const parser: Combo.Parser<DiscourseConfig> = (() => {
-  const C = Combo;
-  return C.object(
-    {
-      serverUrl: C.fmap(C.string, (serverUrl) => {
-        const httpRE = new RegExp(/^https?:\/\//);
-        if (!httpRE.test(serverUrl)) {
-          throw new Error(
-            "expected server url to start with 'https://' or 'http://'"
-          );
-        }
-        return serverUrl;
-      }),
-    },
-    {
-      mirrorOptions: optionsShapeParser,
-      weights: weightsConfigParser,
-    }
-  );
-})();
+export const parser: C.Parser<DiscourseConfig> = C.object(
+  {
+    serverUrl: C.fmap(C.string, (serverUrl) => {
+      const httpRE = new RegExp(/^https?:\/\//);
+      if (!httpRE.test(serverUrl)) {
+        throw new Error(
+          "expected server url to start with 'https://' or 'http://'"
+        );
+      }
+      return serverUrl;
+    }),
+  },
+  {
+    mirrorOptions: optionsShapeParser,
+    weights: weightsConfigParser,
+  }
+);

--- a/src/plugins/discourse/config.test.js
+++ b/src/plugins/discourse/config.test.js
@@ -1,0 +1,33 @@
+// @flow
+
+import {upgrade} from "./config";
+
+describe("plugins/discourse/config", () => {
+  it("parses weights successfully when none are present", () => {
+    expect(upgrade({serverUrl: "https://test.test"})).toEqual({
+      serverUrl: "https://test.test",
+      "weights": {
+        "categoryWeights": new Map(),
+        "defaultCategoryWeight": 1,
+        "defaultTagWeight": 1,
+        "tagWeights": new Map(),
+      },
+    });
+  });
+  it("accepts a partially filled-in serializedWeightsConfig", () => {
+    expect(
+      upgrade({
+        serverUrl: "https://test.test",
+        weights: {defaultCategoryWeight: 5},
+      })
+    ).toEqual({
+      serverUrl: "https://test.test",
+      "weights": {
+        "categoryWeights": new Map(),
+        "defaultCategoryWeight": 5,
+        "defaultTagWeight": 1,
+        "tagWeights": new Map(),
+      },
+    });
+  });
+});

--- a/src/plugins/discourse/weights.js
+++ b/src/plugins/discourse/weights.js
@@ -14,7 +14,7 @@ export opaque type TagId: string = string;
 
 export function parseCategoryId(id: string): CategoryId {
   const result = parseInt(id, 10);
-  if (Number.isNaN(result)) {
+  if (Number.isNaN(result) || result.toString() !== id) {
     throw new Error(`CategoryId should be a string integer; got ${id}`);
   }
   return id;
@@ -48,7 +48,7 @@ function upgrade(s: SerializedWeightsConfig): WeightsConfig {
   };
 }
 
-const serializedWeightsConfigParser: C.Parser<SerializedWeightsConfig> = C.object(
+export const serializedWeightsConfigParser: C.Parser<SerializedWeightsConfig> = C.object(
   {},
   {
     defaultCategoryWeight: C.number,

--- a/src/plugins/discourse/weights.js
+++ b/src/plugins/discourse/weights.js
@@ -3,97 +3,58 @@
 import {type NodeWeight} from "../../core/weights";
 import * as C from "../../util/combo";
 import * as NullUtil from "../../util/null";
+import {orElse as either} from "../../util/null";
 import {DEFAULT_TRUST_LEVEL_TO_WEIGHT} from "./createGraph";
 import {type User} from "./fetch";
 
-type WeightConfig = {|
-  [string]: NodeWeight,
-|};
-export type SerializedConfig = {|
-  +defaultWeight?: NodeWeight,
-  +weights?: WeightConfig,
-|};
+// Expected to be an integer string, like "1" or "123"
+export opaque type CategoryId: string = string;
+// No restrictions (can be more specific later if we investigate Discourse)
+export opaque type TagId: string = string;
 
-type TagWeights = Map<string, NodeWeight>;
-
-export type TagConfig = {|
-  +defaultWeight: NodeWeight,
-  +weights: TagWeights,
-|};
-
-type CategoryWeights = Map<number, NodeWeight>;
-
-export type CategoryConfig = {|
-  +defaultWeight: NodeWeight,
-  +weights: CategoryWeights,
-|};
-
-export function upgradeCategories(c: SerializedConfig): CategoryConfig {
-  const newConfig = {
-    defaultWeight: NullUtil.orElse(c.defaultWeight, 1),
-    weights: new Map(),
-  };
-  if (c.weights) {
-    const mapWeights = Object.entries(c.weights).map(
-      ([categoryString, weight]) => [
-        parseInt(categoryString, 10),
-        // needed to satisfy flow here, or it enforces "mixed" type
-        parseInt(weight, 10),
-      ]
-    );
-    newConfig.weights = new Map(mapWeights);
-  }
-
-  return newConfig;
-}
-
-export function upgradeTags(c: SerializedConfig): TagConfig {
-  const newConfig = {
-    defaultWeight: NullUtil.orElse(c.defaultWeight, 1),
-    weights: new Map(),
-  };
-  if (c.weights) {
-    const mapWeights = Object.entries(c.weights).map(([tag, weight]) => [
-      tag,
-      // needed to satisfy flow here, or it enforces a "mixed" type
-      parseInt(weight, 10),
-    ]);
-    newConfig.weights = new Map(mapWeights);
-  }
-
-  return newConfig;
-}
-
-export const tagConfigParser: C.Parser<TagConfig> = C.fmap(
-  C.object(
-    {},
-    {
-      defaultWeight: C.number,
-      weights: C.dict(C.number),
-    }
-  ),
-  upgradeTags
-);
-
-// categoryIDs should all be numbers, so the parser verifies that it is
-// indeed a number, then return a string since it is a dict key
-export function parseCategoryId(id: string): string {
+export function parseCategoryId(id: string): CategoryId {
   const result = parseInt(id, 10);
   if (Number.isNaN(result)) {
-    throw new Error(`CategoryId should be a number; got ${id}`);
+    throw new Error(`CategoryId should be a string integer; got ${id}`);
   }
   return id;
 }
 
-export const categoryConfigParser: C.Parser<CategoryConfig> = C.fmap(
-  C.object(
-    {},
-    {
-      defaultWeight: C.number,
-      weights: C.dict(C.number, C.fmap(C.string, parseCategoryId)),
-    }
-  ),
-  upgradeCategories
+export type SerializedWeightsConfig = {|
+  +defaultTagWeight?: NodeWeight,
+  +tagWeights: {[TagId]: NodeWeight},
+  +defaultCategoryWeight?: NodeWeight,
+  +categoryWeights: {[CategoryId]: NodeWeight},
+|};
+
+export type WeightsConfig = {|
+  +defaultTagWeight: number,
+  +tagWeights: Map<TagId, number>,
+  +defaultCategoryWeight: number,
+  +categoryWeights: Map<CategoryId, number>,
+|};
+
+function upgrade(s: SerializedWeightsConfig): WeightsConfig {
+  return {
+    defaultTagWeight: either(s.defaultTagWeight, 1),
+    defaultCategoryWeight: either(s.defaultCategoryWeight, 1),
+    tagWeights: MapUtil.fromObject(s.tagWeights || {}),
+    categoryWeights: MapUtil.fromObject(s.categoryWeights || {}),
+  };
+}
+
+const serializedWeightsConfigParser: Parser<SerializedWeightsConfig> = C.object(
+  {
+    defaultCategoryWeight: C.number,
+    defaultTagWeight: C.number,
+    categoryWeight: C.dict(C.number, C.fmap(C.string, parseCategoryId)),
+    tagWeight: C.dict(C.number, C.string),
+  }
+);
+
+export const weightsConfigParser: Parser<WeightsConfig> = C.fmap(
+  serializedWeightsConfigParser,
+  upgrade
 );
 
 export function likeWeight(user: ?User): NodeWeight {

--- a/src/plugins/discourse/weights.js
+++ b/src/plugins/discourse/weights.js
@@ -2,7 +2,7 @@
 
 import {type NodeWeight} from "../../core/weights";
 import * as C from "../../util/combo";
-import * as NullUtil from "../../util/null";
+import * as MapUtil from "../../util/map";
 import {orElse as either} from "../../util/null";
 import {DEFAULT_TRUST_LEVEL_TO_WEIGHT} from "./createGraph";
 import {type User} from "./fetch";
@@ -20,11 +20,16 @@ export function parseCategoryId(id: string): CategoryId {
   return id;
 }
 
+// parse out the opaque type
+export function parseTagId(id: string): TagId {
+  return id;
+}
+
 export type SerializedWeightsConfig = {|
   +defaultTagWeight?: NodeWeight,
-  +tagWeights: {[TagId]: NodeWeight},
+  +tagWeights?: {|[TagId]: NodeWeight|},
   +defaultCategoryWeight?: NodeWeight,
-  +categoryWeights: {[CategoryId]: NodeWeight},
+  +categoryWeights?: {|[CategoryId]: NodeWeight|},
 |};
 
 export type WeightsConfig = {|
@@ -43,16 +48,17 @@ function upgrade(s: SerializedWeightsConfig): WeightsConfig {
   };
 }
 
-const serializedWeightsConfigParser: Parser<SerializedWeightsConfig> = C.object(
+const serializedWeightsConfigParser: C.Parser<SerializedWeightsConfig> = C.object(
+  {},
   {
     defaultCategoryWeight: C.number,
     defaultTagWeight: C.number,
-    categoryWeight: C.dict(C.number, C.fmap(C.string, parseCategoryId)),
-    tagWeight: C.dict(C.number, C.string),
+    categoryWeights: C.dict(C.number, C.fmap(C.string, parseCategoryId)),
+    tagWeights: C.dict(C.number, C.fmap(C.string, parseTagId)),
   }
 );
 
-export const weightsConfigParser: Parser<WeightsConfig> = C.fmap(
+export const weightsConfigParser: C.Parser<WeightsConfig> = C.fmap(
   serializedWeightsConfigParser,
   upgrade
 );

--- a/src/plugins/discourse/weights.test.js
+++ b/src/plugins/discourse/weights.test.js
@@ -29,7 +29,7 @@ describe("plugins/discourse/weights", () => {
   describe("parseCategoryId", () => {
     it("rejects keys that arent numbers", () => {
       const thunk = () => parseCategoryId("bad");
-      expect(thunk).toThrow(`CategoryId should be a number; got bad`);
+      expect(thunk).toThrow(`CategoryId should be a string integer; got bad`);
     });
     it("accepts keys that are numbers", () => {
       expect(parseCategoryId("5")).toEqual("5");

--- a/src/plugins/discourse/weights.test.js
+++ b/src/plugins/discourse/weights.test.js
@@ -1,6 +1,6 @@
 // @flow
 
-import {_trustLevelWeight, likeWeight} from "./weights";
+import {_trustLevelWeight, likeWeight, parseCategoryId} from "./weights";
 import {DEFAULT_TRUST_LEVEL_TO_WEIGHT as weights} from "./createGraph";
 
 describe("plugins/discourse/weights", () => {
@@ -23,6 +23,16 @@ describe("plugins/discourse/weights", () => {
           weights[trustLevel.toString()]
         );
       });
+    });
+  });
+
+  describe("parseCategoryId", () => {
+    it("rejects keys that arent numbers", () => {
+      const thunk = () => parseCategoryId("bad");
+      expect(thunk).toThrow(`CategoryId should be a number; got bad`);
+    });
+    it("accepts keys that are numbers", () => {
+      expect(parseCategoryId("5")).toEqual("5");
     });
   });
 });

--- a/src/plugins/discourse/weights.test.js
+++ b/src/plugins/discourse/weights.test.js
@@ -34,5 +34,9 @@ describe("plugins/discourse/weights", () => {
     it("accepts keys that are numbers", () => {
       expect(parseCategoryId("5")).toEqual("5");
     });
+    it("rejects non-integer keys that are numbers", () => {
+      const thunk = () => parseCategoryId("5.5");
+      expect(thunk).toThrow("CategoryId should be a string integer; got 5.5");
+    });
   });
 });


### PR DESCRIPTION
These configs are unopinionated, in that they may be partially
shaped (only containing a default weight, or configured weights), and
the parser will resolve to the defaults if anything is missing from the 
config file.

builds towards #2455
paired with @decentralion 
test plan: yarn unit