### PR TITLE
cli/grain2: grain2 command using CredGrainView

### DIFF
--- a/src/cli/grain2.js
+++ b/src/cli/grain2.js
@@ -1,0 +1,114 @@
+// @flow
+
+import fs from "fs-extra";
+import {join} from "path";
+import {loadFileWithDefault, loadJson} from "../util/disk";
+import {Ledger} from "../core/ledger/ledger";
+import {applyDistributions2} from "../core/ledger/applyDistributions";
+import {computeCredAccounts2} from "../core/ledger/credAccounts";
+import stringify from "json-stable-stringify";
+import * as G from "../core/ledger/grain";
+import dedent from "../util/dedent";
+import {loadCredGraph} from "./common";
+
+import * as GrainConfig from "../api/grainConfig";
+import type {Command} from "./command";
+
+function die(std, message) {
+  std.err("fatal: " + message);
+  return 1;
+}
+
+const grain2Command: Command = async (args, std) => {
+  let simulation = false;
+  if (args.length === 1 && (args[0] === "--simulation" || args[0] === "-s")) {
+    simulation = true;
+  } else if (args.length !== 0) {
+    return die(std, "usage: sourcecred grain2 [--simulation]");
+  }
+
+  const baseDir = process.cwd();
+  const grainConfigPath = join(baseDir, "config", "grain.json");
+  const grainConfig = await loadJson(grainConfigPath, GrainConfig.parser);
+  const distributionPolicy = GrainConfig.toDistributionPolicy(grainConfig);
+
+  const ledgerPath = join(baseDir, "data", "ledger.json");
+  const ledger = Ledger.parse(
+    await loadFileWithDefault(ledgerPath, () => new Ledger().serialize())
+  );
+
+  const credGraph = await loadCredGraph(baseDir);
+
+  const distributions = applyDistributions2(
+    distributionPolicy,
+    credGraph,
+    ledger,
+    +Date.now()
+  );
+
+  let totalDistributed = G.ZERO;
+  const recipientIdentities = new Set();
+  for (const {allocations} of distributions) {
+    for (const {receipts} of allocations) {
+      for (const {amount, id} of receipts) {
+        totalDistributed = G.add(amount, totalDistributed);
+        recipientIdentities.add(id);
+      }
+    }
+  }
+
+  console.log(
+    simulation ? `——SIMULATED DISTRIBUTION——\n` : ``,
+    `Distributed ${G.format(totalDistributed)} to ${
+      recipientIdentities.size
+    } identities in ${distributions.length} distributions`
+  );
+
+  if (!simulation) {
+    await fs.writeFile(ledgerPath, ledger.serialize());
+
+    const credAccounts = computeCredAccounts2(ledger, credGraph);
+    const accountsPath = join(baseDir, "output", "accounts.json");
+    await fs.writeFile(accountsPath, stringify(credAccounts));
+  }
+
+  return 0;
+};
+
+export const grain2Help: Command = async (args, std) => {
+  std.out(
+    dedent`\
+      usage: sourcecred grain2 [--simulation || -s]
+
+      Distribute Grain (or whatever currency this Cred instance is tracking)
+      for Cred intervals in which Grain was not already distributed.
+
+      When the '--simulation' (-s) flag is provided, no grain will actually be distributed,
+      allowing for testing the output of various configurations.
+
+      When run, this will identify all the completed Cred intervals (currently, weeks)
+      and find the latest Cred interval for which there was no Grain distribution.
+      Then, it will distribute Grain for all of them, making a corresponding change
+      to the Ledger. This could result in zero or more distributions, depending on how
+      many recent Cred intervals had no corresponding Grain distribution.
+
+      Grain is distributed based on the configuration in the config/grain.json
+      file. The fields are as follows:
+
+      immediatePerWeek: The amount of grain to distribute for activity in the most
+      recent period. (value type: integer)
+
+      balancedPerWeek: The amount of grain to distribute according to all-time cred
+      scores. (value type: integer)
+
+      maxSimultaneousDistributions: The maximum number of distributions to create in
+      a single 'sourcecred grain' call if distributions have been missed. If set to
+      1, then the command will create at most one distribution. If unset, defaults
+      to Infinity.
+      (value type: integer)
+      `.trimRight()
+  );
+  return 0;
+};
+
+export default grain2Command;

