### PR TITLE
CLI: Run 'credrank' quietly during 'go'

### DIFF
--- a/src/cli/credrank.js
+++ b/src/cli/credrank.js
@@ -24,10 +24,14 @@ function die(std, message) {
 const credrankCommand: Command = async (args, std) => {
   let shouldIncludeDiff = false;
   let isSimulation = false;
+  let shouldRunStealth = false;
   const processedArgs = args.filter((arg) => {
     switch (arg) {
       case "-d":
         shouldIncludeDiff = true;
+        return false;
+      case "--stealth":
+        shouldRunStealth = true;
         return false;
       case "-s":
       case "--simulate":
@@ -39,7 +43,10 @@ const credrankCommand: Command = async (args, std) => {
   });
 
   if (processedArgs.length !== 0) {
-    return die(std, "usage: sourcecred credrank [-d]");
+    return die(
+      std,
+      "usage: sourcecred credrank [-d] [-s | --simulate] [--stealth]"
+    );
   }
   const taskReporter = new LoggingTaskReporter();
   taskReporter.start("credrank");
@@ -74,7 +81,7 @@ const credrankCommand: Command = async (args, std) => {
       printCredSummaryTable(credGraph);
     }
     taskReporter.finish("load prior graph");
-  } else {
+  } else if (!shouldRunStealth) {
     printCredSummaryTable(credGraph);
   }
 

--- a/src/cli/go.js
+++ b/src/cli/go.js
@@ -5,6 +5,7 @@ import dedent from "../util/dedent";
 
 import load from "./load";
 import graph from "./graph";
+import credrank from "./credrank";
 import score from "./score";
 
 function die(std, message) {
@@ -23,14 +24,15 @@ const goCommand: Command = async (args, std) => {
   }
 
   const commandSequence = [
-    {name: "load", command: load},
-    {name: "graph", command: graph},
-    {name: "score", command: score},
+    {name: "load", command: load, args: []},
+    {name: "graph", command: graph, args: []},
+    {name: "credrank", command: credrank, args: ["--stealth"]},
+    {name: "score", command: score, args: []},
   ];
 
-  for (const {name, command} of commandSequence) {
+  for (const {name, command, args} of commandSequence) {
     if (name === "load" && noLoad) continue;
-    const ret = await command([], std);
+    const ret = await command(args, std);
     if (ret !== 0) {
       return die(std, `go: failed on command ${name}`);
     }


### PR DESCRIPTION
<!-- Please read our contributor guide before submitting your PR: -->
<!-- https://github.com/sourcecred/sourcecred/blob/master/CONTRIBUTING.md -->

# Description
I am making this change in time for the upcoming version release, which will not include the credrank migration.
This adds `credrank` to the `go` command, which will allow us to forcefully browse to the unfinished `explorer-home` page and compare the results on live instances. This will be nice to preview what changes to cred are coming in the following version release.

I also added a `--stealth` flag so that the `go` command doesn't print credrank scores that are not actually being used, so as not to confuse our instance maintainers. We can remove this flag after the migration.
<!-- Possible prompts:
  Why is the change important?
  Did you consider and reject alternate formulations of the same idea?
  Are there relevant issues or discussions elsewhere?
-->

# Test Plan
```
scdev go && scdev serve
```
Verified that both the `explorer` (from the menu) and `explorer-home` (from forceful browsing) pages work.
<!-- Possible prompts:
  How well covered by automated tests is this change?
  How did you manually test this change? How can a reviewer replicate the tests?
-->
