### PR TITLE
Ledger: move reuseable test code into testUtils

### DIFF
--- a/src/api/ledgerManager.test.js
+++ b/src/api/ledgerManager.test.js
@@ -4,28 +4,11 @@ import {Ledger} from "../core/ledger/ledger";
 import * as uuid from "../util/uuid";
 import {LedgerManager} from "./ledgerManager";
 import type {LedgerLog} from "../core/ledger/ledger";
-import * as G from "../core/ledger/grain";
-import {createUuidMock} from "../core/ledger/testUtils";
+import {g, id1, id2, createTestLedgerFixture} from "../core/ledger/testUtils";
+
+const {ledgerWithIdentities} = createTestLedgerFixture();
 
 describe("api/ledgerManager", () => {
-  // Helper for constructing Grain values.
-  const g = (s) => G.fromString(s);
-
-  const {resetFakeUuid, setNextUuid} = createUuidMock();
-
-  const id1 = uuid.fromString("YVZhbGlkVXVpZEF0TGFzdA");
-  const id2 = uuid.fromString("URgLrCxgvjHxtGJ9PgmckQ");
-
-  function ledgerWithIdentities() {
-    resetFakeUuid();
-    const ledger = new Ledger();
-    setNextUuid(id1);
-    ledger.createIdentity("USER", "steven");
-    setNextUuid(id2);
-    ledger.createIdentity("ORGANIZATION", "crystal-gems");
-    return ledger;
-  }
-
   const mockStorage = {
     read: jest.fn(() => Promise.resolve(new Ledger())),
     write: jest.fn((ledger: Ledger) => {

--- a/src/core/ledger/diffLedger.test.js
+++ b/src/core/ledger/diffLedger.test.js
@@ -1,26 +1,13 @@
 // @flow
 
 import {diffLedger} from "./diffLedger";
-import * as uuid from "../../util/uuid";
 import {Ledger} from "./ledger";
-import {createUuidMock} from "./testUtils"; // for spy purposes
+import {id1, id2, createTestLedgerFixture, createUuidMock} from "./testUtils";
+
+const uuidMock = createUuidMock();
+const {ledgerWithIdentities} = createTestLedgerFixture(uuidMock);
 
 describe("core/ledger/diffLedger", () => {
-  const {resetFakeUuid, setNextUuid} = createUuidMock();
-
-  const id1 = uuid.fromString("YVZhbGlkVXVpZEF0TGFzdA");
-  const id2 = uuid.fromString("URgLrCxgvjHxtGJ9PgmckQ");
-
-  function ledgerWithIdentities() {
-    resetFakeUuid();
-    const ledger = new Ledger();
-    setNextUuid(id1);
-    ledger.createIdentity("USER", "steven");
-    setNextUuid(id2);
-    ledger.createIdentity("ORGANIZATION", "crystal-gems");
-    return ledger;
-  }
-
   it("should handle the empty case", () => {
     const a = new Ledger();
     const b = new Ledger();
@@ -67,7 +54,7 @@ describe("core/ledger/diffLedger", () => {
     const aLedgerLog = a.eventLog();
 
     // Create a duplicate event out-of-order in b to test if it gets filtered
-    setNextUuid(aLedgerLog[aLedgerLog.length - 1].uuid);
+    uuidMock.setNextUuid(aLedgerLog[aLedgerLog.length - 1].uuid);
     b.activate(id2);
 
     // Create a new event in b to test if it gets ignored

--- a/src/core/ledger/ledger.test.js
+++ b/src/core/ledger/ledger.test.js
@@ -1,76 +1,37 @@
 // @flow
 
-import cloneDeep from "lodash.clonedeep";
 import {NodeAddress} from "../graph";
 import {Ledger} from "./ledger";
 import {newIdentity} from "../identity";
 import * as G from "./grain";
 import * as uuid from "../../util/uuid";
-import {createUuidMock} from "./testUtils"; // for spy purposes
+import {
+  createUuidMock,
+  failsWithoutMutation,
+  createDateMock,
+  createTestLedgerFixture,
+  id1,
+  id2,
+  id3,
+  g,
+} from "./testUtils";
+
+const uuidMock = createUuidMock();
+const dateMock = createDateMock();
+const {
+  identity1,
+  identity2,
+  ledgerWithIdentities,
+  ledgerWithActiveIdentities,
+} = createTestLedgerFixture(uuidMock, dateMock);
+const {resetFakeUuid, setNextUuid} = uuidMock;
+const {setFakeDate} = dateMock;
+
+const allocationId1: uuid.Uuid = uuid.random();
+const allocationId2: uuid.Uuid = uuid.random();
+const allocationId3: uuid.Uuid = uuid.random();
 
 describe("core/ledger/ledger", () => {
-  // Helper for constructing Grain values.
-  const g = (s) => G.fromString(s);
-
-  let nextFakeDate = 0;
-  function resetFakeDate() {
-    nextFakeDate = 0;
-  }
-  function setFakeDate(ts: number) {
-    // Use this when you want specific timestamps, rather than just
-    // auto-incrementing
-    jest.spyOn(global.Date, "now").mockImplementationOnce(() => ts);
-  }
-  jest.spyOn(global.Date, "now").mockImplementation(() => nextFakeDate++);
-
-  const {resetFakeUuid, setNextUuid} = createUuidMock();
-
-  const id1 = uuid.fromString("YVZhbGlkVXVpZEF0TGFzdA");
-  const id2 = uuid.fromString("URgLrCxgvjHxtGJ9PgmckQ");
-  const id3 = uuid.fromString("EpbMqV0HmcolKvpXTwSddA");
-
-  const allocationId1 = uuid.random();
-  const allocationId2 = uuid.random();
-  const allocationId3 = uuid.random();
-
-  // Verify that a method fails, throwing an error, without mutating the ledger.
-  function failsWithoutMutation(
-    ledger: Ledger,
-    operation: (Ledger) => any,
-    message: string
-  ) {
-    const copy = cloneDeep(ledger);
-    expect(() => operation(ledger)).toThrow(message);
-    expect(copy).toEqual(ledger);
-  }
-
-  const identity1 = () => {
-    setNextUuid(id1);
-    return newIdentity("USER", "steven");
-  };
-  const identity2 = () => {
-    setNextUuid(id2);
-    return newIdentity("ORGANIZATION", "crystal-gems");
-  };
-
-  function ledgerWithIdentities() {
-    resetFakeUuid();
-    resetFakeDate();
-    const ledger = new Ledger();
-    setNextUuid(id1);
-    ledger.createIdentity("USER", "steven");
-    setNextUuid(id2);
-    ledger.createIdentity("ORGANIZATION", "crystal-gems");
-    return ledger;
-  }
-
-  function ledgerWithActiveIdentities() {
-    const ledger = ledgerWithIdentities();
-    ledger.activate(id1);
-    ledger.activate(id2);
-    return ledger;
-  }
-
   const alias = {
     address: NodeAddress.fromParts(["alias"]),
     description: "alias",

--- a/src/core/ledger/testUtils.js
+++ b/src/core/ledger/testUtils.js
@@ -1,4 +1,9 @@
 // @flow
+
+import cloneDeep from "lodash.clonedeep";
+import {Ledger} from "./ledger";
+import {newIdentity, type Identity, type IdentityId} from "../identity";
+import * as G from "./grain";
 import * as uuid from "../../util/uuid";
 
 export interface UuidMock {
@@ -6,7 +11,19 @@ export interface UuidMock {
   setNextUuid(id: uuid.Uuid): void;
 }
 
-export function createUuidMock(): UuidMock {
+export interface DateMock {
+  resetFakeDate(): void;
+  setFakeDate(id: number): void;
+}
+
+export interface LedgerMock {
+  identity1(): Identity;
+  identity2(): Identity;
+  ledgerWithIdentities(): Ledger;
+  ledgerWithActiveIdentities(): Ledger;
+}
+
+export const createUuidMock = (): UuidMock => {
   const randomMock = jest.spyOn(uuid, "random");
 
   let nextFakeUuidIndex = 0;
@@ -26,6 +43,78 @@ export function createUuidMock(): UuidMock {
   }
 
   randomMock.mockImplementation(nextFakeUuid);
+  return {resetFakeUuid, setNextUuid};
+};
 
-  return {setNextUuid, resetFakeUuid};
+export const createDateMock = (): DateMock => {
+  let nextFakeDate = 0;
+
+  function resetFakeDate() {
+    nextFakeDate = 0;
+  }
+  function setFakeDate(ts: number) {
+    // Use this when you want specific timestamps, rather than just
+    // auto-incrementing
+    jest.spyOn(global.Date, "now").mockImplementationOnce(() => ts);
+  }
+  jest.spyOn(global.Date, "now").mockImplementation(() => nextFakeDate++);
+
+  return {setFakeDate, resetFakeDate};
+};
+
+export const createTestLedgerFixture = (
+  uuidMock: UuidMock = createUuidMock(),
+  dateMock: DateMock = createDateMock()
+): LedgerMock => {
+  const identity1 = (): Identity => {
+    uuidMock.setNextUuid(id1);
+    return newIdentity("USER", "steven");
+  };
+  const identity2 = (): Identity => {
+    uuidMock.setNextUuid(id2);
+    return newIdentity("ORGANIZATION", "crystal-gems");
+  };
+
+  const ledgerWithIdentities = (): Ledger => {
+    uuidMock.resetFakeUuid();
+    dateMock.resetFakeDate();
+    const ledger = new Ledger();
+    uuidMock.setNextUuid(id1);
+    ledger.createIdentity("USER", "steven");
+    uuidMock.setNextUuid(id2);
+    ledger.createIdentity("ORGANIZATION", "crystal-gems");
+    return ledger;
+  };
+
+  const ledgerWithActiveIdentities = (): Ledger => {
+    const ledger = ledgerWithIdentities();
+    ledger.activate(id1);
+    ledger.activate(id2);
+    return ledger;
+  };
+
+  return {
+    identity1,
+    identity2,
+    ledgerWithIdentities,
+    ledgerWithActiveIdentities,
+  };
+};
+
+// Helper for constructing Grain values.
+export const g = (s: string): G.Grain => G.fromString(s);
+
+export const id1: IdentityId = uuid.fromString("YVZhbGlkVXVpZEF0TGFzdA");
+export const id2: IdentityId = uuid.fromString("URgLrCxgvjHxtGJ9PgmckQ");
+export const id3: IdentityId = uuid.fromString("EpbMqV0HmcolKvpXTwSddA");
+
+// Verify that a method fails, throwing an error, without mutating the ledger.
+export function failsWithoutMutation(
+  ledger: Ledger,
+  operation: (Ledger) => any,
+  message: string
+) {
+  const copy = cloneDeep(ledger);
+  expect(() => operation(ledger)).toThrow(message);
+  expect(copy).toEqual(ledger);
 }


### PR DESCRIPTION
<!-- Please read our contributor guide before submitting your PR: -->
<!-- https://github.com/sourcecred/sourcecred/blob/master/CONTRIBUTING.md -->

# Description
Simple refactor to move some test code into the ledger/testUtils module because I want to reuse some of it for the CredGrainView tests.
<!-- Possible prompts:
  Why is the change important?
  Did you consider and reject alternate formulations of the same idea?
  Are there relevant issues or discussions elsewhere?
-->

# Test Plan
yarn test
<!-- Possible prompts:
  How well covered by automated tests is this change?
  How did you manually test this change? How can a reviewer replicate the tests?
-->
