### PR TITLE
Create NetworkReadInstance

### DIFF
--- a/src/api/index.js
+++ b/src/api/index.js
@@ -34,12 +34,16 @@ import * as storage from "./ledgerStorage";
 import * as credrank from "./main/credrank";
 import * as graphApi from "./main/graph";
 import * as grainApi from "./main/grain";
+import * as readInstance from "../api/instance/readInstance";
 
 const api = {
   api: {
     graph: graphApi,
     credrank,
     grain: grainApi,
+  },
+  instance: {
+    readInstance,
   },
   core: {
     address,

--- a/src/api/instance/readInstance.js
+++ b/src/api/instance/readInstance.js
@@ -1,0 +1,62 @@
+// @flow
+
+import {ReadOnlyInstance} from "./instance";
+import {type CredrankInput} from "../main/credrank";
+import {type WeightedGraph} from "../../core/weightedGraph";
+import {type GraphInput} from "../main/graph";
+import {type GrainInput} from "../main/grain";
+import {join as pathJoin} from "path";
+import {loadJson} from "../../util/storage";
+import {
+  CredGraph,
+  parser as credGraphParser,
+} from "../../core/credrank/credGraph";
+import {NetworkStorage} from "../../core/storage/networkStorage";
+import {OriginStorage} from "../../core/storage/originStorage";
+import {ZipStorage} from "../../core/storage/zip";
+import {DataStorage} from "../../core/storage";
+
+export const getNetworkReadInstance = (base: string): ReadInstance =>
+  new ReadInstance(new NetworkStorage(base));
+export const getOriginReadInstance = (base: string): ReadInstance =>
+  new ReadInstance(new OriginStorage(base));
+
+const CREDGRAPH_PATH: $ReadOnlyArray<string> = [
+  "output",
+  "credGraph.json.gzip",
+];
+
+/**
+This is an Instance implementation that reads and writes using relative paths
+on the given base URL. The base URL given should end with a trailing slash.
+ */
+export class ReadInstance implements ReadOnlyInstance {
+  _storage: DataStorage;
+  _zipStorage: ZipStorage;
+
+  constructor(storage: DataStorage) {
+    this._storage = storage;
+    this._zipStorage = new ZipStorage(this._storage);
+  }
+
+  async readGraphInput(): Promise<GraphInput> {
+    throw "not yet implemented";
+  }
+
+  async readCredrankInput(): Promise<CredrankInput> {
+    throw "not yet implemented";
+  }
+
+  async readGrainInput(): Promise<GrainInput> {
+    throw "not yet implemented";
+  }
+
+  async readWeightedGraphForPlugin(): Promise<WeightedGraph> {
+    throw "not yet implemented";
+  }
+
+  async readCredGraph(): Promise<CredGraph> {
+    const credGraphPath = pathJoin(...CREDGRAPH_PATH);
+    return await loadJson(this._zipStorage, credGraphPath, credGraphParser);
+  }
+}

--- a/src/core/storage/networkStorage.js
+++ b/src/core/storage/networkStorage.js
@@ -1,0 +1,39 @@
+// @flow
+
+import {DataStorage} from "./index";
+import fetch from "cross-fetch";
+
+/**
+ * This class serves as a simple wrapper for http GET requests using fetch.
+ * If an empty string is passed as the base, the base will be interpretted
+ * as '.'
+ */
+export class NetworkStorage implements DataStorage {
+  _base: string;
+
+  constructor(base: string) {
+    this._base = base;
+  }
+
+  /**
+   * This get method will error if a non-200 or 300-level status was returned,
+   * or if the resource traverses above the base path.
+   */
+  async get(resource: string): Promise<Uint8Array> {
+    const path = new URL(resource, this._base).href;
+    if (!path.startsWith(this._base))
+      throw new Error(
+        `Path traversal is not allowed. ${path} does not begin with ${this._base} -- try adding trailing / to base`
+      );
+    const result = await fetch(path);
+    if (!result.ok) {
+      const error = new Error(
+        `Error fetching ${resource}: ${result.status} ${result.statusText}`
+      );
+      error.number = result.status;
+      throw error;
+    }
+
+    return new Uint8Array(await result.arrayBuffer());
+  }
+}

--- a/src/core/storage/originStorage.js
+++ b/src/core/storage/originStorage.js
@@ -2,13 +2,13 @@
 
 import {DataStorage} from "./index";
 import normalize from "../../util/pathNormalize";
-import {join as pathJoin} from "path";
+import {join as pathJoin, isAbsolute} from "path";
 import fetch from "cross-fetch";
 
 /**
  * This class serves as a simple wrapper for http GET requests using fetch.
  */
-export class NetworkStorage implements DataStorage {
+export class OriginStorage implements DataStorage {
   _base: string;
   constructor(base: string) {
     this._base = normalize(base);
@@ -18,7 +18,15 @@ export class NetworkStorage implements DataStorage {
    * This get method will error if a non-200 or 300-level status was returned.
    */
   async get(resource: string): Promise<Uint8Array> {
-    const result = await fetch(normalize(pathJoin(this._base, resource)));
+    const path = normalize(pathJoin(this._base, resource));
+    if (
+      !path.startsWith(this._base) &&
+      (path.startsWith("..") || isAbsolute(path) || this._base !== ".")
+    )
+      throw new Error(
+        `Path traversal is not allowed. ${path} is not a subpath of ${this._base}`
+      );
+    const result = await fetch(path);
     if (!result.ok) {
       const error = new Error(
         `Error fetching ${resource}: ${result.status} ${result.statusText}`

--- a/src/core/storage/originStorage.test.js
+++ b/src/core/storage/originStorage.test.js
@@ -1,0 +1,88 @@
+// @flow
+
+import {OriginStorage} from "./originStorage";
+
+jest.mock("cross-fetch", () => ({
+  // needed to utilize fetch as a default export.
+  __esModule: true,
+  default: (path) => {
+    switch (path) {
+      case "base/validPath":
+        return Promise.resolve({
+          arrayBuffer: () => new Uint8Array([1, 2]).buffer,
+          ok: true,
+          status: 200,
+          statusText: "OK",
+        });
+      case "/base/validPath":
+        return Promise.resolve({
+          arrayBuffer: () => new Uint8Array([1, 2]).buffer,
+          ok: true,
+          status: 200,
+          statusText: "OK",
+        });
+      case "base/serverError":
+        return Promise.resolve({
+          arrayBuffer: () => new ArrayBuffer(0),
+          ok: false,
+          status: 500,
+          statusText: "INTERNAL ERROR",
+        });
+      default:
+        return Promise.resolve({
+          arrayBuffer: () => new ArrayBuffer(0),
+          ok: false,
+          status: 404,
+          statusText: "NOT FOUND",
+        });
+    }
+  },
+}));
+
+describe("core/storage/originStorage", () => {
+  describe("OriginStorage", () => {
+    const value = new Uint8Array([1, 2]);
+    it("works when base path is empty", async () => {
+      expect.hasAssertions();
+      const storage = new OriginStorage("");
+      const result = await storage.get("base/validPath");
+      await expect(result).toEqual(value);
+    });
+    it("works when base is a relative path", async () => {
+      expect.hasAssertions();
+      const storage = new OriginStorage("base");
+      const result = await storage.get("validPath");
+      await expect(result).toEqual(value);
+    });
+    it("works when base is an absolute path", async () => {
+      expect.hasAssertions();
+      const storage = new OriginStorage("/base");
+      const result = await storage.get("validPath");
+      await expect(result).toEqual(value);
+    });
+    it("throws on upward traversal when the base is relative", async () => {
+      expect.hasAssertions();
+      const storage = new OriginStorage("base");
+      const thunk = async () => storage.get("../validPath");
+      await expect(thunk()).rejects.toThrow("Path traversal is not allowed");
+    });
+    it("throws on upward traversal when the base is absolute", async () => {
+      expect.hasAssertions();
+      const storage = new OriginStorage("/base/test");
+      const thunk = async () => storage.get("../validPath");
+      await expect(thunk()).rejects.toThrow("Path traversal is not allowed");
+    });
+    it("throws an error if the http response is not ok", async () => {
+      expect.hasAssertions();
+      const storage = new OriginStorage("base");
+      const thunk = async () => storage.get("invalidPath");
+      await expect(thunk()).rejects.toThrow(
+        "Error fetching invalidPath: 404 NOT FOUND"
+      );
+      const dunk = async () => storage.get("serverError");
+      await expect(dunk()).rejects.toThrow(
+        "Error fetching serverError: 500 INTERNAL ERROR"
+      );
+    });
+  });
+});

--- a/src/ui/load.js
+++ b/src/ui/load.js
@@ -13,7 +13,7 @@ import {LedgerManager} from "../api/ledgerManager";
 import {rawParser as rawInstanceConfigParser} from "../api/rawInstanceConfig";
 import {createLedgerDiskStorage} from "./utils/ledgerDiskStorage";
 import * as Combo from "../util/combo";
-import {NetworkStorage} from "../core/storage/network";
+import {OriginStorage} from "../core/storage/originStorage";
 import {ZipStorage} from "../core/storage/zip";
 import {loadJson, loadJsonWithDefault} from "../util/storage";
 
@@ -40,22 +40,22 @@ export async function load(): Promise<LoadResult> {
   // than ternaries. There's also a lot of repeated code here
 
   const diskStorage = createLedgerDiskStorage("data/ledger.json");
-  const networkStorage = new NetworkStorage("");
+  const originStorage = new OriginStorage("");
   const ledgerManager = new LedgerManager({
     storage: diskStorage,
   });
 
   const queries = [
-    loadJson(networkStorage, "sourcecred.json", rawInstanceConfigParser),
-    loadJson(networkStorage, "static/server-info.json", backendParser),
+    loadJson(originStorage, "sourcecred.json", rawInstanceConfigParser),
+    loadJson(originStorage, "static/server-info.json", backendParser),
     loadJsonWithDefault(
-      networkStorage,
+      originStorage,
       "config/currencyDetails.json",
       currencyParser,
       defaultCurrencyConfig
     ),
     loadJsonWithDefault(
-      new ZipStorage(networkStorage),
+      new ZipStorage(originStorage),
       "output/credGraph.json.gzip",
       Combo.fmap(credGraphJsonParser, (graphJson) =>
         CredGraph.fromJSON(graphJson)


### PR DESCRIPTION
<!-- Please read our contributor guide before submitting your PR: -->
<!-- https://github.com/sourcecred/sourcecred/blob/master/CONTRIBUTING.md -->

# Description
This is a proof of concept / partial implementation for a NetworkReadInstance that allows users in node or in the browser to read important instance data from a URL. By packaging fetch and pako together in our library, this will unblock people who want to do analysis on CredGraph in observables and in discord bots.
<!-- Possible prompts:
  Why is the change important?
  Did you consider and reject alternate formulations of the same idea?
  Are there relevant issues or discussions elsewhere?
-->

# Design Choices
I chose to separate OriginStorage from NetworkStorage so that we are delineating explicitly between those two cases. Also, we can probably deprecated OriginStorage at some point, since we can get the origin URL from the `window` state.


I chose to make the ReadInstance storage-agnostic so that we can eventually incorporate all forms of storage including local disk storage. The blocker on being able to do this is the tight coupling between Plugin implementations and disk storage.

# Test Plan

## NetworkReadInstance testing in node with a URL
```
yarn build
node
sc = require("./dist/server/api.js")
i = sc.sourcecred.instance.readInstance.getNetworkReadInstance("https://raw.githubusercontent.com/sourcecred/cred/gh-pages/")
i.readCredGraph().then(r => console.log(r.intervals().length))
```

## OriginStorage regression testing
```
yarn start --instance path/to/instance
```
Verified that the cred explorer loads.
<!-- Possible prompts:
  How well covered by automated tests is this change?
  How did you manually test this change? How can a reviewer replicate the tests?
-->
