### PR TITLE
Discord: Include messages from deleted authors in the graph

### DIFF
--- a/packages/sourcecred/src/plugins/discord/createGraph.js
+++ b/packages/sourcecred/src/plugins/discord/createGraph.js
@@ -319,9 +319,9 @@ export function _createGraphFromMessages(
     } = graphMessage;
     if (author) {
       wg.graph.addNode(memberNode(author));
-      wg.graph.addNode(messageNode(message, guildId, channelName));
       wg.graph.addEdge(authorsMessageEdge(message, author));
     }
+    wg.graph.addNode(messageNode(message, guildId, channelName));
 
     for (const {reaction, reactingMember} of reactions) {
       const node = reactionNode(reaction, message.timestampMs, guildId);


### PR DESCRIPTION
Changed block under conditional check for author existence, now message node is always added, whether or not the author is found. 
Tests passing, but I'm having trouble with my flow configuration in VSCode, so flow test was not running. But our git has testing suite, no? Sorry, first PR in a looooong time. 
Issue: 
https://app.zenhub.com/workspaces/dev-sprint-planning-5bf5e0624b5806bc2bf6ecc9/issues/sourcecred/sourcecred/2629