### PR TITLE
Discourse: implement configurable tag and category weights

### DIFF
--- a/src/plugins/discourse/plugin.js
+++ b/src/plugins/discourse/plugin.js
@@ -65,7 +65,7 @@ export class DiscoursePlugin implements Plugin {
     const _ = rd; // TODO(#1808): not yet used
     const config = await loadConfig(ctx);
     const repo = await repository(ctx, config.serverUrl);
-    return createGraph(config.serverUrl, repo);
+    return createGraph(config, repo);
   }
 
   async referenceDetector(

--- a/src/plugins/discourse/weights.js
+++ b/src/plugins/discourse/weights.js
@@ -6,6 +6,7 @@ import * as MapUtil from "../../util/map";
 import {orElse as either} from "../../util/null";
 import {DEFAULT_TRUST_LEVEL_TO_WEIGHT} from "./createGraph";
 import {type User} from "./fetch";
+import {type CategoryId as MirrorCategoryId, type Tag} from "./fetch";
 
 // Expected to be an integer string, like "1" or "123"
 export opaque type CategoryId: string = string;
@@ -26,10 +27,69 @@ export function parseTagId(id: string): TagId {
 }
 
 export type SerializedWeightsConfig = {|
+  /**
+   * Tags can be configured to confer specific like-weight multipliers when
+   * added to a Topic.
+   * If a tag does not have a configured weight, the defaultWeight is applied.
+   * An example configuration might look like:
+   * ```
+   * "weights": {
+   *   "defaultTagWeight": 1,
+   *   "tagWeights": {
+   *     "foo": 0,
+   *     "bar": 1.25,
+   *     "baz": 2
+   *   }
+   *   // categoryWeight configs...
+   * }
+   * ```
+   * where foo and bar are the names of tags used in discourse.
+   *
+   * When multiple tags are assigned to a topic, their weights are multiplied
+   * together to yield a total tag Weight multiplier. In our example configuration,
+   * if both foo and bar are added to a topic, likes on posts in the topic will
+   * have a weight of 0, (0 * 1.25 = 0), which means that no cred will be minted
+   * by those likes.
+   *
+   * If "bar" and "baz" are both added to another topic, the likes on all posts
+   * in that topic will carry a weight of 2.5 (1.25 * 2 = 2.5), which means that
+   * 2.5x as much cred will be minted by those likes.
+   */
   +defaultTagWeight?: NodeWeight,
   +tagWeights?: {|[TagId]: NodeWeight|},
+  /**
+   * Categories can be configured to confer a specific like-weight multiplier
+   * when added to a Topic.
+   * If a category does not have a configured weight, the defaultWeight is applied.
+   * An example configuration might look like:
+   * ```
+   * weights: {
+   *  "defaultCategoryWeight": 1,
+   *  "categoryWeights": {
+   *    "5": 0,
+   *    "36": 1.25
+   *  }
+   *  // tagWeight configs...
+   * }
+   * ```
+   * where "5" and "36" are the categoryIds in discourse.
+   *
+   * An easy way to find the categoryId for a given category is to browse to the
+   * categories section in discourse
+   * (e.g. https://discourse.sourcecred.io/categories).
+   * Then mousing over or clicking on a category will bring you to a url that
+   * has the shape https://exampleUrl.com/c/<category name>/<categoryId>
+   * Clicking on the community category in sourcecred navigates to
+   * https://discourse.sourcecred.io/c/community/26 for example, where the
+   * categoryId is 26
+   */
   +defaultCategoryWeight?: NodeWeight,
   +categoryWeights?: {|[CategoryId]: NodeWeight|},
+  /*
+   * Tags and Topic Category can be used in combination to create like-weight
+   * multipliers on Topics. This means that if any assigned tag or topic category
+   * is set to 0, all likes on that topic will mint zero cred.
+   */
 |};
 
 export type WeightsConfig = {|
@@ -63,11 +123,17 @@ export const weightsConfigParser: C.Parser<WeightsConfig> = C.fmap(
   upgrade
 );
 
-export function likeWeight(user: ?User): NodeWeight {
-  if (user == null) {
-    return 0;
-  }
-  return _trustLevelWeight(user.trustLevel);
+export function likeWeight(
+  weights: WeightsConfig,
+  user: ?User,
+  category: ?MirrorCategoryId,
+  tags: ?$ReadOnlyArray<Tag>
+): NodeWeight {
+  const trustLevel = user == null ? 0 : _trustLevelWeight(user.trustLevel);
+  const categoryWeight =
+    category == null ? 1 : _categoryWeight(category, weights);
+  const tagWeight = tags == null ? 1 : _weightFromTags(tags, weights);
+  return trustLevel * categoryWeight * tagWeight;
 }
 
 export function _trustLevelWeight(trustLevel: number | null): NodeWeight {
@@ -86,4 +152,21 @@ export function _trustLevelWeight(trustLevel: number | null): NodeWeight {
     throw new Error(`invalid trust level: ${String(key)}`);
   }
   return weight;
+}
+
+export function _categoryWeight(
+  category: MirrorCategoryId,
+  {categoryWeights, defaultCategoryWeight}: WeightsConfig
+): NodeWeight {
+  const weight = categoryWeights.get(category);
+  return weight == null ? defaultCategoryWeight : weight;
+}
+
+export function _weightFromTags(
+  tags: $ReadOnlyArray<Tag>,
+  {tagWeights, defaultTagWeight}: WeightsConfig
+): NodeWeight {
+  const weightForTag = (tagId: TagId) =>
+    either(tagWeights.get(tagId), defaultTagWeight);
+  return tags.reduce((acc, tag) => acc * weightForTag(tag), 1);
 }

--- a/src/plugins/discourse/weights.test.js
+++ b/src/plugins/discourse/weights.test.js
@@ -1,13 +1,32 @@
 // @flow
 
-import {_trustLevelWeight, likeWeight, parseCategoryId} from "./weights";
+import {
+  _trustLevelWeight,
+  _categoryWeight,
+  _weightFromTags,
+  likeWeight,
+  parseCategoryId,
+  weightsConfigParser,
+  type WeightsConfig,
+} from "./weights";
+
 import {DEFAULT_TRUST_LEVEL_TO_WEIGHT as weights} from "./createGraph";
+
+function getConfig(s?: Object): WeightsConfig {
+  return weightsConfigParser.parseOrThrow({
+    defaultTagWeight: 1,
+    defaultCategoryWeight: 1,
+    tagWeights: {},
+    categoryWeights: {},
+    ...s,
+  });
+}
 
 describe("plugins/discourse/weights", () => {
   describe("likeWeight", () => {
     it("has a weight of 0 for a null or undefined User", () => {
-      expect(likeWeight(null)).toEqual(0);
-      expect(likeWeight()).toEqual(0);
+      expect(likeWeight(getConfig(), null)).toEqual(0);
+      expect(likeWeight(getConfig())).toEqual(0);
     });
   });
 
@@ -23,6 +42,57 @@ describe("plugins/discourse/weights", () => {
           weights[trustLevel.toString()]
         );
       });
+    });
+  });
+
+  describe("_categoryWeight", () => {
+    it("returns the default weight when the category doesn't have a configured default weight", () => {
+      expect(_categoryWeight("1", getConfig())).toBe(1);
+    });
+    it("returns the default weight when the category doesn't have a set weight", () => {
+      expect(_categoryWeight("1", getConfig({defaultCategoryWeight: 3}))).toBe(
+        3
+      );
+    });
+    it("returns the configured weight", () => {
+      const config = getConfig({
+        defaultCategoryWeight: 2,
+        categoryWeights: {"1": 5},
+      });
+      expect(_categoryWeight("1", config)).toBe(5);
+    });
+    it("can return a weight set to 0", () => {
+      const config = getConfig({
+        defaultCategoryWeight: 7,
+        categoryWeights: {"1": 0},
+      });
+      expect(_categoryWeight("1", config)).toBe(0);
+    });
+  });
+
+  describe("_tagWeight", () => {
+    it("returns the default weight when the tag doesn't have a configured weight", () => {
+      expect(_weightFromTags(["tag"], getConfig())).toBe(1);
+    });
+    it("returns the default weight when the tag doesn't have a configured weight", () => {
+      const config = getConfig({
+        defaultTagWeight: 2,
+        tagWeights: {"you're": 5},
+      });
+      expect(_weightFromTags(["you're"], config)).toBe(5);
+    });
+    it("can return a weight set to 0", () => {
+      const config = getConfig({defaultTagWeight: 5, tagWeights: {"it": 0}});
+      expect(_weightFromTags(["it"], config)).toBe(0);
+    });
+    it("returns default tag weight when no tags are assigned", () => {
+      expect(_weightFromTags([], getConfig())).toBe(1);
+    });
+    it("returns the default tag weight when no individual tags are configured", () => {
+      const config = getConfig({
+        defaultTagWeight: 5,
+      });
+      expect(_weightFromTags(["you're", "good"], config)).toBe(25);
     });
   });
 


