### PR TITLE
policies: Use NonnegativeGrain as budget type

### DIFF
--- a/src/api/grainConfig.js
+++ b/src/api/grainConfig.js
@@ -1,9 +1,9 @@
 // @flow
 
 import {type DistributionPolicy} from "../core/ledger/applyDistributions";
-import * as G from "../core/ledger/grain";
 import * as C from "../util/combo";
 import * as NullUtil from "../util/null";
+import {fromInteger as toNonnegativeGrain} from "../core/ledger/nonnegativeGrain";
 import {toDiscount} from "../core/ledger/policies/recent";
 
 export type GrainConfig = {|
@@ -49,10 +49,11 @@ export function toDistributionPolicy(x: GrainConfig): DistributionPolicy {
       `balanced budget must be nonnegative integer, got ${balancedPerWeek}`
     );
   }
+
   const allocationPolicies = [];
   if (immediatePerWeek > 0) {
     allocationPolicies.push({
-      budget: G.fromInteger(immediatePerWeek),
+      budget: toNonnegativeGrain(immediatePerWeek),
       policyType: "IMMEDIATE",
     });
   }
@@ -62,14 +63,14 @@ export function toDistributionPolicy(x: GrainConfig): DistributionPolicy {
       throw new Error(`no recentWeeklyDecayRate specified for recent policy`);
     }
     allocationPolicies.push({
-      budget: G.fromInteger(recentPerWeek),
+      budget: toNonnegativeGrain(recentPerWeek),
       policyType: "RECENT",
       discount: toDiscount(recentWeeklyDecayRate),
     });
   }
   if (balancedPerWeek > 0) {
     allocationPolicies.push({
-      budget: G.fromInteger(balancedPerWeek),
+      budget: toNonnegativeGrain(balancedPerWeek),
       policyType: "BALANCED",
     });
   }

--- a/src/api/grainConfig.test.js
+++ b/src/api/grainConfig.test.js
@@ -3,7 +3,7 @@
 import {parser, toDistributionPolicy, type GrainConfig} from "./grainConfig";
 import {type DistributionPolicy} from "../core/ledger/applyDistributions";
 import {toDiscount} from "../core/ledger/policies/recent";
