### PR TITLE
Re-add /explorer as redirect to /explorer-home

### DIFF
--- a/src/ui/components/AdminApp.js
+++ b/src/ui/components/AdminApp.js
@@ -104,11 +104,14 @@ const customRoutes = (
     weights: emptyWeights(),
   });
   const routes = [
-    <Route key="explorer-home" exact path="/explorer-home">
+    <Route key="explorer" exact path="/explorer">
       <ExplorerHome initialView={credGrainView} currency={currency} />
     </Route>,
     <Route key="root" exact path="/">
-      <Redirect to={credGrainView ? "/explorer-home" : "/accounts"} />
+      <Redirect to={credGrainView ? "/explorer" : "/accounts"} />
+    </Route>,
+    <Route key="explorer-home" exact path="/explorer-home">
+      <Redirect to={"/explorer"} />
     </Route>,
     <Route key="accounts" exact path="/accounts">
       <AccountOverview currency={currency} />


### PR DESCRIPTION
<!-- Please read our contributor guide before submitting your PR: -->
<!-- https://github.com/sourcecred/sourcecred/blob/master/CONTRIBUTING.md -->

# Description
We broke a URL (/explorer) for no real reason as a part of 0.8.0. Since root redirects to the explorer url, users had the explorer url bookmarked/hyperlinked, and those broke when we changed the url to be /explorer-home. This makes /explorer the primary URL again, and creates a redirect from /explorer-home to /explorer. In case anyone hasn't updated their hyperlinks/bookmarks yet, this will avoid some minor confusion and also be a reminder not to break stuff unnecessarily.
<!-- Possible prompts:
  Why is the change important?
  Did you consider and reject alternate formulations of the same idea?
  Are there relevant issues or discussions elsewhere?
-->

# Test Plan
1. scdev serve
1. verify that /explorer loads by default
2. forceful browse to /explorer-home and verify redirect to /explorer
<!-- Possible prompts:
  How well covered by automated tests is this change?
  How did you manually test this change? How can a reviewer replicate the tests?
-->
