### PR TITLE
Set up grain distribution tracking for grain integrations

### DIFF
--- a/src/core/ledger/ledger.test.js
+++ b/src/core/ledger/ledger.test.js
@@ -1619,7 +1619,6 @@ describe("core/ledger/ledger", () => {
             version: "1",
           },
         ]);
-        expect(ledger._trackGrainIntegration).toBe(true);
       });
       it("can disable integrations", () => {
         const ledger = new Ledger();
@@ -1643,7 +1642,6 @@ describe("core/ledger/ledger", () => {
             version: "1",
           },
         ]);
-        expect(ledger._trackGrainIntegration).toBe(false);
       });
       it("is a no-op when repeatedly enabling integrations", () => {
         const ledger = new Ledger();
@@ -1659,7 +1657,6 @@ describe("core/ledger/ledger", () => {
             version: "1",
           },
         ]);
-        expect(ledger._trackGrainIntegration).toBe(true);
       });
       it("is a no-op when attempting to repeatedly disable integrations", () => {
         const ledger = new Ledger();

--- a/src/core/ledger/ledger.test.js
+++ b/src/core/ledger/ledger.test.js
@@ -1598,6 +1598,154 @@ describe("core/ledger/ledger", () => {
     });
   });
 
+  describe("Grain Integrations", () => {
+    const getEmptyDistribution = (time: number = 1) => ({
+      credTimestamp: time,
+      allocations: [],
+      id: uuid.random(),
+    });
+    describe("Toggle Integrations", () => {
+      it("can enable integrations", () => {
+        const ledger = new Ledger();
+        ledger.enableIntegrationTracking();
+        expect(ledger.eventLog()).toEqual([
+          {
+            "action": {
+              type: "TOGGLE_INTEGRATION",
+            },
+            ledgerTimestamp: 4,
+            uuid: "000000000000000000017A",
+            version: "1",
+          },
+        ]);
+        expect(ledger._trackIntegration).toBe(true);
+      });
+      it("can disable integrations", () => {
+        const ledger = new Ledger();
+        ledger.enableIntegrationTracking();
+        ledger.disableIntegrationTracking();
+        expect(ledger.eventLog()).toEqual([
+          {
+            "action": {
+              type: "TOGGLE_INTEGRATION",
+            },
+            ledgerTimestamp: 5,
+            uuid: "000000000000000000018A",
+            version: "1",
+          },
+          {
+            "action": {
+              type: "TOGGLE_INTEGRATION",
+            },
+            ledgerTimestamp: 6,
+            uuid: "000000000000000000019A",
+            version: "1",
+          },
+        ]);
+        expect(ledger._trackIntegration).toBe(false);
+      });
+      it("is a no-op when repeatedly disabling integrations", () => {
+        const ledger = new Ledger();
+        ledger.enableIntegrationTracking();
+        ledger.enableIntegrationTracking();
+        expect(ledger.eventLog()).toEqual([
+          {
+            "action": {
+              type: "TOGGLE_INTEGRATION",
+            },
+            ledgerTimestamp: 7,
+            uuid: "000000000000000000020A",
+            version: "1",
+          },
+        ]);
+        expect(ledger._trackIntegration).toBe(true);
+      });
+      it("is a no-op when attempting to repeatedly enable integrations", () => {
+        const ledger = new Ledger();
+        ledger.disableIntegrationTracking();
+        expect(ledger.eventLog()).toEqual([]);
+      });
+      describe("runIntegration", () => {
+        it("does not run if a integration tracking is disabled", () => {
+          const distribution = getEmptyDistribution();
+          const ledger = new Ledger();
+          ledger.distributeGrain(distribution);
+          const thunk = () => ledger.runIntegration(distribution.id);
+          expect(thunk).toThrow("integration tracking not enabled");
+          expect(Array.from(ledger.trackedDistributions())).toEqual([]);
+        });
+        it("runs when integration tracking is enabled", () => {
+          const distribution = getEmptyDistribution();
+          const ledger = new Ledger();
+          ledger.enableIntegrationTracking();
+          ledger.distributeGrain(distribution);
+          ledger.runIntegration(distribution.id);
+          expect(ledger.eventLog()).toEqual([
+            {
+              "action": {
+                type: "TOGGLE_INTEGRATION",
+              },
+              ledgerTimestamp: 9,
+              uuid: "000000000000000000024A",
+              version: "1",
+            },
+            {
+              uuid: "000000000000000000025A",
+              version: "1",
+              ledgerTimestamp: 10,
+              action: {
+                "distribution": {
+                  "allocations": [],
+                  "credTimestamp": 1,
+                  "id": "000000000000000000023A",
+                },
+                type: "DISTRIBUTE_GRAIN",
+              },
+            },
+            {
+              "action": {
+                "id": "000000000000000000023A",
+                "type": "RUN_INTEGRATION",
+              },
+              "ledgerTimestamp": 11,
+              "uuid": "000000000000000000026A",
+              "version": "1",
+            },
+          ]);
+          expect(Array.from(ledger.trackedDistributions())).toEqual([
+            distribution.id,
+          ]);
+          expect(ledger.integrationExecuted(distribution.id)).toBe(true);
+        });
+      });
+      describe("trackDistributions", () => {
+        const distribution = getEmptyDistribution();
+        const ledger = new Ledger();
+        ledger.distributeGrain(distribution);
+        ledger.enableIntegrationTracking();
+        const distribution2 = getEmptyDistribution(7);
+        ledger.distributeGrain(distribution2);
+        it("doesn't return untracked distributions", () => {
+          expect(Array.from(ledger.trackedDistributions())).toEqual([
+            distribution2.id,
+          ]);
+        });
+        describe("integrationExecuted", () => {
+          it("returns undefined for untracked distributions", () => {
+            expect(ledger.integrationExecuted(distribution.id)).toBe(undefined);
+          });
+          it("returns false for tracked integrations not yet executed", () => {
+            expect(ledger.integrationExecuted(distribution2.id)).toBe(false);
+          });
+          it("returns true for executed integrations", () => {
+            ledger.runIntegration(distribution2.id);
+            expect(ledger.integrationExecuted(distribution2.id)).toBe(true);
+          });
+        });
+      });
+    });
+  });
+
   describe("uuids", () => {
     it("ledger events have uuids", () => {
       const ledger = new Ledger();


### PR DESCRIPTION
# Semantics

A "tracked distribution" is a distribution that has been created when
distribution tracking is enabled

Tracked distributions are catalogued as "not executed" upon creation, and
only when `markDistributionExecuted` is called, will they be marked as "executed".
Note that `markDistributionExecuted` does not itself executed integration
functionality. This exists outside of the ledger context for now.

# Further Details

Grain integration tracking will allow us to track which distributions are
eligible to be processed by a grain integration. This will be needed for
situations where a grain integration is actually transacting funds, such as
on a blockchain. Grain integrations that generate some form of output that
does not directly relate to a transaction can still execute, but they
may be executed multiple times to generate the report in different
contexts, so there is no need to track these executions in the ledger.

# merge plan

Merge before #3007

# Test Plan
unit tests are provided.