### PR TITLE
Update github access token regex

### DIFF
--- a/src/plugins/github/token.js
+++ b/src/plugins/github/token.js
@@ -13,15 +13,16 @@ export opaque type GithubToken: string = string;
  * https://developer.github.com/v3/apps/#create-a-new-installation-token
  */
 export function validateToken(token: string): GithubToken {
-  const personalAccessTokenRE = /^[A-Fa-f0-9]{40}$/;
-  if (personalAccessTokenRE.test(token)) {
+  const accessTokenRE = /^gh[pousr]_[A-Za-z0-9_]*$/;
+  const oldAccessTokenRE = /^[A-Fa-f0-9]{40}$/;
+  if (accessTokenRE.test(token) || oldAccessTokenRE.test(token)) {
     return token;
   }
 
   // We're currently being lenient with installation tokens, since we're not completely
   // sure on the exact format. We're only warning on unexpected values but leave it up
   // to the GitHub API to reject the token if it's actually invalid.
-  const installationAccessTokenRE = /^(v\d+)\.([A-Fa-f0-9]+)$/;
+  const installationAccessTokenRE = /^(v\d+)\.([A-Za-z0-9_]+)$/;
   const matches = installationAccessTokenRE.exec(token);
   if (matches != null) {
     const [_, version, hexCode] = matches;

--- a/src/plugins/github/token.test.js
+++ b/src/plugins/github/token.test.js
@@ -48,6 +48,17 @@ describe("plugins/github/token", () => {
 
     it("should accept a personal access token format", () => {
       // Given
+      const token = "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";
+
+      // When
+      const validated = validateToken(token);
+
+      // Then
+      expect(token).toEqual(validated);
+    });
+
+    it("should accept an old personal access token format", () => {
+      // Given
       const token = "1bfb713d900c4962586ec615260b3902438b1d3c";
 
       // When


### PR DESCRIPTION
<!-- Please read our contributor guide before submitting your PR: -->
<!-- https://github.com/sourcecred/sourcecred/blob/master/CONTRIBUTING.md -->

# Description
Users with new-style tokens are blocked from using our github plugin currently. Updated the accepted github api key format to fit with new changes, while maintaining compatibility for old keys.
https://github.blog/changelog/2021-03-04-authentication-token-format-updates/

<!-- Possible prompts:
  Why is the change important?
  Did you consider and reject alternate formulations of the same idea?
  Are there relevant issues or discussions elsewhere?
-->

# Test Plan
`scdev graph -s` with an old format key and a new format one.
<!-- Possible prompts:
  How well covered by automated tests is this change?
  How did you manually test this change? How can a reviewer replicate the tests?
-->
