### PR TITLE
Implement readCredrankInput() in readInstance.js

### DIFF
--- a/packages/sourcecred/src/api/instance/readInstance.js
+++ b/packages/sourcecred/src/api/instance/readInstance.js
@@ -35,7 +35,7 @@ import {parser as pluginBudgetParser} from "../pluginBudgetConfig";
 import {
   rawParser as rawConfigParser,
   type RawInstanceConfig,
-} from "../RawinstanceConfig";
+} from "../rawinstanceConfig";
 import {NetworkStorage} from "../../core/storage/networkStorage";
 import {OriginStorage} from "../../core/storage/originStorage";
 import {ZipStorage} from "../../core/storage/zip";

--- a/packages/sourcecred/src/api/instance/readInstance.js
+++ b/packages/sourcecred/src/api/instance/readInstance.js
@@ -35,7 +35,7 @@ import {parser as pluginBudgetParser} from "../pluginBudgetConfig";
 import {
   rawParser as rawConfigParser,
   type RawInstanceConfig,
-} from "../rawinstanceConfig";
+} from "../rawInstanceConfig";
 import {NetworkStorage} from "../../core/storage/networkStorage";
 import {OriginStorage} from "../../core/storage/originStorage";
 import {ZipStorage} from "../../core/storage/zip";

--- a/packages/sourcecred/src/api/instance/readInstance.js
+++ b/packages/sourcecred/src/api/instance/readInstance.js
@@ -2,10 +2,19 @@
 
 import {ReadOnlyInstance} from "./instance";
 import {type CredrankInput} from "../main/credrank";
-import {type WeightedGraph} from "../../core/weightedGraph";
+import {
+  type WeightedGraph,
+  type WeightedGraphJSON,
+  fromJSON as weightedGraphFromJSON,
+} from "../../core/weightedGraph";
 import {type GraphInput} from "../main/graph";
 import {type GrainInput} from "../main/grain";
 import {type AnalysisInput} from "../main/analysis";
