### PR TITLE
Add Ethereum plugin to public API

### DIFF
--- a/src/api/index.js
+++ b/src/api/index.js
@@ -5,7 +5,6 @@ import deepFreeze from "deep-freeze";
 // Exports for calling SourceCred code programmatically. Both the
 // structure and the contents of this API are experimental and subject
 // to change.
-import * as address from "../core/address";
 import * as discourseAddress from "../plugins/discourse/address";
 import * as discourseDeclaration from "../plugins/discourse/declaration";
 import * as discordDeclaration from "../plugins/experimental-discord/declaration";
@@ -13,6 +12,10 @@ import * as initiativesDeclaration from "../plugins/initiatives/declaration";
 import * as githubDeclaration from "../plugins/github/declaration";
 import * as githubEdges from "../plugins/github/edges";
 import * as githubNodes from "../plugins/github/nodes";
+import * as ethereumDeclaration from "../plugins/ethereum/declaration";
+import * as ethereumUtils from "../plugins/ethereum/utils";
+
+import * as address from "../core/address";
 import * as graph from "../core/graph";
 import * as weightedGraph from "../core/weightedGraph";
 import * as weights from "../core/weights";
@@ -51,6 +54,10 @@ const api = {
       declaration: githubDeclaration,
       edges: githubEdges,
       nodes: githubNodes,
+    },
+    ethereum: {
+      declaration: ethereumDeclaration,
+      utils: ethereumUtils,
     },
     discourse: {
       address: discourseAddress,

--- a/src/plugins/ethereum/createIdentities.js
+++ b/src/plugins/ethereum/createIdentities.js
@@ -6,7 +6,7 @@ import {JsonLog} from "../../util/jsonLog";
 import {type EthAddress} from "./ethAddress";
 import {nodeAddressForEthAddress} from "./ethAddressNode";
 
-export function _createIdentity(address: EthAddress): IdentityProposal {
+export function createIdentity(address: EthAddress): IdentityProposal {
   const alias = {
     description: address,
     address: nodeAddressForEthAddress(address),
@@ -23,5 +23,5 @@ export function _createIdentity(address: EthAddress): IdentityProposal {
 export function createIdentities(
   ethAddresses: JsonLog<EthAddress>
 ): $ReadOnlyArray<IdentityProposal> {
-  return Array.from(ethAddresses.values()).map(_createIdentity);
+  return Array.from(ethAddresses.values()).map(createIdentity);
 }

--- a/src/plugins/ethereum/utils.js
+++ b/src/plugins/ethereum/utils.js
@@ -1,0 +1,16 @@
+// @flow
+
+import {createIdentity, createIdentities} from "./createIdentities";
+import {parseAddress, truncateEthAddress} from "./ethAddress";
+import {nodeAddressForEthAddress} from "./ethAddressNode";
+
+export const address = {
+  parseAddress,
+  truncateEthAddress,
+  nodeAddressForEthAddress,
+};
+
+export const identity = {
+  createIdentities,
+  createIdentity,
+};


### PR DESCRIPTION
# Description

Allows programmatic creation / linking of identities from the SourceCred NPM package


# Test Plan

Ensure CI tests pass and Ethereum plugin is available in packaged output (`npm pack`)

e.g. 
```js
import sourcecred from 'sourcecred';

const identities = sourcecred.plugins.ethereum.utils.identity.createIdentities([...])
```