### PR TITLE
CredGrainView: add per interval aggregates

### DIFF
--- a/src/core/credGrainView.test.js
+++ b/src/core/credGrainView.test.js
@@ -85,8 +85,14 @@ describe("core/credGrainView", () => {
       expect(credGrainView.participants()).toEqual(expectedParticipants);
     });
 
+    it("should have correct aggregates", () => {
+      expect(credGrainView.totalGrainPerInterval()).toEqual([g("10"), g("20")]);
+      // cred is not easily tested because of expectedParticipant2's cred is
+      // so small that it is lost to imprecision during addition.
+    });
+
     describe("when time scoped to exactly the last interval", () => {
-      it("should have participant data for the last interval", () => {
+      it("should have participant and aggregate data for the last interval", () => {
         const timeScopedCredGrainView = credGrainView.withTimeScope(
           GraphUtil.intervals[GraphUtil.intervals.length - 1].startTimeMs,
           GraphUtil.intervals[GraphUtil.intervals.length - 1].endTimeMs
@@ -119,11 +125,14 @@ describe("core/credGrainView", () => {
         expect(timeScopedCredGrainView.participants()).toEqual(
           expectedParticipants
         );
+        expect(timeScopedCredGrainView.totalGrainPerInterval()).toEqual([
+          g("20"),
+        ]);
       });
     });
 
     describe("when time scoped to exactly the first interval", () => {
-      it("should have participant data for the first interval", () => {
+      it("should have participant and aggregate data for the first interval", () => {
         const timeScopedCredGrainView = credGrainView.withTimeScope(
           GraphUtil.intervals[0].startTimeMs,
           GraphUtil.intervals[0].endTimeMs
@@ -154,6 +163,9 @@ describe("core/credGrainView", () => {
         expect(timeScopedCredGrainView.participants()).toEqual(
           expectedParticipants
         );
+        expect(timeScopedCredGrainView.totalGrainPerInterval()).toEqual([
+          g("10"),
+        ]);
       });
     });
 


### PR DESCRIPTION
<!-- Please read our contributor guide before submitting your PR: -->
<!-- https://github.com/sourcecred/sourcecred/blob/master/CONTRIBUTING.md -->

# Description
Doing aggregations in the front end is becoming too heavy-duty, and misses out on optimizations available when doing it in the CredGrainView. This adds two getters to CredGrainView/TimeScopedCredGrainView: totalCredPerInterval and totalGrainPerInterval. These are simply aggregations of the values of every participant's credPerInterval and grainEarnedPerInterval, as inspired by https://github.com/sourcecred/sourcecred/pull/2817/files
<!-- Possible prompts:
  Why is the change important?
  Did you consider and reject alternate formulations of the same idea?
  Are there relevant issues or discussions elsewhere?
-->

# Test Plan
Unit tests, will also be manually tested in others' current PRs where it is needed. This code is not for exposed prod pages yet, so don't feel the need to test too thoroughly upfront.
<!-- Possible prompts:
  How well covered by automated tests is this change?
  How did you manually test this change? How can a reviewer replicate the tests?
-->



┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1200032326400385/1200052071189798) by [Unito](https://www.unito.io/learn-more)
