### PR TITLE
Discord: add confidence dampener config to emoji weighting

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
     "test": "lerna run test --stream --",
     "build": "lerna run build --stream",
     "install": "lerna bootstrap && ./scripts/flow-mono.sh",
-    "start": "lerna run start --stream"
+    "start": "lerna run start --stream",
+    "clean": "lerna clean"
   },
   "workspaces": [
     "packages/*"

--- a/packages/sourcecred/src/plugins/discord/config.js
+++ b/packages/sourcecred/src/plugins/discord/config.js
@@ -72,11 +72,16 @@ const parserJson: C.Parser<DiscordConfigJson> = C.array(
   C.object(
     {
       guildId: C.string,
-      reactionWeightConfig: C.object({
-        weights: C.dict(C.number),
-        defaultWeight: C.number,
-        applyAveraging: C.boolean,
-      }),
+      reactionWeightConfig: C.object(
+        {
+          weights: C.dict(C.number),
+          defaultWeight: C.number,
+          applyAveraging: C.boolean,
+        },
+        {
+          confidenceDampener: C.number,
+        }
+      ),
     },
     {
       roleWeightConfig: C.object({

--- a/packages/sourcecred/src/plugins/discord/reactionWeights.js
+++ b/packages/sourcecred/src/plugins/discord/reactionWeights.js
@@ -20,6 +20,7 @@ export type ReactionWeightConfig = {|
   +weights: EmojiWeightMap,
   +defaultWeight: NodeWeight,
   +applyAveraging: boolean,
+  +confidenceDampener?: number,
 |};
 
 export type WeightConfig = {|
@@ -55,7 +56,7 @@ export function reactionWeight(
       ).reduce(
         (total, member) => total + _roleWeight(weights.roleWeights, member),
         0
-      )
+      ) + (weights.emojiWeights.confidenceDampener || 0)
     : null;
   const averagingMultiplier = roleMultipliedReactingMembers
     ? 1 / roleMultipliedReactingMembers

--- a/packages/sourcecred/src/plugins/discord/reactionWeights.test.js
+++ b/packages/sourcecred/src/plugins/discord/reactionWeights.test.js
@@ -198,6 +198,32 @@ describe("plugins/discord/reactionWeights", () => {
         )
       ).toEqual(0);
     });
+    it("dampens emoji average when dampener >0", () => {
+      const emojiWeights = {
+        defaultWeight: 1,
+        weights: {"💜": 3, "sourcecred:8": 4},
+        applyAveraging: true,
+        confidenceDampener: 2,
+      };
+      const roleWeights = {
+        defaultWeight: 1,
+        weights: {[badassRoleId]: 5, [plebeRoleId]: 3},
+      };
+      const channelWeights = {defaultWeight: 1, weights: {[channelId]: 6}};
+      const weights = {emojiWeights, roleWeights, channelWeights};
+      // This is the role weight of the reactor and excludes the author
+      const expectedAveragingModifier = 7;
+      expect(
+        reactionWeight(
+          weights,
+          message,
+          reacterReaction,
+          reacterMember,
+          new Set(),
+          reactions
+        )
+      ).toEqual((4 * 5 * 6) / expectedAveragingModifier);
+    });
     it("sets the weight to 0 for a self-reaction", () => {
       const emojiWeights = {
         defaultWeight: 1,


### PR DESCRIPTION
<!-- Please read our contributor guide before submitting your PR: -->
<!-- https://github.com/sourcecred/sourcecred/blob/master/CONTRIBUTING.md -->

# Description
Another experimental discord weighting feature. This adds an optional "confidenceDampener" config attribute to the reactionWeights section of the discord config. It only has an effect if the reaction averaging config is enable. If confidenceDampener is set to a positive number, it will insert that number of 0 votes into the averaging function. This means that the more people that vote, the higher the resulting weight will be, but instead of linear increase, it will logarithmically approach the average. A higher config value means more people need to add reactions to get close to the upper limit. Example numbers:

Confidence dampener = 1
1 people adding 1 emoji => 1/2 => 0.5
2 people adding 1 emoji => 2/3 => 0.67
3 people adding 1 emoji => 3/4 => 0.75
4 people adding 1 emoji => 4/5 => 0.80
5 people adding 1 emoji => 5/6 => 0.83

Confidence dampener = 2
1 people adding 1 emoji => 1/3 => 0.33
2 people adding 1 emoji => 2/4 => 0.5
3 people adding 1 emoji => 3/5 => 0.6
4 people adding 1 emoji => 4/6 => 0.67
5 people adding 1 emoji => 5/7 => 0.71
<!-- Possible prompts:
  Why is the change important?
  Did you consider and reject alternate formulations of the same idea?
  Are there relevant issues or discussions elsewhere?
-->

# Test Plan
1. checked out the gh-pages branch of our cred instance
2. set `"applyAveraging": true` in discord config
2. `scdev graph` to set the before state
3. add `"confidenceDampener": 1` in discord config
4. `scdev graph -s -d`

```
NodeAddress["sourcecred","discord","REACTION","837745357369639042","🤔","743870755825254531","844370465622589460"]
Old:    0.047619047619047616
New:    0.045454545454545456

NodeAddress["sourcecred","discord","REACTION","837745357369639042","🤘","427964041764274177","847553201393500170"]
Old:    1
New:    0.75

NodeAddress["sourcecred","discord","REACTION","837745357369639042","🧠","509919418000605205","854393962499407872"]
Old:    1
New:    0.75

NodeAddress["sourcecred","discord","REACTION","837745357369639042","🫂","427964041764274177","854798890355654666"]
Old:    0.75
New:    0.6000000000000001

NodeAddress["sourcecred","discord","REACTION","837745357369639042","🫂","691097086363566151","854798890355654666"]
Old:    0.25
New:    0.2

=============================================================
  sourcecred/discord - Summary of Changes
=============================================================
Node Diffs: 0
Node Weight Diffs: 21469
Edge Diffs: 0
Edge Weight Diffs: 0
```

<!-- Possible prompts:
  How well covered by automated tests is this change?
  How did you manually test this change? How can a reviewer replicate the tests?
-->
