### PR TITLE
Implement write method for GitHubStorage

### DIFF
--- a/src/api/ledgerStorage/github.js
+++ b/src/api/ledgerStorage/github.js
@@ -12,9 +12,9 @@ import {
 import type {LedgerStorage} from "../ledgerManager";
 
 const GET_LEDGER_QUERY = `
-query getLedger($owner:String!, $repo:String!) {
+query getLedger($owner: String!, $repo: String!, $expression:String!) {
   repository(owner: $owner, name: $repo) {
-    object(expression: "master:data/ledger.json") {
+    object(expression: $expression) {
       ... on Blob {
         oid
       }
@@ -23,16 +23,37 @@ query getLedger($owner:String!, $repo:String!) {
 }
 `;
 
+type CreateBlobRes = {
+  sha: string,
+  url: string,
+};
+
+type Opts = {
+  apiToken: GithubToken,
+  repo: RepoIdString,
+  branch: string,
+};
+
 export class GithubStorage implements LedgerStorage {
-  constructor(apiToken: GithubToken, repoId: RepoIdString) {
-    this._token = apiToken;
-    this._repoId = stringToRepoId(repoId);
+  static ENDPOINT: string = "https://api.github.com";
+
+  constructor(opts: Opts) {
+    this._token = opts.apiToken;
+    this._repoId = stringToRepoId(opts.repo);
+    this._branch = opts.branch;
   }
+
   _token: GithubToken;
   _repoId: RepoId;
+  _branch: string;
+
+  _getRepoEndpoint(): string {
+    const {owner, name} = this._repoId;
+    return `${GithubStorage.ENDPOINT}/repos/${owner}/${name}`;
+  }
 
   async read(): Promise<Ledger> {
-    const opts = {
+    const options = {
       method: "POST",
       headers: {
         Authorization: `Bearer ${this._token}`,
@@ -42,17 +63,18 @@ export class GithubStorage implements LedgerStorage {
         variables: {
           owner: this._repoId.owner,
           repo: this._repoId.name,
+          expression: `${this._branch}:data/ledger.json`,
         },
       }),
     };
 
-    const res = await fetch(`https://api.github.com/graphql`, opts);
+    const result = await fetch(`${GithubStorage.ENDPOINT}/graphql`, options);
 
-    const {data} = await res.json();
+    const {data} = await result.json();
     const blobSha = data.repository.object.oid;
 
     const ledgerBlobRes = await fetch(
-      `https://api.github.com/repos/${this._repoId.owner}/${this._repoId.name}/git/blobs/${blobSha}`,
+      `${this._getRepoEndpoint()}/git/blobs/${blobSha}`,
       {
         method: "GET",
         headers: {
@@ -67,7 +89,77 @@ export class GithubStorage implements LedgerStorage {
     return Ledger.parse(rawLedger);
   }
 
-  async write() {
-    throw new Error("method not implemented");
+  async write(ledger: Ledger, message?: string) {
+    const ledgerData = ledger.serialize();
+
+    // Get latest commit hash of target branch
+    const targetBranchResult = await fetch(
+      `${this._getRepoEndpoint()}/git/ref/heads/${this._branch}`,
+      {
+        method: "GET",
+        headers: {
+          Authorization: `Bearer ${this._token}`,
+        },
+      }
+    );
+
+    const targetBranchData = await targetBranchResult.json();
+    const baseCommit = targetBranchData.object.sha;
+
+    // Create a new tree from the latest commit and update the ledger blob
+    const uploadLedgerBlobResult = await fetch(
+      `${this._getRepoEndpoint()}/git/trees`,
+      {
+        method: "POST",
+        headers: {
+          Authorization: `Bearer ${this._token}`,
+        },
+        body: JSON.stringify({
+          tree: [
+            {
+              content: ledgerData,
+              type: "blob",
+              path: "data/ledger.json",
+              mode: "100644", // see https://docs.github.com/en/rest/reference/git#create-a-tree
+            },
+          ],
+          base_tree: baseCommit,
+        }),
+      }
+    );
+
+    const uploadLedgerBlobTree: CreateBlobRes = await uploadLedgerBlobResult.json();
+
+    // Create a commit with the new tree on top of the target branch
+    const commitLedgerResult = await fetch(
+      `${this._getRepoEndpoint()}/git/commits`,
+      {
+        method: "POST",
+        headers: {
+          Authorization: `Bearer ${this._token}`,
+        },
+        body: JSON.stringify({
+          message: `Ledger Update${message ? `: ${message}` : ""}`,
+          tree: uploadLedgerBlobTree.sha,
+          parents: [baseCommit],
+          author: {
+            name: "credbot",
+            email: "credbot@users.noreply.github.com",
+          },
+        }),
+      }
+    );
+    const newLedgerCommit = await commitLedgerResult.json();
+
+    // Update the target branch to point to the new commit
+    await fetch(`${this._getRepoEndpoint()}/git/refs/heads/${this._branch}`, {
+      method: "PATCH",
+      headers: {
+        Authorization: `Bearer ${this._token}`,
+      },
+      body: JSON.stringify({
+        sha: newLedgerCommit.sha,
+      }),
+    });
   }
 }


### PR DESCRIPTION
# Description

This completes the implementation of the GithubStorage class to be used by the LedgerManager.
The write operation happens 4 steps to allow for ledger.json files larger than 1MB:

1. Get latest commit hash of target branch
2. Upload a Blob of the serialized ledger and create a new tree from the latest commit
3. Create a new commit with the new tree that includes the updated ledger.json file
4. Update the target branch to point at the new commit

# Test Plan

Setup a script with LedgerManager and GithubStorage to programmatically update the ledger
and call the persist() method. Ensure the target branch is updated with the new changes in the ledger.

(I have a [discord bot setup for this](https://github.com/MetaFam/TheGame/pull/332/files), can demo live to anyone reviewing in case you dont want to set everything up yourself)