### PR TITLE
Add MVP weights configuration page

### DIFF
--- a/src/api/bundledDeclarations.js
+++ b/src/api/bundledDeclarations.js
@@ -1,0 +1,35 @@
+// @flow
+
+import type {PluginDeclaration} from "../analysis/pluginDeclaration";
+import {declaration as githubDeclaration} from "../plugins/github/declaration";
+import {declaration as discourseDeclaration} from "../plugins/discourse/declaration";
+import {declaration as discordDeclaration} from "../plugins/discord/declaration";
+import {declaration as initiativesDeclaration} from "../plugins/initiatives/declaration";
+import {declaration as ethereumDeclaration} from "../plugins/ethereum/declaration";
+import {type RawInstanceConfig} from "./rawInstanceConfig";
+import {type PluginId} from "./pluginId";
+
+export function bundledDeclarations(): {[pluginId: string]: PluginDeclaration} {
+  return {
+    "sourcecred/github": githubDeclaration,
+    "sourcecred/discourse": discourseDeclaration,
+    "sourcecred/discord": discordDeclaration,
+    "sourcecred/initiatives": initiativesDeclaration,
+    "sourcecred/ethereum": ethereumDeclaration,
+  };
+}
+
+export function upgradeRawInstanceConfig(
+  raw: RawInstanceConfig
+): $ReadOnlyMap<PluginId, PluginDeclaration> {
+  const allBundledPlugins = bundledDeclarations();
+  const bundledPlugins = new Map();
+  for (const id of raw.bundledPlugins) {
+    const plugin = allBundledPlugins[id];
+    if (plugin == null) {
+      throw new Error("bad bundled plugin: " + JSON.stringify(id));
+    }
+    bundledPlugins.set(id, plugin);
+  }
+  return bundledPlugins;
+}

--- a/src/ui/components/AdminApp.js
+++ b/src/ui/components/AdminApp.js
@@ -13,6 +13,7 @@ import pink from "@material-ui/core/colors/pink";
 import {makeStyles} from "@material-ui/core/styles";
 import fakeDataProvider from "ra-data-fakerest";
 import {ExplorerHome} from "./ExplorerHome/ExplorerHome";
+import WeightsConfigSection from "./Explorer/WeightsConfigSection";
 import {LedgerAdmin} from "./LedgerAdmin";
 import {CredGrainView} from "../../core/credGrainView";
 import {AccountOverview} from "./AccountOverview";
@@ -25,6 +26,8 @@ import AppBar from "./AppBar";
 import createMenu from "./Menu";
 import {LedgerProvider} from "../utils/LedgerContext";
 import {LedgerViewer} from "./LedgerViewer/LedgerViewer";
+import {type PluginDeclarations} from "../../analysis/pluginDeclaration";
+import {type WeightsT, empty as emptyWeights} from "../../core/weights";
 
 const dataProvider = fakeDataProvider({}, true);
 
