### PR TITLE
Proposed Fixes to ExplorerHome/ExplorerTimeline from PR #2787

### DIFF
--- a/src/ui/components/ExplorerHome/ExplorerHome.js
+++ b/src/ui/components/ExplorerHome/ExplorerHome.js
@@ -261,10 +261,10 @@ export const ExplorerHome = ({
         (intervalTotal, i) => intervalTotal + participantCred[i]
       );
     const grainAccumulator = (
-      grainTimelineAccumalator: Array<Grain>,
+      grainTimelineAccumulator: Array<Grain>,
       participantGrain
     ) =>
-      grainTimelineAccumalator.map((intervalTotal, i) =>
+      grainTimelineAccumulator.map((intervalTotal, i) =>
         add(intervalTotal, participantGrain[i])
       );
     const credTimeline: Array<number> = allParticipantsCred.reduce(

--- a/src/ui/components/ExplorerHome/ExplorerTimeline.js
+++ b/src/ui/components/ExplorerHome/ExplorerTimeline.js
@@ -30,20 +30,19 @@ const ExplorerTimeline = (props: ExplorerTimelineProps): ReactNode => {
   const height = props.height || 25;
   const viewBox = `0 0 ${width} ${height}`;
   const intervals = props.timelines.cred.length;
-  let range, grainValues;
+
+  let grainValues;
   if (grainExists) {
     const grain = props.timelines.grain || [];
     const grainAsNumber = grain.map((g) => {
       return Number(g);
     });
-    const credAndGrain = props.timelines.cred.concat(grainAsNumber);
-    range = extent(credAndGrain);
+
     // This is a temporary/quick fix to ensure that the timeline lines fill the entire x-axis
     // and ensures that a line is displayed when there is only one interval.
     grainValues = grainAsNumber.concat(grainAsNumber[intervals - 1]);
-  } else {
-    range = extent(props.timelines.cred);
   }
+
   // This is a temporary/quick fix to ensure that the timeline lines fill the entire x-axis
   // and ensures that a line is displayed when there is only one interval.
   const credValues = props.timelines.cred.concat(
@@ -57,14 +56,14 @@ const ExplorerTimeline = (props: ExplorerTimelineProps): ReactNode => {
       style={{overflow: "visible"}}
     >
       <path
-        d={drawLine(credValues, range, height, width)}
+        d={drawLine(credValues, height, width)}
         stroke={CRED_COLOR}
         fill="none"
         strokeWidth={1}
       />
       {grainExists && (
         <path
-          d={drawLine(grainValues, range, height, width)}
+          d={drawLine(grainValues, height, width)}
           stroke={GRAIN_COLOR}
           fill="none"
           strokeWidth={1}
@@ -96,10 +95,11 @@ const ExplorerTimeline = (props: ExplorerTimelineProps): ReactNode => {
   );
 };
 
-function drawLine(data, range, height, width) {
+function drawLine(data, height, width) {
   if (!data) {
     return null;
   }
+  const range = extent(data);
   const xScale = scaleLinear()
     .domain([0, data.length - 1])
     .range([0, width]);

--- a/src/ui/components/ExplorerHome/ExplorerTimeline.js
+++ b/src/ui/components/ExplorerHome/ExplorerTimeline.js
@@ -30,10 +30,10 @@ const ExplorerTimeline = (props: ExplorerTimelineProps): ReactNode => {
   const height = props.height || 25;
   const viewBox = `0 0 ${width} ${height}`;
   const intervals = props.timelines.cred.length;
-  let grainAsNumber, range, grainValues;
+  let range, grainValues;
   if (grainExists) {
     const grain = props.timelines.grain || [];
-    grainAsNumber = grain.map((g) => {
+    const grainAsNumber = grain.map((g) => {
       return Number(g);
     });
     const credAndGrain = props.timelines.cred.concat(grainAsNumber);

--- a/src/ui/components/ExplorerHome/ExplorerTimeline.js
+++ b/src/ui/components/ExplorerHome/ExplorerTimeline.js
@@ -60,14 +60,14 @@ const ExplorerTimeline = (props: ExplorerTimelineProps): ReactNode => {
         d={drawLine(credValues, range, height, width)}
         stroke={CRED_COLOR}
         fill="none"
-        stokewidth={1}
+        strokeWidth={1}
       />
       {grainExists && (
         <path
           d={drawLine(grainValues, range, height, width)}
           stroke={GRAIN_COLOR}
           fill="none"
-          stokewidth={1}
+          strokeWidth={1}
         />
       )}
       {props.hasLegend ? (


### PR DESCRIPTION
# Description
![topchart-2](https://user-images.githubusercontent.com/7217000/109565698-b2011d80-7a97-11eb-99da-e87c34466eb6.gif)

This PR is in response to some of the feedback we got from Thena on our last PR https://github.com/sourcecred/sourcecred/pull/2787

These changes include:
- Changing `grainAsNumber` to a const instead of a let
- Fixing typos in 2 variables
- Changing the `ExplorerTimeline` so there is a separate range for each line that is displayed


We do have some concerns about having the separate ranges for each line:
- For the single-week view, the lines overlap with each other.
- The lines don't make sense in relation to each other, in the future there needs to be an axis label that can communicate to the user what the line values are.  

Paired with @saintmedusa 


