### PR TITLE
UI: Add identity id tooltip to Grain Accounts page

### DIFF
--- a/packages/sourcecred/src/ui/components/AccountOverview.js
+++ b/packages/sourcecred/src/ui/components/AccountOverview.js
@@ -14,6 +14,7 @@ import * as G from "../../core/ledger/grain";
 import {useLedger} from "../utils/LedgerContext";
 import {formatTimestamp} from "../utils/dateHelpers";
 import {makeStyles} from "@material-ui/core/styles";
+import IdentityDetails from "./LedgerViewer/IdentityDetails";
 
 type OverviewProps = {|+currency: CurrencyDetails|};
 
@@ -77,7 +78,7 @@ export const AccountOverview = ({
 const AccountRow = (account: Account, suffix: string, decimals: number) => (
   <TableRow key={account.identity.id}>
     <TableCell component="th" scope="row">
-      {account.identity.name}
+      <IdentityDetails id={account.identity.id} name={account.identity.name} />
     </TableCell>
     <TableCell align="right">{account.active ? "✅" : "🛑"}</TableCell>
     <TableCell align="right">


### PR DESCRIPTION
<!-- Please read our contributor guide before submitting your PR: -->
<!-- https://github.com/sourcecred/sourcecred/blob/master/CONTRIBUTING.md -->

# Description
Sometimes you just want to look up someone's identity ID, and the easiest way before this was through the tooltips on the Ledger History page, which is a pain. This adds the same tooltip on the grain accounts page so it's less annoying to look up someone's ID.
<!-- Possible prompts:
  Why is the change important?
  Did you consider and reject alternate formulations of the same idea?
  Are there relevant issues or discussions elsewhere?
-->

# Test Plan
![chrome-capture (11)](https://user-images.githubusercontent.com/11550396/127718999-b91f1218-715b-4c77-bf13-f3db8e560e74.gif)

<!-- Possible prompts:
  How well covered by automated tests is this change?
  How did you manually test this change? How can a reviewer replicate the tests?
-->
