### PR TITLE
Load CLI: stringify errors before logging them

### DIFF
--- a/packages/sourcecred/src/cli/load.js
+++ b/packages/sourcecred/src/cli/load.js
@@ -103,7 +103,7 @@ const loadCommand: Command = async (args, std) => {
         throw e;
       })
       .catch((e) => {
-        fail(std, name, e);
+        fail(std, name, JSON.stringify(e));
         failedPlugins.push(name);
       });
     loadPromises.push(loadWithPossibleRetry);


### PR DESCRIPTION
# Description
We have an any->string cast on this line and it results in [object Object] console output. This fixes the issue by using JSON.stringify as far upstream as possible, so that the error object remains in object form elsewhere.
![](https://cdn.discordapp.com/attachments/718263631158050896/843986845279715358/unknown.png)

# Test plan
update the CLI code to
```
    const loadPlugin = () => {return Promise.reject({test: "test1"})};
      // plugin
      //   .load(dirContext, childTaskReporter)
      //   .then(() => taskReporter.finish(task));
```
and run `yarn load` to verify output is stringified.