### PR TITLE
Activity Table to show all time contribution charts

### DIFF
--- a/src/ui/components/ExplorerHome/ExplorerHome.js
+++ b/src/ui/components/ExplorerHome/ExplorerHome.js
@@ -203,12 +203,26 @@ export const ExplorerHome = ({
   const [selectedInterval, setSelectedInterval] = useState<Interval>(
     TIMEFRAME_OPTIONS[1].selector(initialView.intervals())
   );
+  const [checkboxes, setCheckboxes] = useState({
+    [IdentityTypes.USER]: false,
+    [IdentityTypes.ORGANIZATION]: false,
+    [IdentityTypes.BOT]: false,
+    [IdentityTypes.PROJECT]: false,
+  });
+
   const updateTimeframe = (index) => {
     setTab(index);
     setSelectedInterval(
       TIMEFRAME_OPTIONS[index].selector(initialView.intervals())
     );
   };
+
+  const allTimeContributionCharts = {};
+  for (const participant of initialView.participants()) {
+    allTimeContributionCharts[String(participant.identity.id)] =
+      participant.credPerInterval;
+  }
+
   const timeScopedCredGrainView = useMemo(
     () =>
       initialView.withTimeScope(
@@ -217,12 +231,6 @@ export const ExplorerHome = ({
       ),
     [selectedInterval]
   );
-  const [checkboxes, setCheckboxes] = useState({
-    [IdentityTypes.USER]: false,
-    [IdentityTypes.ORGANIZATION]: false,
-    [IdentityTypes.BOT]: false,
-    [IdentityTypes.PROJECT]: false,
-  });
 
   const allParticipants = useMemo(
     () => Array.from(timeScopedCredGrainView.participants()),
@@ -510,7 +518,11 @@ export const ExplorerHome = ({
                         {format(row.grainEarned, 2, currencySuffix)}
                       </TableCell>
                       <TableCell align="right">
-                        <CredTimeline data={row.credPerInterval} />
+                        <CredTimeline
+                          data={
+                            allTimeContributionCharts[String(row.identity.id)]
+                          }
+                        />
                       </TableCell>
                     </TableRow>
                   ))


### PR DESCRIPTION
# Description
Currently when the activity table participant list is limited by timeframe, the contribution charts are also scoped to the same timeframe. Per issue #2260, the activity charts should show activity for All Time, regardless of the time window selected for the activity table.

Closes #2260 

# Test Plan
- Load page, filter by name to someone who has a lot of historical activity (like decentralion)
- Toggle between all four timeframes (this week, last week, last month, all time) and confirm that activity table graph does not change

## After fix
https://www.loom.com/share/2210c5375ec64dab9936d6004b4e05f9