-import {fromInteger} from "../core/ledger/grain";
+import {fromInteger as toNonnegativeGrain} from "../core/ledger/nonnegativeGrain";
 
 describe("api/grainConfig", () => {
   describe("parser", () => {
@@ -106,16 +106,16 @@ describe("api/grainConfig", () => {
       const expectedDistributionPolicy: DistributionPolicy = {
         allocationPolicies: [
           {
-            budget: fromInteger(20),
+            budget: toNonnegativeGrain(20),
             policyType: "IMMEDIATE",
           },
           {
-            budget: fromInteger(30),
+            budget: toNonnegativeGrain(30),
             policyType: "RECENT",
             discount: toDiscount(0.1),
           },
           {
-            budget: fromInteger(10),
+            budget: toNonnegativeGrain(10),
             policyType: "BALANCED",
           },
         ],

--- a/src/api/ledgerManager.test.js
+++ b/src/api/ledgerManager.test.js
@@ -4,7 +4,13 @@ import {Ledger} from "../core/ledger/ledger";
 import * as uuid from "../util/uuid";
 import {LedgerManager} from "./ledgerManager";
 import type {LedgerLog} from "../core/ledger/ledger";
-import {g, id1, id2, createTestLedgerFixture} from "../core/ledger/testUtils";
+import {
+  g,
+  nng,
+  id1,
+  id2,
+  createTestLedgerFixture,
+} from "../core/ledger/testUtils";
 
 const {ledgerWithIdentities} = createTestLedgerFixture();
 
@@ -31,7 +37,7 @@ describe("api/ledgerManager", () => {
   };
 
   const allocation = {
-    policy: {policyType: "IMMEDIATE", budget: g("15")},
+    policy: {policyType: "IMMEDIATE", budget: nng("15")},
     id: uuid.random(),
     receipts: [
       {amount: g("10"), id: id1},

--- a/src/core/credGrainView.test.js
+++ b/src/core/credGrainView.test.js
@@ -3,7 +3,7 @@
 import {CredGrainView} from "./credGrainView";
 import * as GraphUtil from "./credrank/testUtils";
 import {createTestLedgerFixture} from "./ledger/testUtils";
-import {g} from "./ledger/testUtils";
+import {g, nng} from "./ledger/testUtils";
 import {Ledger} from "./ledger/ledger";
 import * as uuid from "../util/uuid";
 
@@ -23,7 +23,7 @@ describe("core/credGrainView", () => {
     const id1 = GraphUtil.participant1.id;
     const id2 = GraphUtil.participant2.id;
     const allocation1 = {
-      policy: {policyType: "IMMEDIATE", budget: g("10")},
+      policy: {policyType: "IMMEDIATE", budget: nng("10")},
       id: allocationId1,
       receipts: [
         {amount: g("3"), id: id1},
@@ -32,7 +32,7 @@ describe("core/credGrainView", () => {
     };
     const allocation2 = {
       id: allocationId2,
-      policy: {policyType: "BALANCED", budget: g("20")},
+      policy: {policyType: "BALANCED", budget: nng("20")},
       receipts: [
         {amount: g("10"), id: id1},
         {amount: g("10"), id: id2},
@@ -289,7 +289,7 @@ describe("core/credGrainView", () => {
     const id1 = GraphUtil.participant1.id;
     const id2 = GraphUtil.participant2.id;
     const allocation1 = {
-      policy: {policyType: "IMMEDIATE", budget: g("10")},
+      policy: {policyType: "IMMEDIATE", budget: nng("10")},
       id: allocationId1,
       receipts: [
         {amount: g("3"), id: id1},

--- a/src/core/ledger/grainAllocation.test.js
+++ b/src/core/ledger/grainAllocation.test.js
@@ -1,30 +1,28 @@
 // @flow
 
-import * as G from "./grain";
 import {random as randomUuid, parser as uuidParser} from "../../util/uuid";
 import {
   computeAllocation,
   type AllocationIdentity,
   _validateAllocationBudget,
 } from "./grainAllocation";
+import {fromString as nngFromString} from "./nonnegativeGrain";
 import {toDiscount} from "./policies/recent";
 
 describe("core/ledger/grainAllocation", () => {
-  // concise helper for grain from a string
-  const g = (x: string) => G.fromString(x);
   // concise helper for grain from a number
-  const ng = (x: number) => g(x.toString());
+  const nng = (x: number) => nngFromString(x.toString());
   // concise helper for an allocation identity
   function aid(paid: number, cred: $ReadOnlyArray<number>): AllocationIdentity {
-    return {id: randomUuid(), paid: ng(paid), cred};
+    return {id: randomUuid(), paid: nng(paid), cred};
   }
-  const immediate = (n: number) => ({policyType: "IMMEDIATE", budget: ng(n)});
+  const immediate = (n: number) => ({policyType: "IMMEDIATE", budget: nng(n)});
   const recent = (n: number, discount: number) => ({
     policyType: "RECENT",
-    budget: ng(n),
+    budget: nng(n),
     discount: toDiscount(discount),
   });
-  const balanced = (n: number) => ({policyType: "BALANCED", budget: ng(n)});
+  const balanced = (n: number) => ({policyType: "BALANCED", budget: nng(n)});
 
   describe("computeAllocation", () => {
     describe("validation", () => {
@@ -32,18 +30,9 @@ describe("core/ledger/grainAllocation", () => {
         const thunk = () => computeAllocation(immediate(5), []);
         expect(thunk).toThrowError("must have at least one identity");
       });
-      it("errors if the budget is negative", () => {
-        const id = aid(5, [1]);
-        const thunk = () => computeAllocation(immediate(-5), [id]);
-        expect(thunk).toThrowError("invalid budget");
-      });
       it("errors if the total cred is zero", () => {
         const thunk = () => computeAllocation(immediate(5), [aid(0, [0])]);
         expect(thunk).toThrowError("cred is zero");
-      });
-      it("errors if there's negative paid", () => {
-        const thunk = () => computeAllocation(immediate(5), [aid(-1, [0])]);
-        expect(thunk).toThrowError("negative paid");
       });
       it("errors if there's NaN or Infinity in Cred", () => {
         const thunk = () => computeAllocation(immediate(5), [aid(0, [NaN])]);
@@ -73,8 +62,8 @@ describe("core/ledger/grainAllocation", () => {
         const i2 = aid(0, [0, 3]);
         const allocation = computeAllocation(policy, [i1, i2]);
         const expectedReceipts = [
-          {id: i1.id, amount: ng(4)},
-          {id: i2.id, amount: ng(6)},
+          {id: i1.id, amount: nng(4)},
+          {id: i2.id, amount: nng(6)},
         ];
         const expectedAllocation = {
           receipts: expectedReceipts,
@@ -89,8 +78,8 @@ describe("core/ledger/grainAllocation", () => {
         const i2 = aid(0, [3, 0]);
         const allocation = computeAllocation(policy, [i1, i2]);
         const expectedReceipts = [
-          {id: i1.id, amount: ng(0)},
-          {id: i2.id, amount: ng(0)},
+          {id: i1.id, amount: nng(0)},
+          {id: i2.id, amount: nng(0)},
         ];
         const expectedAllocation = {
           receipts: expectedReceipts,
@@ -109,9 +98,9 @@ describe("core/ledger/grainAllocation", () => {
         const i3 = aid(0, [100, 0, 0]);
         const allocation = computeAllocation(policy, [i1, i2, i3]);
         const expectedReceipts = [
-          {id: i1.id, amount: ng(38)},
-          {id: i2.id, amount: ng(31)},
-          {id: i3.id, amount: ng(31)},
+          {id: i1.id, amount: nng(38)},
+          {id: i2.id, amount: nng(31)},
+          {id: i3.id, amount: nng(31)},
         ];
         const expectedAllocation = {
           receipts: expectedReceipts,
@@ -127,8 +116,8 @@ describe("core/ledger/grainAllocation", () => {
         const i2 = aid(100, [100, 100, 100]);
         const allocation = computeAllocation(policy, [i1, i2]);
         const expectedReceipts = [
-          {id: i1.id, amount: ng(50)},
-          {id: i2.id, amount: ng(50)},
+          {id: i1.id, amount: nng(50)},
+          {id: i2.id, amount: nng(50)},
         ];
         const expectedAllocation = {
           receipts: expectedReceipts,
@@ -144,8 +133,8 @@ describe("core/ledger/grainAllocation", () => {
         const i2 = aid(0, [0, 10, 100]);
         const allocation = computeAllocation(policy, [i1, i2]);
         const expectedReceipts = [
-          {id: i1.id, amount: ng(0)},
-          {id: i2.id, amount: ng(100)},
+          {id: i1.id, amount: nng(0)},
+          {id: i2.id, amount: nng(100)},
         ];
         const expectedAllocation = {
           receipts: expectedReceipts,
@@ -161,8 +150,8 @@ describe("core/ledger/grainAllocation", () => {
         const i2 = aid(0, [0, 10, 100]);
         const allocation = computeAllocation(policy, [i1, i2]);
         const expectedReceipts = [
-          {id: i1.id, amount: ng(0)},
-          {id: i2.id, amount: ng(0)},
+          {id: i1.id, amount: nng(0)},
+          {id: i2.id, amount: nng(0)},
         ];
         const expectedAllocation = {
           receipts: expectedReceipts,
@@ -180,8 +169,8 @@ describe("core/ledger/grainAllocation", () => {
         const i2 = aid(0, [3, 0]);
         const allocation = computeAllocation(policy, [i1, i2]);
         const expectedReceipts = [
-          {id: i1.id, amount: ng(40)},
-          {id: i2.id, amount: ng(60)},
+          {id: i1.id, amount: nng(40)},
+          {id: i2.id, amount: nng(60)},
         ];
         const expectedAllocation = {
           receipts: expectedReceipts,
@@ -196,8 +185,8 @@ describe("core/ledger/grainAllocation", () => {
         const i2 = aid(30, [3, 0]);
         const allocation = computeAllocation(policy, [i1, i2]);
         const expectedReceipts = [
-          {id: i1.id, amount: ng(20)},
-          {id: i2.id, amount: ng(0)},
+          {id: i1.id, amount: nng(20)},
+          {id: i2.id, amount: nng(0)},
         ];
         const expectedAllocation = {
           receipts: expectedReceipts,
@@ -212,8 +201,8 @@ describe("core/ledger/grainAllocation", () => {
         const i2 = aid(0, [3, 0]);
         const allocation = computeAllocation(policy, [i1, i2]);
         const expectedReceipts = [
-          {id: i1.id, amount: ng(0)},
-          {id: i2.id, amount: ng(0)},
+          {id: i1.id, amount: nng(0)},
+          {id: i2.id, amount: nng(0)},
         ];
         const expectedAllocation = {
           receipts: expectedReceipts,
@@ -229,12 +218,12 @@ describe("core/ledger/grainAllocation", () => {
         const i1 = aid(0, [1]);
         const policy = {
           policyType: "SPECIAL",
-          budget: ng(100),
+          budget: nng(100),
           memo: "something",
           recipient: i1.id,
         };
         const allocation = computeAllocation(policy, [i1]);
-        const expectedReceipts = [{id: i1.id, amount: ng(100)}];
+        const expectedReceipts = [{id: i1.id, amount: nng(100)}];
         const expectedAllocation = {
           receipts: expectedReceipts,
           id: uuidParser.parseOrThrow(allocation.id),
@@ -247,7 +236,7 @@ describe("core/ledger/grainAllocation", () => {
         const other = aid(0, [1]);
         const policy = {
           policyType: "SPECIAL",
-          budget: ng(100),
+          budget: nng(100),
           memo: "something",
           recipient: id,
         };

--- a/src/core/ledger/ledger.test.js
+++ b/src/core/ledger/ledger.test.js
@@ -14,6 +14,7 @@ import {
   id2,
   id3,
   g,
+  nng,
 } from "./testUtils";
 
 const uuidMock = createUuidMock();
@@ -838,7 +839,7 @@ describe("core/ledger/ledger", () => {
       describe("when the distribution has a single allocation", () => {
         let ledger;
         const allocation = {
-          policy: {policyType: "IMMEDIATE", budget: g("10")},
+          policy: {policyType: "IMMEDIATE", budget: nng("10")},
           id: allocationId1,
           receipts: [
             {amount: g("3"), id: id1},
@@ -900,7 +901,7 @@ describe("core/ledger/ledger", () => {
       describe("when the distribution has multiple allocations", () => {
         let ledger;
         const allocation1 = {
-          policy: {policyType: "IMMEDIATE", budget: g("10")},
+          policy: {policyType: "IMMEDIATE", budget: nng("10")},
           id: allocationId1,
           receipts: [
             {amount: g("3"), id: id1},
@@ -909,7 +910,7 @@ describe("core/ledger/ledger", () => {
         };
         const allocation2 = {
           id: allocationId2,
-          policy: {policyType: "BALANCED", budget: g("20")},
+          policy: {policyType: "BALANCED", budget: nng("20")},
           receipts: [
             {amount: g("10"), id: id1},
             {amount: g("10"), id: id2},
@@ -987,7 +988,7 @@ describe("core/ledger/ledger", () => {
       describe("when there are multiple distributions", () => {
         let ledger;
         const allocation1 = {
-          policy: {policyType: "IMMEDIATE", budget: g("10")},
+          policy: {policyType: "IMMEDIATE", budget: nng("10")},
           id: allocationId1,
           receipts: [
             {amount: g("3"), id: id1},
@@ -996,7 +997,7 @@ describe("core/ledger/ledger", () => {
         };
         const allocation2 = {
           id: allocationId2,
-          policy: {policyType: "BALANCED", budget: g("20")},
+          policy: {policyType: "BALANCED", budget: nng("20")},
           receipts: [
             {amount: g("10"), id: id1},
             {amount: g("10"), id: id2},
@@ -1084,7 +1085,7 @@ describe("core/ledger/ledger", () => {
       it("fails if any receipt has invalid id", () => {
         const ledger = ledgerWithActiveIdentities();
         const allocation = {
-          policy: {policyType: "IMMEDIATE", budget: g("7")},
+          policy: {policyType: "IMMEDIATE", budget: nng("7")},
           id: uuid.random(),
           receipts: [
             {id: id1, amount: g("3")},
@@ -1102,11 +1103,11 @@ describe("core/ledger/ledger", () => {
       it("fails if any receipt has invalid amount", () => {
         const ledger = ledgerWithActiveIdentities();
         const allocation = {
-          policy: {policyType: "IMMEDIATE", budget: g("7")},
+          policy: {policyType: "IMMEDIATE", budget: nng("7")},
           id: uuid.random(),
           receipts: [
             {id: id1, amount: g("3")},
-            {id: id2, amount: g("-4")},
+            {id: id2, amount: G.fromString("-4")},
           ],
         };
         const distribution = {
@@ -1121,7 +1122,7 @@ describe("core/ledger/ledger", () => {
         const ledger = ledgerWithIdentities();
         ledger.activate(id1);
         const allocation = {
-          policy: {policyType: "IMMEDIATE", budget: g("7")},
+          policy: {policyType: "IMMEDIATE", budget: nng("7")},
           id: uuid.random(),
           receipts: [
             {id: id1, amount: g("3")},
@@ -1318,7 +1319,7 @@ describe("core/ledger/ledger", () => {
           ledger.transferGrain({
             from: id1,
             to: id2,
-            amount: g("-3"),
+            amount: G.fromString("-3"),
             memo: "test",
           });
         failsWithoutMutation(
@@ -1424,7 +1425,7 @@ describe("core/ledger/ledger", () => {
         allocations: [
           {
             id: allocationId,
-            policy: {policyType: "IMMEDIATE", budget: g("100")},
+            policy: {policyType: "IMMEDIATE", budget: nng("100")},
             receipts: [
               {id: id1, amount: g("50")},
               {id: id2, amount: g("50")},

--- a/src/core/ledger/nonnegativeGrain.js
+++ b/src/core/ledger/nonnegativeGrain.js
@@ -1,0 +1,39 @@
+// @flow
+
+import * as G from "./grain";
+import * as P from "../../util/combo";
+
+/**
+ * The NonnegativeGrain type ensures Grain amount is >= 0,
+ * which is particularly useful in the case of policy budgets
+ * or grain transfers.
+ */
+export opaque type NonnegativeGrain: G.Grain = G.Grain;
+
+export function fromGrain(g: G.Grain): NonnegativeGrain {
+  if (G.lt(g, G.ZERO)) {
+    throw new Error(`Grain amount must be nonnegative, got ${g}`);
+  }
+  return g;
+}
+
+export function fromInteger(n: number): NonnegativeGrain {
+  return fromGrain(G.fromInteger(n));
+}
+
+export function fromString(s: string): NonnegativeGrain {
+  return fromGrain(G.fromString(s));
+}
+
+export const grainParser: P.Parser<NonnegativeGrain> = P.fmap(
+  G.parser,
+  fromGrain
+);
+export const numberParser: P.Parser<NonnegativeGrain> = P.fmap(
+  P.number,
+  fromInteger
+);
+export const stringParser: P.Parser<NonnegativeGrain> = P.fmap(
+  P.string,
+  fromString
+);

--- a/src/core/ledger/nonnegativeGrain.test.js
+++ b/src/core/ledger/nonnegativeGrain.test.js
@@ -1,0 +1,56 @@
+// @flow
+
+import {fromGrain, fromInteger, fromString} from "./nonnegativeGrain";
+import {ONE, type Grain} from "./grain";
+import {g} from "./testUtils";
+
+describe("core/ledger/nonnegativeGrain", () => {
+  describe("fromGrain", () => {
+    it("fromGrain works on valid Grain values", () => {
+      expect(fromGrain(ONE)).toEqual(ONE);
+    });
+    it("errors on -1", () => {
+      const negativeOne: Grain = g("-1");
+      expect(() => fromGrain(negativeOne)).toThrowError(
+        "Grain amount must be nonnegative"
+      );
+    });
+  });
+
+  describe("fromString", () => {
+    it("fromString works on valid Grain values", () => {
+      expect(fromString(ONE)).toEqual(ONE);
+    });
+    it("fromString errors on invalid Grain values", () => {
+      expect(() => fromString("123.4")).toThrowError("Invalid integer: 123.4");
+    });
+    it("errors on -1", () => {
+      expect(() => fromString("-1")).toThrowError(
+        "Grain amount must be nonnegative"
+      );
+    });
+  });
+
+  describe("fromInteger", () => {
+    it("works on 0", () => {
+      expect(fromInteger(0)).toEqual("0");
+    });
+    it("works on 1", () => {
+      expect(fromInteger(1)).toEqual(ONE);
+    });
+    it("works on 3", () => {
+      expect(fromInteger(3)).toEqual("3000000000000000000");
+    });
+    it("errors on -1", () => {
+      expect(() => fromInteger(-1)).toThrowError(
+        "Grain amount must be nonnegative"
+      );
+    });
+    it("errors for non-integers", () => {
+      for (const bad of [1.2, NaN, Infinity, -Infinity]) {
+        const thunk = () => fromInteger(bad);
+        expect(thunk).toThrowError(`not an integer: ${bad}`);
+      }
+    });
+  });
+});

--- a/src/core/ledger/policies/balanced.js
+++ b/src/core/ledger/policies/balanced.js
@@ -5,6 +5,7 @@ import * as G from "../grain";
 import * as P from "../../../util/combo";
 import {type GrainReceipt} from "../grainAllocation";
 import {type ProcessedIdentities} from "../processedIdentities";
+import {type NonnegativeGrain, grainParser} from "../nonnegativeGrain";
 
 /**
  * The Balanced policy attempts to pay Grain to everyone so that their
@@ -20,7 +21,7 @@ export type Balanced = "BALANCED";
 
 export type BalancedPolicy = {|
   +policyType: Balanced,
-  +budget: G.Grain,
+  +budget: NonnegativeGrain,
 |};
 
 /**
@@ -78,5 +79,5 @@ export function balancedReceipts(
 
 export const balancedPolicyParser: P.Parser<BalancedPolicy> = P.object({
   policyType: P.exactly(["BALANCED"]),
-  budget: G.parser,
+  budget: grainParser,
 });

--- a/src/core/ledger/policies/immediate.js
+++ b/src/core/ledger/policies/immediate.js
@@ -4,6 +4,7 @@ import * as G from "../grain";
 import * as P from "../../../util/combo";
 import {type GrainReceipt} from "../grainAllocation";
 import {type ProcessedIdentities} from "../processedIdentities";
+import {type NonnegativeGrain, grainParser} from "../nonnegativeGrain";
 
 /**
  * The Immediate policy evenly distributes its Grain budget
@@ -17,7 +18,7 @@ export type Immediate = "IMMEDIATE";
 
 export type ImmediatePolicy = {|
   +policyType: Immediate,
-  +budget: G.Grain,
+  +budget: NonnegativeGrain,
 |};
 
 /**
@@ -37,5 +38,5 @@ export function immediateReceipts(
 
 export const immediatePolicyParser: P.Parser<ImmediatePolicy> = P.object({
   policyType: P.exactly(["IMMEDIATE"]),
-  budget: G.parser,
+  budget: grainParser,
 });

--- a/src/core/ledger/policies/recent.js
+++ b/src/core/ledger/policies/recent.js
@@ -4,6 +4,7 @@ import * as G from "../grain";
 import * as P from "../../../util/combo";
 import {type GrainReceipt} from "../grainAllocation";
 import {type ProcessedIdentities} from "../processedIdentities";
+import {type NonnegativeGrain, grainParser} from "../nonnegativeGrain";
 
 /**
  * The Recent policy distributes cred using a time discount factor, weighing
@@ -27,7 +28,7 @@ export type Recent = "RECENT";
 
 export type RecentPolicy = {|
   +policyType: Recent,
-  +budget: G.Grain,
+  +budget: NonnegativeGrain,
   +discount: Discount,
 |};
 
@@ -50,7 +51,7 @@ export function recentReceipts(
 
 export const recentPolicyParser: P.Parser<RecentPolicy> = P.object({
   policyType: P.exactly(["RECENT"]),
-  budget: G.parser,
+  budget: grainParser,
   discount: P.fmap(P.number, toDiscount),
 });
 

--- a/src/core/ledger/policies/special.js
+++ b/src/core/ledger/policies/special.js
@@ -5,7 +5,7 @@ import * as P from "../../../util/combo";
 import {type IdentityId} from "../../identity";
 import {type GrainReceipt} from "../grainAllocation";
 import {type ProcessedIdentities} from "../processedIdentities";
-import * as G from "../grain";
+import {type NonnegativeGrain, grainParser} from "../nonnegativeGrain";
 
 /**
  * The Special policy is a power-maintainer tool for directly paying Grain
@@ -20,7 +20,7 @@ export type Special = "SPECIAL";
 
 export type SpecialPolicy = {|
   +policyType: Special,
-  +budget: G.Grain,
+  +budget: NonnegativeGrain,
   +memo: string,
   +recipient: IdentityId,
 |};
@@ -39,7 +39,7 @@ export function specialReceipts(
 
 export const specialPolicyParser: P.Parser<SpecialPolicy> = P.object({
   policyType: P.exactly(["SPECIAL"]),
-  budget: G.parser,
+  budget: grainParser,
   memo: P.string,
   recipient: uuidParser,
 });

--- a/src/core/ledger/testUtils.js
+++ b/src/core/ledger/testUtils.js
@@ -4,6 +4,10 @@ import cloneDeep from "lodash.clonedeep";
 import {Ledger} from "./ledger";
 import {newIdentity, type Identity, type IdentityId} from "../identity";
 import * as G from "./grain";
+import {
+  type NonnegativeGrain,
+  fromString as toNonnegativeGrain,
+} from "./nonnegativeGrain";
 import * as uuid from "../../util/uuid";
 
 export interface UuidMock {
@@ -112,6 +116,9 @@ export const createTestLedgerFixture = (
 
 // Helper for constructing Grain values.
 export const g = (s: string): G.Grain => G.fromString(s);
+
+// Helper for constructing NonnegativeGrain values.
+export const nng = (s: string): NonnegativeGrain => toNonnegativeGrain(s);
 
 export const id1: IdentityId = uuid.fromString("YVZhbGlkVXVpZEF0TGFzdA");
 export const id2: IdentityId = uuid.fromString("URgLrCxgvjHxtGJ9PgmckQ");

--- a/src/ui/components/SpecialDistribution.js
+++ b/src/ui/components/SpecialDistribution.js
@@ -11,6 +11,7 @@ import {computeAllocation} from "../../core/ledger/grainAllocation";
 import * as uuid from "../../util/uuid";
 import type {TimestampMs} from "../../util/timestamp";
 import {useLedger} from "../utils/LedgerContext";
+import {fromGrain as nonnegative} from "../../core/ledger/nonnegativeGrain";
 
 const useStyles = makeStyles((theme) => ({
   root: {
@@ -67,7 +68,7 @@ export const SpecialDistribution = ({
     if (recipient && amount && amount !== ZERO) {
       const policy = {
         policyType: "SPECIAL",
-        budget: fromFloatString(amount),
+        budget: nonnegative(fromFloatString(amount)),
         memo,
         recipient: recipient.identity.id,
       };


### PR DESCRIPTION
__Context__
This commit uses the `NonnegativeGrain` type for the budget
type of grain allocation policies.  This helps strongly enforce the nonnegativity
of budgets, while reducing the need to manually check if budgets are negative.
In addition, we use `NonnegativeGrain`'s parser to parse directly into policies without any upgrading.

__Test Plan__
Policy unit tests all updated to lift budget input into `NonnegativeGrain`.
