### PR TITLE
Fix createIdentity in discord plugin and add tests

### DIFF
--- a/src/plugins/discord/createIdentities.js
+++ b/src/plugins/discord/createIdentities.js
@@ -7,8 +7,8 @@ import {memberAddress} from "./createGraph";
 import {type IdentityProposal} from "../../core/ledger/identityProposal";
 import {coerce, nameFromString} from "../../core/identity/name";
 
-export function _createIdentity(member: Model.GuildMember): IdentityProposal {
-  let name = member.nick !== null ? member.nick : member.user.username;
+export function createIdentity(member: Model.GuildMember): IdentityProposal {
+  let name = member.nick || member.user.username;
   // Discord allows very long names. Let's ensure the length is reasonable.
   name = name.slice(0, 39);
   const description = `discord/${escape(name)}#${member.user.discriminator}`;
@@ -28,5 +28,5 @@ export function _createIdentity(member: Model.GuildMember): IdentityProposal {
 export function createIdentities(
   repo: SqliteMirrorRepository
 ): $ReadOnlyArray<IdentityProposal> {
-  return repo.members().map((m) => _createIdentity(m));
+  return repo.members().map((m) => createIdentity(m));
 }

--- a/src/plugins/discord/createIdentities.test.js
+++ b/src/plugins/discord/createIdentities.test.js
@@ -1,0 +1,117 @@
+// @flow
+
+import {createIdentities, createIdentity} from "./createIdentities";
+import {type GuildMember} from "./models";
+import {memberAddress} from "./createGraph";
+import {SqliteMirrorRepository} from "./mirrorRepository";
+
+describe("plugins/discord/createIdentities", () => {
+  const user = {
+    bot: false,
+    id: "678394436757094410",
+    username: "meta",
+    discriminator: "1234",
+  };
+  describe("createIdentity", () => {
+    it("creates a standard identity correctly", () => {
+      const member = {
+        nick: "metadreamer",
+        roles: [],
+        user,
+      };
+      const identity = createIdentity(member);
+      const expectedAlias = {
+        description: "discord/metadreamer#1234",
+        address: memberAddress(member),
+      };
+      expect(identity).toEqual({
+        pluginName: "discord",
+        name: "metadreamer",
+        type: "USER",
+        alias: expectedAlias,
+      });
+    });
+
+    it("coerces the username correctly", () => {
+      const member = {
+        nick: "coerceion?needed?",
+        roles: [],
+        user,
+      };
+      const identity = createIdentity(member);
+      expect(identity.name).toEqual("coerceion-needed-");
+    });
+
+    it("restricts the length of the name correctly", () => {
+      const member = {
+        nick: "123456789-123456789-123456789-123456789-123456789-",
+        roles: [],
+        user,
+      };
+      expect(member.nick.length).toBeGreaterThan(40);
+
+      const identity = createIdentity(member);
+      expect(identity.name.length).toBeLessThan(40);
+    });
+
+    it("falls back to username if member does not have a nickname set", () => {
+      [undefined, null, ""].forEach((nick) => {
+        const member = {
+          nick,
+          roles: [],
+          user,
+        };
+        const identity = createIdentity(member);
+        expect(identity.name).toEqual(user.username);
+      });
+    });
+
+    it("sets the type to BOT for bot members", () => {
+      const botMember = {
+        nick: "123456789-123456789-123456789-123456789-123456789-",
+        roles: [],
+        user: {
+          ...user,
+          bot: true,
+        },
+      };
+      const identity = createIdentity(botMember);
+
+      expect(identity.type).toEqual("BOT");
+    });
+  });
+
+  describe("createIdentities", () => {
+    function mockRepositoryForMembers(
+      members: $ReadOnlyArray<GuildMember>
+    ): SqliteMirrorRepository {
+      const mockRepo = {
+        members: () => members,
+      };
+      return (mockRepo: any);
+    }
+    it("handles a case with no identities", () => {
+      const repo = mockRepositoryForMembers([]);
+      expect(createIdentities(repo)).toEqual([]);
+    });
+    it("handles a case with 2 identities", () => {
+      const member1 = {
+        nick: "member1",
+        roles: [],
+        user,
+      };
+      const member2 = {
+        nick: "member2",
+        roles: [],
+        user: {
+          ...user,
+          id: "778394436757094410",
+        },
+      };
+      const members = [member1, member2];
+      const repo = mockRepositoryForMembers(members);
+      const expected = members.map((m) => createIdentity(m));
+      expect(createIdentities(repo)).toEqual(expected);
+    });
+  });
+});

--- a/src/plugins/discord/mirrorRepository.js
+++ b/src/plugins/discord/mirrorRepository.js
@@ -434,7 +434,7 @@ export class SqliteMirrorRepository {
         username: member.user.username,
         discriminator: member.user.discriminator,
         bot: Number(member.user.bot),
-        nick: member.nick,
+        nick: member.nick || null,
       });
 
     for (const role of member.roles) {

--- a/src/plugins/discord/models.js
+++ b/src/plugins/discord/models.js
@@ -64,7 +64,7 @@ export type User = {|
 
 export type GuildMember = {|
   +user: User,
-  +nick: string | null,
+  +nick: ?string,
   +roles: $ReadOnlyArray<Snowflake>,
 |};
 


### PR DESCRIPTION


<!-- Please read our contributor guide before submitting your PR: -->
<!-- https://github.com/sourcecred/sourcecred/blob/master/CONTRIBUTING.md -->

# Description

Previously if the `member.nick` field was undefined or an empty string, the createIdentity function
would throw a "Cannot read properly 'slice' of undefined" error instead of falling back to the username.

Additionally, the code was previously untested so I added tests to ensure correctness in the future.


# Test Plan

Ensure CI tests pass
