### PR TITLE
Bugfix: remove duplicate accounts from ledger.accounts

### DIFF
--- a/src/core/ledger/ledger.js
+++ b/src/core/ledger/ledger.js
@@ -159,7 +159,7 @@ export class Ledger {
    * Return all the Accounts in the ledger.
    */
   accounts(): $ReadOnlyArray<Account> {
-    return Array.from(this._accounts.values());
+    return Array.from(new Set(this._accounts.values()));
   }
 
   /**

--- a/src/core/ledger/ledger.test.js
+++ b/src/core/ledger/ledger.test.js
@@ -526,6 +526,11 @@ describe("core/ledger/ledger", () => {
         expect(ledger.account(id2)).toEqual(ledger.account(id1));
         expect(ledger.account(newId)).toEqual(ledger.account(id1));
       });
+      it("accounts() returns only the new account", () => {
+        const ledger = ledgerWithActiveIdentities();
+        ledger.mergeIdentities({base: id1, target: id2});
+        expect(ledger.accounts()).toEqual([ledger.account(id1)]);
+      });
       it("does not change the base account's login or id", () => {
         const ledger = ledgerWithActiveIdentities();
         const before = ledger.account(id1).identity;


### PR DESCRIPTION
<!-- Please read our contributor guide before submitting your PR: -->
<!-- https://github.com/sourcecred/sourcecred/blob/master/CONTRIBUTING.md -->

# Description
https://github.com/sourcecred/sourcecred/pull/2803 introduced a bug because it caused there to be multiple entries per account in the `_accounts` map in the ledger, causing the `accounts()` getter to be return duplicates. This PR is a super simple solution.

# Alternatives considered
We could also add a new array/set property that stores all of accounts without duplicates in order to make the getter faster, but that would result in more code complexity and longer ledger construction time that would probably negate the latency savings in most cases.
<!-- Possible prompts:
  Why is the change important?
  Did you consider and reject alternate formulations of the same idea?
  Are there relevant issues or discussions elsewhere?
-->

# Test Plan
- Go to the `explorer-home` page and confirm that there are no longer duplicates.
- Confirm that new unit test fails before ledger change and succeeds after.
<!-- Possible prompts:
  How well covered by automated tests is this change?
  How did you manually test this change? How can a reviewer replicate the tests?
-->
