### PR TITLE
Discord: do not throw for unknown channel type

### DIFF
--- a/src/plugins/discord/models.js
+++ b/src/plugins/discord/models.js
@@ -20,7 +20,8 @@ export type ChannelType =
   | "GROUP_DM"
   | "GUILD_CATEGORY"
   | "GUILD_NEWS"
-  | "GUILD_STORE";
+  | "GUILD_STORE"
+  | "UNKNOWN";
 
 export function channelTypeFromId(id: number): ChannelType {
   switch (id) {
@@ -39,7 +40,7 @@ export function channelTypeFromId(id: number): ChannelType {
     case 6:
       return "GUILD_STORE";
     default: {
-      throw new Error(`Unknown channel type ID: ${id}`);
+      return "UNKNOWN";
     }
   }
 }


### PR DESCRIPTION
<!-- Please read our contributor guide before submitting your PR: -->
<!-- https://github.com/sourcecred/sourcecred/blob/master/CONTRIBUTING.md -->

# Description
The discord plugin has a fragility that throws on unknown channel types. This is a problem because when new channel types are added by discord, such as their new Stage channel type, our plugin breaks. This is currently happening to 1Hive.

We don't really care about channel type. We only care whether it is a text channel or not, and we ignore other channels. So there's really no reason to be picky about non-text channels. This PR creates a default "UKNOWN" channel type that gracefully handles unknown channel types.
<!-- Possible prompts:
  Why is the change important?
  Did you consider and reject alternate formulations of the same idea?
  Are there relevant issues or discussions elsewhere?
-->

# Test Plan
@befitsandpiper is going to test this change on the 1Hive instance. Results TBA.
<!-- Possible prompts:
  How well covered by automated tests is this change?
  How did you manually test this change? How can a reviewer replicate the tests?
-->
