### PR TITLE
Implement readWeightedGraphForPlugin() in readInstance.js

### DIFF
--- a/packages/sourcecred/src/api/instance/readInstance.js
+++ b/packages/sourcecred/src/api/instance/readInstance.js
@@ -154,8 +154,17 @@ export class ReadInstance implements ReadOnlyInstance {
     throw "not yet implemented";
   }
 
-  async readWeightedGraphForPlugin(): Promise<WeightedGraph> {
-    throw "not yet implemented";
+  async readWeightedGraphForPlugin(pluginId: string): Promise<WeightedGraph> {
+    const outputPath = pathJoin(
+      this.createPluginGraphDirectory(pluginId),
+      ...GRAPHS_PATH
+    );
+    const graphJSON = await loadJson(
+      this._zipStorage,
+      outputPath,
+      ((Combo.raw: any): Combo.Parser<WeightedGraphJSON>)
+    );
+    return weightedGraphFromJSON(graphJSON);
   }
 
   async readCredGraph(): Promise<CredGraph> {
@@ -260,5 +269,9 @@ export class ReadInstance implements ReadOnlyInstance {
     const [pluginOwner, pluginName] = idParts;
     const pathComponents = [...components, pluginOwner, pluginName];
     return pathJoin(...pathComponents);
+  }
+
+  createPluginGraphDirectory(pluginId: string): string {
+    return this.createPluginDirectory(GRAPHS_DIRECTORY, pluginId);
   }
 }


### PR DESCRIPTION
Following the model of localInstance.js, this implements readWeightedGraphForPlugin() in readInstance.js and its corresponding private function in readInstance.js so in a browser-compatible way. 

# Test Plan
## Testing in node 
```yarn build
node
sc = require("./packages/sourcecred/dist/server/api.js")
i = sc.sourcecred.instance.readInstance.getNetworkReadInstance("https://raw.githubusercontent.com/sourcecred/cred/gh-pages/")
i.readWeightedGraphForPlugin("sourcecred/discourse").then(r => console.log(r.graph._nodes))
```
The output should be a large object and should not error. 