### PR TITLE
Add credGraph and credrank to api build

### DIFF
--- a/src/api/index.js
+++ b/src/api/index.js
@@ -26,6 +26,7 @@ import * as markovChain from "../core/algorithm/markovChain";
 import * as credView from "../analysis/credView";
 import * as credData from "../analysis/credData";
 import * as credResult from "../analysis/credResult";
+import * as credGraph from "../core/credrank/credGraph";
 import * as ledger from "../core/ledger/ledger";
 import * as ledgerUtils from "../core/ledger/utils";
 import * as grain from "../core/ledger/grain";
@@ -33,8 +34,12 @@ import * as identity from "../core/identity";
 
 import * as manager from "./ledgerManager";
 import * as storage from "./ledgerStorage";
+import * as credrank from "./credrank";
 
 const api = {
+  api: {
+    credrank,
+  },
   core: {
     address,
     algorithm: {
@@ -44,6 +49,7 @@ const api = {
     graph,
     weightedGraph,
     weights,
+    credGraph,
   },
   analysis: {
     credView,


### PR DESCRIPTION
<!-- Please read our contributor guide before submitting your PR: -->
<!-- https://github.com/sourcecred/sourcecred/blob/master/CONTRIBUTING.md -->

# Description
This adds the `api/credrank.js` and `core/credrank/credGraph.js` modules to the library build. Most importantly, this will allow library users to run the credrank algorithm and load credGraphs from json.
<!-- Possible prompts:
  Why is the change important?
  Did you consider and reject alternate formulations of the same idea?
  Are there relevant issues or discussions elsewhere?
-->

# Test Plan
```
yarn build
node
sc = require("./dist/server/api.js")
```
```
{
  sourcecred: {
    api: { credrank: [Object [Module]] },
    core: {
      address: [Object [Module]],
      algorithm: [Object],
      graph: [Object [Module]],
      weightedGraph: [Object [Module]],
      weights: [Object [Module]],
      credGraph: [Object [Module]]
    },
    analysis: {
      credView: [Object [Module]],
      credData: [Object [Module]],
      credResult: [Object [Module]]
    },
    ledger: {
      ledger: [Object [Module]],
      identity: [Object [Module]],
      grain: [Object [Module]],
      utils: [Object [Module]],
      manager: [Object [Module]],
      storage: [Object [Module]]
    },
    plugins: {
      github: [Object],
      ethereum: [Object],
      discourse: [Object],
      discord: [Object],
      initiatives: [Object]
    }
  }
}
```
<!-- Possible prompts:
  How well covered by automated tests is this change?
  How did you manually test this change? How can a reviewer replicate the tests?
-->
