### PR TITLE
grainConfig: take array of policies

### DIFF
--- a/src/api/grainConfig.js
+++ b/src/api/grainConfig.js
@@ -3,33 +3,45 @@
 import {type DistributionPolicy} from "../core/ledger/applyDistributions";
 import * as C from "../util/combo";
 import * as NullUtil from "../util/null";
+import {
+  type AllocationPolicy,
+  policyConfigParser,
+} from "../core/ledger/policies";
 import {fromInteger as toNonnegativeGrain} from "../core/ledger/nonnegativeGrain";
 import {toDiscount} from "../core/ledger/policies/recent";
 
 export type GrainConfig = {|
-  +immediatePerWeek?: number,
-  +balancedPerWeek?: number,
-  +recentPerWeek?: number,
-  +recentWeeklyDecayRate?: number,
+  +immediatePerWeek?: number, // (deprecated)
+  +balancedPerWeek?: number, // (deprecated)
+  +recentPerWeek?: number, // (deprecated)
+  +recentWeeklyDecayRate?: number, // (deprecated)
+  +allocationPolicies?: $ReadOnlyArray<AllocationPolicy>,
   +maxSimultaneousDistributions?: number,
 |};
 
 export const parser: C.Parser<GrainConfig> = C.object(
   {},
   {
+    allocationPolicies: C.array<AllocationPolicy>(policyConfigParser),
+    maxSimultaneousDistributions: C.number,
     immediatePerWeek: C.number,
     balancedPerWeek: C.number,
     recentPerWeek: C.number,
     recentWeeklyDecayRate: C.number,
-    maxSimultaneousDistributions: C.number,
   }
 );
 
 /**
  * Create a DistributionPolicy from GrainConfig, checking that config
  * fields can form valid policies.
+ *
+ * Moving forward, policies will need to be passed in the `allocationPolicies`
+ * parameter; however to avoid backcompatability issues, we optionally allow
+ * the deprecated fields for the time being.
  */
 export function toDistributionPolicy(x: GrainConfig): DistributionPolicy {
+  const allocationPolicies = NullUtil.orElse(x.allocationPolicies, []);
+
   const immediatePerWeek = NullUtil.orElse(x.immediatePerWeek, 0);
   const recentPerWeek = NullUtil.orElse(x.recentPerWeek, 0);
   const balancedPerWeek = NullUtil.orElse(x.balancedPerWeek, 0);
@@ -50,9 +62,9 @@ export function toDistributionPolicy(x: GrainConfig): DistributionPolicy {
     );
   }
 
