### PR TITLE
Add ignoreActiveStatus option to Special Distributions

### DIFF
--- a/packages/sourcecred/src/core/ledger/grainAllocation.js
+++ b/packages/sourcecred/src/core/ledger/grainAllocation.js
@@ -68,17 +68,15 @@ export function computeAllocation(
   });
 }
 
-/* This is a simplified case that should not require a credGrainView */
 export function computeAllocationSpecial(
   policy: AllocationPolicy,
-  identities: $ReadOnlyArray<AllocationIdentity>
+  credGrainView: CredGrainView
 ): Allocation {
   const validatedPolicy = _validatePolicy(policy);
-  const processedIdentities = processIdentities(identities);
   if (validatedPolicy.policyType === "SPECIAL") {
     return _validateAllocationBudget({
       policy,
-      receipts: specialReceipts(validatedPolicy, processedIdentities),
+      receipts: specialReceipts(validatedPolicy, credGrainView),
       id: randomUuid(),
     });
   } else {
@@ -121,7 +119,7 @@ function receipts(
     case "BALANCED":
       return balancedReceipts(policy, credGrainView, effectiveTimestamp);
     case "SPECIAL":
-      return specialReceipts(policy, identities);
+      return specialReceipts(policy, credGrainView);
     // istanbul ignore next: unreachable per Flow
     default:
       throw new Error(`Unknown policyType: ${(policy.policyType: empty)}`);

--- a/packages/sourcecred/src/core/ledger/grainAllocation.test.js
+++ b/packages/sourcecred/src/core/ledger/grainAllocation.test.js
@@ -441,16 +441,22 @@ describe("core/ledger/grainAllocation", () => {
         done();
       });
 
-      it("distributes the budget to the stated recipient", () => {
+      it("computeAllocation distributes the budget to the stated recipient", async () => {
         const i1 = aid(0, [1]);
+        const credGraph2 = await GraphUtil.credGraph2();
+        const ledger = ledgerWithActiveIdentities(id3, id4);
+        const credGrainView = CredGrainView.fromCredGraphAndLedger(
+          credGraph2,
+          ledger
+        );
         const policy = {
           policyType: "SPECIAL",
           budget: nng(100),
           memo: "something",
-          recipient: i1.id,
+          recipient: id3,
         };
         const allocation = computeAllocation(policy, [i1], credGrainView, 0);
-        const expectedReceipts = [{id: i1.id, amount: nng(100)}];
+        const expectedReceipts = [{id: id3, amount: nng(100)}];
         const expectedAllocation = {
           receipts: expectedReceipts,
           id: uuidParser.parseOrThrow(allocation.id),
@@ -474,16 +480,21 @@ describe("core/ledger/grainAllocation", () => {
 
       //Test ComputeAllocationSpecial function
 
-      it("distributes the budget to the stated recipient", () => {
-        const i1 = aid(0, [1]);
+      it("computeAllocationSpecial distributes the budget to the stated recipient", async () => {
+        const credGraph2 = await GraphUtil.credGraph2();
+        const ledger = ledgerWithActiveIdentities(id3, id4);
+        const credGrainView = CredGrainView.fromCredGraphAndLedger(
+          credGraph2,
+          ledger
+        );
         const policy = {
           policyType: "SPECIAL",
           budget: nng(100),
           memo: "something",
-          recipient: i1.id,
+          recipient: id3,
         };
-        const allocation = computeAllocationSpecial(policy, [i1]);
-        const expectedReceipts = [{id: i1.id, amount: nng(100)}];
+        const allocation = computeAllocationSpecial(policy, credGrainView);
+        const expectedReceipts = [{id: id3, amount: nng(100)}];
         const expectedAllocation = {
           receipts: expectedReceipts,
           id: uuidParser.parseOrThrow(allocation.id),
@@ -491,16 +502,20 @@ describe("core/ledger/grainAllocation", () => {
         };
         expect(allocation).toEqual(expectedAllocation);
       });
-      it("errors if the recipient is not available", () => {
-        const {id} = aid(0, [1]);
-        const other = aid(0, [1]);
+      it("errors if the recipient is not available", async () => {
+        const credGraph = await GraphUtil.credGraph2();
+        const ledger = ledgerWithActiveIdentities(id3, id4);
+        const credGrainView = CredGrainView.fromCredGraphAndLedger(
+          credGraph,
+          ledger
+        );
         const policy = {
           policyType: "SPECIAL",
           budget: nng(100),
           memo: "something",
-          recipient: id,
+          recipient: uuid.random(),
         };
-        const thunk = () => computeAllocationSpecial(policy, [other]);
+        const thunk = () => computeAllocationSpecial(policy, credGrainView);
         expect(thunk).toThrowError("no active grain account for identity");
       });
     });

--- a/packages/sourcecred/src/core/ledger/ledger.js
+++ b/packages/sourcecred/src/core/ledger/ledger.js
@@ -583,7 +583,7 @@ export class Ledger {
     if (!parseResult.ok) {
       throw new Error(`invalid distribution: ${parseResult.err}`);
     }
-    for (const {receipts} of distribution.allocations) {
+    for (const {receipts, policy} of distribution.allocations) {
       for (const {id, amount} of receipts) {
         if (!this._accounts.has(id)) {
           throw new Error(`cannot distribute; invalid id ${id}`);
@@ -592,7 +592,7 @@ export class Ledger {
           throw new Error(`negative Grain amount: ${amount}`);
         }
         const {active} = this.account(id);
-        if (!active) {
+        if (!active && !policy.ignoreActiveStatus) {
           throw new Error(`attempt to distribute to inactive account: ${id}`);
         }
       }

--- a/packages/sourcecred/src/ui/components/AdminApp.js
+++ b/packages/sourcecred/src/ui/components/AdminApp.js
@@ -131,7 +131,10 @@ const customRoutes = (
           <Transfer currency={currency} />
         </Route>,
         <Route key="special-distribution" exact path="/special-distribution">
-          <SpecialDistribution currency={currency} />
+          <SpecialDistribution
+            currency={currency}
+            credGrainView={credGrainView}
+          />
         </Route>,
         <Route key="weight-config" exact path="/weight-config">
           <WeightsConfigSection

--- a/packages/sourcecred/src/ui/components/SpecialDistribution.js
+++ b/packages/sourcecred/src/ui/components/SpecialDistribution.js
@@ -4,10 +4,11 @@ import {Button, Container, TextField} from "@material-ui/core";
 import {Alert} from "@material-ui/lab";
 import {makeStyles} from "@material-ui/core/styles";
 import {div, fromFloatString, lt, ZERO} from "../../core/ledger/grain";
-import {type Account} from "../../core/ledger/ledger";
-import {type CurrencyDetails} from "../../api/currencyConfig";
+import type {Account} from "../../core/ledger/ledger";
+import type {CurrencyDetails} from "../../api/currencyConfig";
 import AccountDropdown from "./AccountSelector";
 import {computeAllocationSpecial} from "../../core/ledger/grainAllocation";
+import type {CredGrainView} from "../../core/credGrainView";
 import * as uuid from "../../util/uuid";
 import type {TimestampMs} from "../../util/timestamp";
 import {useLedger} from "../utils/LedgerContext";
@@ -50,11 +51,24 @@ const useStyles = makeStyles((theme) => ({
   headerText: {color: theme.palette.text.primary},
 }));
 
-type SpecialDistributionProps = {|+currency: CurrencyDetails|};
+type SpecialDistributionProps = {|
+  +currency: CurrencyDetails,
+  +credGrainView: CredGrainView | null,
+|};
 
 export const SpecialDistribution = ({
   currency: {name: currencyName},
+  credGrainView,
 }: SpecialDistributionProps): ReactNode => {
+  if (!credGrainView)
+    return (
+      <div className={useStyles.root}>
+        <p>
+          This page is unavailable because Cred information was unable to load.
+          Calculate cred through the CLI in order to use this page.
+        </p>
+      </div>
+    );
   const {ledger, updateLedger, saveToDisk} = useLedger();
 
   const classes = useStyles();
@@ -72,9 +86,7 @@ export const SpecialDistribution = ({
         memo,
         recipient: recipient.identity.id,
       };
-      const allocation = computeAllocationSpecial(policy, [
-        {cred: [1], paid: ZERO, id: recipient.identity.id},
-      ]);
+      const allocation = computeAllocationSpecial(policy, credGrainView);
       const distribution = {
         id: uuid.random(),
         credTimestamp,


### PR DESCRIPTION
<!-- Please read our contributor guide before submitting your PR: -->
<!-- https://github.com/sourcecred/sourcecred/blob/master/CONTRIBUTING.md -->
# Description
Before this change: Special Distributions can be added in the grain.json config but will fail if the recipient is not active (activated to receive grain).

After this change: An optional `ignoreActiveStatus` attribute can be added to a Special Distribution and set to true to allow that distribution to succeed whether or not the recipient is activated. (see test plan for examples)

# Design Decisions
- The special distribution now takes a credGrainView. This is aligned with a larger effort of deprecating allocationIdentities and processedIdentities data structures in favor of using the credGrainView as input for all policies.
- Ledger handling of DistributeGrain events has changed to allow distribution to inactive accounts when the policy has a truthy `ignoreActiveStatus` attribute. This will apply to all grain policies, so the door is open for other policies to implement such configuration in the future. I believe this is a reasonable change to the Ledger's assumptions since the policy data structure is stored in the LedgerLog and thus the condition can be checked and enforced during regeneration. One reason not to distribute to inactive participants is consent to income, however a Special Distribution is semantically unlikely to be sent to someone without their involvement.

# Justification
The Special Distribution type hasn't been publicly endorsed because it breaks "Grain comes from Cred." However, now that it is possible to include Special Distributions in the grain config, it may actually be a very nice solution to the question of "how does sourcecred work when some people are getting fixed salaries?" This is a reality of most organizations and probably will be for some time, and with good reason--it prioritizes meeting human needs, unlike our purely meritocratic paradigm.

The target use case for this PR: People with fixed salaries can be paid through special distributions instead of being paid outside of the sourcecred system, so that if they ever stop being salaried and want to earn normal grain, the Balanced policy will be aware of their previous pay and will not try to "catch them up" unless they actually were underpaid.

This is something the upcoming Product circle will likely dogfood.
<!-- Possible prompts:
  Why is the change important?
  Did you consider and reject alternate formulations of the same idea?
  Are there relevant issues or discussions elsewhere?
-->

# Test Plan
- regression tested the Special Distribution UI page at `/special-distribution`
- Tested `grain.json` changes on sourcecred/cred/gh-pages with `scdev grain -s -f`
### Regression test grain config with active account
Input:
```
{
  "allocationPolicies": [
    {
      "policyType": "SPECIAL",
      "memo": "test",
      "budget": 1000,
      "recipient": "6wyPOVWLmZ2b35eCmOrz1w"
    }
  ],
  "maxSimultaneousDistributions": 100
}

```
Output:
```
SPECIAL Policy
Budget 1,000.000g
Memo: test
Recepient: 6wyPOVWLmZ2b35eCmOrz1w
|          name          |    total    |     %     |
| ---------------------- | ----------- | --------- |
|         Thena          |  1,000.000  |  100.00%  |
```
### Test inactive account without ignore flag
input config:
```
{
  "allocationPolicies": [
    {
      "policyType": "SPECIAL",
      "memo": "test",
      "budget": 1000,
      "recipient": "6XoP0YuaULs3BWR6QaKmpg"
    }
  ],
  "maxSimultaneousDistributions": 100
}
```
Output:
```
Error: no active grain account for identity: 6XoP0YuaULs3BWR6QaKmpg
    at specialReceipts (webpack:///./src/core/ledger/policies/special.js?:18:281)
    at receipts (webpack:///./src/core/ledger/grainAllocation.js?:16:830)
    at computeAllocation (webpack:///./src/core/ledger/grainAllocation.js?:15:296)
```
### Test inactive with ignore flag
input config:
```
{
  "allocationPolicies": [
    {
      "policyType": "SPECIAL",
      "memo": "test",
      "budget": 1000,
      "recipient": "6XoP0YuaULs3BWR6QaKmpg",
      "ignoreActiveStatus": true
    }
  ],
  "maxSimultaneousDistributions": 100
}

```
Output:
```
SPECIAL Policy
Budget 1,000.000g
Memo: test
Recepient: 6XoP0YuaULs3BWR6QaKmpg
IgnoreActiveStatus: true
|          name          |    total    |     %     |
| ---------------------- | ----------- | --------- |
|     buffalonetwork     |  1,000.000  |  100.00%  |
```
<!-- Possible prompts:
  How well covered by automated tests is this change?
  How did you manually test this change? How can a reviewer replicate the tests?
-->
