### PR TITLE
Discord: Add Weights to self-reacts in Props Channels

### DIFF
--- a/src/plugins/discord/createGraph.js
+++ b/src/plugins/discord/createGraph.js
@@ -327,7 +327,13 @@ export function _createGraphFromMessages(
       const node = reactionNode(reaction, message.timestampMs, guildId);
       wg.weights.nodeWeights.set(
         node.address,
-        reactionWeight(weights, message, reaction, reactingMember)
+        reactionWeight(
+          weights,
+          message,
+          reaction,
+          reactingMember,
+          propsChannels
+        )
       );
       wg.graph.addNode(node);
       wg.graph.addNode(memberNode(reactingMember));

--- a/src/plugins/discord/reactionWeights.js
+++ b/src/plugins/discord/reactionWeights.js
@@ -30,10 +30,15 @@ export function reactionWeight(
   weights: WeightConfig,
   message: Model.Message,
   reaction: Model.Reaction,
-  reactingMember: Model.GuildMember
+  reactingMember: Model.GuildMember,
+  propsChannels: Set<Model.Snowflake>
 ): NodeWeight {
-  if (message.authorId === reaction.authorId) {
-    // Self-reactions do not mint Cred.
+  if (
+    message.authorId === reaction.authorId &&
+    !propsChannels.has(message.channelId)
+  ) {
+    // Self-reactions do not mint Cred
+    // on channels that are not props channels
     return 0;
   }
 

--- a/src/plugins/discord/reactionWeights.test.js
+++ b/src/plugins/discord/reactionWeights.test.js
@@ -123,7 +123,13 @@ describe("plugins/discord/reactionWeights", () => {
       const channelWeights = {defaultWeight: 1, weights: {[channelId]: 6}};
       const weights = {emojiWeights, roleWeights, channelWeights};
       expect(
-        reactionWeight(weights, message, reacterReaction, reacterMember)
+        reactionWeight(
+          weights,
+          message,
+          reacterReaction,
+          reacterMember,
+          new Set()
+        )
       ).toEqual(4 * 5 * 6);
     });
     it("sets the weight to 0 for a self-reaction", () => {
@@ -132,8 +138,30 @@ describe("plugins/discord/reactionWeights", () => {
       const channelWeights = {defaultWeight: 1, weights: {}};
       const weights = {emojiWeights, roleWeights, channelWeights};
       expect(
-        reactionWeight(weights, message, authorSelfReaction, authorMember)
+        reactionWeight(
+          weights,
+          message,
+          authorSelfReaction,
+          authorMember,
+          new Set()
+        )
       ).toEqual(0);
+    });
+    it("sets a  nonzero-weight for a self-reaction in a props channel", () => {
+      const emojiWeights = {defaultWeight: 5, weights: {}};
+      const roleWeights = {defaultWeight: 2, weights: {}};
+      const channelWeights = {defaultWeight: 3, weights: {}};
+      const weights = {emojiWeights, roleWeights, channelWeights};
+      const propsChannelSet = new Set([message.channelId]);
+      expect(
+        reactionWeight(
+          weights,
+          message,
+          authorSelfReaction,
+          authorMember,
+          propsChannelSet
+        )
+      ).toEqual(5 * 2 * 3);
     });
   });
 });


### PR DESCRIPTION
Because we will eventually stop minting any cred to props-channel
posters, I think it makes sense to allow self-reacts in props channels to
have a non-zero weight. I've observed many people in the SC community
self-reacting to props messages mentioning others in the last couple
months.

This opens up an avenue for abuse by mint one's-self more cred
intentionally, but once we stop minting cred to message authors in props
channels, this will cease to be a concern. Additionally, this can be
guarded against socially through enforcement of creddiquette.

# Test Plan
A unit test has been added to verify the logic for the
special case of props message self-reacts.