### PR TITLE
server: provide CORS headers

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "bottleneck": "^2.19.5",
     "chalk": "^4.0.0",
     "commonmark": "0.29.1",
+    "cors": "^2.8.5",
     "d3-array": "^2.4.0",
     "d3-format": "^2.0.0",
     "d3-scale": "^3.2.1",

--- a/src/cli/serve.js
+++ b/src/cli/serve.js
@@ -1,6 +1,7 @@
 // @flow
 
 import type {$Response as ExpressResponse} from "express";
+import cors from "cors";
 
 import type {Command} from "./command";
 import {loadInstanceConfig} from "./common";
@@ -29,6 +30,7 @@ const serveCommand: Command = async (args, std) => {
   }
 
   const server = express();
+  server.use(cors());
 
   // override static config to enable ledger updates
   server.get(

--- a/yarn.lock
+++ b/yarn.lock
@@ -3338,6 +3338,14 @@ core-util-is@1.0.2, core-util-is@~1.0.0:
   resolved "https://registry.yarnpkg.com/core-util-is/-/core-util-is-1.0.2.tgz#b5fd54220aa2bc5ab57aab7140c940754503c1a7"
   integrity sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=
 
+cors@^2.8.5:
+  version "2.8.5"
+  resolved "https://registry.yarnpkg.com/cors/-/cors-2.8.5.tgz#eac11da51592dd86b9f06f6e7ac293b3df875d29"
+  integrity sha512-KIHbLJqu73RGr/hnbrO9uBeixNGuvSQjul/jdFvS/KFSIH1hWVd1ng7zOHx+YrEfInLG7q4n6GHQ9cDtxv/P6g==
+  dependencies:
+    object-assign "^4"
+    vary "^1"
+
 create-ecdh@^4.0.0:
   version "4.0.3"
   resolved "https://registry.yarnpkg.com/create-ecdh/-/create-ecdh-4.0.3.tgz#c9111b6f33045c4697f144787f9254cdc77c45ff"
@@ -7946,7 +7954,7 @@ oauth-sign@~0.9.0:
   resolved "https://registry.yarnpkg.com/oauth-sign/-/oauth-sign-0.9.0.tgz#47a7b016baa68b5fa0ecf3dee08a85c679ac6455"
   integrity sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ==
 
-object-assign@^4.0.1, object-assign@^4.1.0, object-assign@^4.1.1:
+object-assign@^4, object-assign@^4.0.1, object-assign@^4.1.0, object-assign@^4.1.1:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/object-assign/-/object-assign-4.1.1.tgz#2109adc7965887cfc05cbbd442cac8bfbb360863"
   integrity sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=
@@ -11177,7 +11185,7 @@ value-equal@^1.0.1:
   resolved "https://registry.yarnpkg.com/value-equal/-/value-equal-1.0.1.tgz#1e0b794c734c5c0cade179c437d356d931a34d6c"
   integrity sha512-NOJ6JZCAWr0zlxZt+xqCHNTEKOsrks2HQd4MqhP1qy4z1SkbEP467eNx6TgDKXMvUOb+OENfJCZwM+16n7fRfw==
 
-vary@~1.1.2:
+vary@^1, vary@~1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/vary/-/vary-1.1.2.tgz#2299f02c6ded30d4a5961b0b9f74524a18f634fc"
   integrity sha1-IpnwLG3tMNSllhsLn3RSShj2NPw=


### PR DESCRIPTION
This modifies the sourcecred serve command so that it provides CORS headers.

This way it will be possible to directly depend on SC data from within observable notebooks.

Test plan: Prior to this change, attempting to load JSON in Observable from the server fails to fetch with a CORS issue. After this change, it works.

You can use this notebook to test locally: https://observablehq.com/@decentralion/localhost-cors-fetch-test