### PR TITLE
Bug fix: observe discord rate-limits

### DIFF
--- a/src/plugins/discord/fetcher.js
+++ b/src/plugins/discord/fetcher.js
@@ -2,7 +2,6 @@
 
 import fetch from "isomorphic-fetch";
 import * as Model from "./models";
-import {type TaskReporter} from "../../util/taskReporter";
 
 export interface DiscordApi {
   guilds(): Promise<$ReadOnlyArray<Model.Guild>>;

--- a/src/plugins/discord/fetcher.test.js
+++ b/src/plugins/discord/fetcher.test.js
@@ -1,6 +1,7 @@
 // @flow
 
 import {snapshotFetcher} from "./mockSnapshotFetcher";
+import {Fetcher} from "./fetcher";
 
 describe("plugins/discord/fetcher", () => {
   describe("snapshot testing", () => {
@@ -36,6 +37,24 @@ describe("plugins/discord/fetcher", () => {
       expect(
         await snapshotFetcher().reactions(channelId, messageId, emoji)
       ).toMatchSnapshot();
+    });
+  });
+  describe("_fetchJson", () => {
+    it("waits when no calls remain", async () => {
+      const spy = jest.spyOn(global.console, "warn");
+      const currentTime = Math.round(Date.now());
+      const mockRes = new Response(null, {
+        headers: {
+          "x-ratelimit-remaining": "0",
+          "x-ratelimit-reset": `${currentTime + 5}`,
+        },
+      });
+      const mockToken = "XYZ";
+      const fetcher = new Fetcher({token: mockToken});
+      fetcher._checkRateLimit(mockRes);
+      await fetcher._wait();
+      expect(console.warn).toBeCalled();
+      spy.mockRestore();
     });
   });
 });

--- a/src/plugins/discord/fetcher.test.js
+++ b/src/plugins/discord/fetcher.test.js
@@ -39,21 +39,23 @@ describe("plugins/discord/fetcher", () => {
       ).toMatchSnapshot();
     });
   });
-  describe("_fetchJson", () => {
-    it("waits when no calls remain", async () => {
-      const spy = jest.spyOn(global.console, "warn");
-      const currentTime = Math.round(Date.now());
+  describe("_checkRateLimit", () => {
+    it("waits when no calls remain", () => {
+      const spy = jest.spyOn(global, "setTimeout");
+      const currentTime = Math.round(Date.now()) / 1000;
       const mockRes = new Response(null, {
         headers: {
           "x-ratelimit-remaining": "0",
-          "x-ratelimit-reset": `${currentTime + 5}`,
+          "x-ratelimit-reset": `${currentTime + 2}`,
         },
       });
       const mockToken = "XYZ";
       const fetcher = new Fetcher({token: mockToken});
       fetcher._checkRateLimit(mockRes);
-      await fetcher._wait();
-      expect(console.warn).toBeCalled();
+      //  testing async is flaky, so we just ensure a timeout is actually set
+      fetcher._wait();
+      expect(setTimeout).toBeCalled();
+      expect(spy.mock.calls[0][1]).toBeGreaterThan(0);
       spy.mockRestore();
     });
   });


### PR DESCRIPTION
<!-- Please read our contributor guide before submitting your PR: -->
<!-- https://github.com/sourcecred/sourcecred/blob/master/CONTRIBUTING.md -->

# Description
There was an issue when loading data from discord API, where we would make endless requests exceeding our rate-limit. This caused inconsistent cred scores several times a day on big instances. The proposed solution adds a new attribute to the fetcher called `timeout`. After a valid response, we check the discord response headers and see if we have any requests remaining before hitting the rate-limit. If not, the `timeout` variable is set to the time when we are allowed to make more requests.

Every time the fetcher is called, it checks if  rate limit timeout has been set by Discord's API and waits for the `timeout` to pass before making any further requests. This design would allow for parallel use of the class, since all fetch requests must observe a the timeout.

<!-- Possible prompts:
  Why is the change important?
  Did you consider and reject alternate formulations of the same idea?
  Are there relevant issues or discussions elsewhere?
-->

# Test Plan
In the tests, we covered the scenario where the fetcher would get a rate-limited response and wait until it can continue.

We also ran integration tests with the SourceCred Production instance

paired with: @topocount 

<!-- Possible prompts:
  How well covered by automated tests is this change?
  How did you manually test this change? How can a reviewer replicate the tests?
-->
