### PR TITLE
Feat/include nsfw channels flag

### DIFF
--- a/src/plugins/discord/__snapshots__/fetcher.test.js.snap
+++ b/src/plugins/discord/__snapshots__/fetcher.test.js.snap
@@ -5,31 +5,37 @@ Array [
   Object {
     "id": "678348980756938813",
     "name": "Text Channels",
+    "nsfw": false,
     "type": "GUILD_CATEGORY",
   },
   Object {
     "id": "678348980798881844",
     "name": "Voice Channels",
+    "nsfw": false,
     "type": "GUILD_CATEGORY",
   },
   Object {
     "id": "678348980849213472",
     "name": "general",
+    "nsfw": false,
     "type": "GUILD_TEXT",
   },
   Object {
     "id": "678348980878573661",
     "name": "General",
+    "nsfw": false,
     "type": "GUILD_VOICE",
   },
   Object {
     "id": "678394406507905129",
     "name": "pagination",
+    "nsfw": false,
     "type": "GUILD_TEXT",
   },
   Object {
     "id": "678696874869522446",
     "name": "notmymessage",
+    "nsfw": false,
     "type": "GUILD_TEXT",
   },
 ]

--- a/src/plugins/discord/__snapshots__/fetcher.test.js.snap
+++ b/src/plugins/discord/__snapshots__/fetcher.test.js.snap
@@ -38,6 +38,30 @@ Array [
     "nsfw": false,
     "type": "GUILD_TEXT",
   },
+  Object {
+    "id": "830088231538130964",
+    "name": "rules",
+    "nsfw": false,
+    "type": "GUILD_TEXT",
+  },
+  Object {
+    "id": "830088231538130965",
+    "name": "moderator-only",
+    "nsfw": false,
+    "type": "GUILD_TEXT",
+  },
+  Object {
+    "id": "830089044695187586",
+    "name": "test stage",
+    "nsfw": false,
+    "type": "UNKNOWN",
+  },
+  Object {
+    "id": "837851969795129344",
+    "name": "test-nsfw",
+    "nsfw": true,
+    "type": "GUILD_TEXT",
+  },
 ]
 `;
 
@@ -55,7 +79,7 @@ Array [
   Object {
     "id": "678348980639498428",
     "name": "SourceCred Test Server",
-    "permissions": 2147483647,
+    "permissions": 33620992,
   },
 ]
 `;
