### PR TITLE
Transfer UI: make max a button and don't clear accounts after save

### DIFF
--- a/packages/sourcecred/src/ui/components/AccountSelector.js
+++ b/packages/sourcecred/src/ui/components/AccountSelector.js
@@ -9,6 +9,7 @@ type DropdownProps = {|
   +ledger: Ledger,
   +setCurrentAccount: (Account | null) => void,
   +placeholder?: string,
+  +currentAccount: Account | null,
 |};
 
 const useStyles = makeStyles({combobox: {margin: "0px 32px 16px"}});
@@ -17,12 +18,14 @@ export default function AccountDropdown({
   placeholder,
   setCurrentAccount,
   ledger,
+  currentAccount,
 }: DropdownProps): ReactNode {
   const classes = useStyles();
   const items = ledger.accounts().filter((a) => a.active);
 
   return (
     <Autocomplete
+      value={currentAccount}
       size="medium"
       className={classes.combobox}
       onChange={(...args) => {

--- a/packages/sourcecred/src/ui/components/SpecialDistribution.js
+++ b/packages/sourcecred/src/ui/components/SpecialDistribution.js
@@ -126,6 +126,7 @@ export const SpecialDistribution = ({
             ledger={ledger}
             setCurrentAccount={setRecipient}
             placeholder="Recipient"
+            currentAccount={recipient}
           />
         </div>
       </div>

--- a/packages/sourcecred/src/ui/components/Transfer.js
+++ b/packages/sourcecred/src/ui/components/Transfer.js
@@ -73,6 +73,7 @@ const useStyles = makeStyles((theme) => ({
   element: {flex: 1, margin: "20px"},
   arrowInput: {width: "40%", display: "inline-block"},
   pageHeader: {color: theme.palette.text.primary},
+  noTransform: {textTransform: "none"},
 }));
 
 type TransferProps = {|+currency: CurrencyDetails|};
@@ -117,8 +118,6 @@ export const Transfer = ({
     setHasUnsavedChanges(false);
     saveToDisk();
     setMemo("");
-    setReceiver(null);
-    setSender(null);
     setAmount("");
   };
 
@@ -135,6 +134,10 @@ export const Transfer = ({
         </div>
       );
     }
+  };
+
+  const handleMax = () => {
+    if (sender) setAmount(format(sender.balance, 2, "").replace(/,/g, ""));
   };
 
   return (
@@ -156,6 +159,7 @@ export const Transfer = ({
             ledger={ledger}
             setCurrentAccount={setSender}
             placeholder="From..."
+            currentAccount={sender}
           />
         </div>
         <div
@@ -175,9 +179,9 @@ export const Transfer = ({
               value={amount}
               onChange={(e) => setAmount(e.currentTarget.value)}
             />
-            <span>
+            <Button onClick={handleMax} className={classes.noTransform}>
               {sender && ` max: ${format(sender.balance, 2, currencySuffix)}`}
-            </span>
+            </Button>
           </div>
           <div className={`${isXSmall ? "" : classes.triangle}`} />
         </div>
@@ -188,6 +192,7 @@ export const Transfer = ({
             ledger={ledger}
             setCurrentAccount={setReceiver}
             placeholder="To..."
+            currentAccount={receiver}
           />
         </div>
       </div>

--- a/packages/sourcecred/src/ui/components/Transfer.js
+++ b/packages/sourcecred/src/ui/components/Transfer.js
@@ -71,9 +71,13 @@ const useStyles = makeStyles((theme) => ({
     flexDirection: "column",
   },
   element: {flex: 1, margin: "20px"},
-  arrowInput: {width: "40%", display: "inline-block"},
+  arrowInput: {
+    width: "40%",
+    minWidth: "86px",
+    display: "inline-block",
+  },
   pageHeader: {color: theme.palette.text.primary},
-  noTransform: {textTransform: "none"},
+  arrowButton: {textTransform: "none", whiteSpace: "nowrap"},
 }));
 
 type TransferProps = {|+currency: CurrencyDetails|};
@@ -179,7 +183,7 @@ export const Transfer = ({
               value={amount}
               onChange={(e) => setAmount(e.currentTarget.value)}
             />
-            <Button onClick={handleMax} className={classes.noTransform}>
+            <Button onClick={handleMax} className={classes.arrowButton}>
               {sender && ` max: ${format(sender.balance, 2, currencySuffix)}`}
             </Button>
           </div>

--- a/packages/sourcecred/src/ui/components/Transfer.js
+++ b/packages/sourcecred/src/ui/components/Transfer.js
@@ -123,15 +123,12 @@ export const Transfer = ({
     saveToDisk();
     setMemo("");
     setAmount("");
+    setSender(null);
+    setReceiver(null);
   };
 
   const handleSaveToLedgerWarning = (_) => {
-    if (
-      hasUnsavedChanges ||
-      sender !== null ||
-      receiver !== null ||
-      amount !== ""
-    ) {
+    if (hasUnsavedChanges) {
       return (
         <div className={classes.saveToLedgerAlert}>
           Changes not saved to ledger


### PR DESCRIPTION
<!-- Please read our contributor guide before submitting your PR: -->
<!-- https://github.com/sourcecred/sourcecred/blob/master/CONTRIBUTING.md -->

# Description
This PR includes 3 minor changes on the Transfer Grain page:
1. Makes the "max: XXX.XXg" field a button that fills the amount text field with the max
2. Pipes the current from and to accounts into the Autocomplete fields so that if we set them to null, the fields will actually clear. (tested before I implemented point 3)
3. Change the save-to-disk behavior to no longer clear the from and to fields. (note: the transfer grain button already does not clear the from and to fields). It seems a little nicer since often people want to reuse one of the accounts in multiple transfers. Would like Design's perspective though.
<!-- Possible prompts:
  Why is the change important?
  Did you consider and reject alternate formulations of the same idea?
  Are there relevant issues or discussions elsewhere?
-->


# Test Plan
## Before:
![chrome-capture (12)](https://user-images.githubusercontent.com/11550396/131556643-d729e1c3-948d-4a67-9043-4c619061945b.gif)
## After:
![chrome-capture (13)](https://user-images.githubusercontent.com/11550396/131556671-5f661bd4-4d87-4e12-b99a-1dba04931920.gif)

<!-- Possible prompts:
  How well covered by automated tests is this change?
  How did you manually test this change? How can a reviewer replicate the tests?
-->
