### PR TITLE
Add last distribution timestamp to the AccountOverview page

### DIFF
--- a/src/ui/components/AccountOverview.js
+++ b/src/ui/components/AccountOverview.js
@@ -12,6 +12,8 @@ import {type Account} from "../../core/ledger/ledger";
 import {type CurrencyDetails} from "../../api/currencyConfig";
 import * as G from "../../core/ledger/grain";
 import {useLedger} from "../utils/LedgerContext";
+import findLast from "lodash.findlast";
+import {formatTimestamp} from "../utils/dateHelpers";
 import {makeStyles} from "@material-ui/core/styles";
 
 type OverviewProps = {|+currency: CurrencyDetails|};
@@ -31,6 +33,13 @@ export const AccountOverview = ({
   const classes = useStyles();
 
   const accounts = ledger.accounts();
+  const lastPayoutEvent = findLast(
+    ledger.eventLog(),
+    (event) => event.action.type === "DISTRIBUTE_GRAIN"
+  );
+  const lastPayoutMessage = lastPayoutEvent
+    ? `Last distribution: ${formatTimestamp(lastPayoutEvent.ledgerTimestamp)}`
+    : "";
 
   function comparator(a: Account, b: Account) {
     if (a.balance === b.balance) {
@@ -41,21 +50,24 @@ export const AccountOverview = ({
 
   const sortedAccounts = accounts.slice().sort(comparator);
   return (
-    <TableContainer component={Paper} className={classes.container}>
-      <Table stickyHeader>
-        <TableHead>
-          <TableRow>
-            <TableCell>Username</TableCell>
-            <TableCell align="right">Active?</TableCell>
-            <TableCell align="right">Current Balance</TableCell>
-            <TableCell align="right">{`${currencyName}`} Earned</TableCell>
-          </TableRow>
-        </TableHead>
-        <TableBody>
-          {sortedAccounts.map((a) => AccountRow(a, currencySuffix))}
-        </TableBody>
-      </Table>
-    </TableContainer>
+    <>
+      <TableContainer component={Paper} className={classes.container}>
+        <Table stickyHeader>
+          <TableHead>
+            <TableRow>
+              <TableCell>Username</TableCell>
+              <TableCell align="right">Active?</TableCell>
+              <TableCell align="right">Current Balance</TableCell>
+              <TableCell align="right">{`${currencyName}`} Earned</TableCell>
+            </TableRow>
+          </TableHead>
+          <TableBody>
+            {sortedAccounts.map((a) => AccountRow(a, currencySuffix))}
+          </TableBody>
+        </Table>
+      </TableContainer>
+      <p align="right">{lastPayoutMessage}</p>
+    </>
   );
 };
 


### PR DESCRIPTION
<!-- Please read our contributor guide before submitting your PR: -->
<!-- https://github.com/sourcecred/sourcecred/blob/master/CONTRIBUTING.md -->

# Description
@Bex2594 requested this feature, and I agree. This helps users quickly know whether or not last week's distribution has dropped yet by adding a "Last distribution" timestamp to the grain accounts page. This is important because distributions are not always merged in a timely fashion, making it harder for users who rely on the income to do financial planning.
<!-- Possible prompts:
  Why is the change important?
  Did you consider and reject alternate formulations of the same idea?
  Are there relevant issues or discussions elsewhere?
-->

# Test Plan
1. `yarn start` against the sourcecred/template-instance repo to verify that the UI hasn't changed with no distributions.
1. `yarn start` against the sourcecred/cred repo. Result:

![Screen Shot 2021-01-18 at 9 52 44 PM](https://user-images.githubusercontent.com/11550396/104994277-06b17300-59d9-11eb-8ba8-11e555014c06.png)

<!-- Possible prompts:
  How well covered by automated tests is this change?
  How did you manually test this change? How can a reviewer replicate the tests?
-->