--- a/src/cli/help.js
+++ b/src/cli/help.js
@@ -4,6 +4,7 @@
 import type {Command} from "./command";
 import {goHelp} from "./go";
 import {grainHelp} from "./grain";
+import {grain2Help} from "./grain2";
 import {graphHelp} from "./graph";
 import {loadHelp} from "./load";
 import {scoreHelp} from "./score";
@@ -24,6 +25,7 @@ const help: Command = async (args, std) => {
     graph: graphHelp,
     score: scoreHelp,
     grain: grainHelp,
+    grain2: grain2Help,
     site: siteHelp,
     serve: serveHelp,
   };

--- a/src/cli/sourcecred.js
+++ b/src/cli/sourcecred.js
@@ -12,6 +12,7 @@ import serve from "./serve";
 import grain from "./grain";
 import credrank from "./credrank";
 import help from "./help";
+import grain2 from "./grain2";
 
 const sourcecred: Command = async (args, std) => {
   if (args.length === 0) {
@@ -39,6 +40,8 @@ const sourcecred: Command = async (args, std) => {
       return serve(args.slice(1), std);
     case "grain":
       return grain(args.slice(1), std);
+    case "grain2":
+      return grain2(args.slice(1), std);
     case "credrank":
       return credrank(args.slice(1), std);
     default:

--- a/src/core/ledger/credAccounts.js
+++ b/src/core/ledger/credAccounts.js
@@ -15,6 +15,7 @@ import {CredView} from "../../analysis/credView";
 import {NodeAddress, type NodeAddressT} from "../graph";
 import {type IntervalSequence} from "../interval";
 import {type Alias} from "../identity";
+import {CredGraph} from "../credrank/credGraph";
 
 export type Cred = $ReadOnlyArray<number>;
 
@@ -58,6 +59,32 @@ export function computeCredAccounts(
       );
     } else {
       userlikeInfo.set(address, {cred: credOverTime.cred, description});
+    }
+  }
+  return _computeCredAccounts(grainAccounts, userlikeInfo, intervals);
+}
+
+export function computeCredAccounts2(
+  ledger: Ledger,
+  credGraph: CredGraph
+): CredAccountData {
+  const grainAccounts = ledger.accounts();
+  const userlikeInfo = new Map();
+  const intervals = credGraph.intervals();
+  const noIntervals = intervals.length === 0;
+  for (const {
+    address,
+    description,
+    credPerInterval,
+  } of credGraph.participants()) {
+    if (noIntervals) {
+      userlikeInfo.set(address, {cred: [], description});
+    } else if (credPerInterval === null) {
+      throw new Error(
+        `userlike ${NodeAddress.toString(address)} does not have detailed cred`
+      );
+    } else {
+      userlikeInfo.set(address, {cred: credPerInterval, description});
     }
   }
   return _computeCredAccounts(grainAccounts, userlikeInfo, intervals);


### PR DESCRIPTION
__Context__
    This commit implements a `grain2` command, which is a simple fork of `grain` that
    moves away from using the soon to be deprecated `CredView` and instead uses `CredGraph`.
    This is part of a larger effort from @blueridger to replace `CredView` with `CredGrainView`.

Note that `grain2` now loads the `CredGraph` instead of `CredResults`.

This commit also implements forks of `applyDistributions` and `computeCredAccounts` to
    take a `CredGraph` instead of a `CredView`.  We can phase out the originals when we
    deprecate `CredView` officially.

__Assumptions__
    - Original applyDistributions and computeCredAccounts works.  I forked this assuming
      it works, but there's no test for it.

__Test Plan__
    Ran `grain2` and `grain` on the same sample instance:
    - Distribution output in ledger matches using JSON.stringify
    - -s flag does not write to ledger in grain2 as expected