+import {
+  type WeightsT,
+  parser as weightsParser,
+  empty as emptyWeights,
+} from "../../core/weights";
 import {join as pathJoin} from "path";
 import {
   loadJson,
@@ -17,6 +26,16 @@ import {
   parser as credGraphParser,
 } from "../../core/credrank/credGraph";
 import {Ledger} from "../../core/ledger/ledger";
+import {
+  parser as dependenciesParser,
+  type DependenciesConfig,
+} from "../dependenciesConfig";
+import {type Budget} from "../../core/mintBudget";
+import {parser as pluginBudgetParser} from "../pluginBudgetConfig";
+import {
+  rawParser as rawConfigParser,
+  type RawInstanceConfig,
+} from "../RawinstanceConfig";
 import {NetworkStorage} from "../../core/storage/networkStorage";
 import {OriginStorage} from "../../core/storage/originStorage";
 import {ZipStorage} from "../../core/storage/zip";
@@ -27,22 +46,46 @@ import {
   type CurrencyDetails,
 } from "../currencyConfig";
 import {defaultCurrencyConfig} from "../currencyConfig";
+import {
+  type PersonalAttributionsConfig,
+  personalAttributionsConfigParser,
+} from "../config/personalAttributionsConfig";
+import * as Combo from "../../util/combo";
 
 export const getNetworkReadInstance = (base: string): ReadInstance =>
   new ReadInstance(new NetworkStorage(base));
 export const getOriginReadInstance = (base: string): ReadInstance =>
   new ReadInstance(new OriginStorage(base));
 
+const DEPENDENCIES_PATH: $ReadOnlyArray<string> = [
+  "config",
+  "dependencies.json",
+];
+
+const WEIGHT_OVERRIDES_PATH: $ReadOnlyArray<string> = [
+  "config",
+  "weights.json",
+];
+
+const BUDGET_PATH: $ReadOnlyArray<string> = ["config", "pluginBudgets.json"];
+
 const GRAIN_PATH: $ReadOnlyArray<string> = ["config", "grain.json"];
 const CURRENCY_PATH: $ReadOnlyArray<string> = [
   "config",
   "currencyDetails.json",
 ];
+const PERSONAL_ATTRIBUTIONS_PATH: $ReadOnlyArray<string> = [
+  "config",
+  "personalAttributions.json",
+];
+const RAW_INSTANCE_CONFIG_PATH: $ReadOnlyArray<string> = ["sourcecred.json"];
 const LEDGER_PATH: $ReadOnlyArray<string> = ["data", "ledger.json"];
 const CREDGRAPH_PATH: $ReadOnlyArray<string> = [
   "output",
   "credGraph.json.gzip",
 ];
+const GRAPHS_DIRECTORY: $ReadOnlyArray<string> = ["output", "graphs"];
+const GRAPHS_PATH: $ReadOnlyArray<string> = ["graph.json.gzip"];
 
 /**
 This is an Instance implementation that reads and writes using relative paths
@@ -62,7 +105,29 @@ export class ReadInstance implements ReadOnlyInstance {
   }
 
   async readCredrankInput(): Promise<CredrankInput> {
-    throw "not yet implemented";
+    const [
+      pluginGraphs,
+      ledger,
+      weightOverrides,
+      dependencies,
+      pluginsBudget,
+      personalAttributions,
+    ] = await Promise.all([
+      this.readPluginGraphs(),
+      this.readLedger(),
+      this.readWeightOverrides(),
+      this.readDependencies(),
+      this.readPluginsBudget(),
+      this.readPersonalAttributions(),
+    ]);
+    return {
+      pluginGraphs,
+      ledger,
+      weightOverrides,
+      dependencies,
+      pluginsBudget,
+      personalAttributions,
+    };
   }
 
   async readGrainInput(): Promise<GrainInput> {
@@ -118,5 +183,82 @@ export class ReadInstance implements ReadOnlyInstance {
       currencyConfigParser,
       defaultCurrencyConfig
     );
+  }
+
+  // Private Functions
+
+  async readRawInstanceConfig(): Promise<RawInstanceConfig> {
+    const pluginsConfigPath = pathJoin(...RAW_INSTANCE_CONFIG_PATH);
+    return loadJson(this._storage, pluginsConfigPath, rawConfigParser);
+  }
+
+  async readPersonalAttributions(): Promise<PersonalAttributionsConfig> {
+    const path = pathJoin(...PERSONAL_ATTRIBUTIONS_PATH);
+    return loadJsonWithDefault(
+      this._storage,
+      path,
+      personalAttributionsConfigParser,
+      () => []
+    );
+  }
+
+  async readPluginGraphs(): Promise<Array<WeightedGraph>> {
+    const instanceConfig = await this.readRawInstanceConfig();
+    const pluginNames = instanceConfig.bundledPlugins;
+    return await Promise.all(
+      pluginNames.map(async (name) => {
+        const outputDir = this.createPluginDirectory(GRAPHS_DIRECTORY, name);
+        const outputPath = pathJoin(outputDir, ...GRAPHS_PATH);
+        const graphJSON = await loadJson(
+          this._zipStorage,
+          outputPath,
+          ((Combo.raw: any): Combo.Parser<WeightedGraphJSON>)
+        );
+        return weightedGraphFromJSON(graphJSON);
+      })
+    );
+  }
+
+  async readWeightOverrides(): Promise<WeightsT> {
+    const weightsPath = pathJoin(...WEIGHT_OVERRIDES_PATH);
+    return loadJsonWithDefault(
+      this._storage,
+      weightsPath,
+      weightsParser,
+      emptyWeights
+    );
+  }
+
+  async readDependencies(): Promise<DependenciesConfig> {
+    const dependenciesPath = pathJoin(...DEPENDENCIES_PATH);
+    return loadJsonWithDefault(
+      this._storage,
+      dependenciesPath,
+      dependenciesParser,
+      () => []
+    );
+  }
+
+  async readPluginsBudget(): Promise<Budget | null> {
+    const budgetPath = pathJoin(...BUDGET_PATH);
+    return loadJsonWithDefault(
+      this._storage,
+      budgetPath,
+      pluginBudgetParser,
+      () => null
+    );
+  }
+
+  createPluginDirectory(
+    components: $ReadOnlyArray<string>,
+    pluginId: string
+  ): string {
+    const idParts = pluginId.split("/");
+    if (idParts.length !== 2) {
+      throw new Error(`Bad plugin name: ${pluginId}`);
+    }
+    const [pluginOwner, pluginName] = idParts;
+    const pathComponents = [...components, pluginOwner, pluginName];
+    return pathJoin(...pathComponents);
   }
 }

--- a/packages/sourcecred/src/api/pluginBudgetConfig.js
+++ b/packages/sourcecred/src/api/pluginBudgetConfig.js
@@ -17,7 +17,7 @@ import {
   timestampISOParser,
 } from "../util/timestamp";
 import * as C from "../util/combo";
-import {bundledPlugins} from "./bundledPlugins";
+import {bundledDeclarations} from "./bundledDeclarations";
 
 /**
  * This module contains logic for setting Cred minting budgets over time on a per-plugin basis.
@@ -67,11 +67,11 @@ function upgradeRawPeriod(p: RawBudgetPeriod): BudgetPeriod {
 function upgrade(config: RawPluginBudgetConfig): Budget {
   const entries = Object.keys(config.plugins).map((key) => {
     const id = pluginIdFromString(key);
-    const plugin = bundledPlugins()[id];
+    const declaration = bundledDeclarations()[id];
     if (id == null) {
       throw new Error(`No available plugin with id ${id}`);
     }
-    const prefix = plugin.declaration().nodePrefix;
+    const prefix = declaration.nodePrefix;
     const periods = config.plugins[id].map(upgradeRawPeriod);
     return {prefix, periods};
   });


### PR DESCRIPTION
# Description
Following the model of our localInstance.js, this implements
readCredRankInput and its corresponding private functions in
readInstance.js (see issue #2989). It also modifies the pluginBudgetConfig.js
to be browser-safe. 

# Test Plan
## Testing in node 
```yarn build
node
sc = require("./packages/sourcecred/dist/server/api.js")
i = sc.sourcecred.instance.readInstance.getNetworkReadInstance("https://raw.githubusercontent.com/sourcecred/cred/gh-pages/")
> i.readCredrankInput().then(r => console.log(r.pluginGraphs))
```
You should see output like this:
```[
  {
    graph: yt {
      _nodes: [Map],
      _edges: [Map],
      _incidentEdges: [Map],
      _modificationCount: 26189,
      _cachedOrder: [Object],
      _invariantsLastChecked: [Object]
    },
    weights: { nodeWeights: [Map], edgeWeights: [Map] }
  },
  {
    graph: yt {
      _nodes: [Map],
      _edges: [Map],
      _incidentEdges: [Map],
      _modificationCount: 77967,
      _cachedOrder: [Object],
      _invariantsLastChecked: [Object]
    },
    weights: { nodeWeights: [Map], edgeWeights: [Map] }
  },
  {
    graph: yt {
      _nodes: [Map],
      _edges: [Map],
      _incidentEdges: [Map],
      _modificationCount: 107742,
      _cachedOrder: [Object],
      _invariantsLastChecked: [Object]
    },
    weights: { nodeWeights: [Map], edgeWeights: [Map] }
  },
  {
    graph: yt {
      _nodes: [Map],
      _edges: [Map],
      _incidentEdges: [Map],
      _modificationCount: 113,
      _cachedOrder: [Object],
      _invariantsLastChecked: [Object]
    },
    weights: { nodeWeights: [Map], edgeWeights: [Map] }
  }
]```