### PR TITLE
Refactor Explorer admin UI components into their own files

### DIFF
--- a/src/ui/components/Explorer/FilterSelect.js
+++ b/src/ui/components/Explorer/FilterSelect.js
@@ -1,0 +1,144 @@
+// @flow
+import React, {type Node as ReactNode} from "react";
+import {
+  Menu,
+  MenuItem,
+  ListItem,
+  ListItemText,
+  List,
+  Divider,
+} from "@material-ui/core";
+import KeyboardArrowDownIcon from "@material-ui/icons/KeyboardArrowDown";
+import KeyboardArrowUpIcon from "@material-ui/icons/KeyboardArrowUp";
+import {makeStyles} from "@material-ui/core/styles";
+import {CredView} from "../../../analysis/credView";
+import {type NodeAddressT} from "../../../core/graph";
+import {type PluginDeclaration} from "../../../analysis/pluginDeclaration";
+
+const styles = makeStyles(() => ({
+  menuHeader: {fontWeight: "bold"},
+  divider: {backgroundColor: "#F20057", height: "2px"},
+}));
+
+export type FilterState = {|
+  // Whether to filter down to a particular type prefix.
+  // If unset, shows all user-typed nodes
+  filter: NodeAddressT | null,
+  anchorEl: HTMLElement | null,
+  name: string | null,
+|};
+
+export const DEFAULT_FILTER: FilterState = {
+  anchorEl: null,
+  filter: null,
+  name: "All users",
+};
+
+const FilterSelect = ({
+  credView,
+  filterState,
+  setFilterState,
+}: {
+  credView: CredView,
+  filterState: FilterState,
+  setFilterState: (FilterState) => void,
+}): ReactNode => {
+  const plugins = credView.plugins();
+
+  const handleMenuClose = () =>
+    setFilterState({...filterState, anchorEl: null});
+
+  const optionGroup = (declaration: PluginDeclaration) => {
+    const header = (
+      <MenuItem
+        key={declaration.nodePrefix}
+        value={declaration.nodePrefix}
+        className={styles.menuHeader}
+        onClick={() =>
+          setFilterState({
+            anchorEl: null,
+            filter: declaration.nodePrefix,
+            name: declaration.name,
+          })
+        }
+      >
+        {declaration.name}
+      </MenuItem>
+    );
+    const entries = declaration.nodeTypes.map((type, index) => (
+      <MenuItem
+        key={index}
+        value={type.prefix}
+        onClick={() =>
+          setFilterState({
+            anchorEl: null,
+            filter: type.prefix,
+            name: type.name,
+          })
+        }
+      >
+        {"\u2003" + type.name}
+      </MenuItem>
+    ));
+    return [header, ...entries];
+  };
+  return (
+    <>
+      <List component="div" aria-label="Device settings">
+        <ListItem
+          button
+          aria-haspopup="true"
+          aria-controls="filter-menu"
+          aria-label="filters"
+          onClick={(event) =>
+            setFilterState({
+              ...filterState,
+              anchorEl: event.currentTarget,
+            })
+          }
+        >
+          <ListItemText
+            primary={
+              filterState.name ? `Filter: ${filterState.name}` : "Filter"
+            }
+          />
+          {filterState.anchorEl ? (
+            <KeyboardArrowUpIcon />
+          ) : (
+            <KeyboardArrowDownIcon />
+          )}
+        </ListItem>
+        <Divider className={styles.divider} />
+      </List>
+
+      <Menu
+        id="lock-menu"
+        anchorEl={filterState.anchorEl}
+        keepMounted
+        open={Boolean(filterState.anchorEl)}
+        onClose={handleMenuClose}
+        getContentAnchorEl={null}
+        anchorOrigin={{vertical: "bottom", horizontal: "left"}}
+        transformOrigin={{vertical: "top", horizontal: "left"}}
+      >
+        <MenuItem
+          key={"All users"}
+          value={""}
+          className={styles.menuHeader}
+          onClick={() =>
+            setFilterState({
+              anchorEl: null,
+              filter: null,
+              name: "All users",
+            })
+          }
+        >
+          All users
+        </MenuItem>
+        {plugins.map(optionGroup)}
+      </Menu>
+    </>
+  );
+};
+
+export default FilterSelect;

