### PR TITLE
Explorer Home Activity table participant type checkbox updates

### DIFF
--- a/src/ui/components/ExplorerHome/ExplorerHome.js
+++ b/src/ui/components/ExplorerHome/ExplorerHome.js
@@ -35,7 +35,6 @@ import {
   add,
   div,
   fromInteger,
-  fromString,
   type Grain,
 } from "../../../core/ledger/grain";
 import ExplorerTimeline from "./ExplorerTimeline";
@@ -341,7 +340,7 @@ export const ExplorerHome = ({
         credAndGrainAggregator.totalCred / tsParticipants.currentPage.length;
       credAndGrainAggregator.avgGrain = div(
         credAndGrainAggregator.totalGrain,
-        fromString(String(tsParticipants.currentPage.length))
+        fromInteger(tsParticipants.currentPage.length)
       );
     }
     return {

--- a/src/ui/components/ExplorerHome/ExplorerHome.js
+++ b/src/ui/components/ExplorerHome/ExplorerHome.js
@@ -35,6 +35,7 @@ import {
   add,
   div,
   fromInteger,
+  fromString,
   type Grain,
 } from "../../../core/ledger/grain";
 import ExplorerTimeline from "./ExplorerTimeline";
@@ -340,7 +341,7 @@ export const ExplorerHome = ({
         credAndGrainAggregator.totalCred / tsParticipants.currentPage.length;
       credAndGrainAggregator.avgGrain = div(
         credAndGrainAggregator.totalGrain,
-        tsParticipants.currentPage.length
+        fromString(String(tsParticipants.currentPage.length))
       );
     }
     return {

--- a/src/ui/components/ExplorerHome/ExplorerHome.js
+++ b/src/ui/components/ExplorerHome/ExplorerHome.js
@@ -327,6 +327,7 @@ export const ExplorerHome = ({
       avgCred: 0,
       avgGrain: fromInteger(0),
     };
+
     if (tsParticipants.currentPage.length > 0) {
       for (const participant of tsParticipants.currentPage) {
         credAndGrainAggregator.totalCred += participant.cred;
@@ -339,7 +340,7 @@ export const ExplorerHome = ({
         credAndGrainAggregator.totalCred / tsParticipants.currentPage.length;
       credAndGrainAggregator.avgGrain = div(
         credAndGrainAggregator.totalGrain,
-        fromInteger(tsParticipants.currentPage.length)
+        tsParticipants.currentPage.length
       );
     }
     return {

--- a/src/ui/components/ExplorerHome/ExplorerHome.js
+++ b/src/ui/components/ExplorerHome/ExplorerHome.js
@@ -209,10 +209,10 @@ export const ExplorerHome = ({
     TIMEFRAME_OPTIONS[1].selector(initialView.intervals())
   );
   const [checkboxes, setCheckboxes] = useState({
-    [IdentityTypes.USER]: false,
-    [IdentityTypes.ORGANIZATION]: false,
-    [IdentityTypes.BOT]: false,
-    [IdentityTypes.PROJECT]: false,
+    [IdentityTypes.USER]: true,
+    [IdentityTypes.ORGANIZATION]: true,
+    [IdentityTypes.BOT]: true,
+    [IdentityTypes.PROJECT]: true,
   });
 
   const updateTimeframe = (index) => {
@@ -372,13 +372,9 @@ export const ExplorerHome = ({
       (type) => newCheckboxes[type] === true
     );
 
-    if (includedTypes.length === 0) {
-      tsParticipants.createOrUpdateFilterFn("identityType", () => true);
-    } else {
-      tsParticipants.createOrUpdateFilterFn("identityType", (participant) =>
-        includedTypes.includes(participant.identity.subtype)
-      );
-    }
+    tsParticipants.createOrUpdateFilterFn("identityType", (participant) =>
+      includedTypes.includes(participant.identity.subtype)
+    );
   };
 
   const handleChangePage = (event, newIndex) => {


### PR DESCRIPTION
# Description
Per issue #2298, checkboxes that filter the activity table by type of participant should start off checked by default, and the table should be empty if none of them are checked. This is a change from the previous behavior where boxes were unchecked by default, and only filtered the list if one or more were checked (all checked and all unchecked were the same results).

# Test Plan
* Load page
* Verify that all checkboxes are checked
* Verify that table contains all expected participants
* Uncheck a checkbox and verify that participant type disappears from the list
* Repeat previous step until all checkboxes are unchecked
* Verify that list is empty

# Demo
https://www.loom.com/share/f3ab05d534c04e0196d562a1bb6fc9ce

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1200032326400385/1200043970364608) by [Unito](https://www.unito.io/learn-more)
