### PR TITLE
Show info message when config file is not found

### DIFF
--- a/packages/sourcecred/src/util/storage.js
+++ b/packages/sourcecred/src/util/storage.js
@@ -51,6 +51,7 @@ export async function loadJsonWithDefault<T>(
     return parser.parseOrThrow(JSON.parse(decode(contents)));
   } catch (e) {
     if (notFound(e)) {
+      console.log(`File not found at path: ${path}. Defaulting.`);
       return def();
     } else {
       throw e;


### PR DESCRIPTION
Tech support went for a wild ride to find out that mac and linux were behaving differently due to file name case sensitivity when pluginBudgets.json was misnamed pluginbudgets.json in the balancer instance. This PR adds a console message that will make it visible when config files are not found. This adds noise to our CLI output, but I think it is worth it for the increased visibility and debugging benefits.

# test plan
scdev credrank
```
thena@thenas-mbp Balancer-Test % scdev credrank -s             
  GO   credrank
  GO   load data
File not found at path: config/weights.json. Defaulting.
File not found at path: config/pluginBudgets.json. Defaulting.
File not found at path: config/personalAttributions.json. Defaulting.
 DONE  load data: 1252ms
  GO   run CredRank
 DONE  run CredRank: 2m 0s
# Top Participants By Cred

| Description | Cred | % |
| --- | --- | --- |
| rabmarut | 5040.8 | 12.5% |

```