--- a/src/ui/components/Explorer/WeightsConfigSection.js
+++ b/src/ui/components/Explorer/WeightsConfigSection.js
@@ -1,0 +1,95 @@
+// @flow
+import React, {type Node as ReactNode} from "react";
+import {Grid, Slider} from "@material-ui/core";
+import {makeStyles} from "@material-ui/core/styles";
+import {format} from "d3-format";
+import {CredView} from "../../../analysis/credView";
+import {type TimelineCredParameters} from "../../../analysis/timeline/params";
+import {type WeightsT} from "../../../core/weights";
+import {WeightConfig} from "../../weights/WeightConfig";
+import {WeightsFileManager} from "../../weights/WeightsFileManager";
+
+export type WeightConfigSectionProps = {|
+  show: boolean,
+  credView: CredView,
+  weights: WeightsT,
+  setWeightsState: ({weights: WeightsT}) => void,
+  params: TimelineCredParameters,
+  setParams: (TimelineCredParameters) => void,
+|};
+
+const useStyles = makeStyles(() => ({
+  weightConfig: {
+    marginTop: 10,
+  },
+}));
+
+const WeightsConfigSection = ({
+  show,
+  credView,
+  weights,
+  setWeightsState,
+  params,
+  setParams,
+}: WeightConfigSectionProps): ReactNode => {
+  if (!show) return [];
+
+  const classes = useStyles();
+
+  return (
+    <Grid container>
+      <Grid container className={classes.weightConfig} spacing={2}>
+        <Grid container item xs={12} direction="column">
+          <Grid>
+            <Grid>Upload/Download weights:</Grid>
+            <Grid>
+              <WeightsFileManager
+                weights={weights}
+                onWeightsChange={(weights: WeightsT) => {
+                  setWeightsState({weights});
+                }}
+              />
+            </Grid>
+          </Grid>
+          <Grid container item spacing={2} alignItems="center">
+            <Grid>α</Grid>
+            <Grid item xs={2}>
+              <Slider
+                value={params.alpha}
+                min={0.05}
+                max={0.95}
+                step={0.05}
+                valueLabelDisplay="auto"
+                onChange={(_, val) => {
+                  setParams({
+                    ...params,
+                    alpha: val,
+                  });
+                }}
+              />
+            </Grid>
+            <Grid>{format(".2f")(params.alpha)}</Grid>
+          </Grid>
+        </Grid>
+        <Grid spacing={2} container item xs={12} style={{display: "flex"}}>
+          <WeightConfig
+            declarations={credView.plugins()}
+            nodeWeights={weights.nodeWeights}
+            edgeWeights={weights.edgeWeights}
+            onNodeWeightChange={(prefix, weight) => {
+              weights.nodeWeights.set(prefix, weight);
+
+              setWeightsState({weights});
+            }}
+            onEdgeWeightChange={(prefix, weight) => {
+              weights.edgeWeights.set(prefix, weight);
+              setWeightsState({weights});
+            }}
+          />
+        </Grid>
+      </Grid>
+    </Grid>
+  );
+};
+
+export default WeightsConfigSection;


### PR DESCRIPTION
# Description
In the course of prepping to do issue #2464, I saw some refactoring that was due for the Explorer page in the admin UI. This is a pure refactoring PR with no functional changes.

- Factor out FilterSelect and WeightsConfigSection components
- Convert from aphrodite to material-ui style creation


# Test Plan
Tested manually. Here are some before and after screenshots (yes they are supposed to be identical)
## Before
<img width="1772" alt="Explorer list before" src="https://user-images.githubusercontent.com/225508/104918965-d5fc1a00-5995-11eb-9c49-10ba14f7894e.png">
<img width="1772" alt="Explorer weights before" src="https://user-images.githubusercontent.com/225508/104918977-d7c5dd80-5995-11eb-9cc3-f354f829366b.png">

## After
<img width="1772" alt="Explorer list after" src="https://user-images.githubusercontent.com/225508/104919026-e6ac9000-5995-11eb-8087-5e33f33ec292.png">
<img width="1772" alt="Explorer weights after" src="https://user-images.githubusercontent.com/225508/104919035-e9a78080-5995-11eb-94a5-35e0704b7327.png">