### PR TITLE
Add Isomorphic Text Encoder/Decoder import

### DIFF
--- a/src/core/storage/textEncoding.js
+++ b/src/core/storage/textEncoding.js
@@ -1,0 +1,31 @@
+// @flow
+
+import {
+  // $FlowIssue[missing-export]
+  TextEncoder as importedTextEncoder,
+  TextDecoder as importedTextDecoder,
+} from "util";
+
+let encoder, decoder;
+// ensure jest skips this condition
+if (typeof window !== "undefined" && typeof process === "undefined") {
+  if (!(window.TextEncoder && window.TextDecoder)) {
+    throw new Error("No Encoder classes available.");
+  }
+  decoder = window.TextDecoder;
+  encoder = window.TextEncoder;
+} else {
+  // load imported libraries or fallback to globals if imports are unavailable
+  /* eslint-disable no-undef */
+  // $FlowIssue[cannot-resolve-name]
+  decoder = importedTextDecoder || globalThis.TextDecoder;
+  /* eslint-disable no-undef */
+  // $FlowIssue[cannot-resolve-name]
+  encoder = importedTextEncoder || globalThis.TextDecoder;
+}
+
+// $FlowIssue[incompatible-call]
+const decode: (a: Uint8Array) => string = (a) => new decoder().decode(a);
+const encode: (s: string) => Uint8Array = (s) => new encoder().encode(s);
+
+export {encode, decode};

--- a/src/core/storage/textEncoding.test.js
+++ b/src/core/storage/textEncoding.test.js
@@ -1,0 +1,13 @@
+// @flow
+
+import {decode, encode} from "./textEncoding";
+
+describe("core/storage/textEncoding", () => {
+  describe("round trip test", () => {
+    it("can encode and decode a string", () => {
+      const test = "test";
+      const result = decode(encode(test));
+      expect(test).toBe(result);
+    });
+  });
+});


### PR DESCRIPTION
This is needed for node V10. Once it is deprecated,, these classes are globally
available in Observable, node V12+ and the browser.

test plan:
1. add this module to the api.js file.
2. `yarn build`

Node:


1. `node`
2. `const sc = require("./dist/server/api.js")`
3. `let t = sc.sourcecred.core.textEncoding`
4. `t.decode(t.encode("a"))` // should output "a"

Observable: https://observablehq.com/@topocount/encoder-test

browser: imported into ui/index.js an completed a round-trip test on
load

builds towards #2768
merge after: #2776 
merge next: #2777 

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1200032326400385/1200038246141847) by [Unito](https://www.unito.io/learn-more)
