### PR TITLE
flow mono is unnecesary when package is deployed

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   "scripts": {
     "test": "lerna run test --stream --",
     "build": "lerna run build --stream",
-    "install": "lerna bootstrap ; ./scripts/flow-mono.sh",
+    "install": "lerna bootstrap && ./scripts/flow-mono.sh",
     "start": "lerna run start --stream"
   },
   "workspaces": [

--- a/packages/sourcecred/package.json
+++ b/packages/sourcecred/package.json
@@ -130,8 +130,7 @@
     "flow": "flow",
     "lint": "eslint src config --max-warnings 0",
     "prepublishOnly": "yarn build",
-    "docs": "node ./scripts/build-docs.js",
-    "postinstall": "../../scripts/flow-mono.sh"
+    "docs": "node ./scripts/build-docs.js"
   },
   "engines": {
     "node": ">=12"

--- a/scripts/flow-mono.sh
+++ b/scripts/flow-mono.sh
@@ -1,6 +1,7 @@
 #!/bin/sh
 toplevel="$(git -C "$(dirname "$0")" rev-parse --show-toplevel)"
 
+# FIXME: this runs two times which is weird
 for package in $(ls ${toplevel}/packages); do
   cd $toplevel
   if [ -f "$toplevel/packages/$package/.flowconfig" ]; then


### PR DESCRIPTION
This should resolve #3058 
But it needs a few tweaks still one of these is to run flow-mono.sh during development or only during ci which I think already runs because flow tests would fail without it, let me know if you think this necessary
Also one caveat is that this needs to be released as a hotfix as the current version breaks all instances