### PR TITLE
Setup separate API builds for web and node environments

### DIFF
--- a/config/webpack.config.api.js
+++ b/config/webpack.config.api.js
@@ -12,7 +12,7 @@ const getClientEnvironment = require("./env");
 
 const env = getClientEnvironment(null);
 
-module.exports = ({
+const baseConfig = {
   // Don't attempt to continue if there are any errors.
   bail: true,
   node: {
@@ -73,4 +73,26 @@ module.exports = ({
     new webpack.DefinePlugin(env.individuallyStringified),
   ],
   mode: process.env.NODE_ENV,
-} /*: any */);
+};
+
+const client = {
+  ...baseConfig,
+  target: "web",
+  output: {
+    ...baseConfig.output,
+    path: `${paths.apiBuild}/client`,
+    libraryTarget: "umd",
+  },
+};
+
+const server = {
+  ...baseConfig,
+  target: "node",
+  output: {
+    ...baseConfig.output,
+    path: `${paths.apiBuild}/server`,
+    libraryTarget: "commonjs",
+  },
+};
+
+module.exports = ([client, server] /*: Array<any>*/);

--- a/package.json
+++ b/package.json
@@ -167,7 +167,8 @@
     "!src/**/*.test.js?(.snap)",
     "!src/ui"
   ],
-  "main": "dist/api.js",
+  "main": "dist/server/api.js",
+  "browser": "dist/client/api.js",
   "module": "src/api/index.js",
   "bin": "./bin/sourcecred.js"
 }


### PR DESCRIPTION
# Description

The current API build is designed to only work in web browsers and not a NodeJS environment in the backend.
In order to allow API access to SourceCred from any environment, this fix creates two separate webpack
builds for web and node environments so that things like `fetch` are correctly polyfilled for the intended
environment. Previously trying to import and use the SourceCred API in a node environment would cause a
fatal error.

# Test Plan

Ensure `yarn build:api` runs correctly and two separate builds are created in dist/server/api.js
and dist/client/api.js.
