### PR TITLE
ExplorerHome UI: timeframe control

### DIFF
--- a/src/ui/components/LedgerViewer/LedgerViewer.js
+++ b/src/ui/components/LedgerViewer/LedgerViewer.js
@@ -93,14 +93,17 @@ export const LedgerViewer = ({
   }, []);
 
   const eventLog = useMemo(() => [...ledger.eventLog()], [ledger]);
-  const ts = useTableState(eventLog, {
-    initialRowsPerPage: PAGINATION_OPTIONS[0],
-    initialSort: {
-      sortName: DATE_SORT.name,
-      sortOrder: SortOrders.DESC,
-      sortFn: DATE_SORT.fn,
-    },
-  });
+  const ts = useTableState(
+    {data: eventLog},
+    {
+      initialRowsPerPage: PAGINATION_OPTIONS[0],
+      initialSort: {
+        sortName: DATE_SORT.name,
+        sortOrder: SortOrders.DESC,
+        sortFn: DATE_SORT.fn,
+      },
+    }
+  );
 
   return (
     <Paper className={classes.container}>

--- a/src/webutil/tableState.js
+++ b/src/webutil/tableState.js
@@ -141,8 +141,8 @@ type FilterFns<T> = {[string]: null | ((T) => boolean)};
   It encapsulates Sort, Pagination, and Filtering.
  */
 export function useTableState<T>(
-  // The base array. It should ideally be memoized before being passed in.
-  data: Array<T>,
+  // The base array. The `data` attribute should ideally be memoized before being passed in.
+  dataWrapper: {data: Array<T>},
   initialOptions?: {
     // The initial rows per page. Defaults to unpaginated.
     initialRowsPerPage?: number,
@@ -159,6 +159,7 @@ export function useTableState<T>(
     },
   }
 ): TableState<T> {
+  const data = useMemo(() => dataWrapper.data, [dataWrapper.data]);
   const optionDefaults = {
     initialRowsPerPage: Infinity,
     initialSort: {},


### PR DESCRIPTION
<!-- Please read our contributor guide before submitting your PR: -->
<!-- https://github.com/sourcecred/sourcecred/blob/master/CONTRIBUTING.md -->

# Description
This adds basic Timeframe Control (https://github.com/sourcecred/sourcecred/issues/2231) to the new ExplorerHome using the 4 preset time windows.

Some things that will need to be worked out after this PR:
- This week an last week show no line graphs because there is only 1 data point. Kinda awk.
- Activity Table header needs styled and timestamps need improved according to spec
<!-- Possible prompts:
  Why is the change important?
  Did you consider and reject alternate formulations of the same idea?
  Are there relevant issues or discussions elsewhere?
-->

# Test Plan
<img width="1165" alt="Screen Shot 2021-02-08 at 3 51 43 PM" src="https://user-images.githubusercontent.com/11550396/107296683-b8ffb780-6a26-11eb-824b-46b2214fd60c.png">
<img width="1004" alt="Screen Shot 2021-02-08 at 3 51 54 PM" src="https://user-images.githubusercontent.com/11550396/107296692-bdc46b80-6a26-11eb-92fb-88aaaca415f0.png">
<img width="1094" alt="Screen Shot 2021-02-08 at 3 52 03 PM" src="https://user-images.githubusercontent.com/11550396/107296697-c026c580-6a26-11eb-9efd-3ee1de532c8b.png">
<img width="962" alt="Screen Shot 2021-02-08 at 3 52 11 PM" src="https://user-images.githubusercontent.com/11550396/107296717-c4eb7980-6a26-11eb-9c28-df99c0d9f0a3.png">

<!-- Possible prompts:
  How well covered by automated tests is this change?
  How did you manually test this change? How can a reviewer replicate the tests?
-->
