### PR TITLE
Return identityId in ensureIdentityExists function

### DIFF
--- a/src/core/ledger/identityProposal.js
+++ b/src/core/ledger/identityProposal.js
@@ -12,6 +12,7 @@ import {
   type IdentityType,
   identityTypeParser,
 } from "../identity";
+import type {IdentityId} from "../identity";
 
 /**
  * An IdentityProposal allows a plugin to report a participant identity,
@@ -51,7 +52,7 @@ export const parser: C.Parser<IdentityProposal> = C.object({
 
 /**
  * Given a Ledger and an IdentityProposal, ensure that some Ledger account
- * exists for the proposed identity.
+ * exists for the proposed identity and return the identity ID.
  *
  * If there is already an account matching the node address of the proposal's
  * alias, then the ledger is unchanged.
@@ -62,14 +63,16 @@ export const parser: C.Parser<IdentityProposal> = C.object({
 export function ensureIdentityExists(
   ledger: Ledger,
   proposal: IdentityProposal
-) {
-  if (ledger.accountByAddress(proposal.alias.address) != null) {
+): IdentityId {
+  const existingAccount = ledger.accountByAddress(proposal.alias.address);
+  if (existingAccount != null) {
     // there is already some account that includes this address; do nothing
-    return;
+    return existingAccount.identity.id;
   }
   const name = _chooseIdentityName(proposal, (n) => ledger.nameAvailable(n));
   const id = ledger.createIdentity(proposal.type, name);
   ledger.addAlias(id, proposal.alias);
+  return id;
 }
 
 const MAX_NUMERIC_DISCRIMINATOR = 100;

--- a/src/core/ledger/identityProposal.test.js
+++ b/src/core/ledger/identityProposal.test.js
@@ -28,19 +28,21 @@ describe("core/ledger/identityProposal", () => {
         alias: otherAlias,
         type: "USER",
       };
-      ensureIdentityExists(ledger, proposal);
+      const returnId = ensureIdentityExists(ledger, proposal);
       // Verify that the ledger didn't mutate.
       expect(ledger.eventLog()).toEqual(log);
+      expect(returnId).toEqual(id);
     });
     it("creates a new identity (with alias) if address isn't taken", () => {
       const ledger = new Ledger();
-      ensureIdentityExists(ledger, proposal);
+      const returnId = ensureIdentityExists(ledger, proposal);
       const account = ledger.accountByAddress(alias.address);
       if (account == null) {
         throw new Error("identity not created");
       }
       expect(account.identity.name).toEqual(proposal.name);
       expect(account.identity.aliases).toEqual([alias]);
+      expect(account.identity.id).toEqual(returnId);
     });
     it("uses the discriminator logic from _chooseIdentityName if needed", () => {
       const ledger = new Ledger();


### PR DESCRIPTION
# Description

Returning the newly generated (or existing) identity ID in this function improves the developer
ergonomics when using this function through the SourceCred API to create identities programmatically
and then do further processing on said identities.

# Test Plan

Ensure CI tests pass