### PR TITLE
CredGrainView: Add advice to common error message

### DIFF
--- a/packages/sourcecred/src/core/credGrainView.js
+++ b/packages/sourcecred/src/core/credGrainView.js
@@ -263,7 +263,7 @@ export class CredGrainView {
         const graphParticipant = graphParticipants.get(account.identity.id);
         if (!graphParticipant)
           throw new Error(
-            `The graph is missing account [${account.identity.name}: ${account.identity.id}] that exists in the ledger.`
+            `The graph is missing account [${account.identity.name}: ${account.identity.id}] that exists in the ledger. Try recalculating the scores.`
           );
 
         const grainEarnedPerInterval = this._calculateGrainEarnedPerInterval(


### PR DESCRIPTION
People get this error frequently and ask about it in tech support. The solution is usually just to rerun `yarn start` since all ledger accounts are given a graph node during `credrank`. I decided not to mention `yarn start` explicitly so that we don't have inconsistency if we ever change the default instance script commands.