### PR TITLE
Set up Grain Integration support in Config API

### DIFF
--- a/packages/sourcecred/.flowconfig
+++ b/packages/sourcecred/.flowconfig
@@ -3,6 +3,7 @@
 <PROJECT_ROOT>/node_modules/webpack-cli/lib/utils/__tests__/.*
 
 [include]
+../../grainIntegrations/
 
 [libs]
 flow-typed

--- a/packages/sourcecred/package.json
+++ b/packages/sourcecred/package.json
@@ -100,6 +100,7 @@
     "prettier": "^2.0.1",
     "raf": "^3.4.1",
     "react-dev-utils": "^11.0.0",
+    "sc-grainIntegration-csv": "^0.0.0",
     "static-site-generator-webpack-plugin": "^3.4.2",
     "url-loader": "^4.0.0",
     "webpack": "^4.42.0",

--- a/packages/sourcecred/src/api/bundledGrainIntegrations.js
+++ b/packages/sourcecred/src/api/bundledGrainIntegrations.js
@@ -1,0 +1,36 @@
+// @flow
+
+import type {GrainIntegrationFunction} from "../core/ledger/grainIntegration";
+import * as C from "../util/combo";
+
+import {csvIntegration} from "sc-grainIntegration-csv";
+
+export type GrainIntegration = {|
+  name: string,
+  function: GrainIntegrationFunction,
+|};
+
+type AllowedDeclarations = {[pluginKey: string]: GrainIntegrationFunction};
+
+const allowedDeclarations: AllowedDeclarations = {
+  "csv": csvIntegration,
+};
+
+export function bundledGrainIntegrations(
+  integrationKey: string
+): GrainIntegrationFunction {
+  const integration = allowedDeclarations[integrationKey];
+  if (!integration)
+    throw new Error(
+      "grain integration not found; enter a valid `integration` value in config/grain.json"
+    );
+  return integration;
+}
+
+export const parser: C.Parser<GrainIntegration> = C.fmap(
+  C.exactly(["csv"]),
+  (integrationKey) => ({
+    name: integrationKey,
+    function: bundledGrainIntegrations(integrationKey),
+  })
+);

--- a/packages/sourcecred/src/api/bundledGrainIntegrations.test.js
+++ b/packages/sourcecred/src/api/bundledGrainIntegrations.test.js
@@ -1,0 +1,14 @@
+// @flow
+
+import {bundledGrainIntegrations} from "./bundledGrainIntegrations";
+import {csvIntegration} from "sc-grainIntegration-csv";
+describe("api/bundledGrainIntegrations", () => {
+  it("returns the csv parser", () => {
+    const result = bundledGrainIntegrations("csv");
+    expect(result).toBe(csvIntegration);
+  });
+  it("errors if integration lookup fails", () => {
+    const thunk = () => bundledGrainIntegrations("badKey");
+    expect(thunk).toThrow("grain integration not found");
+  });
+});

--- a/packages/sourcecred/src/api/currencyConfig.js
+++ b/packages/sourcecred/src/api/currencyConfig.js
@@ -2,7 +2,10 @@
 
 import * as C from "../util/combo";
 import * as NullUtil from "../util/null";
-
+import {
+  type Currency as IntegrationCurrency,
+  currencyParser as integrationCurrencyParser,
+} from "../core/ledger/currency";
 /**
  * Shape of currencyDetails.json on disk
  */
