### PR TITLE
Bugfix: Explicitly stringify Discourse CategoryIds

### DIFF
--- a/src/plugins/discourse/__snapshots__/fetch.test.js.snap
+++ b/src/plugins/discourse/__snapshots__/fetch.test.js.snap
@@ -37,7 +37,7 @@ Object {
   ],
   "topic": Object {
     "authorUsername": "d11",
-    "categoryId": 1,
+    "categoryId": "1",
     "id": 11,
     "tags": Array [],
     "timestampMs": 1564744349408,
@@ -303,7 +303,7 @@ Needing at least &gt; 20 posts.</p>",
   ],
   "topic": Object {
     "authorUsername": "beanow.sc-test",
-    "categoryId": 6,
+    "categoryId": "6",
     "id": 26,
     "tags": Array [],
     "timestampMs": 1573839733506,
@@ -324,7 +324,7 @@ exports[`plugins/discourse/fetch snapshot testing loads topics ordered by bumped
 Array [
   Object {
     "bumpedMs": 1554938179399,
-    "categoryId": 1,
+    "categoryId": "1",
     "id": 7,
     "tags": Array [],
     "timestampMs": 1554236412879,
@@ -332,7 +332,7 @@ Array [
   },
   Object {
     "bumpedMs": 1609910999621,
-    "categoryId": 5,
+    "categoryId": "5",
     "id": 37,
     "tags": Array [
       "a-special-topic",
@@ -343,7 +343,7 @@ Array [
   },
   Object {
     "bumpedMs": 1609910679216,
-    "categoryId": 1,
+    "categoryId": "1",
     "id": 58,
     "tags": Array [],
     "timestampMs": 1609910679121,
@@ -351,7 +351,7 @@ Array [
   },
   Object {
     "bumpedMs": 1573840598964,
-    "categoryId": 5,
+    "categoryId": "5",
     "id": 57,
     "tags": Array [],
     "timestampMs": 1573840598902,
@@ -359,7 +359,7 @@ Array [
   },
   Object {
     "bumpedMs": 1573840590166,
-    "categoryId": 5,
+    "categoryId": "5",
     "id": 56,
     "tags": Array [],
     "timestampMs": 1573840590101,
@@ -367,7 +367,7 @@ Array [
   },
   Object {
     "bumpedMs": 1573840580352,
-    "categoryId": 5,
+    "categoryId": "5",
     "id": 55,
     "tags": Array [],
     "timestampMs": 1573840580295,
@@ -375,7 +375,7 @@ Array [
   },
   Object {
     "bumpedMs": 1573840574181,
-    "categoryId": 5,
+    "categoryId": "5",
     "id": 54,
     "tags": Array [],
     "timestampMs": 1573840574124,
@@ -383,7 +383,7 @@ Array [
   },
   Object {
     "bumpedMs": 1573840567788,
-    "categoryId": 5,
+    "categoryId": "5",
     "id": 53,
     "tags": Array [],
     "timestampMs": 1573840567727,
@@ -391,7 +391,7 @@ Array [
   },
   Object {
     "bumpedMs": 1573840562068,
-    "categoryId": 5,
+    "categoryId": "5",
     "id": 52,
     "tags": Array [],
     "timestampMs": 1573840562010,
@@ -399,7 +399,7 @@ Array [
   },
   Object {
     "bumpedMs": 1573840551728,
-    "categoryId": 5,
+    "categoryId": "5",
     "id": 51,
     "tags": Array [],
     "timestampMs": 1573840551656,
@@ -407,7 +407,7 @@ Array [
   },
   Object {
     "bumpedMs": 1573840544868,
-    "categoryId": 5,
+    "categoryId": "5",
     "id": 50,
     "tags": Array [],
     "timestampMs": 1573840544797,
@@ -415,7 +415,7 @@ Array [
   },
   Object {
     "bumpedMs": 1573840538301,
-    "categoryId": 5,
+    "categoryId": "5",
     "id": 49,
     "tags": Array [],
     "timestampMs": 1573840538246,
@@ -423,7 +423,7 @@ Array [
   },
   Object {
     "bumpedMs": 1573840532029,
-    "categoryId": 5,
+    "categoryId": "5",
     "id": 48,
     "tags": Array [],
     "timestampMs": 1573840531935,
@@ -431,7 +431,7 @@ Array [
   },
   Object {
     "bumpedMs": 1573840525734,
-    "categoryId": 5,
+    "categoryId": "5",
     "id": 47,
     "tags": Array [],
     "timestampMs": 1573840525656,
@@ -439,7 +439,7 @@ Array [
   },
   Object {
     "bumpedMs": 1573840516283,
-    "categoryId": 5,
+    "categoryId": "5",
     "id": 46,
     "tags": Array [],
     "timestampMs": 1573840516235,
@@ -447,7 +447,7 @@ Array [
   },
   Object {
     "bumpedMs": 1573840509355,
-    "categoryId": 5,
+    "categoryId": "5",
     "id": 45,
     "tags": Array [],
     "timestampMs": 1573840509297,
@@ -455,7 +455,7 @@ Array [
   },
   Object {
     "bumpedMs": 1573840503032,
-    "categoryId": 5,
+    "categoryId": "5",
     "id": 44,
     "tags": Array [],
     "timestampMs": 1573840502978,
@@ -463,7 +463,7 @@ Array [
   },
   Object {
     "bumpedMs": 1573840496395,
-    "categoryId": 5,
+    "categoryId": "5",
     "id": 43,
     "tags": Array [],
     "timestampMs": 1573840496337,
@@ -471,7 +471,7 @@ Array [
   },
   Object {
     "bumpedMs": 1573840486299,
-    "categoryId": 5,
+    "categoryId": "5",
     "id": 42,
     "tags": Array [],
     "timestampMs": 1573840486242,
@@ -479,7 +479,7 @@ Array [
   },
   Object {
     "bumpedMs": 1573840480604,
-    "categoryId": 5,
+    "categoryId": "5",
     "id": 41,
     "tags": Array [],
     "timestampMs": 1573840480538,
@@ -487,7 +487,7 @@ Array [
   },
   Object {
     "bumpedMs": 1573840474450,
-    "categoryId": 5,
+    "categoryId": "5",
     "id": 40,
     "tags": Array [],
     "timestampMs": 1573840474386,
@@ -495,7 +495,7 @@ Array [
   },
   Object {
     "bumpedMs": 1573840469806,
-    "categoryId": 5,
+    "categoryId": "5",
     "id": 39,
     "tags": Array [],
     "timestampMs": 1573840469748,
@@ -503,7 +503,7 @@ Array [
   },
   Object {
     "bumpedMs": 1573840464212,
-    "categoryId": 5,
+    "categoryId": "5",
     "id": 38,
     "tags": Array [],
     "timestampMs": 1573840464152,
@@ -511,7 +511,7 @@ Array [
   },
   Object {
     "bumpedMs": 1573840428729,
-    "categoryId": 5,
+    "categoryId": "5",
     "id": 36,
     "tags": Array [],
     "timestampMs": 1573840428677,
@@ -519,7 +519,7 @@ Array [
   },
   Object {
     "bumpedMs": 1573840372677,
-    "categoryId": 5,
+    "categoryId": "5",
     "id": 35,
     "tags": Array [],
     "timestampMs": 1573840372613,
@@ -527,7 +527,7 @@ Array [
   },
   Object {
     "bumpedMs": 1573840366708,
-    "categoryId": 5,
+    "categoryId": "5",
     "id": 34,
     "tags": Array [],
     "timestampMs": 1573840366625,
@@ -535,7 +535,7 @@ Array [
   },
   Object {
     "bumpedMs": 1573840360335,
-    "categoryId": 5,
+    "categoryId": "5",
     "id": 33,
     "tags": Array [],
     "timestampMs": 1573840360253,
@@ -543,7 +543,7 @@ Array [
   },
   Object {
     "bumpedMs": 1573840354669,
-    "categoryId": 5,
+    "categoryId": "5",
     "id": 32,
     "tags": Array [],
     "timestampMs": 1573840354599,
@@ -551,7 +551,7 @@ Array [
   },
   Object {
     "bumpedMs": 1573840348410,
-    "categoryId": 5,
+    "categoryId": "5",
     "id": 31,
     "tags": Array [],
     "timestampMs": 1573840348348,
@@ -559,7 +559,7 @@ Array [
   },
   Object {
     "bumpedMs": 1573840335123,
-    "categoryId": 5,
+    "categoryId": "5",
     "id": 30,
     "tags": Array [],
     "timestampMs": 1573840335060,
@@ -567,7 +567,7 @@ Array [
   },
   Object {
     "bumpedMs": 1573840310550,
-    "categoryId": 5,
+    "categoryId": "5",
     "id": 29,
     "tags": Array [],
     "timestampMs": 1573840310488,
@@ -575,7 +575,7 @@ Array [
   },
   Object {
     "bumpedMs": 1573840233231,
-    "categoryId": 5,
+    "categoryId": "5",
     "id": 28,
     "tags": Array [],
     "timestampMs": 1573840233177,
@@ -583,7 +583,7 @@ Array [
   },
   Object {
     "bumpedMs": 1573840159198,
-    "categoryId": 5,
+    "categoryId": "5",
     "id": 27,
     "tags": Array [],
     "timestampMs": 1573840159140,
@@ -591,7 +591,7 @@ Array [
   },
   Object {
     "bumpedMs": 1573839872244,
-    "categoryId": 6,
+    "categoryId": "6",
     "id": 26,
     "tags": Array [],
     "timestampMs": 1573839733506,
@@ -599,7 +599,7 @@ Array [
   },
   Object {
     "bumpedMs": 1571855191281,
-    "categoryId": 1,
+    "categoryId": "1",
     "id": 21,
     "tags": Array [],
     "timestampMs": 1571855191140,
@@ -607,7 +607,7 @@ Array [
   },
   Object {
     "bumpedMs": 1570420159922,
-    "categoryId": 1,
+    "categoryId": "1",
     "id": 20,
     "tags": Array [],
     "timestampMs": 1570420159868,
@@ -615,7 +615,7 @@ Array [
   },
   Object {
     "bumpedMs": 1570049836311,
-    "categoryId": 1,
+    "categoryId": "1",
     "id": 19,
     "tags": Array [],
     "timestampMs": 1570049491690,
@@ -623,7 +623,7 @@ Array [
   },
   Object {
     "bumpedMs": 1570049410625,
-    "categoryId": 1,
+    "categoryId": "1",
     "id": 18,
     "tags": Array [],
     "timestampMs": 1570049410568,
@@ -631,7 +631,7 @@ Array [
   },
   Object {
     "bumpedMs": 1564951839667,
-    "categoryId": 1,
+    "categoryId": "1",
     "id": 11,
     "tags": Array [],
     "timestampMs": 1564744349408,
@@ -639,7 +639,7 @@ Array [
   },
   Object {
     "bumpedMs": 1564744632755,
-    "categoryId": 1,
+    "categoryId": "1",
     "id": 13,
     "tags": Array [],
     "timestampMs": 1564744553843,

--- a/src/plugins/discourse/fetch.js
+++ b/src/plugins/discourse/fetch.js
@@ -282,7 +282,7 @@ export class Fetcher implements Discourse {
     const tags = json.tags || [];
     const topic: TopicView = {
       id: json.id,
-      categoryId: json.category_id,
+      categoryId: json.category_id.toString(),
       title: json.title,
       tags,
       timestampMs: Date.parse(json.created_at),
@@ -418,7 +418,7 @@ function parseLatestTopic(json: any): TopicLatest {
 
   return {
     id: json.id,
-    categoryId: json.category_id,
+    categoryId: json.category_id.toString(),
     tags: json.tags,
     title: json.title,
     timestampMs: Date.parse(json.created_at),


### PR DESCRIPTION
When refactoring Discourse CategoryIds to be strings instead of ints, I
was initially relying on the sqlite mirror to implicitly convert the
integers to strings. Testing on the sqlite console had returned expected
results. However, I had not considered the middleware we use to
interact with sqlite DB's, and in integration testing it was found that
the categoryId strings all contained an appended `.0`.

These appended zero-value decimals cause lookup mismatches downstream
when like-weights are calculated, and rather than applying the expected
weight, the default weight is applied.

For example, if I have the following configuration:
```json
categoryWeights: {
  "16": 5
}
```

the topic's categoryId loaded into memory from sqlite would be `16.0`,
and in `_categoryWeight` the lookup `weights.get(`16.0`)` will return
`undefined` and the defaultWeight will be assigned. This means the that
`weights.get(`16`) will never execute and the configured weight of 5
will never be applied.

By calling `toString` on the `category_id` api-returned value as soon as we
receive the response from the discourse API, we bypass this issue, and
moreover, conform to flow's expectation that topic.categoryId is a
string immediately.

# Test Plan
```bash
yarn unit
```
On a local instance of the sc's cred repo:
1. Optionally remove all plugins from sourcecred.json except for 
`sourcecred/discourse` to speed up testing.
2. Run `sourcecred.js go && sourcecred.js serve`and observe the 
current users' cred values.
3. Add category configs in the discourse config so it appears like so:
```json
{
  "serverUrl": "https://discourse.sourcecred.io",
  "weights": {
    "categoryWeights": {
      "13": 5,
      "26": 5
    }
  }
}
```
4. run `sourcecred.js go --no-load && sourcecred.js serve`
5. Observe the cred values increase

I considered writing some defensive tests for mirror and/or
mirrorRepository to capture the issue detailed above, but if we just
stringify the result immediately, I'm not sure it's worth writing them.

ht to @s-ben for finding this bug