### PR TITLE
Update the root clean command to remove all node_modules

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "build": "lerna run build --stream",
     "install": "lerna bootstrap && ./scripts/flow-mono.sh",
     "start": "lerna run start --stream",
-    "clean": "lerna clean"
+    "clean": "lerna clean --yes && rm -rf node_modules"
   },
   "workspaces": [
     "packages/*"


### PR DESCRIPTION
Installing packages without cleaning child node_modules folders can lead
to inconsistent builds and failing tests. This clean command will remove
all package folders without confirmation, for a more frictionless
workflow. If one wanted to access the confirmations, they could just run
`yarn exec lerna clean && rm -rf node_modules`

test plan: Run `yarn clean` and verify that the root node_modules and
all package node_modules folders have been deleted.