### PR TITLE
cli/grain(2): add deprecation info for grain and grain2 commands

### DIFF
--- a/src/cli/grain.js
+++ b/src/cli/grain.js
@@ -23,6 +23,13 @@ function die(std, message) {
   return 1;
 }
 
+/**
+ * The grain command is soon to be deprecated, as part of a transition
+ * to @blueridger's `CredGrainView`.  This original grain command uses
+ * `CredView`, which will be deprecated.
+ *
+ * grain2 forks this command and eliminates the dependence on `CredView`
+ */
 const grainCommand: Command = async (args, std) => {
   let simulation = false;
   if (args.length === 1 && (args[0] === "--simulation" || args[0] === "-s")) {

--- a/src/cli/grain2.js
+++ b/src/cli/grain2.js
@@ -19,6 +19,13 @@ function die(std, message) {
   return 1;
 }
 
+/**
+ * The grain command is soon to be deprecated, as part of a transition
+ * to @blueridger's `CredGrainView`.  The original grain command uses
+ * `CredView`, which will be deprecated.
+ *
+ * This grain2 command forks this command and eliminates the dependence on `CredView`
+ */
 const grain2Command: Command = async (args, std) => {
   let simulation = false;
   if (args.length === 1 && (args[0] === "--simulation" || args[0] === "-s")) {

--- a/src/core/ledger/applyDistributions.js
+++ b/src/core/ledger/applyDistributions.js
@@ -66,6 +66,11 @@ export function applyDistributions(
   });
 }
 
+/**
+ * applyDistributions2 is a fork of applyDistributions that
+ * uses a CredGraph instead of a CredView, as part of a move
+ * away from CredView in favor of CredGrainView.
+ */
 export function applyDistributions2(
   policy: DistributionPolicy,
   credGraph: CredGraph,

--- a/src/core/ledger/credAccounts.js
+++ b/src/core/ledger/credAccounts.js
@@ -64,6 +64,11 @@ export function computeCredAccounts(
   return _computeCredAccounts(grainAccounts, userlikeInfo, intervals);
 }
 
+/**
+ * computeCredAccounts2 is a fork of applyDistributions that
+ * uses a CredGraph instead of a CredView, as part of a move
+ * away from CredView in favor of CredGrainView.
+ */
 export function computeCredAccounts2(
   ledger: Ledger,
   credGraph: CredGraph


### PR DESCRIPTION
This commit adds context around the deprecation of the grain
command in favor of "grain2", which does not rely on the soon
to be deprecated `CredView`.