### PR TITLE
Utilize SourceMaps for package.json module property

### DIFF
--- a/config/webpack.config.api.js
+++ b/config/webpack.config.api.js
@@ -95,4 +95,13 @@ const server = {
   },
 };
 
-module.exports = ([client, server] /*: Array<any>*/);
+const devModule = {
+  ...server,
+  devtool: "source-map",
+  output: {
+    ...server.output,
+    path: `${paths.apiBuild}/module`,
+  },
+};
+
+module.exports = ([client, server, devModule] /*: Array<any>*/);

--- a/package.json
+++ b/package.json
@@ -174,6 +174,6 @@
   ],
   "main": "dist/server/api.js",
   "browser": "dist/client/api.js",
-  "module": "src/api/index.js",
+  "module": "dist/module/api.js",
   "bin": "./bin/sourcecred.js"
 }


### PR DESCRIPTION
# Description
Netlify functions utilize the path provided in the module property to
package and deploy lambda functions. @hammadj had set this up to provide
human readable code to improve dev experience. This change attempts to
accomodate both use cases by yielding commonjs code and also providing
full source maps (flow annotations included) on build.

enables the merge of https://github.com/sourcecred/account-service/pull/1
cc @blueridger 

# Test Plan
1. yarn && yarn build
2. yarn link
3. cd ../path/to/sourcecred/account-service
4. git fetch origin && git checkout sc-core
5. yarn && yarn link sourcecred
6. yarn dev
7. browse to: http://localhost:9000/.netlify/functions/mergeAccounts and
   the hello world message load and print the last interval end
   datetime
