### PR TITLE
Better error for wrong repository name

### DIFF
--- a/packages/sourcecred/src/plugins/github/fetchGithubRepo.js
+++ b/packages/sourcecred/src/plugins/github/fetchGithubRepo.js
@@ -327,7 +327,6 @@ export async function postQuery(
           console.error(error.error);
           break;
         case "GRAPHQL_ERROR":
-
           error.error.errors.forEach((error) => {
             if (error.type === "NOT_FOUND") {
               console.error(

--- a/packages/sourcecred/src/plugins/github/fetchGithubRepo.js
+++ b/packages/sourcecred/src/plugins/github/fetchGithubRepo.js
@@ -329,7 +329,7 @@ export async function postQuery(
         case "GRAPHQL_ERROR":
 
           error.error.errors.forEach((error) => {
-            if (error.type == "NOT_FOUND") {
+            if (error.type === "NOT_FOUND") {
               console.error(
                 "Unable to find the specified repository. Please check for typos " +
                   "in the repository owner and name and confirm that you are using the correct token in " +

--- a/packages/sourcecred/src/plugins/github/fetchGithubRepo.js
+++ b/packages/sourcecred/src/plugins/github/fetchGithubRepo.js
@@ -133,7 +133,7 @@ const GITHUB_GRAPHQL_SERVER = "https://api.github.com/graphql";
 
 type GithubResponseError =
   | {|+type: "FETCH_ERROR", error: Error|}
-  | {|+type: "GRAPHQL_ERROR", error: mixed|}
+  | {|+type: "GRAPHQL_ERROR", error: {errors: [{|type: string|}]}|}
   | {|+type: "RATE_LIMIT_EXCEEDED", error: mixed|}
   | {|+type: "GITHUB_INTERNAL_EXECUTION_ERROR", error: mixed|}
   | {|+type: "BAD_CREDENTIALS", error: mixed|}
@@ -313,8 +313,7 @@ export async function postQuery(
   });
   return retryGithubFetch(postBody, token).catch(
     (error: GithubResponseError) => {
-      const type = error.type;
-      switch (type) {
+      switch (error.type) {
         case "GITHUB_INTERNAL_EXECUTION_ERROR":
         case "NO_DATA":
           console.error(
@@ -328,10 +327,21 @@ export async function postQuery(
           console.error(error.error);
           break;
         case "GRAPHQL_ERROR":
-          console.error(
-            "Unexpected GraphQL error; this may be a bug in SourceCred: ",
-            JSON.stringify({postBody: postBody, error: error.error})
-          );
+
+          error.error.errors.forEach((error) => {
+            if (error.type == "NOT_FOUND") {
+              console.error(
+                "Unable to find the specified repository. Please check for typos " +
+                  "in the repository owner and name and confirm that you are using the correct token in " +
+                  "$SOURCECRED_GITHUB_TOKEN"
+              );
+            } else {
+              console.error(
+                "Unexpected GraphQL error: " +
+                  JSON.stringify({postBody: postBody, error: error})
+              );
+            }
+          });
           break;
         case "RATE_LIMIT_EXCEEDED":
           console.error(
@@ -348,7 +358,10 @@ export async function postQuery(
           );
           break;
         default:
-          throw new Error((type: empty));
+          console.error(
+            "Unexpected GitHub Error: " +
+              JSON.stringify({postBody: postBody, error: error})
+          );
       }
       return Promise.reject(error);
     }


### PR DESCRIPTION
Redoing this PR on non-forked branch. Graphql returns an object with a list of errors, so iterating over them. Giving a nice message if an error is 'NOT_FOUND' and keeping previous behavior for any error that is not 'NOT_FOUND'. In the latter case, only sowing the errors inside the graphql error now.

Test Plan:

From the packages/sourcecred directory of the local sourcecred/sourcecred repo:
yarn build
chmod +x bin/fetchAndPrintGithubRepo.js
bin/fetchAndPrintGithubRepo.js [a github user] [a nonexistant repository] [a valid github api token for the specified user]

Confirm the follwing error:
Unable to find the specified repository. Please check for typos in the repository owner and name and confirm that you are using the correct token in $SOURCECRED_GITHUB_TOKEN

bin/fetchAntPrintGithubRepo.js [a github user] [the name of one of that user's repos] [a valid github api token for the specified user]

Confirm a non-error object starting with:

{
    "__typename": "Repository",
