### PR TITLE
Core: Implement WeightedGraph2

### DIFF
--- a/src/core/weightedGraph2.js
+++ b/src/core/weightedGraph2.js
@@ -2,20 +2,40 @@
 
 import {
   type Edge,
+  type EdgesOptions,
   type Node,
   type EdgeAddressT,
   type NodeAddressT,
+  type GraphComparison,
+  type GraphJSON,
+  compareGraphs,
   Graph,
 } from "./graph";
 import {type NodeWeight} from "./weights/nodeWeights";
 import {type EdgeWeight} from "./weights/edgeWeights";
-import {type WeightsComparison} from "./weights/weightsT";
-import {NodeTrie, EdgeTrie} from "./trie";
+import {
+  type WeightsComparison,
+  type WeightsJSON,
+  compareWeightsT,
+} from "./weights/weightsT";
+import {
+  Weights,
+  type WeightsI,
+  fromJSON as fromWeightsJSON,
+} from "./weights/weights";
+import {toCompat, fromCompat, type Compatible} from "../util/compat";
 
 /**
  * An entry in the array returned by AddressModule.toParts()
  */
 export type AddressPart = string;
+
+export type WeightedGraphJSON = {|
+  graph: GraphJSON,
+  weights: WeightsJSON,
+|};
+
+export type CompatibleWeightedGraphJSON = Compatible<WeightedGraphJSON>;
 
 export type WeightedNode = {|
   +node: Node,
@@ -27,6 +47,14 @@ export type WeightedEdge = {|
   +weight: EdgeWeight,
 |};
 
+export type WeightedGraphComparison = {|
+  graphComparison: GraphComparison,
+  weightsComparison: WeightsComparison,
+  weightedGraphsAreEqual: boolean,
+|};
+
+const COMPAT_INFO = {type: "sourcecred/weightedgraph", version: "0.1.0"};
+
 /**
  * The WeightedGraph2 class is a replacement for the WeightedGraph type. This class
  * eliminates the need give every node and edge that exists a weight. Rather,
@@ -37,89 +65,252 @@ export type WeightedEdge = {|
  * WeightedGraph2 should completely replace it.
  */
 export class WeightedGraph2 {
-  _nodeWeights: NodeTrie<NodeWeight>;
-  _edgeWeights: EdgeTrie<EdgeWeight>;
-  graph: Graph;
+  _weights: WeightsI;
+  _graph: Graph;
+
+  constructor(graph?: Graph, weights?: WeightsI) {
+    this._graph = graph ? graph : new Graph();
+    this._weights = weights ? weights : Weights();
+  }
 
   /**
    * Set the weight for a node address prefix.
    */
-  setNodePrefixWeight(
-    _unused_prefix: NodeAddressT,
-    _unused_w: NodeWeight
-  ): this {
-    throw new Error("method not implemented");
+  setNodePrefixWeight(prefix: NodeAddressT, w: NodeWeight): this {
+    this._weights.setNodeWeight(prefix, w);
+    return this;
   }
 
   /**
    * Set the weights for an edge address prefix.
    */
-  setEdgePrefixWeight(
-    _unused_prefix: EdgeAddressT,
-    _unused_w: NodeWeight
-  ): this {
-    throw new Error("method not implemented");
+  setEdgePrefixWeight(prefix: EdgeAddressT, w: EdgeWeight): this {
+    this._weights.setEdgeWeight(prefix, w);
+    return this;
   }
 
   /**
    * Add a node and optionally assign its weight. If a weight is not passed in,
    * the weight will default to 1.
    */
-  addNode(_unused_n: Node, _unused_w?: NodeWeight): this {
-    throw new Error("method not implemented");
+  addNode(n: Node, w?: NodeWeight): this {
+    this._graph.addNode(n);
+    if (w != null) this._weights.setNodeWeight(n.address, w);
+    return this;
   }
 
-  node(_unused_a: NodeAddressT): ?WeightedNode {
-    throw new Error("method not implemented");
+  /**
+   * Returns the WeightedNode matching a given NodeAddressT, if such a node
+   * exists, or undefined otherwise.
+   */
+  node(n: NodeAddressT): ?WeightedNode {
+    const node = this._graph.node(n);
+    if (node) {
+      return {
+        node,
+        weight: this.getNodeAddressWeight(n),
+      };
+    }
   }
 
+  /**
+   * Returns an iterator over all of the WeightedNodes in the graph.
+   *
+   * Optionally, the caller can provide a node prefix. If
+   * provided, the iterator will only contain nodes matching that
+   * prefix. See semantics of [Address.hasPrefix][1] for details.
+   *
+   * Clients must not modify the graph during iteration. If they do so, an
+   * error may be thrown at the iteration call site.
+   *
+   * Nodes are yielded in address-sorted order.
+   *
+   * [1]: https://github.com/sourcecred/sourcecred/blob/7c7fa2d83d4fd5ba38efb2b2f4e0244235ac1312/src/core/address.js#L74
+   */
   nodes(options?: {|+prefix: NodeAddressT|}): Iterator<WeightedNode> {
-    const _ = options;
-    throw new Error("method not implemented");
+    return this._nodesIterator(options);
+  }
+
+  *_nodesIterator(options?: {|+prefix: NodeAddressT|}): Iterator<WeightedNode> {
+    const nodes = this._graph.nodes(options);
+    for (const node of nodes) {
+      const weight = this.getNodeAddressWeight(node.address);
+      yield {node, weight};
+    }
   }
 
   /**
    * Add an edge and optionally assign its weight. If a prefix of the edge's
    * address doesn't have a weight assigned, the weight will default to 1.
+   *
+   * It is permitted to add an edge if its src or dst are not in the graph. See
+   * the discussion of 'Dangling Edges' in the module docstring for semantics.
+   *
+   * It is an error to add an edge if a distinct edge with the same address
+   * already exists in the graph (i.e., if the source or destination are
+   * different).
+   *
+   * Adding an edge that already exists to the graph is a no-op. (This
+   * operation is idempotent.)
+   *
+   * Returns `this` for chaining.
    */
-  addEdge(_unused_e: Edge, _unused_w?: EdgeWeight): this {
-    throw new Error("method not implemented");
+  addEdge(e: Edge, w?: EdgeWeight): this {
+    this._graph.addEdge(e);
+    if (w != null) this._weights.setEdgeWeight(e.address, w);
+    return this;
   }
 
-  edge(_unused_a: EdgeAddressT): ?WeightedEdge {
-    throw new Error("method not implemented");
+  /**
+   * Returns the WeightedEdge matching a given EdgeAddressT, if such an edge
+   * exists, or null otherwise.
+   */
+  edge(e: EdgeAddressT): ?WeightedEdge {
+    const edge = this._graph.edge(e);
+    if (edge) {
+      return {
+        edge,
+        weight: this.getEdgeAddressWeight(e),
+      };
+    }
   }
 
-  edges(options?: {|+prefix: EdgeAddressT|}): Iterator<WeightedEdge> {
-    const _ = options;
-    throw new Error("method not implemented");
+  /**
+   * Returns an iterator over Weightededges in the graph, optionally filtered by
+   * edge address prefix, source address prefix, and/or destination address
+   * prefix.
+   *
+   * The caller must pass an options object with a boolean field `showDangling`,
+   * which determines whether dangling edges will be included in the results.
+   * The caller may also pass fields `addressPrefix`, `srcPrefix`, and `dstPrefix`
+   * to perform prefix-based address filtering of edges that are returned.
+   * (See the module docstring for more context on dangling edges.)
+   *
+   * Suppose that you want to find every WeightedEdge that represents authorship
+   * by a user. If all authorship edges have the `AUTHORS_EDGE_PREFIX` prefix
+   * and all user nodes have the `USER_NODE_PREFIX` prefix, then you could call:
+   *
+   * wg.edges({
+   *  showDangling: true,  // or false, irrelevant for this example
+   *  addressPrefix: AUTHORS_EDGE_PREFIX,
+   *  srcPrefix: USER_NODE_PREFIX,
+   * });
+   *
+   * In this example, as `dstPrefix` was left unset, it will default to
+   * `NodeAddress.empty`, which is a prefix of every node address.
+   *
+   * Clients must not modify the graph during iteration. If they do so, an
+   * error may be thrown at the iteration call site.
+   *
+   * The weightedEdges are yielded in sorted address order.
+   */
+  edges(options: EdgesOptions): Iterator<WeightedEdge> {
+    return this._edgesIterator(options);
+  }
+
+  *_edgesIterator(options: EdgesOptions): Iterator<WeightedEdge> {
+    const edges = this._graph.edges(options);
+    for (const edge of edges) {
+      const weight = this.getEdgeAddressWeight(edge.address);
+      yield {edge, weight};
+    }
   }
 
   /**
    * Return the weight of a Node address.
    */
-  getNodeAddressWeight(_unused_a: NodeAddressT): NodeWeight {
-    throw new Error("method not implemented");
+  getNodeAddressWeight(n: NodeAddressT): NodeWeight {
+    return this._weights.getNodeWeight(n);
   }
 
   /**
    * Return the weight of an Edge address.
    */
-  getEdgeAddressWeight(_unused_a: EdgeAddressT): EdgeWeight {
-    throw new Error("method not implemented");
+  getEdgeAddressWeight(e: EdgeAddressT): EdgeWeight {
+    return this._weights.getEdgeWeight(e);
   }
 
   // Utilities
 
-  merge(_unused_wg: WeightedGraph2): WeightedGraph2 {
-    throw new Error("method not implemented");
+  /**
+   * Produce a copy of this WeightedGraph.
+   *
+   * The copy is equal to the original, but distinct, so that they may be
+   * modified independently.
+   */
+  copy(): WeightedGraph2 {
+    return WeightedGraph2.merge([this]);
   }
 
-  compareWeights(_unused_wg: WeightedGraph2): WeightsComparison {
-    throw new Error("method not implemented");
+  /**
+   * Compute the union of the given WeightedGraphs. The result is a new
+   * WeightedGraph that has all of the nodes and all of the edges from all the
+   * inputs.
+   *
+   * If two of the given graphs have edges with the same address, the edges
+   * must be equal (i.e. must have the same source and destination in each
+   * graph). If this is not the case, an error will be thrown.
+   *
+   * Example usage:
+   *
+   * let wg1 = new WeightedGraph().addNode(a).addNode(b).addEdge(e);
+   * let wg2 = new WeightedGraph().addNode(b).addNode(c).addEdge(f);
+   * let wg3 = WeightedGraph.merge([g1, g2]);
+   * Array.from(wg3.nodes()).length;  // 3
+   * Array.from(wg3.edges()).length;  // 2
+   * wg1 = new WeightedGraph().addNode(a).addNode(b).addEdge(x);
+   * wg2 = new WeightedGraph().addNode(c);
+   * wg3 = WeightedGraph.merge([g1, g2]);
+   *
+   * The newly created WeightedGraph is a separate instance from any of the
+   * input WeightedGraphs, and may be mutated independently.
+   */
+  static merge(wgs: Iterable<WeightedGraph2>): WeightedGraph2 {
+    const graphs: Array<Graph> = [];
+    const weights: Array<WeightsI> = [];
+    for (const wg of wgs) {
+      graphs.push(wg._graph);
+      weights.push(wg._weights);
+    }
+    return new WeightedGraph2(Graph.merge(graphs), Weights().merge(weights));
   }
 
-  // TODO: add JSON serialization and deserialization helpers
-  // TODO: Add a tagging system so nodes and edges can have their weights
-  // programmatically shifted
+  /**
+   * Serialize a WeightedGraph into a plain JavaScript object.
+   */
+  toJSON(): CompatibleWeightedGraphJSON {
+    const rawJSON = {
+      graph: this._graph.toJSON(),
+      weights: this._weights.toJSON(),
+    };
+    return toCompat(COMPAT_INFO, rawJSON);
+  }
+
+  /**
+   * Deserializes a CompatibleWeightedGraphJSON into a new WeightedGraph.
+   */
+  static fromJSON(compatJson: CompatibleWeightedGraphJSON): WeightedGraph2 {
+    const {graph, weights} = fromCompat<WeightedGraphJSON>(
+      COMPAT_INFO,
+      compatJson
+    );
+    return new WeightedGraph2(Graph.fromJSON(graph), fromWeightsJSON(weights));
+  }
+}
+
+export function compareWeightedGraphs(
+  wg1: WeightedGraph2,
+  wg2: WeightedGraph2
+): WeightedGraphComparison {
+  const graphComparison = compareGraphs(wg1._graph, wg2._graph);
+  const weightsComparison = compareWeightsT(
+    wg1._weights.eject(),
+    wg2._weights.eject()
+  );
+  return {
+    graphComparison,
+    weightsComparison,
+    weightedGraphsAreEqual:
+      graphComparison.graphsAreEqual && weightsComparison.weightsAreEqual,
+  };
 }

--- a/src/core/weightedGraph2.test.js
+++ b/src/core/weightedGraph2.test.js
@@ -1,0 +1,253 @@
+// @flow
+import {WeightedGraph2 as WG, compareWeightedGraphs} from "./weightedGraph2";
+import {type EdgeWeight} from "./weights/edgeWeights";
+import {type NodeWeight} from "./weights/nodeWeights";
+import {Graph} from "./graph";
+
+import * as GraphUtil from "./graphTestUtil";
+
+describe("src/core/weightedGraph2", () => {
+  function getWG(graph?: Graph): WG {
+    return new WG(graph);
+  }
+  function testWg(graph?: Graph) {
+    const node1 = GraphUtil.node("test");
+    const node2 = GraphUtil.node("test2");
+    return {
+      wg: getWG(graph),
+      node1,
+      node2,
+      nodeWeight: 5,
+      edge: GraphUtil.edge("edge1", node1, node2),
+      edgeWeight: {forwards: 2, backwards: 2},
+      defaultEdgeWeight: {forwards: 1, backwards: 1},
+      defaultNodeWeight: 1,
+    };
+  }
+  describe("constructor", () => {
+    it("can be instantiated without args", () => {
+      getWG();
+    });
+    it("can be instantiated with a valid graph param", () => {
+      const g = new Graph();
+      getWG(g);
+    });
+  });
+  describe("setNodePrefixWeight", () => {
+    it("can set the weight for a node prefix", () => {
+      const {wg, node1, nodeWeight} = testWg();
+      const result = wg.setNodePrefixWeight(node1.address, nodeWeight);
+      expect(result.getNodeAddressWeight(node1.address)).toEqual(nodeWeight);
+    });
+    it("can overwrite an existing weight", () => {
+      const {wg, node1, nodeWeight, defaultNodeWeight} = testWg();
+      wg.setNodePrefixWeight(
+        node1.address,
+        defaultNodeWeight
+      ).setNodePrefixWeight(node1.address, nodeWeight);
+      expect(wg.getNodeAddressWeight(node1.address)).toEqual(nodeWeight);
+    });
+  });
+  describe("setEdgePrefixWeight", () => {
+    it("can set the weight for an edge prefix", () => {
+      const {wg, edge, edgeWeight} = testWg();
+      wg.setEdgePrefixWeight(edge.address, edgeWeight);
+      expect(wg.getEdgeAddressWeight(edge.address)).toEqual(edgeWeight);
+    });
+    it("can overwrite an existing weight", () => {
+      const {wg, edge, edgeWeight} = testWg();
+      const newWeight = {forwards: 4, backwards: 4};
+      wg.setEdgePrefixWeight(edge.address, edgeWeight).setEdgePrefixWeight(
+        edge.address,
+        newWeight
+      );
+      expect(wg.getEdgeAddressWeight(edge.address)).toEqual(newWeight);
+    });
+  });
+  describe("addNode", () => {
+    it("adds an node", () => {
+      const {node1, wg, defaultNodeWeight} = testWg();
+      wg.addNode(node1);
+      expect(wg._graph.node(node1.address)).toEqual(node1);
+      expect(wg.getNodeAddressWeight(node1.address)).toEqual(defaultNodeWeight);
+    });
+    it("can add a duplicated node", () => {
+      const {node1, wg, defaultNodeWeight} = testWg();
+      wg.addNode(node1).addNode(node1);
+      expect(wg._graph.node(node1.address)).toEqual(node1);
+      expect(wg.getNodeAddressWeight(node1.address)).toEqual(defaultNodeWeight);
+    });
+    it("cannot modify an existing node", () => {
+      const {node1, wg, node2} = testWg();
+      const changedNode = {...node1, description: node2.description};
+      const thunk = () => wg.addNode(node1).addNode(changedNode);
+      expect(thunk).toThrow("conflict between new node");
+    });
+    it("accepts a configured weight", () => {
+      const {node1, wg, nodeWeight} = testWg();
+      wg.addNode(node1, nodeWeight);
+      expect(wg._graph.node(node1.address)).toEqual(node1);
+      expect(wg.getNodeAddressWeight(node1.address)).toEqual(nodeWeight);
+    });
+  });
+  describe("node", () => {
+    it("returns a node with the default weight if one exists", () => {
+      const {node1, wg, defaultNodeWeight} = testWg();
+      wg.addNode(node1);
+      expect(wg.node(node1.address)).toEqual({
+        node: node1,
+        weight: defaultNodeWeight,
+      });
+    });
+    it("returns an node with the configured weight if one exists", () => {
+      const {node1, wg, nodeWeight} = testWg();
+      wg.addNode(node1, nodeWeight);
+      expect(wg.node(node1.address)).toEqual({node: node1, weight: nodeWeight});
+    });
+    it("returns a node with a product of weights on its prefixes", () => {
+      const {wg, nodeWeight, node1, defaultNodeWeight} = testWg();
+      function nodeProduct(ws: $ReadOnlyArray<NodeWeight>): NodeWeight {
+        return ws.reduce(
+          (totalWeight, nextWeight) => totalWeight * nextWeight,
+          defaultNodeWeight
+        );
+      }
+      const subNode1 = GraphUtil.partsNode(["test", "two"]);
+      wg.setNodePrefixWeight(node1.address, nodeWeight);
+      wg.addNode(subNode1, nodeWeight);
+      expect(wg.node(subNode1.address)).toEqual({
+        node: subNode1,
+        weight: nodeProduct([nodeWeight, nodeWeight]),
+      });
+    });
+    it("returns undefined if no node exists", () => {
+      const {node1, wg} = testWg();
+      expect(wg.node(node1.address)).toBe(undefined);
+    });
+  });
+  describe("nodes", () => {
+    it("returns an array of nodes", () => {
+      const {node1, wg, defaultNodeWeight} = testWg();
+      wg.addNode(node1);
+      expect(Array.from(wg.nodes())).toEqual([
+        {node: node1, weight: defaultNodeWeight},
+      ]);
+    });
+  });
+  describe("addEdge", () => {
+    it("adds an edge", () => {
+      const {edge, wg, defaultEdgeWeight} = testWg();
+      wg.addEdge(edge);
+      expect(wg._graph.edge(edge.address)).toEqual(edge);
+      expect(wg.getEdgeAddressWeight(edge.address)).toEqual(defaultEdgeWeight);
+    });
+    it("can add a duplicated edge", () => {
+      const {edge, wg, defaultEdgeWeight} = testWg();
+      wg.addEdge(edge).addEdge(edge);
+      expect(wg._graph.edge(edge.address)).toEqual(edge);
+      expect(wg.getEdgeAddressWeight(edge.address)).toEqual(defaultEdgeWeight);
+    });
+    it("cannot modify an existing edge", () => {
+      const {edge, wg, node2} = testWg();
+      const changedEdge = {...edge, src: node2.address};
+      const thunk = () => wg.addEdge(edge).addEdge(changedEdge);
+      expect(thunk).toThrow("conflict between new edge");
+    });
+    it("accepts a configured weight", () => {
+      const {edge, wg, edgeWeight} = testWg();
+      wg.addEdge(edge, edgeWeight);
+      expect(wg._graph.edge(edge.address)).toEqual(edge);
+      expect(wg.getEdgeAddressWeight(edge.address)).toEqual(edgeWeight);
+    });
+  });
+  describe("edge", () => {
+    it("returns an edge with the default weight if one exists", () => {
+      const {edge, wg, defaultEdgeWeight} = testWg();
+      wg.addEdge(edge);
+      expect(wg.edge(edge.address)).toEqual({edge, weight: defaultEdgeWeight});
+    });
+    it("returns an edge with the configured weight if one exists", () => {
+      const {edge, wg, edgeWeight} = testWg();
+      wg.addEdge(edge, edgeWeight);
+      expect(wg.edge(edge.address)).toEqual({edge, weight: edgeWeight});
+    });
+    it("returns an edge with a product of weights on its prefixes", () => {
+      const {wg, edgeWeight, node1, node2, edge, defaultEdgeWeight} = testWg();
+      function edgeProduct(ws: $ReadOnlyArray<EdgeWeight>): EdgeWeight {
+        return ws.reduce(
+          (totalWeight, nextWeight) => ({
+            forwards: totalWeight.forwards * nextWeight.forwards,
+            backwards: totalWeight.backwards * nextWeight.backwards,
+          }),
+          defaultEdgeWeight
+        );
+      }
+      const edge2 = GraphUtil.partsEdge(["edge1", "two"], node1, node2);
+      wg.setEdgePrefixWeight(edge.address, edgeWeight);
+      wg.addEdge(edge2, edgeWeight);
+      expect(wg.edge(edge2.address)).toEqual({
+        edge: edge2,
+        weight: edgeProduct([edgeWeight, edgeWeight]),
+      });
+    });
+    it("returns undefined if no edge exists", () => {
+      const {edge, wg} = testWg();
+      expect(wg.edge(edge.address)).toBe(undefined);
+    });
+  });
+  describe("edges", () => {
+    const defaultOptions = {showDangling: true};
+    it("returns an array of edges", () => {
+      const {edge, wg, defaultEdgeWeight} = testWg();
+      wg.addEdge(edge);
+      expect(Array.from(wg.edges(defaultOptions))).toEqual([
+        {edge, weight: defaultEdgeWeight},
+      ]);
+    });
+  });
+  describe("merge and copy", () => {
+    it("merges two WeightedGraph2's", () => {
+      const {wg: wg1, node1, node2, nodeWeight, defaultNodeWeight} = testWg();
+      const wg2 = wg1.copy();
+      wg1.addNode(node1, nodeWeight);
+      wg2.addNode(node2);
+      expect(compareWeightedGraphs(wg1, wg2).weightedGraphsAreEqual).toBe(
+        false
+      );
+      const wg3 = WG.merge([wg1, wg2]);
+      expect(wg3.node(node1.address)).toEqual({
+        node: node1,
+        weight: nodeWeight,
+      });
+      expect(wg3.node(node1.address)).toEqual({
+        node: node1,
+        weight: nodeWeight,
+      });
+      expect(wg3.node(node2.address)).toEqual({
+        node: node2,
+        weight: defaultNodeWeight,
+      });
+    });
+    it("copy creates an identical, distinct WeightedGraph instance", () => {
+      const {wg: wg1, node1, node2, nodeWeight, edge, edgeWeight} = testWg();
+      wg1.addNode(node1, nodeWeight).addNode(node2).addEdge(edge, edgeWeight);
+      const wg2 = wg1.copy();
+      expect(compareWeightedGraphs(wg1, wg2).weightedGraphsAreEqual).toBe(true);
+      expect(wg1).not.toBe(wg2);
+      const subNode1 = GraphUtil.partsNode(["test", "two"]);
+      wg2.addNode(subNode1, nodeWeight);
+      // ensure wg1 is not also updated
+      expect(compareWeightedGraphs(wg1, wg2).weightedGraphsAreEqual).toBe(
+        false
+      );
+    });
+  });
+  describe("JSON", () => {
+    it("toJSON and fromJSON serialize and deserialize correctly", () => {
+      const {wg: wg1, node1, node2, nodeWeight, edge, edgeWeight} = testWg();
+      wg1.addNode(node1, nodeWeight).addNode(node2).addEdge(edge, edgeWeight);
+      const wg2 = WG.fromJSON(wg1.toJSON());
+      expect(compareWeightedGraphs(wg1, wg2).weightedGraphsAreEqual).toBe(true);
+    });
+  });
+});


### PR DESCRIPTION
WeightedGraph2 is a class that encapsulates `WeightsI` and `Graph`. It
provides an API that is similar to Graph in both form and expected
behavior, except it returns a calculated weight along with each node
and edge.

It also allows address prefixes to have weights assigned, which allows
for weight values to compound beyond an addresses' configured weight.
This behavior is actually provided via the algorithm's `WeightsEvaluator`,
but this API allows for more intuitive configuration

test plan: yarn unit

Tests cover the entire class and verify the functionality described here
and in the docstrings



┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1200032326400385/1200038310768785) by [Unito](https://www.unito.io/learn-more)
