### PR TITLE
ExplorerHome: fix duplicate timeline value

### DIFF
--- a/src/ui/components/ExplorerHome/ExplorerTimeline.js
+++ b/src/ui/components/ExplorerHome/ExplorerTimeline.js
@@ -29,25 +29,18 @@ const ExplorerTimeline = (props: ExplorerTimelineProps): ReactNode => {
   const width = props.width || 300;
   const height = props.height || 25;
   const viewBox = `0 0 ${width} ${height}`;
-  const intervals = props.timelines.cred.length;
 
   let grainValues;
   if (grainExists) {
     const grain = props.timelines.grain || [];
-    const grainAsNumber = grain.map((g) => {
+    grainValues = grain.map((g) => {
       return Number(g);
     });
-
-    // This is a temporary/quick fix to ensure that the timeline lines fill the entire x-axis
-    // and ensures that a line is displayed when there is only one interval.
-    grainValues = grainAsNumber.concat(grainAsNumber[intervals - 1]);
+    if (grainValues.length === 1) grainValues.push(grainValues[0]);
   }
 
-  // This is a temporary/quick fix to ensure that the timeline lines fill the entire x-axis
-  // and ensures that a line is displayed when there is only one interval.
-  const credValues = props.timelines.cred.concat(
-    props.timelines.cred[intervals - 1]
-  );
+  const credValues = props.timelines.cred;
+  if (credValues.length === 1) credValues.push(credValues[0]);
   return (
     <svg
       viewBox={props.responsive ? viewBox : null}


### PR DESCRIPTION
<!-- Please read our contributor guide before submitting your PR: -->
<!-- https://github.com/sourcecred/sourcecred/blob/master/CONTRIBUTING.md -->

# Description
Currently, the ExplorerHome timeline feature duplicates the last value in the array no matter what. This changes it so that it only duplicates the value for arrays of size 1.
<!-- Possible prompts:
  Why is the change important?
  Did you consider and reject alternate formulations of the same idea?
  Are there relevant issues or discussions elsewhere?
-->

# Test Plan
Verified that "this week" and "last week" still show a horizontal line. Verified that "this month" and "all time" no longer have a horizontal line at the end.
![chrome-capture](https://user-images.githubusercontent.com/11550396/109710865-103f0680-7b53-11eb-90a0-b14efee4ef0c.gif)

<!-- Possible prompts:
  How well covered by automated tests is this change?
  How did you manually test this change? How can a reviewer replicate the tests?
-->
