### PR TITLE
Explorer Home activity table updates for launch

### DIFF
--- a/src/ui/components/AdminApp.js
+++ b/src/ui/components/AdminApp.js
@@ -33,6 +33,7 @@ const dataProvider = fakeDataProvider({}, true);
 const theme = createMuiTheme({
   palette: {
     type: "dark",
+    backgroundColor: "#303030",
     primary: pink,
     blueish: "#6174CC",
     lavender: "#C5A2C5",

--- a/src/ui/components/ExplorerHome/ExplorerHome.js
+++ b/src/ui/components/ExplorerHome/ExplorerHome.js
@@ -21,6 +21,7 @@ import {
 } from "@material-ui/core";
 import {makeStyles} from "@material-ui/core/styles";
 import TableSortLabel from "@material-ui/core/TableSortLabel";
+import grey from "@material-ui/core/colors/grey";
 import deepFreeze from "deep-freeze";
 import bigInt from "big-integer";
 import {CredGrainView} from "../../../core/credGrainView";
@@ -136,6 +137,13 @@ const useStyles = makeStyles((theme) => ({
   },
   rowAverage: {
     fontStyle: "italic",
+  },
+  averageTotalsNotice: {
+    fontStyle: "italic",
+    color: grey[500],
+  },
+  paginator: {
+    backgroundColor: theme.palette.backgroundColor,
   },
 }));
 
@@ -514,6 +522,22 @@ export const ExplorerHome = ({
             <Table aria-label="simple table">
               <TableHead>
                 <TableRow>
+                  <TablePagination
+                    rowsPerPageOptions={PAGINATION_OPTIONS}
+                    className={classes.paginator}
+                    colSpan={4}
+                    count={tsParticipants.length}
+                    rowsPerPage={tsParticipants.rowsPerPage}
+                    page={tsParticipants.pageIndex}
+                    SelectProps={{
+                      inputProps: {"aria-label": "rows per page"},
+                      native: true,
+                    }}
+                    onChangePage={handleChangePage}
+                    onChangeRowsPerPage={handleChangeRowsPerPage}
+                  />
+                </TableRow>
+                <TableRow>
                   <TableCell>
                     <b>Participant</b>
                   </TableCell>
@@ -555,7 +579,7 @@ export const ExplorerHome = ({
               <TableBody>
                 {tsParticipants.currentPage.length > 0 ? (
                   tsParticipants.currentPage.map((row) => (
-                    <TableRow key={row.identity.name}>
+                    <TableRow key={row.identity.id}>
                       <TableCell
                         component="th"
                         scope="row"
@@ -588,6 +612,16 @@ export const ExplorerHome = ({
                     </TableCell>
                   </TableRow>
                 )}
+                <TableRow key="help-text">
+                  <TableCell
+                    colSpan={4}
+                    align="center"
+                    className={classes.averageTotalsNotice}
+                  >
+                    Average and Total numbers represent the list shown above
+                    only.
+                  </TableCell>
+                </TableRow>
                 <TableRow key="average" className={classes.rowAverage}>
                   <TableCell component="th" scope="row">
                     Average
@@ -623,6 +657,7 @@ export const ExplorerHome = ({
                 <TableRow>
                   <TablePagination
                     rowsPerPageOptions={PAGINATION_OPTIONS}
+                    className={classes.paginator}
                     colSpan={4}
                     count={tsParticipants.length}
                     rowsPerPage={tsParticipants.rowsPerPage}


### PR DESCRIPTION
# Description
Per the final items in issue #2298, these are some of the cleanup tasks remaining for the activity table on the Explorer Home page:


* Added additional paginator at top
* Removed background color from paginators
* Added note for Average and Total summaries at bottom

# Test Plan
* Load page
* Make changes in top paginator
* Verify table reflects changes
* Verify bottom paginator reflects changes
* Make changes in bottom paginator
* Verify table reflects changes
* Verify top paginator reflects changes

# Screenshots
### Top paginator
![](https://user-images.githubusercontent.com/225508/110628129-0a74a100-81a3-11eb-8c42-6fb751cf1121.png)


### Bottom paginator and notice
![](https://user-images.githubusercontent.com/225508/110628162-152f3600-81a3-11eb-84ec-1ed627d4f7cb.png)



┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1200032326400385/1200044011726368) by [Unito](https://www.unito.io/learn-more)
