### PR TITLE
Add support for a text descriptor in number strings in config files

### DIFF
--- a/packages/sourcecred/src/plugins/discord/config.js
+++ b/packages/sourcecred/src/plugins/discord/config.js
@@ -86,11 +86,11 @@ const parserJson: C.Parser<DiscordConfigJson> = C.array(
     {
       roleWeightConfig: C.object({
         defaultWeight: C.number,
-        weights: C.dict(C.number),
+        weights: C.dict(C.number, C.delimited("//")),
       }),
       channelWeightConfig: C.object({
         defaultWeight: C.number,
-        weights: C.dict(C.number),
+        weights: C.dict(C.number, C.delimited("//")),
       }),
       propsChannels: C.array(C.string),
       includeNsfwChannels: C.boolean,

--- a/packages/sourcecred/src/plugins/discourse/weights.js
+++ b/packages/sourcecred/src/plugins/discourse/weights.js
@@ -113,7 +113,10 @@ export const serializedWeightsConfigParser: C.Parser<SerializedWeightsConfig> = 
   {
     defaultCategoryWeight: C.number,
     defaultTagWeight: C.number,
-    categoryWeights: C.dict(C.number, C.fmap(C.string, parseCategoryId)),
+    categoryWeights: C.dict(
+      C.number,
+      C.fmap(C.delimited("//"), parseCategoryId)
+    ),
     tagWeights: C.dict(C.number, C.fmap(C.string, parseTagId)),
   }
 );

--- a/packages/sourcecred/src/util/combo.js
+++ b/packages/sourcecred/src/util/combo.js
@@ -469,3 +469,6 @@ export const dict: PDict = (function dict<V, K: string>(
     return success(result);
   });
 }: any);
+
+export const delimited: (string) => Parser<string> = (delimiter) =>
+  fmap(string, (s) => s.split(delimiter)[0]);

--- a/packages/sourcecred/src/util/combo.test.js
+++ b/packages/sourcecred/src/util/combo.test.js
@@ -588,6 +588,15 @@ describe("src/util/combo", () => {
     });
   });
 
+  describe("delimited", () => {
+    it("deletes delimiter and text after delimiter", () => {
+      expect(C.delimited("//").parseOrThrow("000//foo")).toEqual("000");
+    });
+    it("returns original string when delimiter not found", () => {
+      expect(C.delimited("//").parseOrThrow("000")).toEqual("000");
+    });
+  });
+
   describe("dict", () => {
     const makeParser = (): C.Parser<{|[string]: number|}> => C.dict(C.number);
     it("is type-safe", () => {


### PR DESCRIPTION
# Description
Paired with @blueridger 

A feature that allows instance maintainers to add a text descriptor
separated by "//" on strings that are otherwise illegible.
This works on both role and channel weights (it is not implemented on 
reaction weights because custom emojis already have text descriptors). 

This also adds it to the Discourse config for category ids.

Sample Discord config (note the places where there are `//` at the end of strings of numbers:
```
[
  {
    "channelWeightConfig": {
      "defaultWeight": 1,
      "weights": {
        "454007860926611478": 3,
        "543168537062014987//didathing": 12,
        "679064720375808026//props": 15,
        "718263631158050896": 3,
        "718512695875469353//memes": 0.1,
        "743545520445718700": 8
      }
    },
    "guildId": "453243919774253079",
    "includeNsfwChannels": false,
    "propsChannels": [
      "679064720375808026",
      "743545520445718700"
    ],
    "reactionWeightConfig": {
      "applyAveraging": false,
      "defaultWeight": 1,
      "weights": {
        "sourcecred:626763367893303303": 3,
        "👎": 0
      }
    },
    "roleWeightConfig": {
      "defaultWeight": 0,
      "weights": {
        "477551557723029514//contributor": 2,
        "717905642299457567//core": 3,
        "717905734863421472//community": 1
      }
    }
  }
]
```

# Test Plan
Pull down changes locally and run `yarn unit` and ensure that the unit tests run properly. 

To test manually, [follow the instructions for using a modified backend](https://github.com/sourcecred/sourcecred/tree/main/packages/sourcecred#using-a-modified-backend) to get the `scdev` command working on your machine, navigate to your instance directory and then..
- run `scdev graph && scdev credrank -d`
- modify the `config/plugins/sourcecred/discord/config.json` to match the sample config above (or just add "//didathing" at the end of one of the weights number strings)
- run `scdev graph && scdev credrank -d` again
- look at the credrank output and ensure that there is no diff (i.e. 0% change)
