### PR TITLE
grain allocation policies: add config parser

### DIFF
--- a/src/core/ledger/policies/balanced.js
+++ b/src/core/ledger/policies/balanced.js
@@ -5,7 +5,11 @@ import * as G from "../grain";
 import * as P from "../../../util/combo";
 import {type GrainReceipt} from "../grainAllocation";
 import {type ProcessedIdentities} from "../processedIdentities";
-import {type NonnegativeGrain, grainParser} from "../nonnegativeGrain";
+import {
+  type NonnegativeGrain,
+  grainParser,
+  numberParser,
+} from "../nonnegativeGrain";
 
 /**
  * The Balanced policy attempts to pay Grain to everyone so that their
@@ -76,6 +80,11 @@ export function balancedReceipts(
   const grainAmounts = G.splitBudget(budget, floatUnderpayment);
   return identities.map(({id}, i) => ({id, amount: grainAmounts[i]}));
 }
+
+export const balancedConfigParser: P.Parser<BalancedPolicy> = P.object({
+  policyType: P.exactly(["BALANCED"]),
+  budget: numberParser,
+});
 
 export const balancedPolicyParser: P.Parser<BalancedPolicy> = P.object({
   policyType: P.exactly(["BALANCED"]),

--- a/src/core/ledger/policies/immediate.js
+++ b/src/core/ledger/policies/immediate.js
@@ -4,7 +4,11 @@ import * as G from "../grain";
 import * as P from "../../../util/combo";
 import {type GrainReceipt} from "../grainAllocation";
 import {type ProcessedIdentities} from "../processedIdentities";
-import {type NonnegativeGrain, grainParser} from "../nonnegativeGrain";
+import {
+  type NonnegativeGrain,
+  grainParser,
+  numberParser,
+} from "../nonnegativeGrain";
 
 /**
  * The Immediate policy evenly distributes its Grain budget
@@ -35,6 +39,11 @@ export function immediateReceipts(
   );
   return identities.map(({id}, i) => ({id, amount: amounts[i]}));
 }
+
+export const immediateConfigParser: P.Parser<ImmediatePolicy> = P.object({
+  policyType: P.exactly(["IMMEDIATE"]),
+  budget: numberParser,
+});
 
 export const immediatePolicyParser: P.Parser<ImmediatePolicy> = P.object({
   policyType: P.exactly(["IMMEDIATE"]),

--- a/src/core/ledger/policies/index.js
+++ b/src/core/ledger/policies/index.js
@@ -5,17 +5,25 @@ import {
   type BalancedPolicy,
   balancedReceipts,
   balancedPolicyParser,
+  balancedConfigParser,
 } from "./balanced";
 import {
   type ImmediatePolicy,
   immediateReceipts,
   immediatePolicyParser,
+  immediateConfigParser,
 } from "./immediate";
-import {type RecentPolicy, recentReceipts, recentPolicyParser} from "./recent";
+import {
+  type RecentPolicy,
+  recentReceipts,
+  recentPolicyParser,
+  recentConfigParser,
+} from "./recent";
 import {
   type SpecialPolicy,
   specialReceipts,
   specialPolicyParser,
+  specialConfigParser,
 } from "./special";
 
 export {balancedReceipts, balancedPolicyParser};
@@ -28,6 +36,13 @@ export type AllocationPolicy =
   | ImmediatePolicy
   | RecentPolicy
   | SpecialPolicy;
+
+export const policyConfigParser: P.Parser<AllocationPolicy> = P.orElse([
+  balancedConfigParser,
+  immediateConfigParser,
+  recentConfigParser,
+  specialConfigParser,
+]);
 
 export const allocationPolicyParser: P.Parser<AllocationPolicy> = P.orElse([
   balancedPolicyParser,

--- a/src/core/ledger/policies/recent.js
+++ b/src/core/ledger/policies/recent.js
@@ -4,7 +4,11 @@ import * as G from "../grain";
 import * as P from "../../../util/combo";
 import {type GrainReceipt} from "../grainAllocation";
 import {type ProcessedIdentities} from "../processedIdentities";
-import {type NonnegativeGrain, grainParser} from "../nonnegativeGrain";
+import {
+  type NonnegativeGrain,
+  grainParser,
+  numberParser,
+} from "../nonnegativeGrain";
 
 /**
  * The Recent policy distributes cred using a time discount factor, weighing
@@ -48,6 +52,12 @@ export function recentReceipts(
 
   return identities.map(({id}, i) => ({id, amount: amounts[i]}));
 }
+
+export const recentConfigParser: P.Parser<RecentPolicy> = P.object({
+  policyType: P.exactly(["RECENT"]),
+  budget: numberParser,
+  discount: P.fmap(P.number, toDiscount),
+});
 
 export const recentPolicyParser: P.Parser<RecentPolicy> = P.object({
   policyType: P.exactly(["RECENT"]),

--- a/src/core/ledger/policies/special.js
+++ b/src/core/ledger/policies/special.js
@@ -5,7 +5,11 @@ import * as P from "../../../util/combo";
 import {type IdentityId} from "../../identity";
 import {type GrainReceipt} from "../grainAllocation";
 import {type ProcessedIdentities} from "../processedIdentities";
-import {type NonnegativeGrain, grainParser} from "../nonnegativeGrain";
+import {
+  type NonnegativeGrain,
+  grainParser,
+  numberParser,
+} from "../nonnegativeGrain";
 
 /**
  * The Special policy is a power-maintainer tool for directly paying Grain
@@ -36,6 +40,13 @@ export function specialReceipts(
   }
   throw new Error(`no active grain account for identity: ${policy.recipient}`);
 }
+
+export const specialConfigParser: P.Parser<SpecialPolicy> = P.object({
+  policyType: P.exactly(["SPECIAL"]),
+  budget: numberParser,
+  memo: P.string,
+  recipient: uuidParser,
+});
 
 export const specialPolicyParser: P.Parser<SpecialPolicy> = P.object({
   policyType: P.exactly(["SPECIAL"]),


### PR DESCRIPTION
__Context__
This commit adds a new parser for each grain allocation policy,
as well as a higher order parser which checks that the data parses
to one of the allocation policies.

This will be used in our upgraded grain config, which will take an
array of allocation policies.  This parser parses user input directly
into allocation policies without needing any upgrade functions.  This
will help us eliminate the `toDistributionPolicy` function in
`api/grainConfig` entirely.

The main difference in this parser is that it allows users to enter
human readable grain amounts instead of attoGrain amounts without
needing to write an upgrade function.

__Test Plan__
Trivial change, tests for the `numberParser` subparser are provided
in `core/ledger/nonnegativegrain.test`.
