### PR TITLE
Use LedgerManager to control loading ledger state on frontend

### DIFF
--- a/src/api/ledgerManager.js
+++ b/src/api/ledgerManager.js
@@ -106,7 +106,17 @@ export class LedgerManager {
    *    conflict with the local changes (e.g. double spend)
    */
   async reloadLedger(): Promise<ReloadResult> {
-    const remoteLedger = await this._storage.read();
+    let remoteLedger: Ledger;
+    try {
+      remoteLedger = await this._storage.read();
+    } catch (e) {
+      return {
+        error: e.message,
+        remoteChanges: [],
+        localChanges: [],
+      };
+    }
+
     const localChanges = this._getLocalChanges(remoteLedger);
     const remoteChanges = this._getRemoteChanges(remoteLedger);
 

--- a/src/ui/components/AdminApp.js
+++ b/src/ui/components/AdminApp.js
@@ -120,6 +120,7 @@ const AdminApp = (): ReactNode => {
         <div>
           <h1>Load Failure</h1>
           <p>Check console for details.</p>
+          <p>{loadResult.error}</p>
         </div>
       );
     case "SUCCESS":
@@ -140,7 +141,7 @@ const AdminInner = ({loadResult: loadSuccess}: AdminInnerProps) => {
 
   return (
     // TODO (@topocount) create context for read-only instance state
-    <LedgerProvider initialLedger={loadSuccess.ledger}>
+    <LedgerProvider ledgerManager={loadSuccess.ledgerManager}>
       <Admin
         layout={createAppLayout(loadSuccess)}
         theme={theme}

--- a/src/ui/components/LedgerAdmin.js
+++ b/src/ui/components/LedgerAdmin.js
@@ -98,12 +98,12 @@ export const LedgerAdmin = (): ReactNode => {
 
   const renderIdentities = () => {
     const renderIdentity = (i: Identity, notLastElement: boolean) => (
-      <>
-        <ListItem button onClick={() => setActiveIdentity(i)} key={i.id}>
+      <span key={i.id}>
+        <ListItem button onClick={() => setActiveIdentity(i)}>
           {i.name}
         </ListItem>
         {notLastElement && <Divider />}
-      </>
+      </span>
     );
     const numAccounts = ledger.accounts().length;
     return (

--- a/src/ui/utils/LedgerContext.js
+++ b/src/ui/utils/LedgerContext.js
@@ -2,6 +2,7 @@
 
 import * as React from "react";
 import {Ledger} from "../../core/ledger/ledger";
+import {LedgerManager} from "../../api/ledgerManager";
 
 const LedgerContext = React.createContext<LedgerContextValue>({
   ledger: new Ledger(),
@@ -14,17 +15,21 @@ type LedgerContextValue = {|
 |};
 
 type LedgerProviderProps = {|
-  +initialLedger: Ledger,
+  +ledgerManager: LedgerManager,
   +children: React.Node,
 |};
 
 export const LedgerProvider = ({
   children,
-  initialLedger,
+  ledgerManager,
 }: LedgerProviderProps): React.Node => {
-  const [{ledger}, setLedgerState] = React.useState({ledger: initialLedger});
+  const [{ledger}, setLedgerState] = React.useState({
+    ledger: ledgerManager.ledger,
+  });
 
-  const updateLedger = (ledger: Ledger) => setLedgerState({ledger});
+  // Workaround to trigger UI update in React since ledger object is mutable
+  const updateLedger = (_?: Ledger) =>
+    setLedgerState({ledger: ledgerManager.ledger});
 
   return (
     <LedgerContext.Provider value={{ledger, updateLedger}}>


### PR DESCRIPTION
# Description

Replaces the manual loading method used previously to using the LedgerManager to abstract
the loading logic. Can be used to enable different ledger storage backends in the future.

# Test Plan

- Ensure ledger still loads correctly and UI updates when making ledger changes
- Edit the ledger.json to include a "bad" event (e.g. double spending grain in a grain transfer) and ensure that loading the ledger fails on the front end

![image](https://user-images.githubusercontent.com/7143583/105441167-36ed5180-5c25-11eb-9ca1-72066484fb9a.png)
