### PR TITLE
UI: Add ?dev=true feature flag + hidden empty Profile page

### DIFF
--- a/src/ui/components/Menu.js
+++ b/src/ui/components/Menu.js
@@ -13,12 +13,24 @@ type menuProps = {|onMenuClick: Function|};
 
 const createMenu = (
   hasBackend: boolean,
-  {name: currencyName}: CurrencyDetails
+  {name: currencyName}: CurrencyDetails,
+  isDev: boolean
 ): ((menuProps) => ReactNode) => {
   const Menu = ({onMenuClick}: menuProps) => {
     const open = useSelector((state) => state.admin.ui.sidebarOpen);
     return (
       <>
+        {isDev && (
+          <>
+            <MenuItemLink
+              to="/profile"
+              primaryText="Profile"
+              leftIcon={<PeopleIcon />}
+              onClick={onMenuClick}
+              sidebarIsOpen={open}
+            />
+          </>
+        )}
         <MenuItemLink
           to="/explorer-home"
           primaryText="Explorer"

--- a/src/ui/components/Profile/ProfilePage.js
+++ b/src/ui/components/Profile/ProfilePage.js
@@ -1,0 +1,8 @@
+// @flow
+
+import React, {type Node as ReactNode} from "react";
+import {Container} from "@material-ui/core";
+
+export const ProfilePage = (): ReactNode => {
+  return <Container>Hello World!</Container>;
+};

--- a/src/ui/load.js
+++ b/src/ui/load.js
@@ -27,6 +27,7 @@ export type LoadSuccess = {|
   +hasBackend: boolean,
   +currency: CurrencyDetails,
   +credGraph: CredGraph | null,
+  +isDev: boolean,
 |};
 export type LoadFailure = {|+type: "FAILURE", +error: any|};
 
@@ -81,6 +82,7 @@ export async function load(): Promise<LoadResult> {
       };
     }
     const bundledPlugins = upgradeRawInstanceConfig(rawInstanceConfig);
+    const isDev = new URLSearchParams(location.search).get("dev") === "true";
     return {
       type: "SUCCESS",
       bundledPlugins,
@@ -88,6 +90,7 @@ export async function load(): Promise<LoadResult> {
       hasBackend,
       currency,
       credGraph,
+      isDev,
     };
   } catch (e) {
     console.error(e);


### PR DESCRIPTION
<!-- Please read our contributor guide before submitting your PR: -->
<!-- https://github.com/sourcecred/sourcecred/blob/master/CONTRIBUTING.md -->

# Description
This PR does 2 things:
1. Adds support for a `?dev=true` URL query parameter that enables devs to add hidden routes that only load and appear in the menu if the parameter is added to the URL.
2. Creates a hello world Profile page as a hidden dev route.
<!-- Possible prompts:
  Why is the change important?
  Did you consider and reject alternate formulations of the same idea?
  Are there relevant issues or discussions elsewhere?
-->

# Test Plan
From `sourcecred/sourcecred` run `yarn start`
1. navigate to `http://localhost:8080/webpack-dev-server/?dev=true` and verify profile page appears in menu, as well as backend routes.
2. navigate to `http://localhost:8080/webpack-dev-server/` and verify profile page does not appear in menu, but backend routes do.

From `sourcecred/cred` run `scdev serve`
1. navigate to `http://localhost:6006/?dev=true` and verify profile page appears in menu.
2. navigate to `http://localhost:6006/` and verify profile page does not appear in menu.
<!-- Possible prompts:
  How well covered by automated tests is this change?
  How did you manually test this change? How can a reviewer replicate the tests?
-->
