### PR TITLE
Responsive Improvements on Explorer Home

### DIFF
--- a/src/ui/components/ExplorerHome/ExplorerHome.js
+++ b/src/ui/components/ExplorerHome/ExplorerHome.js
@@ -6,7 +6,6 @@ import {
   FormControlLabel,
   FormGroup,
   FormLabel,
-  Hidden,
   Paper,
   Tab,
   Tabs,
@@ -23,6 +22,7 @@ import {
 import {makeStyles} from "@material-ui/core/styles";
 import TableSortLabel from "@material-ui/core/TableSortLabel";
 import grey from "@material-ui/core/colors/grey";
+import useMediaQuery from "@material-ui/core/useMediaQuery";
 import deepFreeze from "deep-freeze";
 import bigInt from "big-integer";
 import {CredGrainView} from "../../../core/credGrainView";
@@ -127,7 +127,7 @@ const useStyles = makeStyles((theme) => ({
     color: theme.palette.orange,
   },
   tab: {
-    minWidth: "100px !important",
+    minWidth: "100px",
   },
   labelCred: {
     color: theme.palette.blueish,
@@ -254,6 +254,7 @@ export const ExplorerHome = ({
     );
 
   const classes = useStyles();
+  const showTableChart = useMediaQuery("(min-width:740px)");
   // default view is Last Week's Activity (array index 1)
   const [tab, setTab] = useState<number>(1);
   const [selectedInterval, setSelectedInterval] = useState<Interval>(
@@ -609,9 +610,7 @@ export const ExplorerHome = ({
                     </TableSortLabel>
                   </TableCell>
                   <TableCell>
-                    <Hidden xsDown>
-                      <b>Contributions Chart (ALL TIME)</b>
-                    </Hidden>
+                    {showTableChart && <b>Contributions Chart (ALL TIME)</b>}
                   </TableCell>
                 </TableRow>
               </TableHead>
@@ -633,7 +632,7 @@ export const ExplorerHome = ({
                         {format(row.grainEarned, 2, currencySuffix)}
                       </TableCell>
                       <TableCell className={classes.timelineCell} align="right">
-                        <Hidden xsDown>
+                        {showTableChart && (
                           <ExplorerTimeline
                             timelines={{
                               cred:
@@ -643,7 +642,7 @@ export const ExplorerHome = ({
                             }}
                             responsive={true}
                           />
-                        </Hidden>
+                        )}
                       </TableCell>
                     </TableRow>
                   ))

--- a/src/ui/components/ExplorerHome/ExplorerHome.js
+++ b/src/ui/components/ExplorerHome/ExplorerHome.js
@@ -45,9 +45,6 @@ import {formatTimestamp} from "../../utils/dateHelpers";
 const useStyles = makeStyles((theme) => ({
   root: {
     width: "100%",
-    minWidth: "1100px",
-    margin: "0 auto",
-    padding: "0 5em 5em",
   },
   arrowBody: {
     color: theme.palette.text.primary,
@@ -95,7 +92,7 @@ const useStyles = makeStyles((theme) => ({
     height: "150px",
   },
   barChartWrapper: {flexGrow: 1, flexBasis: 0, margin: "20px"},
-  tableWrapper: {flexGrow: 0, flexBasis: 0, margin: "20px auto"},
+  tableWrapper: {flexGrow: 1, flexBasis: 0, margin: "20px 0 0"},
   checklabel: {
     margin: "5px",
   },
@@ -128,11 +125,19 @@ const useStyles = makeStyles((theme) => ({
   [`label-${IdentityTypes.ORGANIZATION}`]: {
     color: theme.palette.orange,
   },
+  tab: {
+    minWidth: "100px !important",
+  },
   labelCred: {
     color: theme.palette.blueish,
   },
   labelGrain: {
     color: theme.palette.darkOrange,
+  },
+  timelineCell: {
+    [theme.breakpoints.up("md")]: {
+      minWidth: "300px",
+    },
   },
   rowAverage: {
     fontStyle: "italic",
@@ -519,7 +524,7 @@ export const ExplorerHome = ({
           onChange={(_, val) => updateTimeframe(val)}
         >
           {TIMEFRAME_OPTIONS.map(({tabLabel}) => (
-            <Tab key={tabLabel} label={tabLabel} />
+            <Tab key={tabLabel} label={tabLabel} className={classes.tab} />
           ))}
         </Tabs>
       </div>
@@ -535,15 +540,14 @@ export const ExplorerHome = ({
               display: "flex",
               justifyContent: "space-between",
               alignItems: "center",
-              marginBottom: "20px",
             }}
           >
-            <span style={{fontSize: "1.5rem"}}>
+            <h2 style={{fontSize: "24px"}}>
               {TIMEFRAME_OPTIONS[tab].tableLabel}
-            </span>
-            <span style={{fontSize: "1rem"}}>
-              {formatInterval(selectedInterval)}
-            </span>
+              <span style={{fontSize: "16px", paddingLeft: "20px"}}>
+                {formatInterval(selectedInterval)}
+              </span>
+            </h2>
             <TextField
               label="Filter Names"
               variant="outlined"
@@ -625,7 +629,7 @@ export const ExplorerHome = ({
                       <TableCell className={classes.labelGrain}>
                         {format(row.grainEarned, 2, currencySuffix)}
                       </TableCell>
-                      <TableCell align="right">
+                      <TableCell className={classes.timelineCell} align="right">
                         <ExplorerTimeline
                           timelines={{
                             cred:
@@ -633,6 +637,7 @@ export const ExplorerHome = ({
                                 String(row.identity.id)
                               ],
                           }}
+                          responsive={true}
                         />
                       </TableCell>
                     </TableRow>

--- a/src/ui/components/ExplorerHome/ExplorerHome.js
+++ b/src/ui/components/ExplorerHome/ExplorerHome.js
@@ -6,6 +6,7 @@ import {
   FormControlLabel,
   FormGroup,
   FormLabel,
+  Hidden,
   Paper,
   Tab,
   Tabs,
@@ -608,7 +609,9 @@ export const ExplorerHome = ({
                     </TableSortLabel>
                   </TableCell>
                   <TableCell>
-                    <b>Contributions Chart (ALL TIME)</b>
+                    <Hidden xsDown>
+                      <b>Contributions Chart (ALL TIME)</b>
+                    </Hidden>
                   </TableCell>
                 </TableRow>
               </TableHead>
@@ -630,15 +633,17 @@ export const ExplorerHome = ({
                         {format(row.grainEarned, 2, currencySuffix)}
                       </TableCell>
                       <TableCell className={classes.timelineCell} align="right">
-                        <ExplorerTimeline
-                          timelines={{
-                            cred:
-                              allTimeContributionCharts[
-                                String(row.identity.id)
-                              ],
-                          }}
-                          responsive={true}
-                        />
+                        <Hidden xsDown>
+                          <ExplorerTimeline
+                            timelines={{
+                              cred:
+                                allTimeContributionCharts[
+                                  String(row.identity.id)
+                                ],
+                            }}
+                            responsive={true}
+                          />
+                        </Hidden>
                       </TableCell>
                     </TableRow>
                   ))
@@ -695,7 +700,7 @@ export const ExplorerHome = ({
                       )}
                     </b>
                   </TableCell>
-                  <TableCell align="right" />
+                  <TableCell />
                 </TableRow>
               </TableBody>
               <TableFooter>


### PR DESCRIPTION
[Re. ExplorerHome: fix width on small screens #2815](https://github.com/sourcecred/sourcecred/issues/2815)

Improves the responsiveness of Explorer Home. Previously the content
overflowed below 1200px. This fixes the page so it flows a bit better between 
sizes, though there is still some screen overflow between 600px and 740px when
the menu is open (the table might be resisting being scaled down, sometimes tables
get stuck while scaling down if the contents of the table cells are too large).

I did take a few design liberties with this code change - i.e. changing the table
so it takes up the same width as the top chart. The layout/alignment felt a little confusing
with the table narrower than the page width. 

I do think we want to give some thought to how we'd like this design to work
at lower sizes (i.e. smaller fonts for the headings, flowing the filter input below
the "Last Week's Activity" heading, a different design for the table or
hiding the Cred Timeline on mobile) so it can work well on phones.

Screen capture of what the page looks like on resize: https://www.loom.com/share/f4a46960f95547599e8513e00de81e51

# Test Plan
Open the Explorer Home and resize the browser. 