-  const allocationPolicies = [];
+  const allocationPoliciesDeprecated = [];
   if (immediatePerWeek > 0) {
-    allocationPolicies.push({
+    allocationPoliciesDeprecated.push({
       budget: toNonnegativeGrain(immediatePerWeek),
       policyType: "IMMEDIATE",
     });
@@ -62,14 +74,14 @@ export function toDistributionPolicy(x: GrainConfig): DistributionPolicy {
     if (recentWeeklyDecayRate == null) {
       throw new Error(`no recentWeeklyDecayRate specified for recent policy`);
     }
-    allocationPolicies.push({
+    allocationPoliciesDeprecated.push({
       budget: toNonnegativeGrain(recentPerWeek),
       policyType: "RECENT",
       discount: toDiscount(recentWeeklyDecayRate),
     });
   }
   if (balancedPerWeek > 0) {
-    allocationPolicies.push({
+    allocationPoliciesDeprecated.push({
       budget: toNonnegativeGrain(balancedPerWeek),
       policyType: "BALANCED",
     });
@@ -78,7 +90,10 @@ export function toDistributionPolicy(x: GrainConfig): DistributionPolicy {
     x.maxSimultaneousDistributions,
     Infinity
   );
-  return {allocationPolicies, maxSimultaneousDistributions};
+  return {
+    allocationPolicies: allocationPolicies.concat(allocationPoliciesDeprecated),
+    maxSimultaneousDistributions,
+  };
 }
 
 function isNonnegativeInteger(x: number): boolean {

--- a/src/api/grainConfig.test.js
+++ b/src/api/grainConfig.test.js
@@ -3,7 +3,36 @@
 import {parser, toDistributionPolicy, type GrainConfig} from "./grainConfig";
 import {type DistributionPolicy} from "../core/ledger/applyDistributions";
 import {toDiscount} from "../core/ledger/policies/recent";
+import {type Uuid, random as randomUuid} from "../util/uuid";
 import {fromInteger as toNonnegativeGrain} from "../core/ledger/nonnegativeGrain";
+import {type BalancedPolicy} from "../core/ledger/policies/balanced";
+import {type ImmediatePolicy} from "../core/ledger/policies/immediate";
+import {type RecentPolicy} from "../core/ledger/policies/recent";
+import {type SpecialPolicy} from "../core/ledger/policies/special";
+
+const balanced = (budget: number): BalancedPolicy => ({
+  policyType: "BALANCED",
+  budget: toNonnegativeGrain(budget),
+});
+const immediate = (budget: number): ImmediatePolicy => ({
+  policyType: "IMMEDIATE",
+  budget: toNonnegativeGrain(budget),
+});
+const recent = (budget: number, discount: number): RecentPolicy => ({
+  policyType: "RECENT",
+  budget: toNonnegativeGrain(budget),
+  discount: toDiscount(discount),
+});
+const special = (
+  budget: number,
+  memo: string,
+  recipient: Uuid
+): SpecialPolicy => ({
+  policyType: "SPECIAL",
+  budget: toNonnegativeGrain(budget),
+  memo,
+  recipient,
+});
 
 describe("api/grainConfig", () => {
   describe("parser", () => {
@@ -11,114 +40,204 @@ describe("api/grainConfig", () => {
       expect(parser.parseOrThrow({})).toEqual({});
     });
 
-    it("errors if malformed params", () => {
-      const grainConfig = {
-        balancedPerWeek: {},
-        immediatePerWeek: 10,
-        recentPerWeek: 10,
-      };
-      expect(() => parser.parseOrThrow(grainConfig)).toThrowError(
-        "expected number"
-      );
+    describe("errors if malformed params", () => {
+      it("errors on malformed allocationPolicies", () => {
+        const grainConfig = {
+          allocationPolicies: {},
+          maxSimultaneousDistributions: 2,
+        };
+        expect(() => parser.parseOrThrow(grainConfig)).toThrowError(
+          "expected array, got object"
+        );
+      });
+
+      it("errors on malformed maxSimultaneousDistributions", () => {
+        const grainConfig = {
+          allocationPolicies: [],
+          maxSimultaneousDistributions: [],
+        };
+        expect(() => parser.parseOrThrow(grainConfig)).toThrowError(
+          "expected number, got array"
+        );
+      });
     });
 
     it("ignores extra params", () => {
       const grainConfig = {
-        recentPerWeek: 30,
+        allocationPolicies: [],
         EXTRA: 30,
       };
 
       const to = {
-        recentPerWeek: 30,
+        allocationPolicies: [],
       };
 
       expect(parser.parseOrThrow(grainConfig)).toEqual(to);
     });
 
-    it("does not throw on negative or zero budgets", () => {
+    it("does not throw on negative maxSimultaneousDistributions", () => {
       const grainConfig = {
-        balancedPerWeek: -1,
-        immediatePerWeek: 0,
-        recentPerWeek: -100,
-        recentWeeklyDecayRate: 0.5,
+        allocationPolicies: [],
+        maxSimultaneousDistributions: -5,
       };
 
       expect(parser.parseOrThrow(grainConfig)).toEqual(grainConfig);
     });
 
-    it("works on well formed object", () => {
+    it("rejects improperly formatted allocation policies", () => {
       const grainConfig = {
+        allocationPolicies: [
+          {
+            policyType: "RECENT",
+            budget: 20,
+            discount: 1.5,
+          },
+        ],
+        maxSimultaneousDistributions: 2,
+      };
+
+      expect(() => parser.parseOrThrow(grainConfig)).toThrowError(
+        `Discount must be in range [0,1]`
+      );
+    });
+
+    it("works on well formed config", () => {
+      const uuid = randomUuid();
+      const grainConfig = {
+        allocationPolicies: [
+          {
+            policyType: "BALANCED",
+            budget: 50,
+          },
+          {
+            policyType: "IMMEDIATE",
+            budget: 10,
+          },
+          {
+            policyType: "RECENT",
+            budget: 20,
+            discount: 0.5,
+          },
+          {
+            policyType: "SPECIAL",
+            budget: 100,
+            memo: "howdy",
+            recipient: uuid,
+          },
+        ],
+        maxSimultaneousDistributions: 2,
+      };
+
+      const expected: GrainConfig = {
+        allocationPolicies: [
+          balanced(50),
+          immediate(10),
+          recent(20, 0.5),
+          special(100, "howdy", uuid),
+        ],
+        maxSimultaneousDistributions: 2,
+      };
+
+      expect(parser.parseOrThrow(grainConfig)).toEqual(expected);
+    });
+
+    it("can take multiple of the same policy", () => {
+      const config = {
+        allocationPolicies: [
+          {
+            policyType: "RECENT",
+            budget: 20,
+            discount: 0.1,
+          },
+          {
+            policyType: "RECENT",
+            budget: 20,
+            discount: 0.1,
+          },
+        ],
+        maxSimultaneousDistributions: 2,
+      };
+
+      const expected: GrainConfig = {
+        allocationPolicies: [recent(20, 0.1), recent(20, 0.1)],
+        maxSimultaneousDistributions: 2,
+      };
+
+      expect(parser.parseOrThrow(config)).toEqual(expected);
+    });
+
+    it("parses deprecated policy config", () => {
+      const config = {
         balancedPerWeek: 10,
         immediatePerWeek: 20,
         recentPerWeek: 30,
-        recentWeeklyDecayRate: 0.5,
+        allocationPolicies: [],
       };
 
-      expect(parser.parseOrThrow(grainConfig)).toEqual(grainConfig);
+      expect(parser.parseOrThrow(config)).toEqual(config);
     });
   });
 
   describe("toDistributionPolicy", () => {
+    it("deprecated policy config works alongside new config", () => {
+      const x: GrainConfig = {
+        allocationPolicies: [recent(50, 0.1)],
+        immediatePerWeek: 10,
+        recentPerWeek: 30,
+        recentWeeklyDecayRate: 0.5,
+        maxSimultaneousDistributions: 10,
+      };
+      const expected: DistributionPolicy = {
+        allocationPolicies: [recent(50, 0.1), immediate(10), recent(30, 0.5)],
+        maxSimultaneousDistributions: 10,
+      };
+      expect(toDistributionPolicy(x)).toEqual(expected);
+    });
+
+    it("errors on deprecated allocation policy with negative budget", () => {
+      const x: GrainConfig = {
+        balancedPerWeek: -1,
+        allocationPolicies: [],
+      };
+
+      expect(() => toDistributionPolicy(x)).toThrowError(
+        `budget must be nonnegative integer`
+      );
+    });
+
+    it("deprecated recent policy with no discount errors", () => {
+      const x: GrainConfig = {
+        recentPerWeek: 10,
+        allocationPolicies: [],
+      };
+
+      expect(() => toDistributionPolicy(x)).toThrowError(
+        `no recentWeeklyDecayRate specified for recent policy`
+      );
+    });
+
     it("can handle missing policies", () => {
       const x: GrainConfig = {
+        allocationPolicies: [balanced(50)],
         maxSimultaneousDistributions: 100,
       };
 
       const expected: DistributionPolicy = {
-        allocationPolicies: [],
+        allocationPolicies: [balanced(50)],
         maxSimultaneousDistributions: 100,
       };
 
       expect(toDistributionPolicy(x)).toEqual(expected);
     });
 
-    it("errors on missing discount for recent policy", () => {
+    it("creates DistributionPolicy with at least 1 allocation policy with positive budgets", () => {
       const x: GrainConfig = {
-        balancedPerWeek: 10,
-        immediatePerWeek: 20,
-        recentPerWeek: 10,
-      };
-
-      expect(() => toDistributionPolicy(x)).toThrowError(
-        "no recentWeeklyDecayRate specified"
-      );
-    });
-
-    it("does not error for missing recentWeeklyDecayRate if 0 recent budget", () => {
-      const x: GrainConfig = {
-        balancedPerWeek: 10,
-        immediatePerWeek: 20,
-        recentPerWeek: 0,
-      };
-
-      expect(() => toDistributionPolicy(x)).not.toThrow();
-    });
-
-    it("creates DistributionPolicy from valid GrainConfig", () => {
-      const x: GrainConfig = {
-        balancedPerWeek: 10,
-        immediatePerWeek: 20,
-        recentPerWeek: 30,
-        recentWeeklyDecayRate: 0.1,
+        allocationPolicies: [immediate(20), recent(30, 0.1), balanced(10)],
         maxSimultaneousDistributions: 2,
       };
 
       const expectedDistributionPolicy: DistributionPolicy = {
-        allocationPolicies: [
-          {
-            budget: toNonnegativeGrain(20),
-            policyType: "IMMEDIATE",
-          },
-          {
-            budget: toNonnegativeGrain(30),
-            policyType: "RECENT",
-            discount: toDiscount(0.1),
-          },
-          {
-            budget: toNonnegativeGrain(10),
-            policyType: "BALANCED",
-          },
-        ],
+        allocationPolicies: [immediate(20), recent(30, 0.1), balanced(10)],
         maxSimultaneousDistributions: 2,
       };
 


### PR DESCRIPTION
__Context__
After implementing the Recent policy and a variant of Balanced (#2584), we can see that adding policy parameters for new policies is both tedious on from our perspective as well as for the user.

More specifically, on the user side, their config is a flat object with parameters from different policies sitting side by side. Here, we implement more structure by taking an array of policies.

Right now, an example config/grain.json might look as follows:

```js
{
  "balancedPerWeek": 30
  "immediatePerWeek": 50,
  "recentPerWeek": 20,
  "maxSimultaneousDistributions": 2,
  "discount": 0.5
}
```

This also forced us to check each policy explicitly downstream in toDistributionPolicy, which could be a lot cleaner if we could leverage the AllocationPolicy type we already have. Now, we have a parser which will eliminate the need for the
function entirely after we remove the deprecated config.

Config now looks (for example) as follows:

```js
{
  allocationPolicies: [
    {
      policyType: "BALANCED",
      budget: 100
    },
    {
      policyType: "RECENT",
      budget: 50,
      discount: 0.1
    },
    {
      policyType: "RECENT",
      budget: 100,
      discount: 0.5
    }]
}
```

Note that for the time being, we support the deprecated config.  For example:
```js
{
  balancedPerWeek: 10,
  immediatePerWeek: 10,
  allocationPolicies: [
    {
      policyType: "BALANCED",
      budget: 100
    },
    {
      policyType: "RECENT",
      budget: 50,
      discount: 0.1
    },
    {
      policyType: "RECENT",
      budget: 100,
      discount: 0.5
    }]
}
```

This also lets us take multiple versions of the same policies. This allows us to create richer ensembles of policies. For instance, I might want to run a Recent policy with a 90% discount, and another one with a 5% discount.

__Test Plan__
Unit tests are provided here for both the parser, and well as toDistributionPolicy, which serves to check the config.