### PR TITLE
converted immediate policy to CredGrainView

### DIFF
--- a/packages/sourcecred/src/core/credGrainView.js
+++ b/packages/sourcecred/src/core/credGrainView.js
@@ -145,14 +145,19 @@ export class CredGrainView {
     );
 
     if (!numIntervalsLookback)
-      return new TimeScopedCredGrainView(this, 0, effectiveTimestamp);
+      return new TimeScopedCredGrainView(this, -Infinity, effectiveTimestamp);
 
-    if (intervalsBeforeEffective.length <= numIntervalsLookback)
-      return new TimeScopedCredGrainView(this, 0, effectiveTimestamp);
+    if (
+      !intervalsBeforeEffective ||
+      intervalsBeforeEffective.length <= numIntervalsLookback
+    )
+      return new TimeScopedCredGrainView(this, -Infinity, effectiveTimestamp);
 
     return new TimeScopedCredGrainView(
       this,
-      intervalsBeforeEffective[0].startTimeMs,
+      intervalsBeforeEffective[
+        intervalsBeforeEffective.length - numIntervalsLookback
+      ].startTimeMs,
       effectiveTimestamp
     );
   }
@@ -163,6 +168,10 @@ export class CredGrainView {
 
   participants(): $ReadOnlyArray<ParticipantCredGrain> {
     return this._participants;
+  }
+
+  activeParticipants(): $ReadOnlyArray<ParticipantCredGrain> {
+    return this._participants.filter((participant) => participant.active);
   }
 
   // This is imprecise, due to floating point rounding.
@@ -294,6 +303,10 @@ export class TimeScopedCredGrainView {
 
   participants(): $ReadOnlyArray<ParticipantCredGrain> {
     return this._participants;
+  }
+
+  activeParticipants(): $ReadOnlyArray<ParticipantCredGrain> {
+    return this._participants.filter((participant) => participant.active);
   }
 
   // This is imprecise, due to floating point rounding.

--- a/packages/sourcecred/src/core/credGrainView.js
+++ b/packages/sourcecred/src/core/credGrainView.js
@@ -136,6 +136,19 @@ export class CredGrainView {
     return new TimeScopedCredGrainView(this, startTimeMs, endTimeMs);
   }
 
+  withTimeScopeFromLookback(effectiveTimestamp: TimestampMs, numIntervalsLookback: number): 
+  TimeScopedCredGrainView {
+    const intervalsBeforeEffective = this._intervals
+    .filter((interval) => interval.endTimeMs <= effectiveTimestamp);
+
+    if (!numIntervalsLookback) return new TimeScopedCredGrainView(this, 0 ,effectiveTimestamp);
+
+    if (intervalsBeforeEffective.length <= numIntervalsLookback) 
+      return new TimeScopedCredGrainView(this, 0, effectiveTimestamp)
+
+    return new TimeScopedCredGrainView(this, intervalsBeforeEffective[0].startTimeMs, effectiveTimestamp)
+  }
+
   intervals(): IntervalSequence {
     return this._intervals;
   }

--- a/packages/sourcecred/src/core/credGrainView.js
+++ b/packages/sourcecred/src/core/credGrainView.js
@@ -136,17 +136,25 @@ export class CredGrainView {
     return new TimeScopedCredGrainView(this, startTimeMs, endTimeMs);
   }
 
-  withTimeScopeFromLookback(effectiveTimestamp: TimestampMs, numIntervalsLookback: number): 
-  TimeScopedCredGrainView {
-    const intervalsBeforeEffective = this._intervals
-    .filter((interval) => interval.endTimeMs <= effectiveTimestamp);
+  withTimeScopeFromLookback(
+    effectiveTimestamp: TimestampMs,
+    numIntervalsLookback: number
+  ): TimeScopedCredGrainView {
+    const intervalsBeforeEffective = this._intervals.filter(
+      (interval) => interval.endTimeMs <= effectiveTimestamp
+    );
 
-    if (!numIntervalsLookback) return new TimeScopedCredGrainView(this, 0 ,effectiveTimestamp);
+    if (!numIntervalsLookback)
+      return new TimeScopedCredGrainView(this, 0, effectiveTimestamp);
 
-    if (intervalsBeforeEffective.length <= numIntervalsLookback) 
-      return new TimeScopedCredGrainView(this, 0, effectiveTimestamp)
+    if (intervalsBeforeEffective.length <= numIntervalsLookback)
+      return new TimeScopedCredGrainView(this, 0, effectiveTimestamp);
 
-    return new TimeScopedCredGrainView(this, intervalsBeforeEffective[0].startTimeMs, effectiveTimestamp)
+    return new TimeScopedCredGrainView(
+      this,
+      intervalsBeforeEffective[0].startTimeMs,
+      effectiveTimestamp
+    );
   }
 
   intervals(): IntervalSequence {

--- a/packages/sourcecred/src/core/ledger/grainAllocation.js
+++ b/packages/sourcecred/src/core/ledger/grainAllocation.js
@@ -115,7 +115,7 @@ function receipts(
 ): $ReadOnlyArray<GrainReceipt> {
   switch (policy.policyType) {
     case "IMMEDIATE":
-      return immediateReceipts(policy, identities);
+      return immediateReceipts(policy, credGrainView, effectiveTimestamp);
     case "RECENT":
       return recentReceipts(policy.budget, identities, policy.discount);
     case "BALANCED":

--- a/packages/sourcecred/src/core/ledger/policies/balanced.js
+++ b/packages/sourcecred/src/core/ledger/policies/balanced.js
@@ -70,34 +70,12 @@ export function balancedReceipts(
     );
   }
 
-  const intervalsBeforeEffective = credGrainView
-    .intervals()
-    .filter((interval) => interval.endTimeMs <= effectiveTimestamp);
-
-  const numIntervalsLookback = ((
-    policy: BalancedPolicy,
-    intervalsLength: number
-  ) => {
-    if (
-      !policy.numIntervalsLookback ||
-      policy.numIntervalsLookback > intervalsLength
-    ) {
-      return intervalsLength;
-    } else {
-      return policy.numIntervalsLookback;
-    }
-  })(policy, intervalsBeforeEffective.length);
-
-  const timeLimitedcredGrainView = credGrainView.withTimeScope(
-    intervalsBeforeEffective[
-      intervalsBeforeEffective.length - numIntervalsLookback
-    ].startTimeMs,
-    effectiveTimestamp
+  const timeLimitedCredGrainView = credGrainView.withTimeScopeFromLookback(
+    effectiveTimestamp,
+    policy.numIntervalsLookback
   );
+  const timeLimitedParticipants = timeLimitedCredGrainView.activeParticipants();
 
-  const timeLimitedParticipants = timeLimitedcredGrainView
-    .participants()
-    .filter((participant) => participant.active);
   const totalCred = sum(
     timeLimitedParticipants.map((participant) => participant.cred)
   );

--- a/packages/sourcecred/src/core/ledger/policies/immediate.js
+++ b/packages/sourcecred/src/core/ledger/policies/immediate.js
@@ -50,37 +50,13 @@ export function immediateReceipts(
     );
   }
 
-  const intervalsBeforeEffective = credGrainView
-    .intervals()
-    .filter((interval) => interval.endTimeMs <= effectiveTimestamp);
-
-  const numIntervalsLookback = ((
-    policy: ImmediatePolicy,
-    intervalsLength: number
-  ) => {
-    if (
-      !policy.numIntervalsLookback ||
-      policy.numIntervalsLookback > intervalsLength
-    ) {
-      return intervalsLength;
-    } else {
-      return policy.numIntervalsLookback;
-    }
-  })(policy, intervalsBeforeEffective.length);
-
-  const timeLimitedcredGrainView = credGrainView.withTimeScope(
-    intervalsBeforeEffective[
-      intervalsBeforeEffective.length - numIntervalsLookback
-    ].startTimeMs,
-    effectiveTimestamp
+  const timeLimitedCredGrainView = credGrainView.withTimeScopeFromLookback(
+    effectiveTimestamp,
+    policy.numIntervalsLookback
   );
-
-  const timeLimitedParticipants = timeLimitedcredGrainView
-    .participants()
-    .filter((participant) => participant.active);
+  const timeLimitedParticipants = timeLimitedCredGrainView.activeParticipants();
 
   const shortTermCredPerIdentity = timeLimitedParticipants.map((p) => p.cred);
-
   const amounts = G.splitBudget(policy.budget, shortTermCredPerIdentity);
 
   return timeLimitedParticipants.map(({identity}, i) => ({

--- a/packages/sourcecred/src/core/ledger/policies/immediate.test.js
+++ b/packages/sourcecred/src/core/ledger/policies/immediate.test.js
@@ -1,28 +1,43 @@
 // @flow
 
 import * as G from "../grain";
-import {processIdentities} from "../processedIdentities";
-import {random as randomUuid} from "../../../util/uuid";
 import {fromGrain} from "../nonnegativeGrain";
 import {immediateReceipts} from "./immediate";
+import * as GraphUtil from "../../credrank/testUtils";
+import {CredGrainView} from "../../credGrainView";
+import {createTestLedgerFixture} from "../../ledger/testUtils";
 
 describe("core/ledger/policies/immediate", () => {
   describe("immediateReceipts", () => {
-    const id1 = randomUuid();
-    const id2 = randomUuid();
-    const identities = [
-      {
-        cred: [10, 20, 30, 40],
-        id: id1,
-        paid: G.ONE,
-      },
-      {
-        cred: [200, 0, 0, 0],
-        id: id2,
-        paid: G.ZERO,
-      },
-    ];
-    const processedIdentities = processIdentities(identities);
+    const {ledgerWithActiveIdentities} = createTestLedgerFixture();
+
+    let credGraph;
+    let credGrainView;
+    let credGraph2;
+    let credGrainViewUnbalanced;
+
+    const id1 = GraphUtil.participant1.id;
+    const id2 = GraphUtil.participant2.id;
+    const id3 = GraphUtil.participant3.id;
+    const id4 = GraphUtil.participant4.id;
+    const unbalancedLedger = ledgerWithActiveIdentities(id3, id4);
+    const emptyLedger = ledgerWithActiveIdentities(id1, id2);
+
+    beforeEach(async (done) => {
+      credGraph = await GraphUtil.credGraph();
+      credGrainView = CredGrainView.fromCredGraphAndLedger(
+        credGraph,
+        emptyLedger
+      );
+
+      credGraph2 = await GraphUtil.credGraph2();
+      credGrainViewUnbalanced = CredGrainView.fromCredGraphAndLedger(
+        credGraph2,
+        unbalancedLedger
+      );
+
+      done();
+    });
 
     it("errors on invalid range", () => {
       const policy = {
@@ -30,7 +45,7 @@ describe("core/ledger/policies/immediate", () => {
         budget: fromGrain(G.ONE),
         numIntervalsLookback: -1,
       };
-      expect(() => immediateReceipts(policy, processedIdentities)).toThrowError(
+      expect(() => immediateReceipts(policy, credGrainView, 0)).toThrowError(
         `numIntervalsLookback must be at least 1`
       );
     });
@@ -41,7 +56,7 @@ describe("core/ledger/policies/immediate", () => {
         budget: fromGrain(G.ONE),
         numIntervalsLookback: 1.5,
       };
-      expect(() => immediateReceipts(policy, processedIdentities)).toThrowError(
+      expect(() => immediateReceipts(policy, credGrainView, 0)).toThrowError(
         `numIntervalsLookback must be an integer`
       );
     });
@@ -50,60 +65,57 @@ describe("core/ledger/policies/immediate", () => {
       const policy1 = {
         policyType: "IMMEDIATE",
         budget: fromGrain(G.ONE),
-        numIntervalsLookback: 4,
+        numIntervalsLookback: 2,
       };
       const policy2 = {
         policyType: "IMMEDIATE",
         budget: fromGrain(G.ONE),
         numIntervalsLookback: 50, // 50 > number of intervals (4)
       };
-      const expected = immediateReceipts(policy1, processedIdentities);
-      const actual = immediateReceipts(policy2, processedIdentities);
+      const expected = immediateReceipts(policy1, credGrainViewUnbalanced, 4);
+      const actual = immediateReceipts(policy2, credGrainViewUnbalanced, 4);
       expect(actual).toEqual(expected);
     });
 
     it("correctly computes GrainReceipt's when numIntervalsLookback equivalent to number of cred intervals", () => {
-      const expectedAmounts = G.splitBudget(G.ONE, [100, 200]);
+      const participants = credGrainViewUnbalanced.participants();
+      const expectedAmounts = G.splitBudget(G.ONE, [
+        participants[0].cred,
+        participants[1].cred,
+      ]);
       const expected = [
         {
-          id: id1,
+          id: id3,
           amount: expectedAmounts[0],
         },
         {
-          id: id2,
+          id: id4,
           amount: expectedAmounts[1],
         },
       ];
       const policy = {
         policyType: "IMMEDIATE",
         budget: fromGrain(G.ONE),
-        numIntervalsLookback: 4,
+        numIntervalsLookback: 2,
       };
-      expect(immediateReceipts(policy, processedIdentities)).toEqual(expected);
+      expect(immediateReceipts(policy, credGrainViewUnbalanced, 4)).toEqual(
+        expected
+      );
     });
 
     it("correctly computes GrainReceipt's with numIntervalsLookback of 1", () => {
-      const identities = [
-        {
-          cred: [0, 40],
-          id: id1,
-          paid: G.ONE,
-        },
-        {
-          cred: [100000, 60],
-          id: id2,
-          paid: G.ZERO,
-        },
-      ];
-      const processedIdentities = processIdentities(identities);
-      const expectedAmounts = G.splitBudget(G.ONE, [40, 60]);
+      const participants = credGrainViewUnbalanced.participants();
+      const expectedAmounts = G.splitBudget(G.ONE, [
+        participants[0].credPerInterval[1],
+        participants[1].credPerInterval[1],
+      ]);
       const expected = [
         {
-          id: id1,
+          id: id3,
           amount: expectedAmounts[0],
         },
         {
-          id: id2,
+          id: id4,
           amount: expectedAmounts[1],
         },
       ];
@@ -112,7 +124,9 @@ describe("core/ledger/policies/immediate", () => {
         budget: fromGrain(G.ONE),
         numIntervalsLookback: 1,
       };
-      expect(immediateReceipts(policy, processedIdentities)).toEqual(expected);
+      expect(immediateReceipts(policy, credGrainViewUnbalanced, 4)).toEqual(
+        expected
+      );
     });
   });
 });


### PR DESCRIPTION

# Description

Transitioned the immediate policy to use CredGrainView instead of Allocation Identities.

# Test Plan
scmain is aliased to a build of the current main branch of sourcecred


bsodenkamp@Benjamins-MacBook-Pro cred % 
bsodenkamp@Benjamins-MacBook-Pro cred % pwd
/Users/bsodenkamp/projects/sourcecred.com/cred
bsodenkamp@Benjamins-MacBook-Pro cred % git status
On branch gh-pages
Your branch is up to date with 'origin/gh-pages'.

nothing to commit, working tree clean
bsodenkamp@Benjamins-MacBook-Pro cred % scdev grain -s -f > /tmp/scdevgrain  
bsodenkamp@Benjamins-MacBook-Pro cred % scmain grain -s -f > /tmp/scprodgrain
bsodenkamp@Benjamins-MacBook-Pro cred % diff /tmp/scdevgrain /tmp/scprodgrain
bsodenkamp@Benjamins-MacBook-Pro cred % 


