### PR TITLE
Implement LedgerDiskStorage for LedgerManager

### DIFF
--- a/src/ui/utils/ledgerDiskStorage.js
+++ b/src/ui/utils/ledgerDiskStorage.js
@@ -1,0 +1,24 @@
+// @flow
+
+import type {LedgerStorage} from "../../api/ledgerManager";
+import {Ledger} from "../../core/ledger/ledger";
+
+export const createLedgerDiskStorage = (
+  ledgerFilePath: string
+): LedgerStorage => ({
+  read: async () => {
+    const response = await fetch(ledgerFilePath);
+    const rawLedger = await response.text();
+    return Ledger.parse(rawLedger);
+  },
+  write: async (ledger) => {
+    await fetch(ledgerFilePath, {
+      headers: {
+        Accept: "text/plain",
+        "Content-Type": "text/plain",
+      },
+      method: "POST",
+      body: ledger.serialize(),
+    });
+  },
+});


### PR DESCRIPTION
# Description

This implementation of LedgerStorage can be used in a locally running frontend to replace
our current method for loading and saving the ledger to the local filesystem. This storage
adapter can later be swapped out for one that talks to GitHub directly, allowing for instance
management without dealing with git and eventually without needing to run it locally once we
have our auth system in place


# Test Plan


Test Plan: Dont have unit tests in frontend code, so just sanity check that the implementation
looks right. Future PR will refactor the loading code to use this instead, that's when it can
be tested in the front end directly.

