### PR TITLE
Make Explorer Home stats circles dynamic

### DIFF
--- a/src/ui/components/ExplorerHome/ExplorerHome.js
+++ b/src/ui/components/ExplorerHome/ExplorerHome.js
@@ -109,15 +109,15 @@ const useStyles = makeStyles((theme) => ({
   pageHeader: {color: theme.palette.text.primary},
   credCircle: {
     borderColor: theme.palette.blueish,
+    "& .title": {
+      color: theme.palette.blueish,
+    },
   },
   grainCircle: {
     borderColor: theme.palette.warning.main,
-  },
-  participantCircle: {
-    borderColor: theme.palette.scPink,
-  },
-  grainPerCredCircle: {
-    borderColor: theme.palette.green,
+    "& .title": {
+      color: theme.palette.warning.main,
+    },
   },
   [`label-${IdentityTypes.BOT}`]: {
     color: theme.palette.purple,
@@ -318,17 +318,16 @@ export const ExplorerHome = ({
     };
   }, [tsParticipants.currentPage]);
 
-  const summaryInfo = [
-    {title: "Cred This Week", value: 610, className: classes.credCircle},
+  const statCircleInfo = [
     {
-      title: `${currencyName}`,
-      value: `6,765${currencySuffix}`,
-      className: classes.grainCircle,
+      title: `Cred ${TIMEFRAME_OPTIONS[tab].tabLabel}`,
+      value: Math.round(credAndGrainSummary.totalCred).toLocaleString(),
+      className: classes.credCircle,
     },
     {
-      title: `${currencyName} per Cred`,
-      value: `22${currencySuffix}`,
-      className: classes.grainPerCredCircle,
+      title: `${currencyName}`,
+      value: format(credAndGrainSummary.totalGrain, 0, currencySuffix),
+      className: classes.grainCircle,
     },
   ];
 
@@ -386,7 +385,7 @@ export const ExplorerHome = ({
       <div className={`${classes.centerRow} ${classes.circle} ${className}`}>
         {value}
       </div>
-      <div>{title}</div>
+      <div className="title">{title}</div>
     </div>
   );
 
@@ -469,7 +468,7 @@ export const ExplorerHome = ({
         </Tabs>
       </div>
       <div className={classes.centerRow}>
-        {summaryInfo.map((circle) =>
+        {statCircleInfo.map((circle) =>
           makeCircle(circle.value, circle.title, circle.className)
         )}
       </div>
@@ -549,7 +548,7 @@ export const ExplorerHome = ({
                         {row.identity.name}
                       </TableCell>
                       <TableCell className={classes.labelCred}>
-                        {Math.round(row.cred)}
+                        {Math.round(row.cred).toLocaleString()}
                       </TableCell>
                       <TableCell className={classes.labelGrain}>
                         {format(row.grainEarned, 2, currencySuffix)}

--- a/src/ui/components/ExplorerHome/ExplorerHome.js
+++ b/src/ui/components/ExplorerHome/ExplorerHome.js
@@ -242,6 +242,7 @@ export const ExplorerHome = ({
     [timeScopedCredGrainView]
   );
 
+  // build structures for timelines at the top of the page
   const {credTotalsTimeline, grainTotalsTimeline} = useMemo(() => {
     const allParticipantsCred: Array<Array<number>> = allParticipants.map(
       (participant) => {
@@ -279,6 +280,29 @@ export const ExplorerHome = ({
     };
   }, [timeScopedCredGrainView]);
 
+  // create summary values for stat circles
+  const totalCredThisPeriod = credTotalsTimeline.reduce(
+    (total, cred) => total + cred,
+    0
+  );
+  const totalGrainThisPeriod = grainTotalsTimeline.reduce(
+    (total, grain) => add(total, grain),
+    fromInteger(0)
+  );
+
+  const statCircleInfo = [
+    {
+      title: `Cred ${TIMEFRAME_OPTIONS[tab].tabLabel}`,
+      value: Math.round(totalCredThisPeriod).toLocaleString(),
+      className: classes.credCircle,
+    },
+    {
+      title: `${currencyName}`,
+      value: format(totalGrainThisPeriod, 0, currencySuffix),
+      className: classes.grainCircle,
+    },
+  ];
+
   const tsParticipants = useTableState(
     {data: allParticipants},
     {
@@ -291,6 +315,7 @@ export const ExplorerHome = ({
     }
   );
 
+  // create summary values for bottom of table
   const {credAndGrainSummary} = useMemo(() => {
     const credAndGrainAggregator = {
       totalCred: 0,
@@ -317,19 +342,6 @@ export const ExplorerHome = ({
       credAndGrainSummary: credAndGrainAggregator,
     };
   }, [tsParticipants.currentPage]);
-
-  const statCircleInfo = [
-    {
-      title: `Cred ${TIMEFRAME_OPTIONS[tab].tabLabel}`,
-      value: Math.round(credAndGrainSummary.totalCred).toLocaleString(),
-      className: classes.credCircle,
-    },
-    {
-      title: `${currencyName}`,
-      value: format(credAndGrainSummary.totalGrain, 0, currencySuffix),
-      className: classes.grainCircle,
-    },
-  ];
 
   const filterIdentities = (event: SyntheticInputEvent<HTMLInputElement>) => {
     // fuzzy match letters "in order, but not necessarily sequentially"

--- a/src/ui/components/ExplorerHome/ExplorerHome.js
+++ b/src/ui/components/ExplorerHome/ExplorerHome.js
@@ -281,13 +281,17 @@ export const ExplorerHome = ({
   }, [timeScopedCredGrainView]);
 
   // create summary values for stat circles
-  const totalCredThisPeriod = credTotalsTimeline.reduce(
-    (total, cred) => total + cred,
-    0
+  const totalCredThisPeriod = useMemo(
+    () => credTotalsTimeline.reduce((total, cred) => total + cred, 0),
+    [credTotalsTimeline]
   );
-  const totalGrainThisPeriod = grainTotalsTimeline.reduce(
-    (total, grain) => add(total, grain),
-    fromInteger(0)
+  const totalGrainThisPeriod = useMemo(
+    () =>
+      grainTotalsTimeline.reduce(
+        (total, grain) => add(total, grain),
+        fromInteger(0)
+      ),
+    [grainTotalsTimeline]
   );
 
   const statCircleInfo = [


### PR DESCRIPTION
# Description
As a final push to get the Explorer Home page going, this PR make the summary statistics circles (hereafter "stats circles") dynamic, showing data pertaining to the timeframe selected.

Currently there are only two circles displayed: Cred and Grain, which are a sum of all the Cred and Grain, respectively, for all participants in the selected time period. Grain is formatted with the grain formatting tool, and cred is formatted with `toLocaleString()` in order to put thousands separators in automagically (and format for other languages too, for free!)

Closes #2237 

# Test Plan
Tested manually. The update turned out to be quite simple as the totals were already calculated for the summary at the bottom of the table, so simply plugging in the values and doing a touch of CSS was all there is to it.

- Load page
- Change timeframe (this week, last week, this month, all time)
- Verify stats circle data changes to correspond to the time period selected
- Enter data into filter box for data table to reduce number of participants shown, and ensure stat circle data **does not** change
- Paginate through to subsequent pages of table data and ensure that stat circle data **does not** change

## Video demo of changes
https://www.loom.com/share/32c8a0426ac7469988b5c31f4c1a31da