### PR TITLE
Cease Support for Node v10

### DIFF
--- a/package.json
+++ b/package.json
@@ -125,6 +125,9 @@
     "prepublishOnly": "yarn build",
     "docs": "node ./scripts/build-docs.js"
   },
+  "engines": {
+    "node": ">=12"
+  },
   "license": "(MIT OR Apache-2.0)",
   "jest": {
     "collectCoverageFrom": [


### PR DESCRIPTION
Node V10 is end-of-life in just over a month. Rather than fixing anymore
bugs related to version compatibility, we've decided to enforce this
end of support in package.json

test plan:
0. install nvm or use some other node version manager
1. `nvm use 10 && yarn` // should error on the yarn installation
2. `nvm use 12 && yarn` // should succeed