### PR TITLE
Sort grain numerically, not alphabetically in Activity Table

### DIFF
--- a/src/ui/components/ExplorerHome/ExplorerHome.js
+++ b/src/ui/components/ExplorerHome/ExplorerHome.js
@@ -23,6 +23,7 @@ import {
 import {makeStyles} from "@material-ui/core/styles";
 import TableSortLabel from "@material-ui/core/TableSortLabel";
 import deepFreeze from "deep-freeze";
+import bigInt from "big-integer";
 import {CredGrainView} from "../../../core/credGrainView";
 import {
   useTableState,
@@ -139,7 +140,7 @@ const CRED_SORT = deepFreeze({
 });
 const GRAIN_SORT = deepFreeze({
   name: Symbol("Grain"),
-  fn: (n) => n.grainEarned,
+  fn: (n) => bigInt(n.grainEarned),
 });
 const PAGINATION_OPTIONS = deepFreeze([50, 100, 200]);
 const TIMEFRAME_OPTIONS: Array<{|


### PR DESCRIPTION
# Description
I got the cred repo going as my test instance and realized that the grain sort on the activity table is sorting string-wise rather than numerically, because grain is represented as a string. I updated the sorting function to wrap the grain string in a bigInt() so it now sorts correctly.

# Test Plan
Tested manually with `cred` repo data (which has real grain values) with the following steps:

- Load page
- Click "Grain" header for ascending sort. Confirm sort is ascending
- Click "Grain" header again for descending sort. Confirm sort is descending

## Before
<img width="705" alt="Screen Shot 2021-02-10 at 22 46 43" src="https://user-images.githubusercontent.com/225508/107578664-52c88f80-6bf4-11eb-871c-61fb2fcf0ca2.png">

## After
<img width="714" alt="Screen Shot 2021-02-10 at 22 46 00" src="https://user-images.githubusercontent.com/225508/107578683-578d4380-6bf4-11eb-90a0-63806a64251a.png">
