### PR TITLE
Refactor AccountOverview to use Ledger APIs

### DIFF
--- a/src/ui/components/AccountOverview.js
+++ b/src/ui/components/AccountOverview.js
@@ -12,7 +12,6 @@ import {type Account} from "../../core/ledger/ledger";
 import {type CurrencyDetails} from "../../api/currencyConfig";
 import * as G from "../../core/ledger/grain";
 import {useLedger} from "../utils/LedgerContext";
-import findLast from "lodash.findlast";
 import {formatTimestamp} from "../utils/dateHelpers";
 import {makeStyles} from "@material-ui/core/styles";
 
@@ -32,15 +31,13 @@ export const AccountOverview = ({
   const {ledger} = useLedger();
   const classes = useStyles();
 
-  const accounts = ledger.accounts();
-  const lastPayoutEvent = findLast(
-    ledger.eventLog(),
-    (event) => event.action.type === "DISTRIBUTE_GRAIN"
-  );
-  const lastPayoutMessage = lastPayoutEvent
-    ? `Last distribution: ${formatTimestamp(lastPayoutEvent.ledgerTimestamp)}`
-    : "";
+  const lastDistributionTimestamp = ledger.lastDistributionTimestamp();
+  const lastPayoutMessage =
+    lastDistributionTimestamp === -Infinity
+      ? ""
+      : `Last distribution: ${formatTimestamp(lastDistributionTimestamp)}`;
 
+  const accounts = ledger.accounts();
   function comparator(a: Account, b: Account) {
     if (a.balance === b.balance) {
       return 0;


### PR DESCRIPTION
This commit does a slight refactor of the AccountOverview so that rather
than manually scanning for the last distribution timestamp by iterating
over every ledger event, it uses the existing
`Ledger.lastDistributionTimestamp` API. This has two benefits:

1. It's much more performant, as now a frontend UI load doesn't need to
do another scan over every event in the ledger history, instead using a
cached property that's present on the ledger
1. It avoids re-implementing ledger specific scanning logic, even though
it does use the public API it still feels like a leakage of ledger
implementation details

Test plan: Load the UI and verify that the display is correct, both in
the case with/without any distributions

Note: This makes a slight semantic change to the last distribution timestamp indicator. Previously, we displayed the ledger timestamp (i.e. when was the distribution event created). Now we show the cred timestamp (i.e. when did the Cred period associated with the last distribution end). I think this is fine.



┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1200032326400385/1200038305658509) by [Unito](https://www.unito.io/learn-more)
