### PR TITLE
Ledger: lastDistributionTimestamp edge case refactor

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+  "javascript.validate.enable": false
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,0 @@
-{
-  "javascript.validate.enable": false
-}

--- a/src/core/ledger/applyDistributions.js
+++ b/src/core/ledger/applyDistributions.js
@@ -47,7 +47,9 @@ export function applyDistributions(
   const credIntervals = credGraph.intervals();
   const distributionIntervals = _chooseDistributionIntervals(
     credIntervals,
-    ledger.lastDistributionTimestamp(),
+    // Distributions after -Infinity are all the current
+    // distributions
+    ledger.lastDistributionTimestamp() || -Infinity,
     currentTimestamp,
     policy.maxSimultaneousDistributions
   );

--- a/src/core/ledger/applyDistributions.js
+++ b/src/core/ledger/applyDistributions.js
@@ -1,6 +1,7 @@
 // @flow
 
 import {type TimestampMs} from "../../util/timestamp";
+import * as NullUtil from "../../util/null";
 import {type IntervalSequence, intervalSequence} from "../interval";
 import {Ledger} from "./ledger";
 import {type AllocationPolicy} from "./policies";
@@ -49,7 +50,7 @@ export function applyDistributions(
     credIntervals,
     // Distributions after -Infinity are all the current
     // distributions
-    ledger.lastDistributionTimestamp() || -Infinity,
+    NullUtil.orElse(ledger.lastDistributionTimestamp(), -Infinity),
     currentTimestamp,
     policy.maxSimultaneousDistributions
   );

--- a/src/core/ledger/applyDistributions.js
+++ b/src/core/ledger/applyDistributions.js
@@ -48,8 +48,6 @@ export function applyDistributions(
   const credIntervals = credGraph.intervals();
   const distributionIntervals = _chooseDistributionIntervals(
     credIntervals,
-    // Distributions after -Infinity are all the current
-    // distributions
     NullUtil.orElse(ledger.lastDistributionTimestamp(), -Infinity),
     currentTimestamp,
     policy.maxSimultaneousDistributions

--- a/src/core/ledger/ledger.js
+++ b/src/core/ledger/ledger.js
@@ -142,7 +142,7 @@ export class Ledger {
   _distributions: Map<DistributionId, $ReadOnly<Distribution>>;
   _allocationsToDistributions: Map<AllocationId, DistributionId>;
   _latestTimestamp: TimestampMs = -Infinity;
-  _lastDistributionTimestamp: TimestampMs = -Infinity;
+  _lastDistributionTimestamp: TimestampMs | null = null;
 
   constructor() {
     this._ledgerEventLog = new JsonLog();
@@ -607,7 +607,10 @@ export class Ledger {
         });
       }
     }
-    if (distribution.credTimestamp > this._lastDistributionTimestamp) {
+    if (
+      this._lastDistributionTimestamp === null ||
+      distribution.credTimestamp > this._lastDistributionTimestamp
+    ) {
       this._lastDistributionTimestamp = distribution.credTimestamp;
     }
   }
@@ -808,14 +811,9 @@ export class Ledger {
    * We provide this because we may want to have a policy that issues one
    * distribution for each interval in the history of the project.
    *
-   * If there were never any distributions, then -Infinity will be returned.
+   * If there were never any distributions, then null will be returned.
    */
-  lastDistributionTimestamp(): TimestampMs {
-    // TODO(#2744): Amend interface to return null instead of -Infinity
-    // This will be a better interface primarily because in flow checking, it's
-    // easy for the client to not realize that -Infinity could get returned, and
-    // making an explicit return `TimestampMs | null` type will encourage callers
-    // to handle the edge case explicitly.
+  lastDistributionTimestamp(): TimestampMs | null {
     return this._lastDistributionTimestamp;
   }
 

--- a/src/core/ledger/ledger.test.js
+++ b/src/core/ledger/ledger.test.js
@@ -1593,8 +1593,6 @@ describe("core/ledger/ledger", () => {
       }
     });
     it("lastDistributionTimestamp returns null if there have not been any distributions", () => {
-      // consider changing this behavior; see
-      // https://github.com/sourcecred/sourcecred/issues/2744
       const ledger = new Ledger();
       expect(ledger.lastDistributionTimestamp()).toEqual(null);
     });

--- a/src/core/ledger/ledger.test.js
+++ b/src/core/ledger/ledger.test.js
@@ -1333,7 +1333,7 @@ describe("core/ledger/ledger", () => {
       });
       it("updates the last distribution timestamp", () => {
         const l = new Ledger();
-        expect(l.lastDistributionTimestamp()).toEqual(-Infinity);
+        expect(l.lastDistributionTimestamp()).toEqual(null);
         l.distributeGrain({
           id: uuid.random(),
           allocations: [],
@@ -1592,11 +1592,11 @@ describe("core/ledger/ledger", () => {
         failsWithoutMutation(ledger, thunk, "invalid timestamp");
       }
     });
-    it("lastDistributionTimestamp returns -Infinity if there have not been any distributions", () => {
+    it("lastDistributionTimestamp returns null if there have not been any distributions", () => {
       // consider changing this behavior; see
       // https://github.com/sourcecred/sourcecred/issues/2744
       const ledger = new Ledger();
-      expect(ledger.lastDistributionTimestamp()).toEqual(-Infinity);
+      expect(ledger.lastDistributionTimestamp()).toEqual(null);
     });
   });
 

--- a/src/ui/components/AccountOverview.js
+++ b/src/ui/components/AccountOverview.js
@@ -33,7 +33,7 @@ export const AccountOverview = ({
 
   const lastDistributionTimestamp = ledger.lastDistributionTimestamp();
   const lastPayoutMessage =
-    lastDistributionTimestamp === -Infinity
+    lastDistributionTimestamp === null
       ? ""
       : `Last distribution: ${formatTimestamp(lastDistributionTimestamp)}`;
 


### PR DESCRIPTION
- now ledger would return null as the default value

# Description
If there has never been any distribution, it would be clearer for the lastDistributionTimestamp to be null, so that handling based on that might be easier than the currenct `lastDistributionTimestamp === -Infinity`

Solves https://github.com/sourcecred/sourcecred/issues/2744
The change is a breaking change in that all the code before that used the comparison to -Infinity would be changed to a null check, I might suggest we use 0 instead as it's the only falsy number in JS and it wouldn't change the interface as much but that's just an idea, null is much much better if it's okay to change that interface

# Test Plan
nothing special just run `yarn test`
