### PR TITLE
Specify a Grain Integration Contract

### DIFF
--- a/src/api/grainConfig.js
+++ b/src/api/grainConfig.js
@@ -9,6 +9,7 @@ import {
 } from "../core/ledger/policies";
 import {fromInteger as toNonnegativeGrain} from "../core/ledger/nonnegativeGrain";
 import {toDiscount} from "../core/ledger/policies/recent";
+import {type Name, parser as nameParser} from "../core/identity/name";
 
 export type GrainConfig = {|
   +immediatePerWeek?: number, // (deprecated)
@@ -17,6 +18,7 @@ export type GrainConfig = {|
   +recentWeeklyDecayRate?: number, // (deprecated)
   +allocationPolicies?: $ReadOnlyArray<AllocationPolicy>,
   +maxSimultaneousDistributions?: number,
+  +sinkIdentity?: Name,
 |};
 
 export const parser: C.Parser<GrainConfig> = C.object(
@@ -28,6 +30,7 @@ export const parser: C.Parser<GrainConfig> = C.object(
     balancedPerWeek: C.number,
     recentPerWeek: C.number,
     recentWeeklyDecayRate: C.number,
+    sinkIdentity: nameParser,
   }
 );
 

--- a/src/core/ledger/grainIntegration.js
+++ b/src/core/ledger/grainIntegration.js
@@ -1,0 +1,124 @@
+// @flow
+
+import {Ledger, type PayoutAddress, type CurrencyId} from "./ledger";
+import {type Distribution} from "./distribution";
+import {getDistributionBalances} from "./distributionSummary/distributionSummary.js";
+import {type Currency} from "./currency.js";
+import {type IdentityId} from "../identity";
+import * as G from "./grain";
+
+type Transfer = {|
+  amount: G.Grain,
+  memo: string,
+|};
+
+export type AccountDistributions = Map<PayoutAddress, G.Grain>;
+export type PayoutAddressToId = Map<PayoutAddress, IdentityId>;
+export type TransferredGrain = Map<PayoutAddress, Transfer>;
+
+export type IntegrationResult = {|
+  // Amounts that are actually distributed by the integration.
+  // If Grain is still not tracked offchain, these can be recorded as transfers
+  // in the ledger to the "sink" Identity.
+  transferredGrain: TransferredGrain,
+|};
+
+export type IntegrationConfig = {|
+  // This determines whether contemporary grain balances are tracked by the ledger.
+  // `true` is effectively the current state of the ledger.
+  // `false` sets all grain balances to zero and disables transfers. This
+  // is utilized to enforce the exististence of token balances outside of the
+  // ledger. Importantly, Grain Receipts from allocations are still tracked,
+  // because some grain distribution strategies rely on this information.
+  accountingEnabled: boolean,
+  // This enables a new ledger event where all distributions after this
+  // config is enabled should have a matching "Integration" event. If not,
+  // an interface should prompt admin interface users that they haven't
+  // distributed funds via a configured integration
+  processDistributions: boolean,
+|};
+
+/**
+ * This function definition is implemented by Grain Integrations.
+ * Grain integrations allow distributions to be executed programmatically
+ * beyond the ledger. However, an integration might have some side-effects
+ * that require the ledger to be updated, and it therefore has the option of
+ * returning a list of of ledger operations. The ledger will update the ledger
+ * if accounting is enabled. Otherwise, grain balances will be tracked
+ * elsewhere.
+ */
+export type grainIntegration = (
+  AccountDistributions,
+  Currency
+) => ?IntegrationResult;
+
+///////////////////
+// Helper functions
+///////////////////
+
+// TODO @topocount: Refactor interface using instance/config properties
+// after grainConfig is updated to include The payout currency details and
+// sink identity
+export function executeGrainIntegration(
+  ledger: Ledger,
+  integration: grainIntegration,
+  distribution: Distribution,
+  currency: Currency,
+  accountingEnabled: boolean,
+  processDistributions: boolean,
+  sink?: IdentityId
+): Ledger {
+  const {distributions, payoutAddressToId} = buildDistributionIndexes(
+    ledger,
+    distribution,
+    JSON.stringify(currency)
+  );
+  // Need to receive actual allocations so users don't lose funds if
+  // decimals are truncated in L2 or in some other environment that must modify
+  // the fixed-point amount for some reason.
+  let result;
+  try {
+    result = integration(distributions, currency);
+    if (processDistributions) ledger.runIntegration(distribution.id);
+  } catch (e) {
+    throw new Error(`Grain Integration failed: ${e}`);
+  }
+  if (result && sink && accountingEnabled && processDistributions) {
+    const {transferredGrain} = result;
+    for (const [address, {amount, memo}] of transferredGrain.entries()) {
+      const recipientId = payoutAddressToId.get(address);
+      if (!recipientId)
+        throw new Error(`Invalid recipient address: ${address}`);
+      ledger.transferGrain({
+        from: recipientId,
+        to: sink,
+        amount,
+        memo: `Integrated Distribution: ${memo}`,
+      });
+    }
+  }
+  return ledger;
+}
+
+export function buildDistributionIndexes(
+  ledger: Ledger,
+  distribution: Distribution,
+  currencyId: CurrencyId
+): {distributions: AccountDistributions, payoutAddressToId: PayoutAddressToId} {
+  const distributions = new Map();
+  const payoutAddressToId = new Map();
+  const balances = getDistributionBalances(distribution);
+  for (const [id, amount] of balances.entries()) {
+    const {payoutAddresses, identity} = ledger.account(id);
+    const address = payoutAddresses.get(currencyId);
+    if (!address) continue;
+    // need to allow for identities that have since been merged to still claim
+    // funds if accounts are merged between a grain distribution a
+    // grainIntegration call.
+    const total = distributions.get(address) ?? G.ZERO;
+    distributions.set(address, G.add(amount, total));
+    payoutAddressToId.set(address, identity.id);
+  }
+
+  return {distributions, payoutAddressToId};
+}

--- a/src/core/ledger/grainIntegration.js
+++ b/src/core/ledger/grainIntegration.js
@@ -9,13 +9,14 @@ import * as NullUtil from "../../util/null";
 import * as G from "./grain";
 
 type Transfer = {|
+  payoutAddress: PayoutAddress,
   amount: G.Grain,
   memo: string,
 |};
 
 export type PayoutDistributions = Array<[PayoutAddress, G.Grain]>;
 export type PayoutAddressToId = Map<PayoutAddress, IdentityId>;
-export type TransferredGrain = Array<[PayoutAddress, Transfer]>;
+export type TransferredGrain = Array<Transfer>;
 
 export type PayoutResult = {|
   // Amounts that are actually distributed by the integration.
@@ -83,10 +84,10 @@ export function executeGrainIntegration(
   }
   if (result && sink && accountingEnabled && processDistributions) {
     const {transferredGrain} = result;
-    for (const [address, {amount, memo}] of transferredGrain) {
-      const recipientId = payoutAddressToId.get(address);
+    for (const {payoutAddress, amount, memo} of transferredGrain) {
+      const recipientId = payoutAddressToId.get(payoutAddress);
       if (!recipientId)
-        throw new Error(`Invalid recipient address: ${address}`);
+        throw new Error(`Invalid recipient address: ${payoutAddress}`);
       ledger.transferGrain({
         from: recipientId,
         to: sink,

--- a/src/core/ledger/grainIntegration.test.js
+++ b/src/core/ledger/grainIntegration.test.js
@@ -78,10 +78,11 @@ describe("src/core/ledger/grainIntegration", () => {
       returnDistribution = false
     ) => (distributions, currency) => {
       const _ = currency;
-      const result = distributions.map(([address, amount]) => [
-        address,
-        {amount, memo: "hello transfer"},
-      ]);
+      const result = distributions.map(([payoutAddress, amount]) => ({
+        payoutAddress,
+        amount,
+        memo: "hello transfer",
+      }));
       if (returnDistribution) return {transferredGrain: result};
     };
     const currency = buildCurrency("BTC");

--- a/src/core/ledger/grainIntegration.test.js
+++ b/src/core/ledger/grainIntegration.test.js
@@ -1,4 +1,5 @@
 // @flow
+
 import {
   type GrainIntegration,
   executeGrainIntegration,
@@ -77,10 +78,10 @@ describe("src/core/ledger/grainIntegration", () => {
       returnDistribution = false
     ) => (distributions, currency) => {
       const _ = currency;
-      const result = new Map();
-      for (const [address, amount] of distributions.entries()) {
-        result.set(address, {amount, memo: "hello transfer"});
-      }
+      const result = distributions.map(([address, amount]) => [
+        address,
+        {amount, memo: "hello transfer"},
+      ]);
       if (returnDistribution) return {transferredGrain: result};
     };
     const currency = buildCurrency("BTC");

--- a/src/core/ledger/grainIntegration.test.js
+++ b/src/core/ledger/grainIntegration.test.js
@@ -1,0 +1,235 @@
+// @flow
+import {
+  type grainIntegration,
+  executeGrainIntegration,
+} from "./grainIntegration";
+import {
+  createUuidMock,
+  createDateMock,
+  createTestLedgerFixture,
+  id1,
+  id2,
+  g,
+  nng,
+} from "./testUtils";
+import * as uuid from "../../util/uuid";
+import {buildCurrency} from "./currency";
+import {parseAddress} from "../../plugins/ethereum/ethAddress";
+import {diffLedger} from "./diffLedger";
+import {Ledger} from "./ledger";
+const allocationId1: uuid.Uuid = uuid.random();
+const allocationId2: uuid.Uuid = uuid.random();
+const uuidMock = createUuidMock();
+const dateMock = createDateMock();
+const {ledgerWithActiveIdentities} = createTestLedgerFixture(
+  uuidMock,
+  dateMock
+);
+
+describe("src/core/ledger/grainIntegration", () => {
+  describe("executeGrainIntegration", () => {
+    let ledger;
+    let sink;
+    const allocation1 = {
+      policy: {
+        policyType: "IMMEDIATE",
+        budget: nng("10"),
+        numIntervalsLookback: 1,
+      },
+      id: allocationId1,
+      receipts: [
+        {amount: g("3"), id: id1},
+        {amount: g("7"), id: id2},
+      ],
+    };
+    const allocation2 = {
+      id: allocationId2,
+      policy: {policyType: "BALANCED", budget: nng("20")},
+      receipts: [
+        {amount: g("10"), id: id1},
+        {amount: g("10"), id: id2},
+      ],
+    };
+    const distribution = {
+      credTimestamp: 1,
+      allocations: [allocation1, allocation2],
+      id: uuid.random(),
+    };
+
+    beforeEach(() => {
+      ledger = ledgerWithActiveIdentities();
+      ledger.enableIntegrationTracking();
+      ledger.distributeGrain(distribution);
+      sink = ledger.createIdentity("ORGANIZATION", "sink");
+      ledger.activate(sink);
+      ledger.setPayoutAddress(
+        id1,
+        parseAddress("0x0000000000000000000000000000000000000001"),
+        currency.chainId
+      );
+      ledger.setPayoutAddress(
+        id2,
+        parseAddress("0x0000000000000000000000000000000000000002"),
+        currency.chainId
+      );
+    });
+    const getmockIntegration: (?boolean) => grainIntegration = (
+      returnDistribution = false
+    ) => (distributions, currency) => {
+      const _ = currency;
+      const result = new Map();
+      for (const [address, amount] of distributions.entries()) {
+        result.set(address, {amount, memo: "hello transfer"});
+      }
+      if (returnDistribution) return {transferredGrain: result};
+    };
+    const currency = buildCurrency("BTC");
+    it("can execute grainIntegration that doesn't update the ledger", () => {
+      const ledgerSnapshot = ledger.serialize();
+      const newLedger = executeGrainIntegration(
+        ledger,
+        getmockIntegration(),
+        distribution,
+        currency,
+        true,
+        true,
+        sink
+      );
+      const result = diffLedger(newLedger, Ledger.parse(ledgerSnapshot));
+      expect(result).toEqual([
+        {
+          "action": {
+            "id": "000000000000000000000A",
+            "type": "RUN_INTEGRATION",
+          },
+          "ledgerTimestamp": 10,
+          "uuid": "000000000000000000011A",
+          "version": "1",
+        },
+      ]);
+    });
+    it("doesn't transfer grain if processDistributions isn't set", () => {
+      const ledgerSnapshot = ledger.serialize();
+      const newLedger = executeGrainIntegration(
+        ledger,
+        getmockIntegration(true),
+        distribution,
+        currency,
+        true,
+        false,
+        sink
+      );
+      const result = diffLedger(newLedger, Ledger.parse(ledgerSnapshot));
+      expect(result).toEqual([]);
+    });
+    it("doesn't transfer grain if a accounting isn't enabled", () => {
+      const ledgerSnapshot = ledger.serialize();
+      const newLedger = executeGrainIntegration(
+        ledger,
+        getmockIntegration(true),
+        distribution,
+        currency,
+        false,
+        true,
+        sink
+      );
+      const result = diffLedger(newLedger, Ledger.parse(ledgerSnapshot));
+      expect(result).toEqual([
+        {
+          "action": {
+            "id": "000000000000000000000A",
+            "type": "RUN_INTEGRATION",
+          },
+          "ledgerTimestamp": 10,
+          "uuid": "000000000000000000011A",
+          "version": "1",
+        },
+      ]);
+    });
+    it("doesn't transfer grain if a sink isn't set", () => {
+      const ledgerSnapshot = ledger.serialize();
+      const newLedger = executeGrainIntegration(
+        ledger,
+        getmockIntegration(true),
+        distribution,
+        currency,
+        true,
+        true
+      );
+      const result = diffLedger(newLedger, Ledger.parse(ledgerSnapshot));
+      expect(result).toEqual([
+        {
+          "action": {
+            "id": "000000000000000000000A",
+            "type": "RUN_INTEGRATION",
+          },
+          "ledgerTimestamp": 10,
+          "uuid": "000000000000000000011A",
+          "version": "1",
+        },
+      ]);
+    });
+    it("Throws if the ledger does not have integrations enabled when it's expected to", () => {
+      ledger.disableIntegrationTracking();
+      const thunk = () =>
+        executeGrainIntegration(
+          ledger,
+          getmockIntegration(),
+          distribution,
+          currency,
+          true,
+          true,
+          sink
+        );
+      expect(thunk).toThrow("integration tracking not enabled");
+    });
+    it("updates the ledger when balances are returned by the integration", () => {
+      const ledgerSnapshot = ledger.serialize();
+      const newLedger = executeGrainIntegration(
+        ledger,
+        getmockIntegration(true),
+        distribution,
+        currency,
+        true,
+        true,
+        sink
+      );
+      const result = diffLedger(newLedger, Ledger.parse(ledgerSnapshot));
+      expect(result).toEqual([
+        {
+          "action": {
+            "id": "000000000000000000000A",
+            "type": "RUN_INTEGRATION",
+          },
+          "ledgerTimestamp": 10,
+          "uuid": "000000000000000000011A",
+          "version": "1",
+        },
+        {
+          ledgerTimestamp: 11,
+          action: {
+            from: "YVZhbGlkVXVpZEF0TGFzdA",
+            to: "000000000000000000006A",
+            amount: "13",
+            memo: "Integrated Distribution: hello transfer",
+            type: "TRANSFER_GRAIN",
+          },
+          version: "1",
+          uuid: "000000000000000000012A",
+        },
+        {
+          ledgerTimestamp: 12,
+          action: {
+            from: "URgLrCxgvjHxtGJ9PgmckQ",
+            to: "000000000000000000006A",
+            amount: "17",
+            memo: "Integrated Distribution: hello transfer",
+            type: "TRANSFER_GRAIN",
+          },
+          version: "1",
+          uuid: "000000000000000000013A",
+        },
+      ]);
+    });
+  });
+});

--- a/src/core/ledger/grainIntegration.test.js
+++ b/src/core/ledger/grainIntegration.test.js
@@ -1,6 +1,6 @@
 // @flow
 import {
-  type grainIntegration,
+  type GrainIntegration,
   executeGrainIntegration,
 } from "./grainIntegration";
 import {
@@ -73,7 +73,7 @@ describe("src/core/ledger/grainIntegration", () => {
         currency.chainId
       );
     });
-    const getmockIntegration: (?boolean) => grainIntegration = (
+    const getmockIntegration: (?boolean) => GrainIntegration = (
       returnDistribution = false
     ) => (distributions, currency) => {
       const _ = currency;
@@ -84,7 +84,7 @@ describe("src/core/ledger/grainIntegration", () => {
       if (returnDistribution) return {transferredGrain: result};
     };
     const currency = buildCurrency("BTC");
-    it("can execute grainIntegration that doesn't update the ledger", () => {
+    it("can execute GrainIntegration that doesn't update the ledger", () => {
       const ledgerSnapshot = ledger.serialize();
       const newLedger = executeGrainIntegration(
         ledger,
@@ -100,7 +100,7 @@ describe("src/core/ledger/grainIntegration", () => {
         {
           "action": {
             "id": "000000000000000000000A",
-            "type": "RUN_INTEGRATION",
+            "type": "MARK_DISTRIBUTION_EXECUTED",
           },
           "ledgerTimestamp": 10,
           "uuid": "000000000000000000011A",
@@ -138,7 +138,7 @@ describe("src/core/ledger/grainIntegration", () => {
         {
           "action": {
             "id": "000000000000000000000A",
-            "type": "RUN_INTEGRATION",
+            "type": "MARK_DISTRIBUTION_EXECUTED",
           },
           "ledgerTimestamp": 10,
           "uuid": "000000000000000000011A",
@@ -161,7 +161,7 @@ describe("src/core/ledger/grainIntegration", () => {
         {
           "action": {
             "id": "000000000000000000000A",
-            "type": "RUN_INTEGRATION",
+            "type": "MARK_DISTRIBUTION_EXECUTED",
           },
           "ledgerTimestamp": 10,
           "uuid": "000000000000000000011A",
@@ -199,7 +199,7 @@ describe("src/core/ledger/grainIntegration", () => {
         {
           "action": {
             "id": "000000000000000000000A",
-            "type": "RUN_INTEGRATION",
+            "type": "MARK_DISTRIBUTION_EXECUTED",
           },
           "ledgerTimestamp": 10,
           "uuid": "000000000000000000011A",

--- a/src/core/ledger/ledger.js
+++ b/src/core/ledger/ledger.js
@@ -90,10 +90,10 @@ export type Account = $ReadOnly<MutableAccount>;
  * Keying on the raw Currency object means keying on the object reference,
  * rather than the contents of the object.
  */
-type CurrencyId = string;
+export type CurrencyId = string;
 
 // Only Eth Addresses are supported at the moment
-type PayoutAddress = EthAddress;
+export type PayoutAddress = EthAddress;
 
 /**
  * PayableAddressStore maps currencies to a participant's


### PR DESCRIPTION
This PR contains two artifacts that should be implemented by Grain
Integrations.

The first is the `IntegrationConfig`. The integration provides the
expected config values. These config values should then be checked
against the current ledger and instance config to ensure the integration
can execute without error.

The second is the `grainIntegration` function interface. This is
interface accepts a map of payout addresses and grain amounts, and a
Currency type, which contains either a protocol indicator or token
address if the protocol is the EVM-based. If the function returns an
`IntegrationResult` and accounting is enabled, the ledger is updated with
the new balances.

Note that the interface shape will change when the needed updates are made to the
needed configs. This is mostly to show the constituent parts needed to make this
work.

Functions that wrap the grain integration are implemented to show how it
is meant to be used, and are meant to be helpers once this feature is in
production.

# Merge Plan

merge after #3003 

# Test Plan

Unit tests are provided for the helper functions.

The helper functions are meant to illustrate how grain integrations will be
used.