### PR TITLE
Allow grain UI to show more than 2 digits past the decimal

### DIFF
--- a/src/api/currencyConfig.js
+++ b/src/api/currencyConfig.js
@@ -4,11 +4,12 @@ import * as C from "../util/combo";
 import * as NullUtil from "../util/null";
 
 /**
- * Shape of concurrencyDetails.json on disk
+ * Shape of currencyDetails.json on disk
  */
 type SerializedCurrencyDetails = {|
   +currencyName?: string,
   +currencySuffix?: string,
+  +decimalsToDisplay?: number,
 |};
 
 /**
@@ -17,10 +18,12 @@ type SerializedCurrencyDetails = {|
 export type CurrencyDetails = {|
   +name: string,
   +suffix: string,
+  +decimals: number,
 |};
 
 export const DEFAULT_NAME = "Grain";
 export const DEFAULT_SUFFIX = "g";
+export const DEFAULT_DECIMALS = 2;
 
 /**
  * Utilized by combo.fmap to enforce default currency values
@@ -32,6 +35,7 @@ function upgrade(c: SerializedCurrencyDetails): CurrencyDetails {
   return {
     name: NullUtil.orElse(c.currencyName, DEFAULT_NAME),
     suffix: NullUtil.orElse(c.currencySuffix, DEFAULT_SUFFIX),
+    decimals: NullUtil.orElse(c.decimalsToDisplay, DEFAULT_DECIMALS),
   };
 }
 
@@ -39,10 +43,18 @@ export function defaultCurrencyConfig(): CurrencyDetails {
   return {
     name: DEFAULT_NAME,
     suffix: DEFAULT_SUFFIX,
+    decimals: DEFAULT_DECIMALS,
   };
 }
 
 export const parser: C.Parser<CurrencyDetails> = C.fmap(
-  C.object({}, {currencyName: C.string, currencySuffix: C.string}),
+  C.object(
+    {},
+    {
+      currencyName: C.string,
+      currencySuffix: C.string,
+      decimalsToDisplay: C.number,
+    }
+  ),
   upgrade
 );

--- a/src/api/currencyConfig.js
+++ b/src/api/currencyConfig.js
@@ -32,6 +32,12 @@ export const DEFAULT_DECIMALS = 2;
  * detail values after parsing the serialized file.
  */
 function upgrade(c: SerializedCurrencyDetails): CurrencyDetails {
+  if (
+    typeof c.decimalsToDisplay === "number" &&
+    (c.decimalsToDisplay > 18 || c.decimalsToDisplay < 0)
+  )
+    throw new Error("currencyConfig: decimalsToDisplay must be between 0-18");
+
   return {
     name: NullUtil.orElse(c.currencyName, DEFAULT_NAME),
     suffix: NullUtil.orElse(c.currencySuffix, DEFAULT_SUFFIX),

--- a/src/ui/components/AccountOverview.js
+++ b/src/ui/components/AccountOverview.js
@@ -26,7 +26,11 @@ const useStyles = makeStyles(() => {
 });
 
 export const AccountOverview = ({
-  currency: {name: currencyName, suffix: currencySuffix},
+  currency: {
+    name: currencyName,
+    suffix: currencySuffix,
+    decimals: decimalsToDisplay,
+  },
 }: OverviewProps): ReactNode => {
   const {ledger} = useLedger();
   const classes = useStyles();
@@ -59,7 +63,9 @@ export const AccountOverview = ({
             </TableRow>
           </TableHead>
           <TableBody>
-            {sortedAccounts.map((a) => AccountRow(a, currencySuffix))}
+            {sortedAccounts.map((a) =>
+              AccountRow(a, currencySuffix, decimalsToDisplay)
+            )}
           </TableBody>
         </Table>
       </TableContainer>
@@ -68,13 +74,17 @@ export const AccountOverview = ({
   );
 };
 
-const AccountRow = (account: Account, suffix: string) => (
+const AccountRow = (account: Account, suffix: string, decimals: number) => (
   <TableRow key={account.identity.id}>
     <TableCell component="th" scope="row">
       {account.identity.name}
     </TableCell>
     <TableCell align="right">{account.active ? "✅" : "🛑"}</TableCell>
-    <TableCell align="right">{G.format(account.balance, 2, suffix)}</TableCell>
-    <TableCell align="right">{G.format(account.paid, 2, suffix)}</TableCell>
+    <TableCell align="right">
+      {G.format(account.balance, decimals, suffix)}
+    </TableCell>
+    <TableCell align="right">
+      {G.format(account.paid, decimals, suffix)}
+    </TableCell>
   </TableRow>
 );

--- a/src/ui/components/ExplorerHome/ExplorerHome.js
+++ b/src/ui/components/ExplorerHome/ExplorerHome.js
@@ -36,6 +36,8 @@ import {
   add,
   divideFloat,
   fromInteger,
+  toFloatRatio,
+  ONE,
 } from "../../../core/ledger/grain";
 import ExplorerTimeline from "./ExplorerTimeline";
 import {IdentityTypes} from "../../../core/identity/identityType";
@@ -341,6 +343,18 @@ export const ExplorerHome = ({
     [grainTotalsTimeline]
   );
 
+  const formatLongNumbers = (number, p) => {
+    return number <= Math.pow(10, p)
+      ? parseFloat(number.toPrecision(p)).toLocaleString(undefined, {
+          maximumSignificantDigits: p,
+        })
+      : number.toLocaleString(undefined, {
+          notation: "compact",
+        });
+  };
+
+  const grainThisPeriodAsNumber = toFloatRatio(totalGrainThisPeriod, ONE);
+
   const statCircleInfo = [
     {
       title: `Cred ${TIMEFRAME_OPTIONS[tab].tabLabel}`,
@@ -349,7 +363,7 @@ export const ExplorerHome = ({
     },
     {
       title: `${currencyName}`,
-      value: format(totalGrainThisPeriod, 0, currencySuffix),
+      value: formatLongNumbers(grainThisPeriodAsNumber, 5) + currencySuffix,
       className: classes.grainCircle,
     },
   ];

--- a/src/ui/components/ExplorerHome/ExplorerHome.js
+++ b/src/ui/components/ExplorerHome/ExplorerHome.js
@@ -235,7 +235,11 @@ type ExplorerHomeProps = {|
 
 export const ExplorerHome = ({
   initialView,
-  currency: {suffix: currencySuffix, name: currencyName},
+  currency: {
+    name: currencyName,
+    suffix: currencySuffix,
+    decimals: decimalsToDisplay,
+  },
 }: ExplorerHomeProps): ReactNode => {
   if (!initialView)
     return (
@@ -623,7 +627,11 @@ export const ExplorerHome = ({
                         {Math.round(row.cred).toLocaleString()}
                       </TableCell>
                       <TableCell className={classes.labelGrain}>
-                        {format(row.grainEarned, 2, currencySuffix)}
+                        {format(
+                          row.grainEarned,
+                          decimalsToDisplay,
+                          currencySuffix
+                        )}
                       </TableCell>
                       <TableCell align="right">
                         <ExplorerTimeline

--- a/src/ui/components/LedgerViewer/GrainReceiptTable.js
+++ b/src/ui/components/LedgerViewer/GrainReceiptTable.js
@@ -17,6 +17,7 @@ type GrainReceiptTableProps = {|
   +allocation: Allocation | null,
   +ledger: Ledger,
   +currencySuffix: string,
+  +decimalsToDisplay: number,
 |};
 
 type GrainTable = (GrainReceiptTableProps) => ReactNode;
@@ -45,7 +46,7 @@ const GrainReceiptTable = (props: GrainReceiptTableProps) => {
                     />
                   </TableCell>
                   <TableCell align="right">
-                    {G.format(r.amount, 4, props.currencySuffix)}
+                    {G.format(r.amount, props.decimalsToDisplay, props.currencySuffix)}
                   </TableCell>
                 </TableRow>
               );

--- a/src/ui/components/LedgerViewer/GrainReceiptTable.js
+++ b/src/ui/components/LedgerViewer/GrainReceiptTable.js
@@ -46,7 +46,11 @@ const GrainReceiptTable = (props: GrainReceiptTableProps) => {
                     />
                   </TableCell>
                   <TableCell align="right">
-                    {G.format(r.amount, props.decimalsToDisplay, props.currencySuffix)}
+                    {G.format(
+                      r.amount,
+                      props.decimalsToDisplay,
+                      props.currencySuffix
+                    )}
                   </TableCell>
                 </TableRow>
               );

--- a/src/ui/components/LedgerViewer/LedgerViewer.js
+++ b/src/ui/components/LedgerViewer/LedgerViewer.js
@@ -66,7 +66,7 @@ const DATE_SORT = deepFreeze({
 const PAGINATION_OPTIONS = deepFreeze([25, 50, 100]);
 
 export const LedgerViewer = ({
-  currency: {suffix: currencySuffix},
+  currency: {suffix: currencySuffix, decimals: decimalsToDisplay},
 }: {
   currency: CurrencyDetails,
 }): ReactNode => {
@@ -139,6 +139,7 @@ export const LedgerViewer = ({
               allocation={allocation}
               ledger={ledger}
               currencySuffix={currencySuffix}
+              decimalsToDisplay={decimalsToDisplay}
             />
           </DialogContent>
         </Dialog>


### PR DESCRIPTION
Allows instance maintainers to customize the number of decimals
that are displayed with their currency (fix for ticket #2778) 

# Description
Adds a new property `decimalsToDisplay` to the `currencyDetails.json` config. The default value is 2. 

Sample `currencyDetails.json`:
```
{
  "decimalsToDisplay": 4
}
```

Adding this property results in this change to the UI: 
<img width="1188" alt="Screen Shot 2021-04-05 at 6 01 45 PM" src="https://user-images.githubusercontent.com/7217000/113644328-5ea36180-9639-11eb-9e88-029376a5ac39.png">


# Test Plan
- load the UI without a currencyDetails.json file
- load the UI with a currencyDetails.json file with a custom value for `decimalsToDisplay`: 
```
{
  "decimalsToDisplay": 4
}
```
- load the UI with a currencyDetails.json file that has other values but not `decimalsToDisplay`, like so: 
```
{
  "currencyName": "honey",
  "currencySuffix": "h" 
}
```