### PR TITLE
Yaz/feb2021/calculate grain per interval optimization

### DIFF
--- a/src/core/credGrainView.js
+++ b/src/core/credGrainView.js
@@ -107,13 +107,19 @@ export class CredGrainView {
     let allocationIndex = 0;
     return this._intervals.map((interval) => {
       let grain = G.ZERO;
-        if (
-          interval.startTimeMs < account.allocationHistory[allocationIndex].credTimestampMs &&
-          account.allocationHistory[allocationIndex].credTimestampMs <= interval.endTimeMs
-        ) {
-          grain = G.add(grain, account.allocationHistory[allocationIndex ].grainReceipt.amount);
-          allocationIndex++;
-        }
+      if (
+        account.allocationHistory.length - 1 > allocationIndex &&
+        interval.startTimeMs <
+          account.allocationHistory[allocationIndex].credTimestampMs &&
+        account.allocationHistory[allocationIndex].credTimestampMs <=
+          interval.endTimeMs
+      ) {
+        grain = G.add(
+          grain,
+          account.allocationHistory[allocationIndex].grainReceipt.amount
+        );
+        allocationIndex++;
+      }
       return grain;
     });
   }

--- a/src/core/credGrainView.js
+++ b/src/core/credGrainView.js
@@ -104,15 +104,16 @@ export class CredGrainView {
   }
 
   _calculateGrainEarnedPerInterval(account: Account): $ReadOnlyArray<Grain> {
+    let allocationIndex = 0;
     return this._intervals.map((interval) => {
       let grain = G.ZERO;
-      account.allocationHistory.forEach((allocationReceipt) => {
         if (
-          interval.startTimeMs < allocationReceipt.credTimestampMs &&
-          allocationReceipt.credTimestampMs <= interval.endTimeMs
-        )
-          grain = G.add(grain, allocationReceipt.grainReceipt.amount);
-      });
+          interval.startTimeMs < account.allocationHistory[allocationIndex].credTimestampMs &&
+          account.allocationHistory[allocationIndex].credTimestampMs <= interval.endTimeMs
+        ) {
+          grain = G.add(grain, account.allocationHistory[allocationIndex ].grainReceipt.amount);
+          allocationIndex++;
+        }
       return grain;
     });
   }

--- a/src/core/credGrainView.js
+++ b/src/core/credGrainView.js
@@ -107,7 +107,7 @@ export class CredGrainView {
     let allocationIndex = 0;
     return this._intervals.map((interval) => {
       let grain = G.ZERO;
-      if (
+      while (
         account.allocationHistory.length - 1 >= allocationIndex &&
         interval.startTimeMs <
           account.allocationHistory[allocationIndex].credTimestampMs &&

--- a/src/core/credGrainView.js
+++ b/src/core/credGrainView.js
@@ -108,7 +108,7 @@ export class CredGrainView {
     return this._intervals.map((interval) => {
       let grain = G.ZERO;
       if (
-        account.allocationHistory.length - 1 > allocationIndex &&
+        account.allocationHistory.length - 1 >= allocationIndex &&
         interval.startTimeMs <
           account.allocationHistory[allocationIndex].credTimestampMs &&
         account.allocationHistory[allocationIndex].credTimestampMs <=

--- a/src/core/credGrainView.test.js
+++ b/src/core/credGrainView.test.js
@@ -44,7 +44,7 @@ describe("core/credGrainView", () => {
     };
     const distribution1 = {
       credTimestamp: 1,
-      allocations: [allocation1],
+      allocations: [allocation1, allocation2],
       id: uuid.random(),
     };
     const distribution2 = {
@@ -69,15 +69,15 @@ describe("core/credGrainView", () => {
           identity: identity1(id1),
           cred: GraphUtil.expectedParticipant1.cred,
           credPerInterval: GraphUtil.expectedParticipant1.credPerInterval,
-          grainEarned: g("13"),
-          grainEarnedPerInterval: [g("3"), g("10")],
+          grainEarned: g("23"),
+          grainEarnedPerInterval: [g("13"), g("10")],
         },
         {
           identity: identity2(id2),
           cred: GraphUtil.expectedParticipant2.cred,
           credPerInterval: GraphUtil.expectedParticipant2.credPerInterval,
-          grainEarned: g("17"),
-          grainEarnedPerInterval: [g("7"), g("10")],
+          grainEarned: g("27"),
+          grainEarnedPerInterval: [g("17"), g("10")],
         },
       ];
 
@@ -145,8 +145,8 @@ describe("core/credGrainView", () => {
             credPerInterval: [
               GraphUtil.expectedParticipant1.credPerInterval[0],
             ],
-            grainEarned: g("3"),
-            grainEarnedPerInterval: [g("3")],
+            grainEarned: g("13"),
+            grainEarnedPerInterval: [g("13")],
           },
           {
             identity: identity2(id2),
@@ -154,8 +154,8 @@ describe("core/credGrainView", () => {
             credPerInterval: [
               GraphUtil.expectedParticipant2.credPerInterval[0],
             ],
-            grainEarned: g("7"),
-            grainEarnedPerInterval: [g("7")],
+            grainEarned: g("17"),
+            grainEarnedPerInterval: [g("17")],
           },
         ];
 
@@ -183,8 +183,8 @@ describe("core/credGrainView", () => {
             credPerInterval: [
               GraphUtil.expectedParticipant1.credPerInterval[0],
             ],
-            grainEarned: g("3"),
-            grainEarnedPerInterval: [g("3")],
+            grainEarned: g("13"),
+            grainEarnedPerInterval: [g("13")],
           },
           {
             identity: identity2(id2),
@@ -192,8 +192,8 @@ describe("core/credGrainView", () => {
             credPerInterval: [
               GraphUtil.expectedParticipant2.credPerInterval[0],
             ],
-            grainEarned: g("7"),
-            grainEarnedPerInterval: [g("7")],
+            grainEarned: g("17"),
+            grainEarnedPerInterval: [g("17")],
           },
         ];
 

--- a/src/core/credGrainView.test.js
+++ b/src/core/credGrainView.test.js
@@ -86,7 +86,7 @@ describe("core/credGrainView", () => {
     });
 
     it("should have correct aggregates", () => {
-      expect(credGrainView.totalGrainPerInterval()).toEqual([g("10"), g("20")]);
+      expect(credGrainView.totalGrainPerInterval()).toEqual([g("30"), g("20")]);
       // cred is not easily tested because of expectedParticipant2's cred is
       // so small that it is lost to imprecision during addition.
     });
@@ -164,7 +164,7 @@ describe("core/credGrainView", () => {
           expectedParticipants
         );
         expect(timeScopedCredGrainView.totalGrainPerInterval()).toEqual([
-          g("10"),
+          g("30"),
         ]);
       });
     });


### PR DESCRIPTION
# Description
See story ["CredGrainView performance optimization #2675"](https://github.com/sourcecred/sourcecred/issues/2675)  in Feature Team Sprint. Acceptance criteria met: O(I+A) instead of O(I*A)
The method `calculateGrainEarnedPerInterval(account)` is now taking advantage of the fact that each account's allocation history is chronological. So we can loop through each interval within the instance of the `credGrainView` without needing to loop through every allocation in the given account's allocation history. 

# Test Plan
yarn test passing
unit tests for `credGrainView` were also tweaked to test `calculateGrainEarnedPerInterval` for times when there is more than one allocation in an interval. (thanks blueridger )



┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1200032326400385/1200078937807564) by [Unito](https://www.unito.io/learn-more)
