### PR TITLE
Implement GithubStorage for LedgerManager (read)

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "bottleneck": "^2.19.5",
     "chalk": "^4.0.0",
     "commonmark": "0.29.1",
+    "cross-fetch": "^3.0.6",
     "d3-array": "^2.4.0",
     "d3-format": "^2.0.0",
     "d3-scale": "^3.2.1",

--- a/src/api/index.js
+++ b/src/api/index.js
@@ -29,6 +29,9 @@ import * as ledgerUtils from "../core/ledger/utils";
 import * as grain from "../core/ledger/grain";
 import * as identity from "../core/identity";
 
+import * as manager from "./ledgerManager";
+import * as storage from "./ledgerStorage";
+
 const api = {
   core: {
     address,
@@ -50,6 +53,8 @@ const api = {
     identity,
     grain,
     utils: ledgerUtils,
+    manager,
+    storage,
   },
   plugins: {
     github: {

--- a/src/api/ledgerStorage/github.js
+++ b/src/api/ledgerStorage/github.js
@@ -1,0 +1,73 @@
+// @flow
+import fetch from "cross-fetch";
+import {decode as base64Decode} from "base-64";
+
+import {Ledger} from "../../core/ledger/ledger";
+import type {GithubToken} from "../../plugins/github/token";
+import {
+  type RepoIdString,
+  type RepoId,
+  stringToRepoId,
+} from "../../plugins/github/repoId";
+import type {LedgerStorage} from "../ledgerManager";
+
+const GET_LEDGER_QUERY = `
+query getLedger($owner:String!, $repo:String!) {
+  repository(owner: $owner, name: $repo) {
+    object(expression: "master:data/ledger.json") {
+      ... on Blob {
+        oid
+      }
+    }
+  }
+}
+`;
+
+export class GithubStorage implements LedgerStorage {
+  constructor(apiToken: GithubToken, repoId: RepoIdString) {
+    this._token = apiToken;
+    this._repoId = stringToRepoId(repoId);
+  }
+  _token: GithubToken;
+  _repoId: RepoId;
+
+  async read(): Promise<Ledger> {
+    const opts = {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${this._token}`,
+      },
+      body: JSON.stringify({
+        query: GET_LEDGER_QUERY,
+        variables: {
+          owner: this._repoId.owner,
+          repo: this._repoId.name,
+        },
+      }),
+    };
+
+    const res = await fetch(`https://api.github.com/graphql`, opts);
+
+    const {data} = await res.json();
+    const blobSha = data.repository.object.oid;
+
+    const ledgerBlobRes = await fetch(
+      `https://api.github.com/repos/${this._repoId.owner}/${this._repoId.name}/git/blobs/${blobSha}`,
+      {
+        method: "GET",
+        headers: {
+          Authorization: `Bearer ${this._token}`,
+        },
+      }
+    );
+    const ledgerDataBase64 = await ledgerBlobRes.json();
+
+    const rawLedger = base64Decode(ledgerDataBase64.content);
+
+    return Ledger.parse(rawLedger);
+  }
+
+  async write() {
+    throw new Error("method not implemented");
+  }
+}

--- a/src/api/ledgerStorage/index.js
+++ b/src/api/ledgerStorage/index.js
@@ -1,0 +1,4 @@
+// @flow
+import {GithubStorage} from "./github";
+
+export {GithubStorage};

--- a/yarn.lock
+++ b/yarn.lock
@@ -3349,6 +3349,13 @@ cross-fetch@^3.0.4:
     node-fetch "2.6.0"
     whatwg-fetch "3.0.0"
 
+cross-fetch@^3.0.6:
+  version "3.0.6"
+  resolved "https://registry.yarnpkg.com/cross-fetch/-/cross-fetch-3.0.6.tgz#3a4040bc8941e653e0e9cf17f29ebcd177d3365c"
+  integrity sha512-KBPUbqgFjzWlVcURG+Svp9TlhA5uliYtiNx/0r8nv0pdypeQCRJ9IaSIc3q/x3q8t3F75cHuwxVql1HFGHCNJQ==
+  dependencies:
+    node-fetch "2.6.1"
+
 cross-spawn@7.0.3, cross-spawn@^7.0.0, cross-spawn@^7.0.2, cross-spawn@^7.0.3:
   version "7.0.3"
   resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-7.0.3.tgz#f73a85b9d5d41d045551c177e2882d4ac85728a6"
@@ -7714,7 +7721,7 @@ node-fetch@2.6.0:
   resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.6.0.tgz#e633456386d4aa55863f676a7ab0daa8fdecb0fd"
   integrity sha512-8dG4H5ujfvFiqDmVu9fQ5bOHUC15JMjMY/Zumv26oOvvVJjM67KF8koCWIabKQ1GJIa9r2mMZscBq/TbdOcmNA==
 
-node-fetch@^2.6.1:
+node-fetch@2.6.1, node-fetch@^2.6.1:
   version "2.6.1"
   resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.6.1.tgz#045bd323631f76ed2e2b55573394416b639a0052"
   integrity sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw==


### PR DESCRIPTION

<!-- Please read our contributor guide before submitting your PR: -->
<!-- https://github.com/sourcecred/sourcecred/blob/master/CONTRIBUTING.md -->

# Description

A GithubStorage class for the LedgerManager would allow reading and writing
the ledger.json file directly to Github programmatically without having to
go through manual git commits. Useful to automate instance maintainer tasks
and in the future enable self-service admin.

Related: #2450


# Test Plan


- Build the NPM package and import it in an external JS file
- create a GithubStorage instance and call the `read()` method
- ensure the ledger is successfully fetched from the given cred instance
