### PR TITLE
Discord Multi-Server support

### DIFF
--- a/packages/sourcecred/src/cli/analysis.js
+++ b/packages/sourcecred/src/cli/analysis.js
@@ -6,13 +6,6 @@ import {Instance} from "../api/instance/instance";
 import {LocalInstance} from "../api/instance/localInstance";
 import {analysis} from "../api/main/analysis";
 
-/**
- * The grain command is soon to be deprecated, as part of a transition
- * to @blueridger's `CredGrainView`.  This original grain command uses
- * `CredView`, which will be deprecated.
- *
- * grain2 forks this command and eliminates the dependence on `CredView`
- */
 const analysisCommand: Command = async () => {
   const baseDir = process.cwd();
   const instance: Instance = new LocalInstance(baseDir);

--- a/packages/sourcecred/src/cli/load.js
+++ b/packages/sourcecred/src/cli/load.js
@@ -103,7 +103,8 @@ const loadCommand: Command = async (args, std) => {
         throw e;
       })
       .catch((e) => {
-        fail(std, name, JSON.stringify(e));
+        const output = e instanceof Error ? e : JSON.stringify(e);
+        fail(std, name, output);
         failedPlugins.push(name);
       });
     loadPromises.push(loadWithPossibleRetry);

--- a/packages/sourcecred/src/plugins/discord/config.test.js
+++ b/packages/sourcecred/src/plugins/discord/config.test.js
@@ -1,52 +1,21 @@
 // @flow
 
