### PR TITLE
Expose coerce helper for names in API

### DIFF
--- a/packages/sourcecred/src/api/index.js
+++ b/packages/sourcecred/src/api/index.js
@@ -19,6 +19,7 @@ import * as ethereumUtils from "../plugins/ethereum/utils";
 import {declarationParser} from "../analysis/pluginDeclaration";
 import {identityProposalsParser} from "../core/ledger/identityProposal";
 import {ConstructorPlugin} from "../plugins/external/plugin";
+import {coerce as coerceNameFromString} from "../core/identity/name";
 
 import * as address from "../core/address";
 import * as graph from "../core/graph";
@@ -93,6 +94,7 @@ const api = {
     },
     declarationParser,
     identityProposalsParser,
+    coerceNameFromString,
   },
 };
 


### PR DESCRIPTION
<!-- Please read our contributor guide before submitting your PR: -->
<!-- https://github.com/sourcecred/sourcecred/blob/master/CONTRIBUTING.md -->

# Description
In 3rd-party plugin development, we enforce that identityProposal names only contain letters, numbers, and dashes. This forces 3rd party developers to clean their platform usernames to meet our requirement. Internally, we have a helper function to do this cleaning, so this PR exposes that helper function for 3rd party use.
<!-- Possible prompts:
  Why is the change important?
  Did you consider and reject alternate formulations of the same idea?
  Are there relevant issues or discussions elsewhere?
-->

# Test Plan
yarn build
<!-- Possible prompts:
  How well covered by automated tests is this change?
  How did you manually test this change? How can a reviewer replicate the tests?
-->