@@ -79,13 +103,37 @@ Array [
     "nick": null,
     "roles": Array [
       "678349848684003359",
+    ],
+    "user": Object {
+      "bot": false,
+      "discriminator": "2630",
+      "id": "258786206387666944",
+      "username": "Thena",
+    },
+  },
+  Object {
+    "nick": null,
+    "roles": Array [
+      "678349848684003359",
+    ],
+    "user": Object {
+      "bot": false,
+      "discriminator": "8826",
+      "id": "318552163649454081",
+      "username": "hz",
+    },
+  },
+  Object {
+    "nick": null,
+    "roles": Array [
+      "678349848684003359",
       "678350026946117694",
     ],
     "user": Object {
       "bot": false,
-      "discriminator": "1337",
+      "discriminator": "3370",
       "id": "420341518948237331",
-      "username": "decentralion",
+      "username": "DandeLion",
     },
   },
   Object {
@@ -117,6 +165,7 @@ Array [
   Object {
     "nick": null,
     "roles": Array [
+      "678349848684003359",
       "678350026946117694",
     ],
     "user": Object {
@@ -165,6 +214,18 @@ Array [
   Object {
     "nick": null,
     "roles": Array [
+      "767909888226492448",
+    ],
+    "user": Object {
+      "bot": true,
+      "discriminator": "9034",
+      "id": "758370311774404618",
+      "username": "topocount's server bot",
+    },
+  },
+  Object {
+    "nick": null,
+    "roles": Array [
       "761706197606334535",
     ],
     "user": Object {
@@ -172,6 +233,18 @@ Array [
       "discriminator": "6627",
       "id": "761705425870782516",
       "username": "SourceCred Test",
+    },
+  },
+  Object {
+    "nick": null,
+    "roles": Array [
+      "772890579632652339",
+    ],
+    "user": Object {
+      "bot": true,
+      "discriminator": "3070",
+      "id": "772886503830323210",
+      "username": "sourcecred-test-thena",
     },
   },
 ]
@@ -450,6 +523,14 @@ Array [
   Object {
     "id": "761706197606334535",
     "name": "SourceCred Test",
+  },
+  Object {
+    "id": "767909888226492448",
+    "name": "SC server bot",
+  },
+  Object {
+    "id": "772890579632652339",
+    "name": "sourcecred-test",
   },
 ]
 `;

--- a/src/plugins/discord/config.js
+++ b/src/plugins/discord/config.js
@@ -64,6 +64,8 @@ export type DiscordConfigJson = {|
   // We can set a higher weight on these props edges, which allows us to flow Cred in a props
   // mostly to the people receiving props, rather than to the author of the props message.
   +propsChannels?: $ReadOnlyArray<Model.Snowflake>,
+  // Whether to include NSFW channels in cred distribution or not
+  +includeNsfwChannels?: boolean,
 |};
 
 const parserJson: C.Parser<DiscordConfigJson> = C.object(
@@ -81,6 +83,7 @@ const parserJson: C.Parser<DiscordConfigJson> = C.object(
       weights: C.dict(C.number),
     }),
     propsChannels: C.array(C.string),
+    includeNsfwChannels: C.boolean,
   }
 );
 
@@ -88,6 +91,7 @@ export type DiscordConfig = {|
   +guildId: Model.Snowflake,
   +weights: WeightConfig,
   +propsChannels: $ReadOnlyArray<Model.Snowflake>,
+  +includeNsfwChannels: boolean,
 |};
 
 /**
@@ -115,6 +119,7 @@ export function _upgrade(json: DiscordConfigJson): DiscordConfig {
       },
     },
     propsChannels: json.propsChannels || [],
+    includeNsfwChannels: json.includeNsfwChannels || false,
   };
 }
 

--- a/src/plugins/discord/config.test.js
+++ b/src/plugins/discord/config.test.js
@@ -24,9 +24,11 @@ describe("plugins/discord/config", () => {
           "759191073943191613": 0.25,
         },
       },
+      includeNsfwChannels: true,
     };
     const parsed: DiscordConfig = parser.parseOrThrow(raw);
     expect(parsed).toEqual(_upgrade(raw));
+    expect(parsed.includeNsfwChannels).toEqual(true);
   });
   it("fills in optional properties", () => {
     const raw = {

--- a/src/plugins/discord/config.test.js
+++ b/src/plugins/discord/config.test.js
@@ -42,5 +42,6 @@ describe("plugins/discord/config", () => {
       weights: {},
       defaultWeight: 1,
     });
+    expect(parsed.includeNsfwChannels).toEqual(false);
   });
 });

--- a/src/plugins/discord/fetcher.js
+++ b/src/plugins/discord/fetcher.js
@@ -125,6 +125,7 @@ export class Fetcher implements DiscordApi {
       id: x.id,
       name: x.name,
       type: Model.channelTypeFromId(x.type),
+      nsfw: x.nsfw,
     }));
   }
 

--- a/src/plugins/discord/mirror.js
+++ b/src/plugins/discord/mirror.js
@@ -12,15 +12,18 @@ export class Mirror {
   +_repo: SqliteMirrorRepository;
   +_api: DiscordApi;
   +guild: Model.Snowflake;
+  +includeNsfwChannels: boolean;
 
   constructor(
     repo: SqliteMirrorRepository,
     api: DiscordApi,
-    guild: Model.Snowflake
+    guild: Model.Snowflake,
+    includeNsfwChannels: boolean
   ) {
     this._repo = repo;
     this._api = api;
     this.guild = guild;
+    this.includeNsfwChannels = includeNsfwChannels;
   }
 
   async update(reporter: TaskReporter) {
@@ -68,6 +71,7 @@ export class Mirror {
     const channels = await this._api.channels(this.guild);
     for (const channel of channels) {
       if (channel.type !== "GUILD_TEXT") continue;
+      if (!this.includeNsfwChannels && channel.nsfw) continue;
       this._repo.addChannel(channel);
     }
     return this._repo.channels();

--- a/src/plugins/discord/mirror.test.js
+++ b/src/plugins/discord/mirror.test.js
@@ -8,10 +8,10 @@ import {Mirror} from "./mirror";
 describe("plugins/discord/mirror", () => {
   describe("smoke test", () => {
     const guildId = "678348980639498428";
-    const includeNsfwChannels = true;
     // const channelId = "678394406507905129";
 
     it("should print", async () => {
+      const includeNsfwChannels = true;
       // Given
       const repo = new SqliteMirrorRepository(
         new Database(":memory:"),
@@ -23,6 +23,24 @@ describe("plugins/discord/mirror", () => {
       const mirror = new Mirror(repo, api, guildId, includeNsfwChannels);
       await mirror.addMembers();
       await mirror.addTextChannels();
+      expect(repo.channels().some((channel) => channel.name.includes('nsfw'))).toBe(true);
+      // await mirror.addMessages(channelId, 10);
+    });
+
+    it("should print", async () => {
+      const includeNsfwChannels = false;
+      // Given
+      const repo = new SqliteMirrorRepository(
+        new Database(":memory:"),
+        guildId
+      );
+      const api = snapshotFetcher();
+
+      // When
+      const mirror = new Mirror(repo, api, guildId, includeNsfwChannels);
+      await mirror.addMembers();
+      await mirror.addTextChannels();
+      expect(repo.channels().every((channel) => !channel.name.includes('nsfw'))).toBe(true);
       // await mirror.addMessages(channelId, 10);
     });
   });

--- a/src/plugins/discord/mirror.test.js
+++ b/src/plugins/discord/mirror.test.js
@@ -8,6 +8,7 @@ import {Mirror} from "./mirror";
 describe("plugins/discord/mirror", () => {
   describe("smoke test", () => {
     const guildId = "678348980639498428";
+    const includeNsfwChannels = true;
     // const channelId = "678394406507905129";
 
     it("should print", async () => {
@@ -19,7 +20,7 @@ describe("plugins/discord/mirror", () => {
       const api = snapshotFetcher();
 
       // When
-      const mirror = new Mirror(repo, api, guildId);
+      const mirror = new Mirror(repo, api, guildId, includeNsfwChannels);
       await mirror.addMembers();
       await mirror.addTextChannels();
       // await mirror.addMessages(channelId, 10);

--- a/src/plugins/discord/mirror.test.js
+++ b/src/plugins/discord/mirror.test.js
@@ -23,7 +23,9 @@ describe("plugins/discord/mirror", () => {
       const mirror = new Mirror(repo, api, guildId, includeNsfwChannels);
       await mirror.addMembers();
       await mirror.addTextChannels();
-      expect(repo.channels().some((channel) => channel.name.includes('nsfw'))).toBe(true);
+      expect(
+        repo.channels().some((channel) => channel.name.includes("nsfw"))
+      ).toBe(true);
       // await mirror.addMessages(channelId, 10);
     });
 
@@ -40,7 +42,9 @@ describe("plugins/discord/mirror", () => {
       const mirror = new Mirror(repo, api, guildId, includeNsfwChannels);
       await mirror.addMembers();
       await mirror.addTextChannels();
-      expect(repo.channels().every((channel) => !channel.name.includes('nsfw'))).toBe(true);
+      expect(
+        repo.channels().every((channel) => !channel.name.includes("nsfw"))
+      ).toBe(true);
       // await mirror.addMessages(channelId, 10);
     });
   });

--- a/src/plugins/discord/models.js
+++ b/src/plugins/discord/models.js
@@ -49,6 +49,7 @@ export type Channel = {|
   +id: Snowflake,
   +type: ChannelType,
   +name: string,
+  +nsfw?: boolean,
 |};
 
 export type Role = {|

--- a/src/plugins/discord/plugin.js
+++ b/src/plugins/discord/plugin.js
@@ -55,11 +55,11 @@ export class DiscordPlugin implements Plugin {
     ctx: PluginDirectoryContext,
     reporter: TaskReporter
   ): Promise<void> {
-    const {guildId} = await loadConfig(ctx);
+    const {guildId, includeNsfwChannels} = await loadConfig(ctx);
     const token = getTokenFromEnv();
     const fetcher = new Fetcher({token});
     const repo = await repository(ctx, guildId);
-    const mirror = new Mirror(repo, fetcher, guildId);
+    const mirror = new Mirror(repo, fetcher, guildId, includeNsfwChannels);
     await mirror.update(reporter);
   }
 

--- a/src/plugins/discord/snapshots/aHR0cHM6Ly9kaXNjb3JkYXBwLmNvbS9hcGkvY2hhbm5lbHMvNjc4Mzk0NDA2NTA3OTA1MTI5L21lc3NhZ2VzP2FmdGVyPTAmbGltaXQ9MTA
+++ b/src/plugins/discord/snapshots/aHR0cHM6Ly9kaXNjb3JkYXBwLmNvbS9hcGkvY2hhbm5lbHMvNjc4Mzk0NDA2NTA3OTA1MTI5L21lc3NhZ2VzP2FmdGVyPTAmbGltaXQ9MTA
@@ -20,7 +20,8 @@
     "tts": false,
     "timestamp": "2020-02-16T00:17:22.234000+00:00",
     "edited_timestamp": "2020-02-16T00:17:38.520000+00:00",
-    "flags": 0
+    "flags": 0,
+    "components": []
   },
   {
     "id": "678394451462193154",
@@ -43,7 +44,8 @@
     "tts": false,
     "timestamp": "2020-02-16T00:17:21.188000+00:00",
     "edited_timestamp": null,
-    "flags": 0
+    "flags": 0,
+    "components": []
   },
   {
     "id": "678394448497082388",
@@ -66,7 +68,8 @@
     "tts": false,
     "timestamp": "2020-02-16T00:17:20.481000+00:00",
     "edited_timestamp": null,
-    "flags": 0
+    "flags": 0,
+    "components": []
   },
   {
     "id": "678394445351092275",
@@ -89,7 +92,8 @@
     "tts": false,
     "timestamp": "2020-02-16T00:17:19.731000+00:00",
     "edited_timestamp": null,
-    "flags": 0
+    "flags": 0,
+    "components": []
   },
   {
     "id": "678394442301833247",
@@ -112,7 +116,8 @@
     "tts": false,
     "timestamp": "2020-02-16T00:17:19.004000+00:00",
     "edited_timestamp": null,
-    "flags": 0
+    "flags": 0,
+    "components": []
   },
   {
     "id": "678394436757094410",
@@ -136,6 +141,7 @@
     "timestamp": "2020-02-16T00:17:17.682000+00:00",
     "edited_timestamp": null,
     "flags": 0,
+    "components": [],
     "reactions": [
       {
         "emoji": {
@@ -168,7 +174,8 @@
     "tts": false,
     "timestamp": "2020-02-16T00:17:16.842000+00:00",
     "edited_timestamp": null,
-    "flags": 0
+    "flags": 0,
+    "components": []
   },
   {
     "id": "678394431149178940",
@@ -191,7 +198,8 @@
     "tts": false,
     "timestamp": "2020-02-16T00:17:16.345000+00:00",
     "edited_timestamp": null,
-    "flags": 0
+    "flags": 0,
+    "components": []
   },
   {
     "id": "678394428569813013",
@@ -214,7 +222,8 @@
     "tts": false,
     "timestamp": "2020-02-16T00:17:15.730000+00:00",
     "edited_timestamp": null,
-    "flags": 0
+    "flags": 0,
+    "components": []
   },
   {
     "id": "678394426153893948",
@@ -238,6 +247,7 @@
     "timestamp": "2020-02-16T00:17:15.154000+00:00",
     "edited_timestamp": null,
     "flags": 0,
+    "components": [],
     "reactions": [
       {
         "emoji": {

--- a/src/plugins/discord/snapshots/aHR0cHM6Ly9kaXNjb3JkYXBwLmNvbS9hcGkvY2hhbm5lbHMvNjc4Mzk0NDA2NTA3OTA1MTI5L21lc3NhZ2VzP2FmdGVyPTY3ODM5NDQ1NTg0OTU2NjIwOCZsaW1pdD0xMA
+++ b/src/plugins/discord/snapshots/aHR0cHM6Ly9kaXNjb3JkYXBwLmNvbS9hcGkvY2hhbm5lbHMvNjc4Mzk0NDA2NTA3OTA1MTI5L21lc3NhZ2VzP2FmdGVyPTY3ODM5NDQ1NTg0OTU2NjIwOCZsaW1pdD0xMA
@@ -20,7 +20,8 @@
     "tts": false,
     "timestamp": "2020-02-16T00:17:32.307000+00:00",
     "edited_timestamp": null,
-    "flags": 0
+    "flags": 0,
+    "components": []
   },
   {
     "id": "678394493124476939",
@@ -43,7 +44,8 @@
     "tts": false,
     "timestamp": "2020-02-16T00:17:31.121000+00:00",
     "edited_timestamp": null,
-    "flags": 0
+    "flags": 0,
+    "components": []
   },
   {
     "id": "678394489391415348",
@@ -66,7 +68,8 @@
     "tts": false,
     "timestamp": "2020-02-16T00:17:30.231000+00:00",
     "edited_timestamp": null,
-    "flags": 0
+    "flags": 0,
+    "components": []
   },
   {
     "id": "678394486644146187",
@@ -89,7 +92,8 @@
     "tts": false,
     "timestamp": "2020-02-16T00:17:29.576000+00:00",
     "edited_timestamp": null,
-    "flags": 0
+    "flags": 0,
+    "components": []
   },
   {
     "id": "678394484291141700",
@@ -112,7 +116,8 @@
     "tts": false,
     "timestamp": "2020-02-16T00:17:29.015000+00:00",
     "edited_timestamp": null,
-    "flags": 0
+    "flags": 0,
+    "components": []
   },
   {
     "id": "678394480184918016",
@@ -136,6 +141,7 @@
     "timestamp": "2020-02-16T00:17:28.036000+00:00",
     "edited_timestamp": null,
     "flags": 0,
+    "components": [],
     "reactions": [
       {
         "emoji": {
@@ -168,7 +174,8 @@
     "tts": false,
     "timestamp": "2020-02-16T00:17:27.302000+00:00",
     "edited_timestamp": null,
-    "flags": 0
+    "flags": 0,
+    "components": []
   },
   {
     "id": "678394473428025354",
@@ -191,7 +198,8 @@
     "tts": false,
     "timestamp": "2020-02-16T00:17:26.425000+00:00",
     "edited_timestamp": null,
-    "flags": 0
+    "flags": 0,
+    "components": []
   },
   {
     "id": "678394469048909841",
@@ -214,7 +222,8 @@
     "tts": false,
     "timestamp": "2020-02-16T00:17:25.381000+00:00",
     "edited_timestamp": null,
-    "flags": 0
+    "flags": 0,
+    "components": []
   },
   {
     "id": "678394468373626890",
@@ -237,6 +246,7 @@
     "tts": false,
     "timestamp": "2020-02-16T00:17:25.220000+00:00",
     "edited_timestamp": null,
-    "flags": 0
+    "flags": 0,
+    "components": []
   }
 ]

--- a/src/plugins/discord/snapshots/aHR0cHM6Ly9kaXNjb3JkYXBwLmNvbS9hcGkvZ3VpbGRzLzY3ODM0ODk4MDYzOTQ5ODQyOA
+++ b/src/plugins/discord/snapshots/aHR0cHM6Ly9kaXNjb3JkYXBwLmNvbS9hcGkvZ3VpbGRzLzY3ODM0ODk4MDYzOTQ5ODQyOA
@@ -5,7 +5,10 @@
   "description": null,
   "splash": null,
   "discovery_splash": null,
-  "features": [],
+  "features": [
+    "COMMUNITY",
+    "NEWS"
+  ],
   "emojis": [
     {
       "name": "sourcecred",
@@ -26,7 +29,7 @@
   "system_channel_id": "678348980849213472",
   "widget_enabled": false,
   "widget_channel_id": null,
-  "verification_level": 0,
+  "verification_level": 1,
   "roles": [
     {
       "id": "678348980639498428",
@@ -37,7 +40,7 @@
       "hoist": false,
       "managed": false,
       "mentionable": false,
-      "permissions_new": "33620992"
+      "permissions_new": "6476071936"
     },
     {
       "id": "678349848684003359",
@@ -48,7 +51,7 @@
       "hoist": false,
       "managed": false,
       "mentionable": false,
-      "permissions_new": "104324673"
+      "permissions_new": "6546775617"
     },
     {
       "id": "678350026946117694",
@@ -59,7 +62,7 @@
       "hoist": false,
       "managed": false,
       "mentionable": false,
-      "permissions_new": "104324681"
+      "permissions_new": "6546775625"
     },
     {
       "id": "678359229433905152",
@@ -73,7 +76,7 @@
       "tags": {
         "bot_id": "678351352770068560"
       },
-      "permissions_new": "66560"
+      "permissions_new": "6442517504"
     },
     {
       "id": "728740243926286386",
@@ -87,7 +90,7 @@
       "tags": {
         "bot_id": "728738433199112280"
       },
-      "permissions_new": "66560"
+      "permissions_new": "6442517504"
     },
     {
       "id": "761706197606334535",
@@ -101,12 +104,40 @@
       "tags": {
         "bot_id": "761705425870782516"
       },
-      "permissions_new": "8"
+      "permissions_new": "6442450952"
+    },
+    {
+      "id": "767909888226492448",
+      "name": "SC server bot",
+      "permissions": 66560,
+      "position": 1,
+      "color": 0,
+      "hoist": false,
+      "managed": true,
+      "mentionable": false,
+      "tags": {
+        "bot_id": "758370311774404618"
+      },
+      "permissions_new": "6442517504"
+    },
+    {
+      "id": "772890579632652339",
+      "name": "sourcecred-test",
+      "permissions": 66560,
+      "position": 1,
+      "color": 0,
+      "hoist": false,
+      "managed": true,
+      "mentionable": false,
+      "tags": {
+        "bot_id": "772886503830323210"
+      },
+      "permissions_new": "6442517504"
     }
   ],
   "default_message_notifications": 1,
   "mfa_level": 0,
-  "explicit_content_filter": 0,
+  "explicit_content_filter": 2,
   "max_presences": null,
   "max_members": 100000,
   "max_video_channel_users": 25,
@@ -115,8 +146,9 @@
   "premium_subscription_count": 0,
   "system_channel_flags": 0,
   "preferred_locale": "en-US",
-  "rules_channel_id": null,
-  "public_updates_channel_id": null,
+  "rules_channel_id": "830088231538130964",
+  "public_updates_channel_id": "830088231538130965",
+  "nsfw": false,
   "embed_enabled": false,
   "embed_channel_id": null
 }

--- a/src/plugins/discord/snapshots/aHR0cHM6Ly9kaXNjb3JkYXBwLmNvbS9hcGkvZ3VpbGRzLzY3ODM0ODk4MDYzOTQ5ODQyOC9jaGFubmVscw
+++ b/src/plugins/discord/snapshots/aHR0cHM6Ly9kaXNjb3JkYXBwLmNvbS9hcGkvZ3VpbGRzLzY3ODM0ODk4MDYzOTQ5ODQyOC9jaGFubmVscw
@@ -21,7 +21,7 @@
   },
   {
     "id": "678348980849213472",
-    "last_message_id": "761706197875032104",
+    "last_message_id": "837852251984363589",
     "type": 0,
     "name": "general",
     "position": 0,
@@ -40,6 +40,7 @@
     "parent_id": "678348980798881844",
     "bitrate": 64000,
     "user_limit": 0,
+    "rtc_region": null,
     "guild_id": "678348980639498428",
     "permission_overwrites": [],
     "nsfw": false
@@ -68,6 +69,86 @@
     "guild_id": "678348980639498428",
     "permission_overwrites": [],
     "nsfw": false,
+    "rate_limit_per_user": 0
+  },
+  {
+    "id": "830088231538130964",
+    "last_message_id": null,
+    "type": 0,
+    "name": "rules",
+    "position": 0,
+    "parent_id": null,
+    "topic": null,
+    "guild_id": "678348980639498428",
+    "permission_overwrites": [
+      {
+        "id": "678348980639498428",
+        "type": "role",
+        "allow": 0,
+        "deny": 2048,
+        "allow_new": "0",
+        "deny_new": "2048"
+      }
+    ],
+    "nsfw": false,
+    "rate_limit_per_user": 0
+  },
+  {
+    "id": "830088231538130965",
+    "last_message_id": "830088232083521567",
+    "type": 0,
+    "name": "moderator-only",
+    "position": 0,
+    "parent_id": null,
+    "topic": null,
+    "guild_id": "678348980639498428",
+    "permission_overwrites": [
+      {
+        "id": "678348980639498428",
+        "type": "role",
+        "allow": 0,
+        "deny": 1024,
+        "allow_new": "0",
+        "deny_new": "1024"
+      }
+    ],
+    "nsfw": false,
+    "rate_limit_per_user": 0
+  },
+  {
+    "id": "830089044695187586",
+    "type": 13,
+    "name": "test stage",
+    "position": 0,
+    "parent_id": "678348980798881844",
+    "topic": null,
+    "bitrate": 40000,
+    "user_limit": 1000,
+    "rtc_region": null,
+    "guild_id": "678348980639498428",
+    "permission_overwrites": [
+      {
+        "id": "678349848684003359",
+        "type": "role",
+        "allow": 20971536,
+        "deny": 0,
+        "allow_new": "20971536",
+        "deny_new": "0"
+      }
+    ],
+    "nsfw": false
+  },
+  {
+    "id": "837851969795129344",
+    "last_message_id": "838027593575825420",
+    "type": 0,
+    "name": "test-nsfw",
+    "position": 3,
+    "parent_id": "678348980756938813",
+    "topic": null,
+    "guild_id": "678348980639498428",
+    "permission_overwrites": [],
+    "nsfw": true,
     "rate_limit_per_user": 0
   }
 ]

--- a/src/plugins/discord/snapshots/aHR0cHM6Ly9kaXNjb3JkYXBwLmNvbS9hcGkvZ3VpbGRzLzY3ODM0ODk4MDYzOTQ5ODQyOC9lbW9qaXM
+++ b/src/plugins/discord/snapshots/aHR0cHM6Ly9kaXNjb3JkYXBwLmNvbS9hcGkvZ3VpbGRzLzY3ODM0ODk4MDYzOTQ5ODQyOC9lbW9qaXM
@@ -6,13 +6,6 @@
     "require_colons": true,
     "managed": false,
     "animated": false,
-    "available": true,
-    "user": {
-      "id": "143776454050709505",
-      "username": "Beanow",
-      "avatar": "6496446fe1455f31f9536b132dcc4ac8",
-      "discriminator": "5887",
-      "public_flags": 0
-    }
+    "available": true
   }
 ]

--- a/src/plugins/discord/snapshots/aHR0cHM6Ly9kaXNjb3JkYXBwLmNvbS9hcGkvZ3VpbGRzLzY3ODM0ODk4MDYzOTQ5ODQyOC9tZW1iZXJzP2FmdGVyPTAmbGltaXQ9MTAwMA
+++ b/src/plugins/discord/snapshots/aHR0cHM6Ly9kaXNjb3JkYXBwLmNvbS9hcGkvZ3VpbGRzLzY3ODM0ODk4MDYzOTQ5ODQyOC9tZW1iZXJzP2FmdGVyPTAmbGltaXQ9MTAwMA
@@ -1,12 +1,5 @@
 [
   {
-    "user": {
-      "id": "143776454050709505",
-      "username": "Beanow",
-      "avatar": "6496446fe1455f31f9536b132dcc4ac8",
-      "discriminator": "5887",
-      "public_flags": 0
-    },
     "roles": [
       "678349848684003359",
       "678350026946117694"
@@ -15,17 +8,56 @@
     "premium_since": null,
     "joined_at": "2020-02-15T21:16:40.215000+00:00",
     "is_pending": false,
+    "pending": false,
+    "user": {
+      "id": "143776454050709505",
+      "username": "Beanow",
+      "avatar": "6496446fe1455f31f9536b132dcc4ac8",
+      "discriminator": "5887",
+      "public_flags": 0
+    },
     "mute": false,
     "deaf": false
   },
   {
+    "roles": [
+      "678349848684003359"
+    ],
+    "nick": null,
+    "premium_since": null,
+    "joined_at": "2020-11-02T18:02:40.116000+00:00",
+    "is_pending": false,
+    "pending": false,
     "user": {
-      "id": "420341518948237331",
-      "username": "decentralion",
-      "avatar": "a70b70bc0471e6a1efe5124c39c76020",
-      "discriminator": "1337",
+      "id": "258786206387666944",
+      "username": "Thena",
+      "avatar": "901b937016ffe1d6fa465ecbe2208371",
+      "discriminator": "2630",
       "public_flags": 0
     },
+    "mute": false,
+    "deaf": false
+  },
+  {
+    "roles": [
+      "678349848684003359"
+    ],
+    "nick": null,
+    "premium_since": null,
+    "joined_at": "2021-04-27T01:08:45.585000+00:00",
+    "is_pending": false,
+    "pending": false,
+    "user": {
+      "id": "318552163649454081",
+      "username": "hz",
+      "avatar": "9354e5b8f1227fc95c494d3b08df59a5",
+      "discriminator": "8826",
+      "public_flags": 0
+    },
+    "mute": false,
+    "deaf": false
+  },
+  {
     "roles": [
       "678349848684003359",
       "678350026946117694"
@@ -34,17 +66,18 @@
     "premium_since": null,
     "joined_at": "2020-02-15T22:31:31.243000+00:00",
     "is_pending": false,
+    "pending": false,
+    "user": {
+      "id": "420341518948237331",
+      "username": "DandeLion",
+      "avatar": "ccec4bb861a03f5c30fb7c68ca672a92",
+      "discriminator": "3370",
+      "public_flags": 0
+    },
     "mute": false,
     "deaf": false
   },
   {
-    "user": {
-      "id": "432981598858903585",
-      "username": "wchargin",
-      "avatar": "012988df3eab485878fd588696097802",
-      "discriminator": "8658",
-      "public_flags": 0
-    },
     "roles": [
       "678349848684003359",
       "678350026946117694"
@@ -53,17 +86,18 @@
     "premium_since": null,
     "joined_at": "2020-02-15T22:21:55.613000+00:00",
     "is_pending": false,
+    "pending": false,
+    "user": {
+      "id": "432981598858903585",
+      "username": "wchargin",
+      "avatar": "012988df3eab485878fd588696097802",
+      "discriminator": "8658",
+      "public_flags": 0
+    },
     "mute": false,
     "deaf": false
   },
   {
-    "user": {
-      "id": "439050857921904640",
-      "username": "Brian Litwin",
-      "avatar": "1cc439c3506ede04a77be8105d934df4",
-      "discriminator": "2386",
-      "public_flags": 0
-    },
     "roles": [
       "678349848684003359",
       "678350026946117694"
@@ -72,35 +106,38 @@
     "premium_since": null,
     "joined_at": "2020-02-16T00:45:23.478000+00:00",
     "is_pending": false,
+    "pending": false,
+    "user": {
+      "id": "439050857921904640",
+      "username": "Brian Litwin",
+      "avatar": "1cc439c3506ede04a77be8105d934df4",
+      "discriminator": "2386",
+      "public_flags": 0
+    },
     "mute": false,
     "deaf": false
   },
   {
-    "user": {
-      "id": "489154203714060300",
-      "username": "topocount",
-      "avatar": "2a6e5d43226461f0bd0f3ddff15f7753",
-      "discriminator": "1337",
-      "public_flags": 0
-    },
     "roles": [
+      "678349848684003359",
       "678350026946117694"
     ],
     "nick": null,
     "premium_since": null,
     "joined_at": "2020-10-02T18:07:37.732000+00:00",
     "is_pending": false,
+    "pending": false,
+    "user": {
+      "id": "489154203714060300",
+      "username": "topocount",
+      "avatar": "ae3bc648fc34000087134ff7eb9a7533",
+      "discriminator": "1337",
+      "public_flags": 0
+    },
     "mute": false,
     "deaf": false
   },
   {
-    "user": {
-      "id": "579830927287386126",
-      "username": "sandpiper",
-      "avatar": "9d5df48f961f46e5a79b5af3e1c82fcd",
-      "discriminator": "3969",
-      "public_flags": 0
-    },
     "roles": [
       "678350026946117694"
     ],
@@ -108,10 +145,26 @@
     "premium_since": null,
     "joined_at": "2020-10-02T18:07:44.893000+00:00",
     "is_pending": false,
+    "pending": false,
+    "user": {
+      "id": "579830927287386126",
+      "username": "sandpiper",
+      "avatar": "8e387caf00d84b7fec05385da5a8cfef",
+      "discriminator": "3969",
+      "public_flags": 0
+    },
     "mute": false,
     "deaf": false
   },
   {
+    "roles": [
+      "678359229433905152"
+    ],
+    "nick": null,
+    "premium_since": null,
+    "joined_at": "2020-02-15T21:57:23.609000+00:00",
+    "is_pending": false,
+    "pending": false,
     "user": {
       "id": "678351352770068560",
       "username": "CredBot-Beanow",
@@ -120,17 +173,18 @@
       "public_flags": 0,
       "bot": true
     },
-    "roles": [
-      "678359229433905152"
-    ],
-    "nick": null,
-    "premium_since": null,
-    "joined_at": "2020-02-15T21:57:23.609000+00:00",
-    "is_pending": false,
     "mute": false,
     "deaf": false
   },
   {
+    "roles": [
+      "728740243926286386"
+    ],
+    "nick": null,
+    "premium_since": null,
+    "joined_at": "2020-07-03T22:33:33.496000+00:00",
+    "is_pending": false,
+    "pending": false,
     "user": {
       "id": "728738433199112280",
       "username": "sts-credbot",
@@ -139,17 +193,38 @@
       "public_flags": 0,
       "bot": true
     },
-    "roles": [
-      "728740243926286386"
-    ],
-    "nick": null,
-    "premium_since": null,
-    "joined_at": "2020-07-03T22:33:33.496000+00:00",
-    "is_pending": false,
     "mute": false,
     "deaf": false
   },
   {
+    "roles": [
+      "767909888226492448"
+    ],
+    "nick": null,
+    "premium_since": null,
+    "joined_at": "2020-10-20T00:39:44.545000+00:00",
+    "is_pending": false,
+    "pending": false,
+    "user": {
+      "id": "758370311774404618",
+      "username": "topocount's server bot",
+      "avatar": null,
+      "discriminator": "9034",
+      "public_flags": 0,
+      "bot": true
+    },
+    "mute": false,
+    "deaf": false
+  },
+  {
+    "roles": [
+      "761706197606334535"
+    ],
+    "nick": null,
+    "premium_since": null,
+    "joined_at": "2020-10-02T21:48:29.344000+00:00",
+    "is_pending": false,
+    "pending": false,
     "user": {
       "id": "761705425870782516",
       "username": "SourceCred Test",
@@ -158,13 +233,26 @@
       "public_flags": 0,
       "bot": true
     },
+    "mute": false,
+    "deaf": false
+  },
+  {
     "roles": [
-      "761706197606334535"
+      "772890579632652339"
     ],
     "nick": null,
     "premium_since": null,
-    "joined_at": "2020-10-02T21:48:29.344000+00:00",
+    "joined_at": "2020-11-02T18:31:13.848000+00:00",
     "is_pending": false,
+    "pending": false,
+    "user": {
+      "id": "772886503830323210",
+      "username": "sourcecred-test-thena",
+      "avatar": null,
+      "discriminator": "3070",
+      "public_flags": 0,
+      "bot": true
+    },
     "mute": false,
     "deaf": false
   }

--- a/src/plugins/discord/snapshots/aHR0cHM6Ly9kaXNjb3JkYXBwLmNvbS9hcGkvZ3VpbGRzLzY3ODM0ODk4MDYzOTQ5ODQyOC9yb2xlcw
+++ b/src/plugins/discord/snapshots/aHR0cHM6Ly9kaXNjb3JkYXBwLmNvbS9hcGkvZ3VpbGRzLzY3ODM0ODk4MDYzOTQ5ODQyOC9yb2xlcw
@@ -8,7 +8,7 @@
     "hoist": false,
     "managed": false,
     "mentionable": false,
-    "permissions_new": "33620992"
+    "permissions_new": "6476071936"
   },
   {
     "id": "678349848684003359",
@@ -19,7 +19,7 @@
     "hoist": false,
     "managed": false,
     "mentionable": false,
-    "permissions_new": "104324673"
+    "permissions_new": "6546775617"
   },
   {
     "id": "678350026946117694",
@@ -30,7 +30,7 @@
     "hoist": false,
     "managed": false,
     "mentionable": false,
-    "permissions_new": "104324681"
+    "permissions_new": "6546775625"
   },
   {
     "id": "678359229433905152",
@@ -44,7 +44,7 @@
     "tags": {
       "bot_id": "678351352770068560"
     },
-    "permissions_new": "66560"
+    "permissions_new": "6442517504"
   },
   {
     "id": "728740243926286386",
@@ -58,7 +58,7 @@
     "tags": {
       "bot_id": "728738433199112280"
     },
-    "permissions_new": "66560"
+    "permissions_new": "6442517504"
   },
   {
     "id": "761706197606334535",
@@ -72,6 +72,34 @@
     "tags": {
       "bot_id": "761705425870782516"
     },
-    "permissions_new": "8"
+    "permissions_new": "6442450952"
+  },
+  {
+    "id": "767909888226492448",
+    "name": "SC server bot",
+    "permissions": 66560,
+    "position": 1,
+    "color": 0,
+    "hoist": false,
+    "managed": true,
+    "mentionable": false,
+    "tags": {
+      "bot_id": "758370311774404618"
+    },
+    "permissions_new": "6442517504"
+  },
+  {
+    "id": "772890579632652339",
+    "name": "sourcecred-test",
+    "permissions": 66560,
+    "position": 1,
+    "color": 0,
+    "hoist": false,
+    "managed": true,
+    "mentionable": false,
+    "tags": {
+      "bot_id": "772886503830323210"
+    },
+    "permissions_new": "6442517504"
   }
 ]

--- a/src/plugins/discord/snapshots/aHR0cHM6Ly9kaXNjb3JkYXBwLmNvbS9hcGkvdXNlcnMvQG1lL2d1aWxkcw
+++ b/src/plugins/discord/snapshots/aHR0cHM6Ly9kaXNjb3JkYXBwLmNvbS9hcGkvdXNlcnMvQG1lL2d1aWxkcw
@@ -4,8 +4,11 @@
     "name": "SourceCred Test Server",
     "icon": null,
     "owner": false,
-    "permissions": 2147483647,
-    "features": [],
-    "permissions_new": "2147483647"
+    "permissions": 33620992,
+    "features": [
+      "NEWS",
+      "COMMUNITY"
+    ],
+    "permissions_new": "6476071936"
   }
 ]


### PR DESCRIPTION
<!-- Please read our contributor guide before submitting your PR: -->
<!-- https://github.com/sourcecred/sourcecred/blob/master/CONTRIBUTING.md -->

# Description
This adds a configuration for the instance maintainer in the discord config file to either include or exclude messages in NSFW channels from cred distribution
<!-- Possible prompts:
  Why is the change important?
  Did you consider and reject alternate formulations of the same idea?
  Are there relevant issues or discussions elsewhere?
-->
Relevant issue #2676 
# Test Plan
unit tests with: yarn test

**Manual test steps**:
run an instance of source cred with discord enabled
I would follow the amazing dev env setup [here](https://github.com/AL0YSI0US/trusty-rabbit-hole/blob/main/setting-up-a-sourcecred-development-env.md)
be sure to have a bot running in a server
add the `includeNsfwChannels` as true in `/config/discord/config.json` so that it might look like this
```json
{
  "guildId": "678348980639498428",
  "reactionWeights": {
    "👍": 1,
    "sourcecred:678399364418502669": 10
  },
  "includeNsfwChannels": true
}
```
Check if cred from nsfw channels is being calculated after running
`scdev go` and then `scdev serve` and checking the explorer

then change `includeNsfwChannels` to false or remove it entirely and check if cred is not distributed to senders in that channels based on reactions and messages.

<!-- Possible prompts:
  How well covered by automated tests is this change?
  How did you manually test this change? How can a reviewer replicate the tests?
-->
