### PR TITLE
Fractional grain

### DIFF
--- a/packages/sourcecred/src/cli/grain.js
+++ b/packages/sourcecred/src/cli/grain.js
@@ -58,7 +58,7 @@ const grainCommand: Command = async (args, std) => {
 
   std.out(
     (simulation ? `——SIMULATED DISTRIBUTION——\n` : ``) +
-      `Distributed ${G.format(totalDistributed)} to ${
+      `Distributed ${G.formatAndTrim(totalDistributed)} to ${
         recipientIdentities.size
       } identities in ${distributions.length} distributions` +
       `\n`

--- a/packages/sourcecred/src/core/ledger/distributionSummary/distributionSummary.js
+++ b/packages/sourcecred/src/core/ledger/distributionSummary/distributionSummary.js
@@ -56,7 +56,7 @@ function timeStamp(credTimeStamp: TimestampMs): string {
 }
 
 function total(total: G.Grain, currencySuffix: string): string {
-  return `#### Total Distributed: ${G.format(total, 0, currencySuffix)}`;
+  return `#### Total Distributed: ${G.formatAndTrim(total, currencySuffix)}`;
 }
 
 function policyAmounts(
@@ -66,7 +66,7 @@ function policyAmounts(
   return distribution.allocations
     .map(({policy}) => {
       const {policyType, budget} = policy;
-      return `#### ${policyType}: ${G.format(budget, 0, currencySuffix)}`;
+      return `#### ${policyType}: ${G.formatAndTrim(budget, currencySuffix)}`;
     })
     .join(`\n`);
 }

--- a/packages/sourcecred/src/core/ledger/nonnegativeGrain.js
+++ b/packages/sourcecred/src/core/ledger/nonnegativeGrain.js
@@ -25,6 +25,10 @@ export function fromString(s: string): NonnegativeGrain {
   return fromGrain(G.fromString(s));
 }
 
+export function fromFloatString(s: string): NonnegativeGrain {
+  return fromGrain(G.fromFloatString(s));
+}
+
 export const grainParser: P.Parser<NonnegativeGrain> = P.fmap(
   G.parser,
   fromGrain
@@ -33,6 +37,10 @@ export const numberParser: P.Parser<NonnegativeGrain> = P.fmap(
   P.number,
   fromInteger
 );
+export const numberOrFloatStringParser: P.Parser<NonnegativeGrain> = P.orElse([
+  P.fmap(P.integer, fromInteger),
+  P.fmap(P.string, fromFloatString),
+]);
 export const stringParser: P.Parser<NonnegativeGrain> = P.fmap(
   P.string,
   fromString

--- a/packages/sourcecred/src/core/ledger/nonnegativeGrain.test.js
+++ b/packages/sourcecred/src/core/ledger/nonnegativeGrain.test.js
@@ -1,6 +1,11 @@
 // @flow
 
-import {fromGrain, fromInteger, fromString} from "./nonnegativeGrain";
+import {
+  fromGrain,
+  fromInteger,
+  fromString,
+  numberOrFloatStringParser,
+} from "./nonnegativeGrain";
 import {ONE, type Grain} from "./grain";
 import {g} from "./testUtils";
 
@@ -51,6 +56,40 @@ describe("core/ledger/nonnegativeGrain", () => {
         const thunk = () => fromInteger(bad);
         expect(thunk).toThrowError(`not an integer: ${bad}`);
       }
+    });
+  });
+
+  describe("numberOrFloatStringParser", () => {
+    it("works on 0", () => {
+      expect(numberOrFloatStringParser.parse(0)).toEqual({
+        ok: true,
+        value: "0",
+      });
+    });
+    it("works on 1", () => {
+      expect(numberOrFloatStringParser.parse(1)).toEqual({
+        ok: true,
+        value: ONE,
+      });
+    });
+    it("works on 3", () => {
+      expect(numberOrFloatStringParser.parse(3)).toEqual({
+        ok: true,
+        value: "3000000000000000000",
+      });
+    });
+    it("works on '3.5' (string)", () => {
+      expect(numberOrFloatStringParser.parse("3.5")).toEqual({
+        ok: true,
+        value: "3500000000000000000",
+      });
+    });
+    it("fails on 3.5 (number)", () => {
+      expect(numberOrFloatStringParser.parse(3.5)).toEqual({
+        ok: false,
+        err:
+          'no parse matched: ["expected integer, got number","expected string, got number"]',
+      });
     });
   });
 });

