### PR TITLE
Discord: show a friendlier message on 403s

### DIFF
--- a/packages/sourcecred/src/plugins/discord/mirror.js
+++ b/packages/sourcecred/src/plugins/discord/mirror.js
@@ -36,7 +36,10 @@ export class Mirror {
       try {
         await this.addMessages(channel.id);
       } catch (e) {
-        console.warn(e);
+        const warn = e?.message?.includes("403")
+          ? "Skipping private channel."
+          : e;
+        console.warn(warn);
       }
       reporter.finish(`discord/${guild.name}/#${channel.name}`);
     }


### PR DESCRIPTION
403's are normal when the bot encounters a private channel it doesn't have perms to see, so we should not output a scary stacktrace.

# Test plan
`scdev load`

Before:
```
  GO   sourcecred/discord: discord/SourceCred Test Server/#moderator-only
Error: 403 Forbidden: bad API username or key?
https://discordapp.com/api/channels/830088231538130965/messages?after=0&limit=100
    at failIfMissing (webpack:///./src/plugins/discord/fetcher.js?:12:2767)
    at Fetcher._fetchJson (webpack:///./src/plugins/discord/fetcher.js?:12:143)
    at processTicksAndRejections (internal/process/task_queues.js:93:5)
    at async Fetcher.messages (webpack:///./src/plugins/discord/fetcher.js?:12:1480)
    at async Mirror.addMessages (webpack:///./src/plugins/discord/mirror.js?:9:88)
    at async Mirror.update (webpack:///./src/plugins/discord/mirror.js?:7:623)
    at async DiscordPlugin.load (webpack:///./src/plugins/discord/plugin.js?:22:1331)
    at async Promise.all (index 0)
    at async loadCommand (webpack:///./src/cli/load.js?:16:277)
 DONE  sourcecred/discord: discord/SourceCred Test Server/#moderator-only: 160ms
```

After:
```
  GO   sourcecred/discord: discord/SourceCred Test Server/#moderator-only
Skipping private channel.
 DONE  sourcecred/discord: discord/SourceCred Test Server/#moderator-only: 158ms
```