### PR TITLE
Fix identity name reference detector

### DIFF
--- a/src/api/main/graph.js
+++ b/src/api/main/graph.js
@@ -27,9 +27,9 @@ export type GraphOutput = {|
 |};
 
 /**
-  
-
-  Might mutate the ledger that is passed in.
+ 
+ 
+ Might mutate the ledger that is passed in.
  */
 export async function graph(
   input: GraphInput,
@@ -84,7 +84,9 @@ export function _hackyIdentityNameReferenceDetector(
   ledger: Ledger
 ): ReferenceDetector {
   const usernameToAddress = new Map(
-    ledger.accounts().map((a) => [a.identity.name, a.identity.address])
+    ledger
+      .accounts()
+      .map((a) => [a.identity.name.toLowerCase(), a.identity.address])
   );
   function addressFromUrl(potentialUsername: string) {
     const prepped = potentialUsername.replace("@", "").toLowerCase();

--- a/src/api/main/graph.test.js
+++ b/src/api/main/graph.test.js
@@ -17,5 +17,16 @@ describe("api/main/graph", () => {
       expect(addressFromUrl("@Steven")).toEqual(identity.address);
       expect(addressFromUrl("stuball")).toEqual(undefined);
     });
+    it("works when username in ledger is capitalized", () => {
+      const ledger = new Ledger();
+      const id = ledger.createIdentity("USER", "Steven");
+      const {identity} = get(ledger.account(id));
+      const {addressFromUrl} = _hackyIdentityNameReferenceDetector(ledger);
+      expect(addressFromUrl("steven")).toEqual(identity.address);
+      expect(addressFromUrl("Steven")).toEqual(identity.address);
+      expect(addressFromUrl("@steven")).toEqual(identity.address);
+      expect(addressFromUrl("@Steven")).toEqual(identity.address);
+      expect(addressFromUrl("stuball")).toEqual(undefined);
+    });
   });
 });


### PR DESCRIPTION
# Description

When referring to user names in initiatives, the existing reference detector converts the string
in the initiative JSON to lowercase but doesnt convert the names in the ledger to lowercase, which
causes the reference detector to not match with an identity when the name in the ledger has uppercase
letters.

This fixes it by converting all the names read from the ledger to lowercase before comparing with the
reference.

# Test Plan

Ensure new unit tests pass
