### PR TITLE
Bugfix: Reinstantiate CredValue for mutation

### DIFF
--- a/src/ui/components/ExplorerHome/ExplorerTimeline.js
+++ b/src/ui/components/ExplorerHome/ExplorerTimeline.js
@@ -29,7 +29,6 @@ const ExplorerTimeline = (props: ExplorerTimelineProps): ReactNode => {
   const width = props.width || 300;
   const height = props.height || 25;
   const viewBox = `0 0 ${width} ${height}`;
-
   let grainValues;
   if (grainExists) {
     const grain = props.timelines.grain || [];
@@ -39,7 +38,7 @@ const ExplorerTimeline = (props: ExplorerTimelineProps): ReactNode => {
     if (grainValues.length === 1) grainValues.push(grainValues[0]);
   }
 
-  const credValues = props.timelines.cred;
+  const credValues = [...props.timelines.cred];
   if (credValues.length === 1) credValues.push(credValues[0]);
   return (
     <svg


### PR DESCRIPTION
Description
-
In explorer timeline component, we attempt to mutate a prop.
Reinstantiation of the value within the component allows the mutation to
occur, and the render succeeds.

The issue occurs specifically when The credValue array is of length 1,
    and we attempt to add a second entry in the array, presumably to
    form a line.

Test Plan
-
Find some data that that has CredView array lengths(s) of 1. I used the
user-provided data here:
https://discord.com/channels/453243919774253079/718263631158050896/822135748014112798

paste the output and data folders into your instance of choice, and
serve it. Ensure explorer home loads.