### PR DESCRIPTION
Tags and categories on a Topic can now be configured with individual weights,
which currently are multiplied together to yield the total weight each like
on a Post in a Topic  will contain in a graph.

Tags and Topic Category can be used in combination to create like-weight
 multipliers on Topics. This means that if any assigned tag or topic category
 is set to 0, all likes on that topic will mint zero cred.

# Tags
Tags can be configured to confer specific like-weight multipliers when
added to a Topic.
If a tag does not have a configured weight, the defaultWeight is applied.
An example configuration might look like:
```json
"weights": {
  "defaultTagWeight": 1,
  "tagWeights": {
    "foo": 0,
    "bar": 1.25,
    "baz": 2
  }
}
```
where foo and bar are the names of tags used in discourse.
  
When multiple tags are assigned to a topic, their weights are multiplied
together to yield a total tag Weight multiplier. In our example configuration,
if both foo and bar are added to a topic, likes on posts in the topic will
have a weight of 0, (0 * 1.25 = 0), which means that no cred will be minted
by those likes.
  
If "bar" and "baz" are both added to another topic, the likes on all posts
in that topic will carry a weight of 2.5 (1.25 * 2 = 2.5), which means that
2.5x as much cred will be minted by those likes.

# Categories
Categories can be configured to confer a specific like-weight multiplier
when added to a Topic.
If a category does not have a configured weight, the defaultWeight is applied.
An example configuration might look like:
```json
weights: {
 "defaultCategoryWeight": 1,
 "categoryWeights": {
   "5": 0,
   "36": 1.25
 }
}
```
where "5" and "36" are the categoryIds in discourse.
  
An easy way to find the categoryId for a given category is to browse to the
categories section in discourse
(e.g. https://discourse.sourcecred.io/categories).
Then mousing over or clicking on a category will bring you to a url that
has the shape https://exampleUrl.com/c/ \<category name\>/\<categoryId\>
Clicking on the community category in sourcecred navigates to
https://discourse.sourcecred.io/c/community/26 for example, where the
categoryId is 26

builds towards #2455

test plan: yarn unit