### PR TITLE
Discord: add reaction weight averaging & default reaction weight config

### DIFF
--- a/src/plugins/discord/config.js
+++ b/src/plugins/discord/config.js
@@ -66,6 +66,11 @@ export type DiscordConfigJson = {|
   +propsChannels?: $ReadOnlyArray<Model.Snowflake>,
   // Whether to include NSFW channels in cred distribution or not
   +includeNsfwChannels?: boolean,
+  // What the weight should be for reactions not specified in reactionWeights
+  +defaultReactionWeight?: number,
+  // Whether reaction weights on a given message should be divided by the number
+  // of unique members that reacted to the message.
+  +applyAveragingToReactions?: boolean,
 |};
 
 const parserJson: C.Parser<DiscordConfigJson> = C.object(
@@ -84,6 +89,8 @@ const parserJson: C.Parser<DiscordConfigJson> = C.object(
     }),
     propsChannels: C.array(C.string),
     includeNsfwChannels: C.boolean,
+    defaultReactionWeight: C.number,
+    applyAveragingToReactions: C.boolean,
   }
 );
 
@@ -114,8 +121,8 @@ export function _upgrade(json: DiscordConfigJson): DiscordConfig {
       ),
       emojiWeights: {
         weights: json.reactionWeights,
-        // TODO: Make the default emoji weight customizable
-        defaultWeight: 1,
+        defaultWeight: NullUtil.orElse(json.defaultReactionWeight, 1),
+        applyAveraging: NullUtil.orElse(json.applyAveragingToReactions, false),
       },
     },
     propsChannels: json.propsChannels || [],

--- a/src/plugins/discord/config.test.js
+++ b/src/plugins/discord/config.test.js
@@ -1,6 +1,6 @@
 // @flow
 
-import {type DiscordConfig, parser, _upgrade} from "./config";
+import {type DiscordConfig, parser} from "./config";
 
 describe("plugins/discord/config", () => {
   it("can load a basic config", () => {
@@ -25,10 +25,40 @@ describe("plugins/discord/config", () => {
         },
       },
       includeNsfwChannels: true,
+      defaultReactionWeight: 0,
+      applyAveragingToReactions: true,
+    };
+    const expected = {
+      guildId: "453243919774253079",
+      propsChannels: [],
+      weights: {
+        emojiWeights: {
+          applyAveraging: true,
+          defaultWeight: 0,
+          weights: {
+            "🥰": 4,
+            "sourcecred:626763367893303303": 16,
+          },
+        },
+        channelWeights: {
+          defaultWeight: 0,
+          weights: {
+            "759191073943191613": 0.25,
+          },
+        },
+        roleWeights: {
+          defaultWeight: 0,
+          weights: {
+            "759191073943191613": 0.5,
+            "762085832181153872": 1,
+            "698296035889381403": 1,
+          },
+        },
+      },
+      includeNsfwChannels: true,
     };
     const parsed: DiscordConfig = parser.parseOrThrow(raw);
-    expect(parsed).toEqual(_upgrade(raw));
-    expect(parsed.includeNsfwChannels).toEqual(true);
+    expect(parsed).toEqual(expected);
   });
   it("fills in optional properties", () => {
     const raw = {
@@ -45,5 +75,7 @@ describe("plugins/discord/config", () => {
       defaultWeight: 1,
     });
     expect(parsed.includeNsfwChannels).toEqual(false);
+    expect(parsed.weights.emojiWeights.applyAveraging).toEqual(false);
+    expect(parsed.weights.emojiWeights.defaultWeight).toEqual(1);
   });
 });

--- a/src/plugins/discord/createGraph.js
+++ b/src/plugins/discord/createGraph.js
@@ -332,7 +332,8 @@ export function _createGraphFromMessages(
           message,
           reaction,
           reactingMember,
-          propsChannels
+          propsChannels,
+          reactions
         )
       );
       wg.graph.addNode(node);

--- a/src/plugins/discord/reactionWeights.js
+++ b/src/plugins/discord/reactionWeights.js
@@ -46,13 +46,13 @@ export function reactionWeight(
   }
 
   const roleMultipliedReactingMembers = weights.emojiWeights.applyAveraging
-    ? [
-        ...new Set(
+    ? Array.from(
+        new Set(
           reactions
             .filter(({reaction}) => reaction.authorId !== message.authorId)
             .map(({reactingMember}) => reactingMember)
-        ),
-      ].reduce(
+        )
+      ).reduce(
         (total, member) => total + _roleWeight(weights.roleWeights, member),
         0
       )


### PR DESCRIPTION
<!-- Please read our contributor guide before submitting your PR: -->
<!-- https://github.com/sourcecred/sourcecred/blob/master/CONTRIBUTING.md -->

# Description
This adds 2 new optional attributes the the discord config:
- **defaultReactionWeight** - This sets the reaction weight for all emojis that aren't specified in the reactionWeights configuration. Omitting this causes a default of 1 (current).
- **applyAveragingToReactions** - This applies an averaging function to reaction weights. It divides the weight of each reaction by the number of people that react to the same message. It also factors in the role weightings of the people by counting someone with a role weight of 2 as 2 people, etc. Set to false by default. This is a feature that can be used to combat the awkward cred inflation that happens when more people join a discord server. You can read more about the philosophy of this feature [here](https://discourse.sourcecred.io/t/imagining-new-discord-props-experiences/1035)

In the future, these might should be re-orged within a new reactionWeightsConfig to match channel and role weight config structures, but that would cause a breaking change, so I added them at root instead.

# Test Plan
Ran this test plan against the prod repo after running `yarn load && yarn start`
## Omit the new configs
`yarn start` and then `scdev graph` and make sure the graph doesn't change between
## Add "defaultReactionWeight": 0
scdev graph sourcecred/discord -d
```
...

NodeAddress["sourcecred","discord","REACTION","837745357369639042","💜","760638567562477649","842137456752984094"]
Old:	3
New:	0

NodeAddress["sourcecred","discord","REACTION","837745357369639042","💪","427964041764274177","839398143426822154"]
Old:	3
New:	0

NodeAddress["sourcecred","discord","REACTION","837745357369639042","🖤","691097086363566151","839884684590710846"]
Old:	1
New:	0

NodeAddress["sourcecred","discord","REACTION","837745357369639042","🖤","760638567562477649","839884684590710846"]
Old:	3
New:	0

=============================================================
  sourcecred/discord - Summary of Changes
=============================================================
Node Diffs: 0
Node Weight Diffs: 13663
Edge Diffs: 0
Edge Weight Diffs: 0
```
## Add "applyAveragingToReactions": true
scdev graph -d && scdev credrank
```
...

NodeAddress["sourcecred","discord","REACTION","837745357369639042","💜","691097086363566151","842137456752984094"]
Old:	1
New:	0.14285714285714285

NodeAddress["sourcecred","discord","REACTION","837745357369639042","💜","760638567562477649","842137456752984094"]
Old:	3
New:	0.42857142857142855

NodeAddress["sourcecred","discord","REACTION","837745357369639042","💪","427964041764274177","839398143426822154"]
Old:	3
New:	0.25

NodeAddress["sourcecred","discord","REACTION","837745357369639042","🖤","691097086363566151","839884684590710846"]
Old:	1
New:	0.25

NodeAddress["sourcecred","discord","REACTION","837745357369639042","🖤","760638567562477649","839884684590710846"]
Old:	3
New:	0.75

=============================================================
  sourcecred/discord - Summary of Changes
=============================================================
Node Diffs: 0
Node Weight Diffs: 18693
Edge Diffs: 0
Edge Weight Diffs: 0
```
