### PR TITLE
Grain: add --force flag to redo last distribution

### DIFF
--- a/src/api/main/grain.js
+++ b/src/api/main/grain.js
@@ -6,12 +6,14 @@ import {type CurrencyDetails} from "../currencyConfig";
 import {type GrainConfig, toDistributionPolicy} from "../grainConfig";
 import {type Distribution} from "../../core/ledger/distribution";
 import {applyDistributions} from "../../core/ledger/applyDistributions";
+import findLastIndex from "lodash.findlastindex";
 
 export type GrainInput = {|
   +credGraph: CredGraph,
   +ledger: Ledger,
   +grainConfig: GrainConfig,
   +currencyDetails: CurrencyDetails,
+  allowLastDistributionOverwrite?: boolean,
 |};
 
 export type GrainOutput = {|
@@ -23,7 +25,7 @@ export type GrainOutput = {|
   A primary SourceCred API that combines the given inputs into a list of
   grain distributions.
 
-  Mutates the ledger that is passed in.
+  May mutate the ledger that is passed in.
  */
 export async function grain(input: GrainInput): Promise<GrainOutput> {
   const distributionPolicy = toDistributionPolicy(input.grainConfig);
@@ -33,5 +35,26 @@ export async function grain(input: GrainInput): Promise<GrainOutput> {
     input.ledger,
     +Date.now()
   );
+  if (input.allowLastDistributionOverwrite && !distributions.length) {
+    const newEventLog = input.ledger.eventLog().slice();
+    newEventLog.splice(
+      findLastIndex(
+        input.ledger.eventLog(),
+        (event) => event.action.type === "DISTRIBUTE_GRAIN"
+      ),
+      1
+    );
+    const ledgerWithoutLastDistribution = Ledger.fromEventLog(newEventLog);
+    const distributionsWithOverwrite = applyDistributions(
+      distributionPolicy,
+      input.credGraph,
+      ledgerWithoutLastDistribution,
+      +Date.now()
+    );
+    return {
+      distributions: distributionsWithOverwrite,
+      ledger: ledgerWithoutLastDistribution,
+    };
+  }
   return {distributions, ledger: input.ledger};
 }

--- a/src/api/main/grain.js
+++ b/src/api/main/grain.js
@@ -6,14 +6,13 @@ import {type CurrencyDetails} from "../currencyConfig";
 import {type GrainConfig, toDistributionPolicy} from "../grainConfig";
 import {type Distribution} from "../../core/ledger/distribution";
 import {applyDistributions} from "../../core/ledger/applyDistributions";
-import findLastIndex from "lodash.findlastindex";
 
 export type GrainInput = {|
   +credGraph: CredGraph,
   +ledger: Ledger,
   +grainConfig: GrainConfig,
   +currencyDetails: CurrencyDetails,
-  allowLastDistributionOverwrite?: boolean,
+  allowMultipleDistributionsPerInterval?: boolean,
 |};
 
 export type GrainOutput = {|
@@ -33,28 +32,8 @@ export async function grain(input: GrainInput): Promise<GrainOutput> {
     distributionPolicy,
     input.credGraph,
     input.ledger,
-    +Date.now()
+    +Date.now(),
+    input.allowMultipleDistributionsPerInterval || false
   );
-  if (input.allowLastDistributionOverwrite && !distributions.length) {
-    const newEventLog = input.ledger.eventLog().slice();
-    newEventLog.splice(
-      findLastIndex(
-        input.ledger.eventLog(),
-        (event) => event.action.type === "DISTRIBUTE_GRAIN"
-      ),
-      1
-    );
-    const ledgerWithoutLastDistribution = Ledger.fromEventLog(newEventLog);
-    const distributionsWithOverwrite = applyDistributions(
-      distributionPolicy,
-      input.credGraph,
-      ledgerWithoutLastDistribution,
-      +Date.now()
-    );
-    return {
-      distributions: distributionsWithOverwrite,
-      ledger: ledgerWithoutLastDistribution,
-    };
-  }
   return {distributions, ledger: input.ledger};
 }

--- a/src/cli/credrank.js
+++ b/src/cli/credrank.js
@@ -31,7 +31,7 @@ const credrankCommand: Command = async (args, std) => {
         shouldRunStealth = true;
         return false;
       case "-s":
-      case "--simulate":
+      case "--simulation":
         isSimulation = true;
         return false;
       default:
@@ -42,7 +42,7 @@ const credrankCommand: Command = async (args, std) => {
   if (processedArgs.length !== 0) {
     return die(
       std,
-      "usage: sourcecred credrank [-d] [-s | --simulate] [--stealth]"
+      "usage: sourcecred credrank [-d] [-s | --simulation] [--stealth]"
     );
   }
   const taskReporter = new LoggingTaskReporter();

--- a/src/cli/grain.js
+++ b/src/cli/grain.js
@@ -16,12 +16,12 @@ function die(std, message) {
 
 const grainCommand: Command = async (args, std) => {
   let simulation = false;
-  let allowLastDistributionOverwrite = false;
+  let allowMultipleDistributionsPerInterval = false;
   const processedArgs = args.filter((arg) => {
     switch (arg) {
       case "-f":
       case "--force":
-        allowLastDistributionOverwrite = true;
+        allowMultipleDistributionsPerInterval = true;
         return false;
       case "-s":
       case "--simulation":
@@ -41,7 +41,7 @@ const grainCommand: Command = async (args, std) => {
   const baseDir = process.cwd();
   const instance: Instance = new LocalInstance(baseDir);
   const grainInput = await instance.readGrainInput();
-  grainInput.allowLastDistributionOverwrite = allowLastDistributionOverwrite;
+  grainInput.allowMultipleDistributionsPerInterval = allowMultipleDistributionsPerInterval;
 
   const {distributions, ledger} = await grain(grainInput);
 

--- a/src/cli/grain.js
+++ b/src/cli/grain.js
@@ -89,7 +89,7 @@ export const grainHelp: Command = async (args, std) => {
       When the '--simulation' (-s) flag is provided, no grain will actually be distributed,
       allowing for testing the output of various configurations.
 
-      When the '--force' (-f) flas is provided, it will overwrite the last distribution
+      When the '--force' (-f) flag is provided, it will overwrite the last distribution
       if a distribution already exists for the past interval.
 
       When run, this will identify all the completed Cred intervals (currently, weeks)

--- a/src/core/ledger/applyDistributions.test.js
+++ b/src/core/ledger/applyDistributions.test.js
@@ -22,7 +22,8 @@ describe("core/ledger/applyDistributions", () => {
           credIntervals,
           lastDistributionTimestamp,
           299,
-          maxSimultaneousDistributions
+          maxSimultaneousDistributions,
+          false
         )
       ).toEqual(expected);
     });
@@ -40,7 +41,8 @@ describe("core/ledger/applyDistributions", () => {
           credIntervals,
           lastDistributionTimestamp,
           299,
-          maxSimultaneousDistributions
+          maxSimultaneousDistributions,
+          false
         )
       ).toEqual(expected);
     });
@@ -58,7 +60,27 @@ describe("core/ledger/applyDistributions", () => {
           credIntervals,
           lastDistributionTimestamp,
           299,
-          maxSimultaneousDistributions
+          maxSimultaneousDistributions,
+          false
+        )
+      ).toEqual(expected);
+    });
+    it("handles the case where we allow multiple distributions in an interval", () => {
+      const credIntervals = intervalSequence([
+        {startTimeMs: 0, endTimeMs: 100},
+        {startTimeMs: 100, endTimeMs: 200},
+        {startTimeMs: 200, endTimeMs: 300},
+      ]);
+      const lastDistributionTimestamp = 2;
+      const maxSimultaneousDistributions = 0;
+      const expected = [{startTimeMs: 100, endTimeMs: 200}];
+      expect(
+        _chooseDistributionIntervals(
+          credIntervals,
+          lastDistributionTimestamp,
+          299,
+          maxSimultaneousDistributions,
+          true
         )
       ).toEqual(expected);
     });
@@ -76,7 +98,8 @@ describe("core/ledger/applyDistributions", () => {
           credIntervals,
           lastDistributionTimestamp,
           299,
-          maxSimultaneousDistributions
+          maxSimultaneousDistributions,
+          false
         )
       ).toEqual(expected);
     });
@@ -94,7 +117,8 @@ describe("core/ledger/applyDistributions", () => {
           credIntervals,
           lastDistributionTimestamp,
           300,
-          maxSimultaneousDistributions
+          maxSimultaneousDistributions,
+          false
         )
       ).toEqual(expected);
     });


### PR DESCRIPTION
<!-- Please read our contributor guide before submitting your PR: -->
<!-- https://github.com/sourcecred/sourcecred/blob/master/CONTRIBUTING.md -->

# Description
I've been running into an annoying reoccurring manual process, so I automated it! As a dev or instance maintainer, sometimes I want to simulate a grain distribution but the past week already has a distribution. So I would manually delete the distribution from the ledger.json to redo it for analytics. With this PR, I don't need to manually edit the JSON. Instead, I simply use the `-f` / `--force` flag to allow the grain command to append another distribution even if there is already an existing distribution for the last interval!

<!-- Possible prompts:
  Why is the change important?
  Did you consider and reject alternate formulations of the same idea?
  Are there relevant issues or discussions elsewhere?
-->

# Test Plan
1. checkout sourcecred/cred gh-pages branch
2. hand delete last distribution from ledger.json
3. `scdev grain -s` and verify 1 expected distribution simulated
5. `scdev grain -f` and verify 1 expected distribution written to ledger
6. `scdev grain -s` and verify 0 expected distributions
7. `scdev grain -f` and verify 1 new expected distribution written to ledger, and verify console output shows the same timestamp as previous distribution
8. `scdev grain --simulation --force` and verify 1 expected distribution simulated