@@ -10,6 +13,7 @@ type SerializedCurrencyDetails = {|
   +currencyName?: string,
   +currencySuffix?: string,
   +decimalsToDisplay?: number,
+  +integrationCurrency?: IntegrationCurrency,
 |};
 
 /**
@@ -19,6 +23,7 @@ export type CurrencyDetails = {|
   +name: string,
   +suffix: string,
   +decimals: number,
+  +integrationCurrency?: IntegrationCurrency,
 |};
 
 export const DEFAULT_NAME = "Grain";
@@ -42,6 +47,7 @@ function upgrade(c: SerializedCurrencyDetails): CurrencyDetails {
     name: NullUtil.orElse(c.currencyName, DEFAULT_NAME),
     suffix: NullUtil.orElse(c.currencySuffix, DEFAULT_SUFFIX),
     decimals: NullUtil.orElse(c.decimalsToDisplay, DEFAULT_DECIMALS),
+    integrationCurrency: c.integrationCurrency,
   };
 }
 
@@ -60,6 +66,7 @@ export const parser: C.Parser<CurrencyDetails> = C.fmap(
       currencyName: C.string,
       currencySuffix: C.string,
       decimalsToDisplay: C.number,
+      integrationCurrency: integrationCurrencyParser,
     }
   ),
   upgrade

--- a/packages/sourcecred/src/api/grainConfig.js
+++ b/packages/sourcecred/src/api/grainConfig.js
@@ -14,6 +14,11 @@ import {
   type NonnegativeGrain,
 } from "../core/ledger/nonnegativeGrain";
 import {toDiscount} from "../core/ledger/policies/recent";
+import {type Name, parser as nameParser} from "../core/identity/name";
+import {
+  type GrainIntegration,
+  parser as bundledGrainIntegrationParser,
+} from "./bundledGrainIntegrations";
 
 export type GrainConfig = {|
   +immediatePerWeek?: NonnegativeGrain, // (deprecated)
@@ -22,6 +27,9 @@ export type GrainConfig = {|
   +recentWeeklyDecayRate?: number, // (deprecated)
   +allocationPolicies?: $ReadOnlyArray<AllocationPolicy>,
   +maxSimultaneousDistributions?: number,
+  +sinkIdentity?: Name,
+  +processDistributions?: boolean,
+  +integration?: GrainIntegration,
 |};
 
 export const parser: C.Parser<GrainConfig> = C.object(
@@ -33,6 +41,9 @@ export const parser: C.Parser<GrainConfig> = C.object(
     balancedPerWeek: numberOrFloatStringParser,
     recentPerWeek: numberOrFloatStringParser,
     recentWeeklyDecayRate: C.number,
+    sinkIdentity: nameParser,
+    processDistributions: C.boolean,
+    integration: bundledGrainIntegrationParser,
   }
 );
 

--- a/packages/sourcecred/src/api/grainConfig.test.js
+++ b/packages/sourcecred/src/api/grainConfig.test.js
@@ -13,6 +13,7 @@ import {type BalancedPolicy} from "../core/ledger/policies/balanced";
 import {type ImmediatePolicy} from "../core/ledger/policies/immediate";
 import {type RecentPolicy} from "../core/ledger/policies/recent";
 import {type SpecialPolicy} from "../core/ledger/policies/special";
+import {nameFromString} from "../core/identity/name";
 
 const toNonnegativeGrain = (budget: number | string): NonnegativeGrain => {
   if (typeof budget === "string") {
@@ -141,6 +142,8 @@ describe("api/grainConfig", () => {
           },
         ],
         maxSimultaneousDistributions: 2,
+        sinkIdentity: "testName",
+        processDistributions: true,
       };
 
       const expected: GrainConfig = {
@@ -151,6 +154,8 @@ describe("api/grainConfig", () => {
           special(100, "howdy", uuid),
         ],
         maxSimultaneousDistributions: 2,
+        sinkIdentity: nameFromString("testName"),
+        processDistributions: true,
       };
 
       expect(parser.parseOrThrow(grainConfig)).toEqual(expected);

--- a/packages/sourcecred/src/core/ledger/grainIntegration.test.js
+++ b/packages/sourcecred/src/core/ledger/grainIntegration.test.js
@@ -1,7 +1,7 @@
 // @flow
 
 import {
-  type GrainIntegration,
+  type GrainIntegrationFunction,
   executeGrainIntegration,
 } from "./grainIntegration";
 import {
@@ -78,10 +78,10 @@ describe("src/core/ledger/grainIntegration", () => {
         currency.chainId
       );
     });
-    const getmockIntegration: (?boolean) => GrainIntegration = (
+    const getmockIntegration: (?boolean) => GrainIntegrationFunction = (
       returnTransfers = false,
       returnOutput = false
-    ) => (distributions = [], currency) => {
+    ) => (distributions = [], _unused_config) => {
       const _ = currency;
       const transferResult = distributions.map(([payoutAddress, amount]) => ({
         payoutAddress,


### PR DESCRIPTION
# Description
This PR sets up a grain config for grain integrations. The config is validated against a `bundledGrainIntegrations` allow-list. and the mapped integration function is then set as a part of the config.

The ledger currency parser is now utilized to allow for token and some other crypto configs to be set in an instance and utilized by the ledger when setting payout addresses. NOTE: this config is not directly utilized by the ledger yet

Finally, The grain integration interface has been updated to accept the entire config. This is done to allow for verification that the instance is configured correctly by the intance, and potentially error if a config is incompatible with the invoke grain integration.


# Merge Strategy
Merge after #3078 

# Test Plan
unit tests have been updated