@@ -94,8 +97,12 @@ const createAppLayout = ({hasBackend, currency}: LoadSuccess) => {
 const customRoutes = (
   hasBackend: boolean,
   currency: CurrencyDetails,
-  credGrainView: CredGrainView | null
+  credGrainView: CredGrainView | null,
+  pluginDeclarations: PluginDeclarations
 ) => {
+  const [weightsState, setWeightsState] = useState<{weights: WeightsT}>({
+    weights: emptyWeights(),
+  });
   const routes = [
     <Route key="explorer-home" exact path="/explorer-home">
       <ExplorerHome initialView={credGrainView} currency={currency} />
@@ -119,6 +126,14 @@ const customRoutes = (
     </Route>,
     <Route key="special-distribution" exact path="/special-distribution">
       <SpecialDistribution currency={currency} />
+    </Route>,
+    <Route key="weight-config" exact path="/weight-config">
+      <WeightsConfigSection
+        show={true}
+        pluginDeclarations={pluginDeclarations}
+        weights={weightsState.weights}
+        setWeightsState={setWeightsState}
+      />
     </Route>,
   ];
   return routes.concat(hasBackend ? backendRoutes : []);
@@ -185,7 +200,8 @@ const AdminInner = ({loadResult: loadSuccess}: AdminInnerProps) => {
         customRoutes={customRoutes(
           loadSuccess.hasBackend,
           loadSuccess.currency,
-          credGrainView
+          credGrainView,
+          Array.from(loadSuccess.bundledPlugins.values())
         )}
       >
         {/*

--- a/src/ui/components/Explorer/WeightsConfigSection.js
+++ b/src/ui/components/Explorer/WeightsConfigSection.js
@@ -1,10 +1,8 @@
 // @flow
 import React, {type Node as ReactNode} from "react";
-import {Grid, Slider} from "@material-ui/core";
+import {Grid} from "@material-ui/core";
 import {makeStyles} from "@material-ui/core/styles";
-import {format} from "d3-format";
 import {type PluginDeclarations} from "../../../analysis/pluginDeclaration";
-import {type TimelineCredParameters} from "../../../analysis/timeline/params";
 import {type WeightsT} from "../../../core/weights";
 import {WeightConfig} from "../../weights/WeightConfig";
 import {WeightsFileManager} from "../../weights/WeightsFileManager";
@@ -14,9 +12,6 @@ export type WeightConfigSectionProps = {|
   pluginDeclarations: PluginDeclarations,
   weights: WeightsT,
   setWeightsState: ({weights: WeightsT}) => void,
-  //TODO: change to use MarkovProcessGraph params instead
-  params: TimelineCredParameters,
-  setParams: (TimelineCredParameters) => void,
 |};
 
 const useStyles = makeStyles(() => ({
@@ -30,8 +25,6 @@ const WeightsConfigSection = ({
   pluginDeclarations,
   weights,
   setWeightsState,
-  params,
-  setParams,
 }: WeightConfigSectionProps): ReactNode => {
   if (!show) return [];
 
@@ -42,7 +35,13 @@ const WeightsConfigSection = ({
       <Grid container className={classes.weightConfig} spacing={2}>
         <Grid container item xs={12} direction="column">
           <Grid>
-            <Grid>Upload/Download weights:</Grid>
+            <Grid>
+              This page is not yet integrated with the rest of the site. If you
+              have an existing weights.json file, upload it here. Once you are
+              done configuring weights, download the file and put it in your
+              /config directory in your instance as weights.json. To see new
+              scores, re-calculate scores using the CLI.
+            </Grid>
             <Grid>
               <WeightsFileManager
                 weights={weights}
@@ -51,25 +50,6 @@ const WeightsConfigSection = ({
                 }}
               />
             </Grid>
-          </Grid>
-          <Grid container item spacing={2} alignItems="center">
-            <Grid>α</Grid>
-            <Grid item xs={2}>
-              <Slider
-                value={params.alpha}
-                min={0.05}
-                max={0.95}
-                step={0.05}
-                valueLabelDisplay="auto"
-                onChange={(_, val) => {
-                  setParams({
-                    ...params,
-                    alpha: val,
-                  });
-                }}
-              />
-            </Grid>
-            <Grid>{format(".2f")(params.alpha)}</Grid>
           </Grid>
         </Grid>
         <Grid spacing={2} container item xs={12} style={{display: "flex"}}>

--- a/src/ui/components/Menu.js
+++ b/src/ui/components/Menu.js
@@ -56,6 +56,13 @@ const createMenu = (
               onClick={onMenuClick}
               sidebarIsOpen={open}
             />
+            <MenuItemLink
+              to="/weight-config"
+              primaryText="Configure Weights"
+              leftIcon={<ExplorerIcon />}
+              onClick={onMenuClick}
+              sidebarIsOpen={open}
+            />
           </>
         )}
       </>

--- a/src/ui/load.js
+++ b/src/ui/load.js
@@ -16,12 +16,14 @@ import * as Combo from "../util/combo";
 import {OriginStorage} from "../core/storage/originStorage";
 import {ZipStorage} from "../core/storage/zip";
 import {loadJson, loadJsonWithDefault} from "../util/storage";
+import {type PluginDeclaration} from "../analysis/pluginDeclaration";
+import {upgradeRawInstanceConfig} from "../api/bundledDeclarations";
 
 export type LoadResult = LoadSuccess | LoadFailure;
 export type LoadSuccess = {|
   +type: "SUCCESS",
   +ledgerManager: LedgerManager,
-  +bundledPlugins: $ReadOnlyArray<pluginId.PluginId>,
+  +bundledPlugins: $ReadOnlyMap<pluginId.PluginId, PluginDeclaration>,
   +hasBackend: boolean,
   +currency: CurrencyDetails,
   +credGraph: CredGraph | null,
@@ -65,7 +67,7 @@ export async function load(): Promise<LoadResult> {
   ];
   try {
     const [
-      {bundledPlugins},
+      rawInstanceConfig,
       {hasBackend},
       currency,
       credGraph,
@@ -78,6 +80,7 @@ export async function load(): Promise<LoadResult> {
         error: `Error processing ledger events: ${ledgerResult.error}`,
       };
     }
+    const bundledPlugins = upgradeRawInstanceConfig(rawInstanceConfig);
     return {
       type: "SUCCESS",
       bundledPlugins,

--- a/src/ui/weights/WeightsFileManager.js
+++ b/src/ui/weights/WeightsFileManager.js
@@ -3,9 +3,8 @@
 import React, {type Node as ReactNode} from "react";
 import stringify from "json-stable-stringify";
 import {FileUploader} from "../../util/FileUploader";
-import Link from "../../webutil/Link";
-import {MdFileDownload, MdFileUpload} from "react-icons/md";
 import {type WeightsT, toJSON, fromJSON} from "../../core/weights";
+import {Button, ButtonGroup} from "@material-ui/core";
 
 export type Props = {|
   +weights: WeightsT,
@@ -17,16 +16,20 @@ export class WeightsFileManager extends React.Component<Props> {
     const onUpload = (json) => this.props.onWeightsChange(fromJSON(json));
     return (
       <div>
-        <Link
-          download="weights.json"
-          title="Download your weights.json"
-          href={`data:text/json,${weightsJSON}`}
-        >
-          <MdFileDownload style={{margin: "2px"}} />
-        </Link>
-        <FileUploader title="Upload weights.json" onUpload={onUpload}>
-          <MdFileUpload style={{margin: "2px"}} />
-        </FileUploader>
+        <ButtonGroup color="primary" variant="contained">
+          <FileUploader title="Upload weights.json" onUpload={onUpload}>
+            <Button variant="contained" color="primary" component="span">
+              Upload Weights
+            </Button>
+          </FileUploader>
+          <Button
+            download="weights.json"
+            title="Download your weights.json"
+            href={`data:text/json,${weightsJSON}`}
+          >
+            Download Weights
+          </Button>
+        </ButtonGroup>
       </div>
     );
   }


### PR DESCRIPTION
<!-- Please read our contributor guide before submitting your PR: -->
<!-- https://github.com/sourcecred/sourcecred/blob/master/CONTRIBUTING.md -->

# Description
When we launched 0.8, we removed the WeightConfigSection, even though it's a pretty important feature. This PR adds an MVP back in. Differences from the 0.7 version:
- It does not yet offer any cred score simulation functionality.
- It has it's own page instead of being a modal on the explorer page.
- It does not include the alpha/beta/gamma weight configuration.

<img width="1250" alt="Screen Shot 2021-04-02 at 5 34 49 PM" src="https://user-images.githubusercontent.com/11550396/113463396-50a3d580-93da-11eb-809d-b8470e96aa8e.png">


# Design choices
I didn't fret too much about the cleanliness in AdminApp.js, since it will change soon as we create a parent Simulator component.

The `bundledDeclarations` module is just a browser-friendly simplification of the `bundledPlugins` module.
# Test Plan
simple case:
1. Opened the new page, changed weights, downloaded the file and visually skimmed.

with upload:
1. Uploaded the weights.json from our prod instance
2. changed 1 weight
3. ran a formatter on the old file and committed changes
4. downloaded the new file, replaced the old file with it, and ran a formatter on it.
5. `git diff`
```
thena@thenas-mbp cred % git diff
diff --git a/config/weights.json b/config/weights.json
index 988971c..c14e155 100644
--- a/config/weights.json
+++ b/config/weights.json
@@ -3235,7 +3235,7 @@
       "N\u0000sourcecred\u0000discourse\u0000like\u0000https://discourse.sourcecred.io\u0000youngkidwarrior\u00003069\u0000": 0.1,
       "N\u0000sourcecred\u0000discourse\u0000like\u0000https://discourse.sourcecred.io\u0000youngkidwarrior\u00003071\u0000": 0.1,
       "N\u0000sourcecred\u0000discourse\u0000post\u0000": 0,
-      "N\u0000sourcecred\u0000discourse\u0000topic\u0000": 0,
+      "N\u0000sourcecred\u0000discourse\u0000topic\u0000": 1,
       "N\u0000sourcecred\u0000discourse\u0000user\u0000": 0,
       "N\u0000sourcecred\u0000github\u0000COMMENT\u0000": 0,
       "N\u0000sourcecred\u0000github\u0000COMMIT\u0000": 0,
```
<!-- Possible prompts:
  How well covered by automated tests is this change?
  How did you manually test this change? How can a reviewer replicate the tests?
-->
