### PR TITLE
BugFix: Add DevServer script to parse instance flag

### DIFF
--- a/config/webpack.config.web.js
+++ b/config/webpack.config.web.js
@@ -41,9 +41,9 @@ function makeConfig(mode /*: "production" | "development" */) /*: Object */ {
       before: (app /*: ExpressApp<ExpressRequest, ExpressResponse> */) => {
         let developmentInstancePath /*: ?string */ =
           process.env["SOURCECRED_DEV_INSTANCE"];
-        const argv = process.argv;
-        if (argv[argv.length - 2] === "--instance") {
-          developmentInstancePath = argv[argv.length - 1];
+        const instance /*: ?string */ = process.env["INSTANCE"];
+        if (instance != null) {
+          developmentInstancePath = instance;
         }
         if (developmentInstancePath == null) {
           developmentInstancePath = "sharness/__snapshots__/test-instance";

--- a/package.json
+++ b/package.json
@@ -108,7 +108,7 @@
   "scripts": {
     "prettify": "prettier --write '**/*.{js,md,yml}'",
     "check-pretty": "prettier --list-different '**/*.{js,md,yml}'",
-    "start": "NODE_ENV=development webpack serve --config config/webpack.config.web.js",
+    "start": "./scripts/devServer.sh",
     "build": "run-p build:* && cp -r ./build ./bin/site-template && chmod +x ./bin/sourcecred.js",
     "build:frontend": "NODE_ENV=production webpack --config config/webpack.config.web.js",
     "build:backend": "NODE_ENV=development webpack --config config/webpack.config.backend.js",

--- a/scripts/devServer.sh
+++ b/scripts/devServer.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+set -eu
+
+# This script is now necessary since webpack-cli no longer accepts arbitrary
+# flags.
+# We now have to set an environment variable from the flag and then
+# access that variable within the node process.
+
+if [ $# -eq 2 ]; then
+  if [ $1 == "--instance" ]; then
+    export INSTANCE=$2
+  else
+    ERR="WARN: unexpected input enountered: $1; expected --instance\nServing default instance"
+    echo -e $ERR >&2
+  fi
+fi
+
+NODE_ENV=development webpack serve --config config/webpack.config.web.js


### PR DESCRIPTION
This script is now necessary since webpack-cli no longer accepts arbitrary
flags.
We now have to set an environment variable from the flag and then
access that variable within the node process.

test plan:
1. run `yarn start` to observe the dev instance build and serve
2. run `yarn start --instance path/to/instance` and observe the
   configured instance get served
3. Any other inputs (1 or 3 arguments) arguments where the argv1 is not
   exactly ""--instance" should cause the default dev instance to be
   built

I'm happy to add further error behavior if desired for the 3rd case
