### PR TITLE
Discourse: Convert CategoryId to string

### DIFF
--- a/src/plugins/discourse/createGraph.test.js
+++ b/src/plugins/discourse/createGraph.test.js
@@ -127,7 +127,7 @@ describe("plugins/discourse/createGraph", () => {
       tags: ["some", "example"],
       timestampMs: 0,
       authorUsername: "decentralion",
-      categoryId: 1,
+      categoryId: "1",
       bumpedMs: 0,
     };
     const post1 = {

--- a/src/plugins/discourse/fetch.js
+++ b/src/plugins/discourse/fetch.js
@@ -18,7 +18,7 @@ import {type TimestampMs} from "../../util/timestamp";
 export type UserId = number;
 export type PostId = number;
 export type TopicId = number;
-export type CategoryId = number;
+export type CategoryId = string;
 export type Tag = string;
 
 /**

--- a/src/plugins/discourse/mirror.test.js
+++ b/src/plugins/discourse/mirror.test.js
@@ -88,7 +88,7 @@ class MockFetcher implements Discourse {
 
   constructor() {
     // Start with 2, as category ID 1 is reserved as "uncategorized".
-    this._nextCategoryId = 2;
+    this._nextCategoryId = "2";
     this._nextTopicId = 1;
     this._nextPostId = 1;
     this._categories = new Set();
@@ -187,7 +187,7 @@ class MockFetcher implements Discourse {
     const timestampMs = 1000 + id;
     return {
       id,
-      categoryId: this._topicToCategory.get(id) || 1,
+      categoryId: this._topicToCategory.get(id) || "1",
       tags: ["example"],
       title: `topic ${id}`,
       timestampMs,
@@ -210,7 +210,7 @@ class MockFetcher implements Discourse {
   addCategory(topic?: $Shape<TopicOptions>): CreatedCategory {
     // Have the new Category exist.
     const categoryId = this._nextCategoryId;
-    this._nextCategoryId++;
+    this._nextCategoryId = String(parseInt(this._nextCategoryId, 10) + 1);
     this._categories.add(categoryId);
 
     // Add the Topic and Post.
@@ -229,7 +229,7 @@ class MockFetcher implements Discourse {
    */
   addTopic(topic?: TopicOptions): CreatedTopic {
     const {categoryId, authorUsername, cooked} = topic || {};
-    if (categoryId === 1) {
+    if (categoryId === "1") {
       throw new Error(
         `Category with ID 1 is reserved as uncategorized, please don't explicitly define it.`
       );

--- a/src/plugins/discourse/mirrorRepository.js
+++ b/src/plugins/discourse/mirrorRepository.js
@@ -216,7 +216,7 @@ export class SqliteMirrorRepository
       dedent`\
         CREATE TABLE topics (
             id INTEGER PRIMARY KEY,
-            category_id INTEGER NOT NULL,
+            category_id TEXT NOT NULL,
             title TEXT NOT NULL,
             timestamp_ms INTEGER NOT NULL,
             bumped_ms INTEGER NOT NULL,

--- a/src/plugins/discourse/mirrorRepository.test.js
+++ b/src/plugins/discourse/mirrorRepository.test.js
@@ -14,7 +14,7 @@ describe("plugins/discourse/mirrorRepository", () => {
       const repository = new SqliteMirrorRepository(db, url);
       const topic: Topic = {
         id: 123,
-        categoryId: 42,
+        categoryId: "42",
         tags: [],
         title: "Sample topic 1",
         timestampMs: 456789,
@@ -31,7 +31,7 @@ describe("plugins/discourse/mirrorRepository", () => {
       const repository = new SqliteMirrorRepository(db, url);
       const topic: Topic = {
         id: 123,
-        categoryId: 42,
+        categoryId: "42",
         tags: ["example", "some"],
         title: "Sample topic 1",
         timestampMs: 456789,
@@ -48,7 +48,7 @@ describe("plugins/discourse/mirrorRepository", () => {
       const repository = new SqliteMirrorRepository(db, url);
       const oldTopic: Topic = {
         id: 123,
-        categoryId: 42,
+        categoryId: "42",
         tags: ["example", "some"],
         title: "Sample topic 1",
         timestampMs: 456789,
@@ -57,7 +57,7 @@ describe("plugins/discourse/mirrorRepository", () => {
       };
       const newTopic: Topic = {
         id: 123,
-        categoryId: 42,
+        categoryId: "42",
         tags: ["example", "other"],
         title: "Sample topic 1",
         timestampMs: 456789,
@@ -75,7 +75,7 @@ describe("plugins/discourse/mirrorRepository", () => {
       const repository = new SqliteMirrorRepository(db, url);
       const topic: Topic = {
         id: 123,
-        categoryId: 42,
+        categoryId: "42",
         tags: ["c", "b", "a"],
         title: "Sample topic 1",
         timestampMs: 456789,
@@ -96,7 +96,7 @@ describe("plugins/discourse/mirrorRepository", () => {
       const repository = new SqliteMirrorRepository(db, url);
       const topic1: Topic = {
         id: 123,
-        categoryId: 42,
+        categoryId: "42",
         tags: ["example", "some"],
         title: "Sample topic 1",
         timestampMs: 456789,
@@ -105,7 +105,7 @@ describe("plugins/discourse/mirrorRepository", () => {
       };
       const topic2: Topic = {
         id: 124,
-        categoryId: 42,
+        categoryId: "42",
         tags: [],
         title: "Sample topic 2",
         timestampMs: 456789,
@@ -162,7 +162,7 @@ describe("plugins/discourse/mirrorRepository", () => {
     const repository = new SqliteMirrorRepository(db, url);
     const topic: Topic = {
       id: 123,
-      categoryId: 1,
+      categoryId: "1",
       tags: ["example", "some"],
       title: "Sample topic",
       timestampMs: 456789,
@@ -185,7 +185,7 @@ describe("plugins/discourse/mirrorRepository", () => {
     const repository = new SqliteMirrorRepository(db, url);
     const topic: Topic = {
       id: 123,
-      categoryId: 1,
+      categoryId: "1",
       tags: ["example", "some"],
       title: "Sample topic",
       timestampMs: 456789,
@@ -242,7 +242,7 @@ describe("plugins/discourse/mirrorRepository", () => {
     const repository = new SqliteMirrorRepository(db, url);
     const topic: Topic = {
       id: 123,
-      categoryId: 1,
+      categoryId: "1",
       tags: ["example", "some"],
       title: "Sample topic",
       timestampMs: 456789,
@@ -298,7 +298,7 @@ describe("plugins/discourse/mirrorRepository", () => {
     const repository = new SqliteMirrorRepository(db, url);
     const topic: Topic = {
       id: 123,
-      categoryId: 1,
+      categoryId: "1",
       tags: ["example", "some"],
       title: "Sample topic",
       timestampMs: 456789,
@@ -353,7 +353,7 @@ describe("plugins/discourse/mirrorRepository", () => {
     const repository = new SqliteMirrorRepository(db, url);
     const topic1: Topic = {
       id: 123,
-      categoryId: 42,
+      categoryId: "42",
       tags: ["example", "some"],
       title: "Sample topic 1",
       timestampMs: 456789,
@@ -362,7 +362,7 @@ describe("plugins/discourse/mirrorRepository", () => {
     };
     const topic2: Topic = {
       id: 456,
-      categoryId: 42,
+      categoryId: "42",
       tags: ["example", "some"],
       title: "Sample topic 2",
       timestampMs: 456789,
@@ -389,7 +389,7 @@ describe("plugins/discourse/mirrorRepository", () => {
     const repository = new SqliteMirrorRepository(db, url);
     const topic: Topic = {
       id: 123,
-      categoryId: 42,
+      categoryId: "42",
       tags: ["example", "some"],
       title: "Sample topic 1",
       timestampMs: 456789,
@@ -423,7 +423,7 @@ describe("plugins/discourse/mirrorRepository", () => {
     const repository = new SqliteMirrorRepository(db, url);
     const topic: Topic = {
       id: 123,
-      categoryId: 1,
+      categoryId: "1",
       tags: ["example", "some"],
       title: "Sample topic",
       timestampMs: 456789,
@@ -457,7 +457,7 @@ describe("plugins/discourse/mirrorRepository", () => {
     const repository = new SqliteMirrorRepository(db, url);
     const topic: Topic = {
       id: 123,
-      categoryId: 1,
+      categoryId: "1",
       tags: ["example", "some"],
       title: "Sample topic",
       timestampMs: 456789,
@@ -499,7 +499,7 @@ describe("plugins/discourse/mirrorRepository", () => {
     const repository = new SqliteMirrorRepository(db, url);
     const topic: Topic = {
       id: 123,
-      categoryId: 1,
+      categoryId: "1",
       tags: ["example", "some"],
       title: "Sample topic",
       timestampMs: 456789,

--- a/src/plugins/discourse/nodesAndEdges.test.js
+++ b/src/plugins/discourse/nodesAndEdges.test.js
@@ -14,7 +14,7 @@ describe("plugins/discourse/nodesAndEdges", () => {
       title: "first topic",
       timestampMs: 0,
       authorUsername: "decentralion",
-      categoryId: 1,
+      categoryId: "1",
       tags: ["some", "example"],
       bumpedMs: 0,
     };

--- a/src/plugins/discourse/referenceDetector.test.js
+++ b/src/plugins/discourse/referenceDetector.test.js
@@ -47,7 +47,7 @@ describe("plugins/discourse/referenceDetector", () => {
       const detector = new DiscourseReferenceDetector(repo);
       const topic: Topic = {
         id: 123,
-        categoryId: 1,
+        categoryId: "1",
         tags: ["some", "example"],
         title: "Sample topic",
         timestampMs: 456789,
@@ -77,7 +77,7 @@ describe("plugins/discourse/referenceDetector", () => {
       const detector = new DiscourseReferenceDetector(repo);
       const topic: Topic = {
         id: 123,
-        categoryId: 1,
+        categoryId: "1",
         tags: ["some", "example"],
         title: "Sample topic",
         timestampMs: 456789,


### PR DESCRIPTION
Even though categoryId is an integer, it makes little sense to
treat it as an such, since it's an identifier, and it has no 
relationship to to other identifiers.

test plan: yarn unit