--- a/packages/sourcecred/src/core/ledger/policies/balanced.js
+++ b/packages/sourcecred/src/core/ledger/policies/balanced.js
@@ -8,7 +8,7 @@ import {type ProcessedIdentities} from "../processedIdentities";
 import {
   type NonnegativeGrain,
   grainParser,
-  numberParser,
+  numberOrFloatStringParser,
 } from "../nonnegativeGrain";
 
 /**
@@ -83,7 +83,7 @@ export function balancedReceipts(
 
 export const balancedConfigParser: P.Parser<BalancedPolicy> = P.object({
   policyType: P.exactly(["BALANCED"]),
-  budget: numberParser,
+  budget: numberOrFloatStringParser,
 });
 
 export const balancedPolicyParser: P.Parser<BalancedPolicy> = P.object({

--- a/packages/sourcecred/src/core/ledger/policies/immediate.js
+++ b/packages/sourcecred/src/core/ledger/policies/immediate.js
@@ -7,7 +7,7 @@ import {type ProcessedIdentities} from "../processedIdentities";
 import {
   type NonnegativeGrain,
   grainParser,
-  numberParser,
+  numberOrFloatStringParser,
 } from "../nonnegativeGrain";
 
 /**
@@ -63,7 +63,7 @@ export function immediateReceipts(
 
 export const immediateConfigParser: P.Parser<ImmediatePolicy> = P.object({
   policyType: P.exactly(["IMMEDIATE"]),
-  budget: numberParser,
+  budget: numberOrFloatStringParser,
   numIntervalsLookback: P.number,
 });
 

--- a/packages/sourcecred/src/core/ledger/policies/recent.js
+++ b/packages/sourcecred/src/core/ledger/policies/recent.js
@@ -7,7 +7,7 @@ import {type ProcessedIdentities} from "../processedIdentities";
 import {
   type NonnegativeGrain,
   grainParser,
-  numberParser,
+  numberOrFloatStringParser,
 } from "../nonnegativeGrain";
 
 /**
@@ -55,7 +55,7 @@ export function recentReceipts(
 
 export const recentConfigParser: P.Parser<RecentPolicy> = P.object({
   policyType: P.exactly(["RECENT"]),
-  budget: numberParser,
+  budget: numberOrFloatStringParser,
   discount: P.fmap(P.number, toDiscount),
 });
 

--- a/packages/sourcecred/src/core/ledger/policies/special.js
+++ b/packages/sourcecred/src/core/ledger/policies/special.js
@@ -9,7 +9,7 @@ import {type ProcessedIdentities} from "../processedIdentities";
 import {
   type NonnegativeGrain,
   grainParser,
-  numberParser,
+  numberOrFloatStringParser,
 } from "../nonnegativeGrain";
 
 /**
@@ -44,7 +44,7 @@ export function specialReceipts(
 
 export const specialConfigParser: P.Parser<SpecialPolicy> = P.object({
   policyType: P.exactly(["SPECIAL"]),
-  budget: numberParser,
+  budget: numberOrFloatStringParser,
   memo: P.string,
   recipient: uuidParser,
 });

--- a/packages/sourcecred/src/util/combo.js
+++ b/packages/sourcecred/src/util/combo.js
@@ -79,6 +79,13 @@ export const number: Parser<number> = new Parser((x) => {
   return success(x);
 });
 
+export const integer: Parser<number> = new Parser((x) => {
+  if (typeof x !== "number" || Math.floor(x) !== x) {
+    return failure("expected integer, got " + typename(x));
+  }
+  return success(x);
+});
+
 export const boolean: Parser<boolean> = new Parser((x) => {
   if (typeof x !== "boolean") {
     return failure("expected boolean, got " + typename(x));


### PR DESCRIPTION
Closes issue #2779 

Paired with @hozzjss on this (thank you!)

# Summary
Currently, grain distributions can only be made in whole integer amounts. For certain projects (in this case, 1Hive) this can cause a problem because they map grain:TOKEN (whatever token they use) 1:1. This means they can only distribute in whole-token quantities. For tokens with high values, this can be undesirable. E.g. the project may want to award half a token's worth of value in a given period.

This PR changes grain budget parsing to allow for, in addition to integer values, string-defined floating point values. The reason we use a string for floating-point values is to avoid floating-point math (rounding) errors.

I also considered allowing floating-point numbers in the budget JSON files, converting them to strings right away, and then converting those to Grain, but I am not convinced that conversion from floating-point number to string representation of floating-point number is always lossless. It may be, and if it is, a future update should allow for that possibility as well. Or I can update this PR with that functionality. I tried to research it, but I could not find any definitive info on it.

# Testing
I modified and added unit tests, as well as tested budgets by hand using `scdev grain -s` on the `cred` repo with floating-point string and integer budgets
## Screenshot
<img width="420" alt="Screen Shot 2021-05-19 at 00 21 22" src="https://user-images.githubusercontent.com/225508/118730580-26965d80-b838-11eb-9ada-e1e6ed8d11ca.png">
