### PR TITLE
Tune up our monorepo config

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   "scripts": {
     "test": "lerna run test --stream --",
     "build": "lerna run build --stream",
-    "install": "lerna bootstrap && ./scripts/flow-mono.sh",
+    "postinstall": "./scripts/flow-mono.sh",
     "start": "lerna run start --stream",
     "clean": "lerna clean --yes && rm -rf node_modules"
   },


### PR DESCRIPTION
Our lerna setup resulted in recursive execution, which is wasteful. I've
researched the correct config for using yarn and lerna, and these
changes are the result.

Yarn's workspaces serve as something of a drop-in backend
for lerna, so running `yarn [install]` with workspaces enabled is
effectively a bootstrap, and is exactly what lerna would do if invoked
directly.

I was initially confused when working with Hz to set this up because we had
the flow-mono script set in the `install` script in package.json, which
completely shadowed yarn's default execution, and the bootstrap process
wouldn't happen. It has been placed in the correct `postinstall` script
and now everything runs as it should.

test plan: `yarn clean && yarn && yarn test`

tests should all pass, indicating a correct install.
Installation and bootstrapping is also slightly faster and the console
is less noisy. Specifically, lerna log notes go away, since yarn manages
the bootstrap process.