### PR TITLE
Activity Table date label formatting

### DIFF
--- a/src/ui/components/ExplorerHome/ExplorerHome.js
+++ b/src/ui/components/ExplorerHome/ExplorerHome.js
@@ -197,12 +197,10 @@ export const ExplorerHome = ({
   if (!initialView) return null;
 
   const classes = useStyles();
-  // default view is Last Week's Activity
+  // default view is Last Week's Activity (array index 1)
   const [tab, setTab] = useState<number>(1);
   const [selectedInterval, setSelectedInterval] = useState<Interval>(
-    TIMEFRAME_OPTIONS[TIMEFRAME_OPTIONS.length - 1].selector(
-      initialView.intervals()
-    )
+    TIMEFRAME_OPTIONS[1].selector(initialView.intervals())
   );
   const updateTimeframe = (index) => {
     setTab(index);

--- a/src/ui/components/ExplorerHome/ExplorerHome.js
+++ b/src/ui/components/ExplorerHome/ExplorerHome.js
@@ -1,10 +1,5 @@
 // @flow
-import React, {
-  useState,
-  useEffect,
-  useMemo,
-  type Node as ReactNode,
-} from "react";
+import React, {useState, useMemo, type Node as ReactNode} from "react";
 import {
   Checkbox,
   Container,
@@ -202,17 +197,19 @@ export const ExplorerHome = ({
   if (!initialView) return null;
 
   const classes = useStyles();
-  const [tab, setTab] = useState<number>(TIMEFRAME_OPTIONS.length - 1);
+  // default view is Last Week's Activity
+  const [tab, setTab] = useState<number>(1);
   const [selectedInterval, setSelectedInterval] = useState<Interval>(
     TIMEFRAME_OPTIONS[TIMEFRAME_OPTIONS.length - 1].selector(
       initialView.intervals()
     )
   );
-  useEffect(() => {
+  const updateTimeframe = (index) => {
+    setTab(index);
     setSelectedInterval(
-      TIMEFRAME_OPTIONS[tab].selector(initialView.intervals())
+      TIMEFRAME_OPTIONS[index].selector(initialView.intervals())
     );
-  }, [tab]);
+  };
   const timeScopedCredGrainView = useMemo(
     () =>
       initialView.withTimeScope(
@@ -354,22 +351,51 @@ export const ExplorerHome = ({
     </div>
   );
 
-  const formatInterval = (interval) =>
-    formatTimestamp(interval.startTimeMs, {
-      month: "short",
-      day: "numeric",
-      hour: undefined,
-      minute: undefined,
-      year: "numeric",
-    }) +
-    " to " +
-    formatTimestamp(interval.endTimeMs, {
-      month: "short",
-      day: "numeric",
-      hour: undefined,
-      minute: undefined,
-      year: "numeric",
-    });
+  const formatInterval = (interval) => {
+    const formatWithYear = (timestamp) =>
+      formatTimestamp(timestamp, {
+        month: "short",
+        day: "numeric",
+        hour: undefined,
+        minute: undefined,
+        year: "numeric",
+      });
+
+    const formatWithoutYear = (timestamp) =>
+      formatTimestamp(timestamp, {
+        month: "short",
+        day: "numeric",
+        hour: undefined,
+        minute: undefined,
+        year: undefined,
+      });
+
+    const isTodayOrLater = (someDate) => {
+      const today = new Date();
+      today.setHours(0);
+      today.setMinutes(0);
+      today.setSeconds(0);
+      today.setMilliseconds(0);
+
+      return someDate >= today;
+    };
+
+    const currentYear = new Date().getFullYear();
+    const startDate = new Date(interval.startTimeMs);
+    const endDate = new Date(interval.endTimeMs);
+
+    const startTime =
+      startDate.getFullYear() === currentYear
+        ? formatWithoutYear(interval.startTimeMs)
+        : formatWithYear(interval.startTimeMs);
+
+    const endTime = isTodayOrLater(endDate)
+      ? "Today"
+      : formatWithYear(interval.endTimeMs);
+
+    return `${startTime} to ${endTime}`;
+  };
+
   // const makeBarChart = () => {
   //   const margin = 60;
   //   const width = 1000 - 2 * margin;
@@ -395,7 +421,7 @@ export const ExplorerHome = ({
           value={tab}
           indicatorColor="primary"
           textColor="primary"
-          onChange={(_, val) => setTab(val)}
+          onChange={(_, val) => updateTimeframe(val)}
         >
           {TIMEFRAME_OPTIONS.map(({tabLabel}) => (
             <Tab key={tabLabel} label={tabLabel} />

--- a/src/ui/components/ExplorerHome/ExplorerHome.js
+++ b/src/ui/components/ExplorerHome/ExplorerHome.js
@@ -370,20 +370,16 @@ export const ExplorerHome = ({
 
     const isTodayOrLater = (someDate) => {
       const today = new Date();
-      today.setHours(0);
-      today.setMinutes(0);
-      today.setSeconds(0);
-      today.setMilliseconds(0);
+      today.setHours(0, 0, 0, 0);
 
       return someDate >= today;
     };
 
-    const currentYear = new Date().getFullYear();
     const startDate = new Date(interval.startTimeMs);
     const endDate = new Date(interval.endTimeMs);
 
     const startTime =
-      startDate.getFullYear() === currentYear
+      startDate.getFullYear() === endDate.getFullYear()
         ? formatWithoutYear(interval.startTimeMs)
         : formatWithYear(interval.startTimeMs);
 


### PR DESCRIPTION
# Description
This PR builds upon @blueridger's work implementing the date interval selection. These changes include:
- Date string formatting as per issue #2260
-- Show start year only when different from end year
-- Show "Today" instead of current or future date
- Default to "Last Week's Activity" time interval on page load
- Eliminated a visible repaint by refactoring interval selection out of `useEffect` and into a small helper function

# Test Plan
Tested manually, viewing date formats when switching between each date interval

## Before
https://www.loom.com/share/4d5b8af1b2c34bb7824e4f3ef8841345

## After
https://www.loom.com/share/e5e20f03e95d400ca846d08dde893ced