### PR TITLE
update docs for ledger.lastDistributionTimestamp

### DIFF
--- a/src/core/ledger/ledger.js
+++ b/src/core/ledger/ledger.js
@@ -704,8 +704,15 @@ export class Ledger {
    *
    * We provide this because we may want to have a policy that issues one
    * distribution for each interval in the history of the project.
+   *
+   * If there were never any distributions, then -Infinity will be returned.
    */
   lastDistributionTimestamp(): TimestampMs {
+    // TODO(#2744): Amend interface to return null instead of -Infinity
+    // This will be a better interface primarily because in flow checking, it's
+    // easy for the client to not realize that -Infinity could get returned, and
+    // making an explicit return `TimestampMs | null` type will encourage callers
+    // to handle the edge case explicitly.
     return this._lastDistributionTimestamp;
   }
 

--- a/src/core/ledger/ledger.test.js
+++ b/src/core/ledger/ledger.test.js
@@ -1416,9 +1416,15 @@ describe("core/ledger/ledger", () => {
         failsWithoutMutation(ledger, thunk, "invalid timestamp");
       }
     });
+    it("lastDistributionTimestamp returns -Infinity if there have not been any distributions", () => {
+      // consider changing this behavior; see
+      // https://github.com/sourcecred/sourcecred/issues/2744
+      const ledger = new Ledger();
+      expect(ledger.lastDistributionTimestamp()).toEqual(-Infinity);
+    });
   });
 
-  describe("timestamps", () => {
+  describe("uuids", () => {
     it("ledger events have uuids", () => {
       const ledger = new Ledger();
       resetFakeUuid();


### PR DESCRIPTION
The API for ledger.lastDistributionTimestamp doesn't specify what
happens when there haven't been any distributions. Counter-intuitively,
we return -Infinity, and we actually depend on that behavior elsewhere,
so it can't easily be changed. This commit just updates the
documentation so that we track this accordingly, and also I filed a new
issue to consider changing this.

Test plan: `yarn test` passes, since it's only an update to docs/test
code, this definitely suffices.

There's a potential improvement refactor here, see https://github.com/sourcecred/sourcecred/issues/2744
