### PR TITLE
Add source files to published NPM package

### DIFF
--- a/config/webpack.config.api.js
+++ b/config/webpack.config.api.js
@@ -33,6 +33,7 @@ module.exports = ({
     chunkFilename: "[name].[chunkhash:8].chunk.js",
     libraryTarget: "umd",
     library: "sourcecred",
+    libraryExport: "default",
     // Use `this` for compatibility with both Node and browser.
     globalObject: "this",
   },

--- a/package.json
+++ b/package.json
@@ -32,11 +32,11 @@
     "json-stable-stringify": "^1.0.1",
     "lodash.clonedeep": "^4.5.0",
     "lodash.differenceby": "^4.8.0",
+    "lodash.findlast": "^4.6.0",
+    "lodash.findlastindex": "^4.6.0",
     "lodash.isequal": "^4.5.0",
     "lodash.sortby": "^4.7.0",
     "lodash.sortedindex": "^4.1.0",
-    "lodash.findlast": "^4.6.0",
-    "lodash.findlastindex": "^4.6.0",
     "object-assign": "^4.1.1",
     "promise": "^8.1.0",
     "ra-data-fakerest": "^3.6.2",
@@ -157,8 +157,12 @@
   },
   "files": [
     "/bin",
-    "/dist"
+    "/dist",
+    "/src",
+    "!src/**/*.test.js?(.snap)",
+    "!src/ui"
   ],
   "main": "dist/api.js",
+  "module": "src/api/index.js",
   "bin": "./bin/sourcecred.js"
 }


### PR DESCRIPTION
Related: #2667 

# Description

This allows editors to show code completion, highlighting, and makes it easy for users to know what options / params
are available when consuming the sourcecred API from the NPM package. This is accomplished by including the src/ folder
in the list of files included in the NPM package.

Adding the ["module" field](https://github.com/dherman/defense-of-dot-js/blob/master/proposal.md) in the package.json also enables users to use the `import sourcecred from 'sourcecred';` syntax and get the same code completion / highlighting benefits as using `const sourcecred = require('sourcecred');`.

Lastly, setting `libraryExport: "default"` in webpack.config.api.js makes it so users dont need to write
`const sourcecred = require('sourcecred').default;` when importing the package.

# Test Plan

Install the test package that's bundled using this new setup and see if code completion / highlighting is working
correctly: `yarn add sourcecred-publish-test`

Here's some gifs of me testing this out:

Before:
![2021-01-19 17 20 06](https://user-images.githubusercontent.com/7143583/105109863-a07d2c80-5a7a-11eb-8163-4aa2a2fda77a.gif)


After:
![2021-01-19 17 39 32](https://user-images.githubusercontent.com/7143583/105111119-75e0a300-5a7d-11eb-93b2-2b44138fce71.gif)

