### PR TITLE
Discord: users mentioned multiple times earn more cred

### DIFF
--- a/src/plugins/discord/fetcher.js
+++ b/src/plugins/discord/fetcher.js
@@ -182,7 +182,10 @@ export class Fetcher implements DiscordApi {
       content: x.content,
       reactionEmoji: (x.reactions || []).map((r) => r.emoji),
       nonUserAuthor: x.webhook_id != null || false,
-      mentions: (x.mentions || []).map((user) => user.id),
+      mentions: (x.mentions || []).map((user) => ({
+        userId: user.id,
+        count: Array.from(x.content.matchAll(`<@!?${user.id}>`)).length,
+      })),
     }));
   }
 

--- a/src/plugins/discord/models.js
+++ b/src/plugins/discord/models.js
@@ -101,7 +101,12 @@ export type Message = {|
   // We could filter based on which types of emoji have been added though.
   +reactionEmoji: $ReadOnlyArray<Emoji>,
   // Snowflake of user IDs.
-  +mentions: $ReadOnlyArray<Snowflake>,
+  +mentions: $ReadOnlyArray<Mention>,
+|};
+
+export type Mention = {|
+  +userId: Snowflake,
+  +count: number,
 |};
 
 export type Reaction = {|

--- a/src/plugins/discord/reactionWeights.test.js
+++ b/src/plugins/discord/reactionWeights.test.js
@@ -28,7 +28,7 @@ describe("plugins/discord/reactionWeights", () => {
     timestampMs: 1,
     content: "hello world",
     reactionEmoji: [heartEmoji, sourcecredEmoji],
-    mentions: [reacterId],
+    mentions: [{userId: reacterId, count: 1}],
   });
 
   const authorMember: GuildMember = deepFreeze({


### PR DESCRIPTION
<!-- Please read our contributor guide before submitting your PR: -->
<!-- https://github.com/sourcecred/sourcecred/blob/master/CONTRIBUTING.md -->

# Description
To myself and others I've talked to, it feels intuitive that a user mentioned twice in a message (especially props or meeting attendance) would earn twice the cred from that message than a user who is only mentioned once. People assume that's why we mention facilitators twice in meeting attendance. However, this was not the case. This PR fixes that by tracking the count for each member mentioned in a message, and using that to set an edge weight multiplier on the PROPS/MENTIONS edge.

In addition to making the logic more intuitive, this will move a little cred from meeting attendees to meeting facilitators/notetakers in our own community.

# Design Choices
Although I am particularly interested in the affect this will have in our meeting attendance channel, I decided to apply this logic across the entire discord experience for several reasons:
- More understandable for users to have consistent logic that is intuitive for them.
- Simpler code.
- It is rare that people are mentioned in a message more that once outside of meeting attendance.

I use a regex matcher on the content because the Discord API does not natively provide information on how many times a mentioned user is mentioned.

# Resources:
[How Discord Mentions Work](https://discordjs.guide/miscellaneous/parsing-mention-arguments.html) (note this link is from Discord.js which we don't use, but the linked section is still applicable)

<!-- Possible prompts:
  Why is the change important?
  Did you consider and reject alternate formulations of the same idea?
  Are there relevant issues or discussions elsewhere?
-->

# Test Plan
This code is not particularly covered with unit tests, but the manual testing I did seems sufficient.
```
<checkout master>
scdev go
<checkout changes>
scdev load
sqlite3 cache/sourcecred/discord/discordMirror.db
<ctrl-c>
scdev graph -d -s
scdev graph
scdev credrank -d -s
```

## Sqlite
```
sqlite> select count(*) from message_mentions where count = 1;
8527
sqlite> select count(*) from message_mentions where count = 2;
188
sqlite> select count(*) from message_mentions where count = 0;
890
sqlite> select count(*) from message_mentions where count = 3;
49
sqlite> select * from message_mentions where count = 2 limit 5;
453243919774253083|537505227042062348|448999206401605632|2
453243919774253083|537505227042062348|439050857921904640|2
453243919774253083|603144782583300107|427964041764274177|2
453243919774253083|693110568265187449|246394246368722944|2
454007860926611478|545425153362886679|420341518948237331|2
```

## Graph Diff
I verified the new nodes/edges are just activity that happened between `load` jobs. This PR is just responsible for the new Edge Weight Diffs.
```
...

EdgeAddress["sourcecred","discord","PROPS","743545520445718700","121773315776970753","786756955238039614","user","443464752094773258"]
Old:	No matching address
New:	{"backwards":1,"forwards":3}

EdgeAddress["sourcecred","discord","PROPS","743545520445718700","121773315776970753","786756955238039614","user","633708951447535616"]
Old:	No matching address
New:	{"backwards":1,"forwards":2}

EdgeAddress["sourcecred","discord","MENTIONS","796471818080616519","420341518948237331","802255736629362688","user","118260545211072517"]
Old:	No matching address
New:	{"backwards":1,"forwards":2}

=============================================================
  sourcecred/discord - Summary of Changes
=============================================================
Node Diffs: 306
Node Weight Diffs: 157
Edge Diffs: 569
Edge Weight Diffs: 239
```

## Cred diff
The following is credrank, and includes a lot of noise from picking up more/less activity (due to time delay and 500s), so it doesn't really serve for anything except to show that nothing too drastic happened.

### Before:
```
| Description | Cred | % |
| --- | --- | --- |
| decentralion | 36712.4 | 19.3% |
| lbstrobbe | 14330.3 | 7.5% |
| wchargin | 12610.0 | 6.6% |
| s-ben | 11463.5 | 6.0% |
| KuraFire | 10843.5 | 5.7% |
| hammad | 10771.8 | 5.7% |
| Thena | 8519.2 | 4.5% |
| topocount | 7875.1 | 4.1% |
| panchomiguel | 7286.9 | 3.8% |
| joiecousins | 7128.3 | 3.7% |
| beanow | 6595.3 | 3.5% |
| sandpiper | 6456.3 | 3.4% |
| bex | 6368.4 | 3.3% |
| Jojo | 2835.6 | 1.5% |
| benoxmo | 2377.9 | 1.2% |
| dependabot | 2141.8 | 1.1% |
| burrrata | 2016.7 | 1.1% |
| eeli | 1894.3 | 1.0% |
| mzargham | 1718.6 | 0.9% |
| youngkidwarrior | 1505.2 | 0.8% |
```

### After:
```
| Description | Cred | % |
| --- | --- | --- |
| decentralion | 36726.6 | 19.3% |
| lbstrobbe | 14780.4 | 7.8% |
| wchargin | 12574.1 | 6.6% |
| KuraFire | 11437.6 | 6.0% |
| s-ben | 11272.8 | 5.9% |
| hammad | 10663.7 | 5.6% |
| Thena | 8381.3 | 4.4% |
| topocount | 7954.5 | 4.2% |
| panchomiguel | 7294.4 | 3.8% |
| joiecousins | 7016.2 | 3.7% |
| beanow | 6597.4 | 3.5% |
| sandpiper | 6461.5 | 3.4% |
| bex | 6346.0 | 3.3% |
| Jojo | 2848.1 | 1.5% |
| benoxmo | 2346.5 | 1.2% |
| dependabot | 2142.2 | 1.1% |
| burrrata | 2017.0 | 1.1% |
| eeli | 1777.0 | 0.9% |
| mzargham | 1716.9 | 0.9% |
| ian | 1470.6 | 0.8% |
```
