### PR TITLE
Update MacOS GNU link to the most updated advice

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,12 +106,11 @@ on our Discord. You can also come to our weekly dev meeting, on Mondays at 12pm 
 - Install [Node] (tested on v14.x.x, v12.x.x and v10.x.x).
 - Install [Yarn] (tested on v1.7.0-v1.22.10).
 - For macOS users: Ensure that your environment provides GNU
-  coreutils. [See this comment for details about what, how, and
-  why.][macos-gnu]
+  coreutils. [See this comment for instructions.][macos-gnu]
 
 [node]: https://nodejs.org/en/
 [yarn]: https://yarnpkg.com/lang/en/
-[macos-gnu]: https://github.com/sourcecred/sourcecred/issues/698#issuecomment-417202213
+[macos-gnu]: https://github.com/sourcecred/sourcecred/issues/698#issuecomment-504217874
 
 If you want to work on the GitHub plugin, you should
 create a [GitHub API token]. No special permissions are required.


### PR DESCRIPTION
<!-- Please read our contributor guide before submitting your PR: -->
<!-- https://github.com/sourcecred/sourcecred/blob/master/CONTRIBUTING.md -->

# Description
Currently, we point to a link that tells new devs to install packages that aren't actually needed and that throw errors. There is another link in the same thread by @decentralion that has commands that actually work. At least 3 developers have had trouble with this and have confirmed that DL's steps work. This updates the link to point to the advice that works.

Why am I not pulling that advice into the README? Laziness. This mitigates the issue enough, and also it seems handy to have the added context in that thread.

<!-- Possible prompts:
  Why is the change important?
  Did you consider and reject alternate formulations of the same idea?
  Are there relevant issues or discussions elsewhere?
-->

# Test Plan
https://github.com/sourcecred/sourcecred/blob/80b4bfb0df30b5ea5352ae69eed5181f41395281/README.md
<!-- Possible prompts:
  How well covered by automated tests is this change?
  How did you manually test this change? How can a reviewer replicate the tests?
-->
