### PR TITLE
core/ledger: add NonnegativeGrain type

### DIFF
--- a/src/core/ledger/nonnegativeGrain.js
+++ b/src/core/ledger/nonnegativeGrain.js
@@ -1,0 +1,39 @@
+// @flow
+
+import * as G from "./grain";
+import * as P from "../../util/combo";
+
+/**
+ * The NonnegativeGrain type ensures Grain amount is >= 0,
+ * which is particularly useful in the case of policy budgets
+ * or grain transfers.
+ */
+export opaque type NonnegativeGrain: G.Grain = G.Grain;
+
+export function fromGrain(g: G.Grain): NonnegativeGrain {
+  if (G.lt(g, G.ZERO)) {
+    throw new Error(`Grain amount must be nonnegative, got ${g}`);
+  }
+  return g;
+}
+
+export function fromInteger(n: number): NonnegativeGrain {
+  return fromGrain(G.fromInteger(n));
+}
+
+export function fromString(s: string): NonnegativeGrain {
+  return fromGrain(G.fromString(s));
+}
+
+export const grainParser: P.Parser<NonnegativeGrain> = P.fmap(
+  G.parser,
+  fromGrain
+);
+export const numberParser: P.Parser<NonnegativeGrain> = P.fmap(
+  P.number,
+  fromInteger
+);
+export const stringParser: P.Parser<NonnegativeGrain> = P.fmap(
+  P.string,
+  fromString
+);

--- a/src/core/ledger/nonnegativeGrain.test.js
+++ b/src/core/ledger/nonnegativeGrain.test.js
@@ -1,0 +1,56 @@
+// @flow
+
+import {fromGrain, fromInteger, fromString} from "./nonnegativeGrain";
+import {ONE, type Grain} from "./grain";
+import {g} from "./testUtils";
+
+describe("core/ledger/nonnegativeGrain", () => {
+  describe("fromGrain", () => {
+    it("fromGrain works on valid Grain values", () => {
+      expect(fromGrain(ONE)).toEqual(ONE);
+    });
+    it("errors on -1", () => {
+      const negativeOne: Grain = g("-1");
+      expect(() => fromGrain(negativeOne)).toThrowError(
+        "Grain amount must be nonnegative"
+      );
+    });
+  });
+
+  describe("fromString", () => {
+    it("fromString works on valid Grain values", () => {
+      expect(fromString(ONE)).toEqual(ONE);
+    });
+    it("fromString errors on invalid Grain values", () => {
+      expect(() => fromString("123.4")).toThrowError("Invalid integer: 123.4");
+    });
+    it("errors on -1", () => {
+      expect(() => fromString("-1")).toThrowError(
+        "Grain amount must be nonnegative"
+      );
+    });
+  });
+
+  describe("fromInteger", () => {
+    it("works on 0", () => {
+      expect(fromInteger(0)).toEqual("0");
+    });
+    it("works on 1", () => {
+      expect(fromInteger(1)).toEqual(ONE);
+    });
+    it("works on 3", () => {
+      expect(fromInteger(3)).toEqual("3000000000000000000");
+    });
+    it("errors on -1", () => {
+      expect(() => fromInteger(-1)).toThrowError(
+        "Grain amount must be nonnegative"
+      );
+    });
+    it("errors for non-integers", () => {
+      for (const bad of [1.2, NaN, Infinity, -Infinity]) {
+        const thunk = () => fromInteger(bad);
+        expect(thunk).toThrowError(`not an integer: ${bad}`);
+      }
+    });
+  });
+});


### PR DESCRIPTION
__Context__
This commit adds a `NonnegativeGrain` type which will be used
by grain allocation policies for the type of their budgets.  This helps
push a subspace of error handling onto Flow.

`NonnegativeGrain` is implemented as an opaque type similar to Grain,
with stricter lifting functions which check for nonnegativity.

__Test Plan__
Unit tests for `NonnegativeGrain` are provided.  The tests are forks of
tests on `Grain`.