-import {type DiscordConfig, parser} from "./config";
+import {type DiscordConfigs, parser} from "./config";
 
 describe("plugins/discord/config", () => {
   it("can load a basic config", () => {
-    const raw = {
-      guildId: "453243919774253079",
-      reactionWeights: {
-        "🥰": 4,
-        "sourcecred:626763367893303303": 16,
-      },
-      roleWeightConfig: {
-        defaultWeight: 0,
-        weights: {
-          "759191073943191613": 0.5,
-          "762085832181153872": 1,
-          "698296035889381403": 1,
-        },
-      },
-      channelWeightConfig: {
-        defaultWeight: 0,
-        weights: {
-          "759191073943191613": 0.25,
-        },
-      },
-      includeNsfwChannels: true,
-      defaultReactionWeight: 0,
-      applyAveragingToReactions: true,
-    };
-    const expected = {
-      guildId: "453243919774253079",
-      propsChannels: [],
-      weights: {
-        emojiWeights: {
-          applyAveraging: true,
-          defaultWeight: 0,
+    const raw = [
+      {
+        guildId: "453243919774253079",
+        reactionWeightConfig: {
           weights: {
             "🥰": 4,
             "sourcecred:626763367893303303": 16,
           },
+          applyAveraging: true,
+          defaultWeight: 2,
         },
-        channelWeights: {
-          defaultWeight: 0,
-          weights: {
-            "759191073943191613": 0.25,
-          },
-        },
-        roleWeights: {
+        roleWeightConfig: {
           defaultWeight: 0,
           weights: {
             "759191073943191613": 0.5,
@@ -54,28 +23,72 @@ describe("plugins/discord/config", () => {
             "698296035889381403": 1,
           },
         },
+        channelWeightConfig: {
+          defaultWeight: 0,
+          weights: {
+            "759191073943191613": 0.25,
+          },
+        },
+        includeNsfwChannels: true,
       },
-      includeNsfwChannels: true,
-    };
-    const parsed: DiscordConfig = parser.parseOrThrow(raw);
+    ];
+    const expected = [
+      {
+        guildId: "453243919774253079",
+        propsChannels: [],
+        weights: {
+          emojiWeights: {
+            weights: {
+              "🥰": 4,
+              "sourcecred:626763367893303303": 16,
+            },
+            applyAveraging: true,
+            defaultWeight: 2,
+          },
+          channelWeights: {
+            defaultWeight: 0,
+            weights: {
+              "759191073943191613": 0.25,
+            },
+          },
+          roleWeights: {
+            defaultWeight: 0,
+            weights: {
+              "759191073943191613": 0.5,
+              "762085832181153872": 1,
+              "698296035889381403": 1,
+            },
+          },
+        },
+        includeNsfwChannels: true,
+      },
+    ];
+    const parsed: DiscordConfigs = parser.parseOrThrow(raw);
     expect(parsed).toEqual(expected);
   });
   it("fills in optional properties", () => {
-    const raw = {
-      guildId: "453243919774253079",
-      reactionWeights: {
-        "🥰": 4,
-        "sourcecred:626763367893303303": 16,
+    const raw = [
+      {
+        guildId: "453243919774253079",
+        reactionWeightConfig: {
+          weights: {
+            "🥰": 4,
+            "sourcecred:626763367893303303": 16,
+          },
+          applyAveraging: true,
+          defaultWeight: 2,
+        },
       },
-    };
-    const parsed: DiscordConfig = parser.parseOrThrow(raw);
-    expect(parsed.weights.roleWeights).toEqual({weights: {}, defaultWeight: 1});
-    expect(parsed.weights.channelWeights).toEqual({
+    ];
+    const parsed: DiscordConfigs = parser.parseOrThrow(raw);
+    expect(parsed[0].weights.roleWeights).toEqual({
       weights: {},
       defaultWeight: 1,
     });
-    expect(parsed.includeNsfwChannels).toEqual(false);
-    expect(parsed.weights.emojiWeights.applyAveraging).toEqual(false);
-    expect(parsed.weights.emojiWeights.defaultWeight).toEqual(1);
+    expect(parsed[0].weights.channelWeights).toEqual({
+      weights: {},
+      defaultWeight: 1,
+    });
+    expect(parsed[0].includeNsfwChannels).toEqual(false);
   });
 });

--- a/packages/sourcecred/src/plugins/discord/createGraph.js
+++ b/packages/sourcecred/src/plugins/discord/createGraph.js
@@ -301,12 +301,12 @@ export function _createGraphFromMessages(
   config: DiscordConfig,
   messages: Iterable<GraphMessage>
 ): WeightedGraphT {
-  const {guildId, weights} = config;
-  const propsChannels = new Set(config.propsChannels);
   const wg = {
     graph: new Graph(),
     weights: emptyWeights(),
   };
+  const {guildId, weights} = config;
+  const propsChannels = new Set(config.propsChannels);
 
   for (const graphMessage of messages) {
     const {

--- a/packages/sourcecred/src/plugins/discord/reactionWeights.js
+++ b/packages/sourcecred/src/plugins/discord/reactionWeights.js
@@ -16,16 +16,16 @@ export type ChannelWeightConfig = {|
 |};
 
 export type EmojiWeightMap = {[Model.Snowflake]: NodeWeight};
-export type EmojiWeightConfig = {|
-  +defaultWeight: NodeWeight,
+export type ReactionWeightConfig = {|
   +weights: EmojiWeightMap,
+  +defaultWeight: NodeWeight,
   +applyAveraging: boolean,
 |};
 
 export type WeightConfig = {|
   +roleWeights: RoleWeightConfig,
   +channelWeights: ChannelWeightConfig,
-  +emojiWeights: EmojiWeightConfig,
+  +emojiWeights: ReactionWeightConfig,
 |};
 
 export function reactionWeight(
@@ -93,7 +93,7 @@ export function _channelWeight(
 }
 
 export function _emojiWeight(
-  config: EmojiWeightConfig,
+  config: ReactionWeightConfig,
   reaction: Model.Reaction
 ): NodeWeight {
   const {defaultWeight, weights} = config;


### PR DESCRIPTION
# Description
This PR rearranges the discord config file (and the plugin code) to be able to support multiple servers. This is a breaking change, so the next version release should be 0.9.0

It also takes the opportunity to reorganize a few of the reaction configs to fit the channel and role config patterns for consistency.

# Design decisions
I chose to run each discord server sequentially during load because the Fetcher is not built to handle parallel use (429 tracking breaks).

I did run the server in parallel during graph because it is safe to do so, and we might even get a little performance boost out of it.

# Test plan
```
scdev load
scdev graph
scdev credrank
scdev serve
```
with config:
```
[
  {
    "channelWeightConfig": {
      "defaultWeight": 1,
      "weights": {
      }
    },
    "guildId": "678348980639498428",
    "includeNsfwChannels": false,
    "propsChannels": [
    ],
    "reactionWeightConfig": {
      "applyAveraging": false,
      "defaultWeight": 1,
      "weights": {
      }
    },
    "roleWeightConfig": {
      "defaultWeight": 1,
      "weights": {
      }
    }
  },
  {
    "channelWeightConfig": {
      "defaultWeight": 1,
      "weights": {
      }
    },
    "guildId": "798975165342023700",
    "includeNsfwChannels": false,
    "propsChannels": [
    ],
    "reactionWeightConfig": {
      "applyAveraging": false,
      "defaultWeight": 1,
      "weights": {
      }
    },
    "roleWeightConfig": {
      "defaultWeight": 1,
      "weights": {
      }
    }
  }
]
```
## Test results:
- my account is in both servers, so I verified that I didn't get added twice in the credGraph/ledger
- verified explorer in browser
- verified console output:
```
thena@thenas-mbp template-instance % scdev load 
  GO   load
  GO   loading sourcecred/discord
  GO   sourcecred/discord: discord/SourceCred Test Server
Discord Rate limit reached. Waiting for 0.837 seconds (until 5/21/2021, 7:14:44 PM)
  GO   sourcecred/discord: discord/SourceCred Test Server/#general
 DONE  sourcecred/discord: discord/SourceCred Test Server/#general: 2068ms
  GO   sourcecred/discord: discord/SourceCred Test Server/#pagination
 DONE  sourcecred/discord: discord/SourceCred Test Server/#pagination: 717ms
  GO   sourcecred/discord: discord/SourceCred Test Server/#notmymessage
 DONE  sourcecred/discord: discord/SourceCred Test Server/#notmymessage: 565ms
  GO   sourcecred/discord: discord/SourceCred Test Server/#rules
 DONE  sourcecred/discord: discord/SourceCred Test Server/#rules: 203ms
  GO   sourcecred/discord: discord/SourceCred Test Server/#moderator-only
Error: 403 Forbidden: bad API username or key?
https://discordapp.com/api/channels/830088231538130965/messages?after=0&limit=100
    at failIfMissing (webpack:///./src/plugins/discord/fetcher.js?:12:2767)
    at Fetcher._fetchJson (webpack:///./src/plugins/discord/fetcher.js?:12:143)
    at processTicksAndRejections (internal/process/task_queues.js:93:5)
    at async Fetcher.messages (webpack:///./src/plugins/discord/fetcher.js?:12:1480)
    at async Mirror.addMessages (webpack:///./src/plugins/discord/mirror.js?:9:88)
    at async Mirror.update (webpack:///./src/plugins/discord/mirror.js?:7:623)
    at async DiscordPlugin.load (webpack:///./src/plugins/discord/plugin.js?:22:1331)
    at async Promise.all (index 0)
    at async loadCommand (webpack:///./src/cli/load.js?:16:277)
 DONE  sourcecred/discord: discord/SourceCred Test Server/#moderator-only: 217ms
 DONE  sourcecred/discord: discord/SourceCred Test Server: 4944ms
  GO   sourcecred/discord: discord/Thena's test server
Discord Rate limit reached. Waiting for 1.696 seconds (until 5/21/2021, 7:14:50 PM)
  GO   sourcecred/discord: discord/Thena's test server/#general
 DONE  sourcecred/discord: discord/Thena's test server/#general: 657ms
  GO   sourcecred/discord: discord/Thena's test server/#demo
 DONE  sourcecred/discord: discord/Thena's test server/#demo: 215ms
  GO   sourcecred/discord: discord/Thena's test server/#open-collective-test
 DONE  sourcecred/discord: discord/Thena's test server/#open-collective-test: 199ms
 DONE  sourcecred/discord: discord/Thena's test server: 3131ms
 DONE  loading sourcecred/discord: 8668ms
 DONE  load: 8671ms
thena@thenas-mbp template-instance % scdev graph
  GO   graph
  GO   reference detector for sourcecred/discord
 DONE  reference detector for sourcecred/discord: 0ms
  GO   generating graph for sourcecred/discord
 DONE  generating graph for sourcecred/discord: 159ms
  GO   writing files
 DONE  writing files: 85ms
 DONE  graph: 256ms
thena@thenas-mbp template-instance % scdev credrank
  GO   credrank
  GO   load data
File not found at path: config/weights.json. Defaulting.
File not found at path: config/pluginBudgets.json. Defaulting.
 DONE  load data: 56ms
  GO   run CredRank
 DONE  run CredRank: 215ms
# Top Participants By Cred

| Description | Cred | % |
| --- | --- | --- |
| Beanow | 4.0 | 50.3% |
| DandeLion | 1.5 | 18.5% |
| Thena | 1.1 | 14.2% |
| Brian-Litwin | 1.0 | 12.3% |
| wchargin | 0.4 | 4.7% |
| dev-meeting-attendance | 0.0 | 0.0% |
| MEE6 | 0.0 | 0.0% |
| hz | 0.0 | 0.0% |
| Message-Manager | 0.0 | 0.0% |
| topocount | 0.0 | 0.0% |
| sandpiper | 0.0 | 0.0% |
| BrianBelhumeur | 0.0 | 0.0% |
| CredBot-Beanow | 0.0 | 0.0% |
| sts-credbot | 0.0 | 0.0% |
| topocount-s-server-bot | 0.0 | 0.0% |
| SourceCred-Test | 0.0 | 0.0% |
| sourcecred-test-thena | 0.0 | 0.0% |
| Discobot | 0.0 | 0.0% |
| SourceCred | 0.0 | 0.0% |
  GO   writing changes
 DONE  writing changes: 79ms
 DONE  credrank: 369ms
```