### PR TITLE
Release sourcecred 0.9.3

### DIFF
--- a/packages/grainIntegration-csv/package.json
+++ b/packages/grainIntegration-csv/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sourcecred/grain-integration-csv",
-  "version": "0.0.1-alpha.0",
+  "version": "0.0.1",
   "description": "print out a csv for each grain distribution",
   "main": "index.js",
   "license": "(MIT OR Apache-2.0)",

--- a/packages/grainIntegration-csv/package.json
+++ b/packages/grainIntegration-csv/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sourcecred/grain-integration-csv",
-  "version": "0.0.1",
+  "version": "0.0.1-alpha.0",
   "description": "print out a csv for each grain distribution",
   "main": "index.js",
   "license": "(MIT OR Apache-2.0)",
@@ -14,5 +14,8 @@
     "flow-bin": "^0.135.0",
     "jest": "^26.0.1",
     "tmp": "^0.2.1"
+  },
+  "publishConfig": {
+    "access": "public"
   }
 }

--- a/packages/sourcecred/package.json
+++ b/packages/sourcecred/package.json
@@ -3,7 +3,7 @@
   "description": "a tool for communities to measure and reward value creation",
   "homepage": "https://sourcecred.io",
   "repository": "github:sourcecred/sourcecred",
-  "version": "0.9.3-alpha.0",
+  "version": "0.9.3",
   "private": false,
   "dependencies": {
     "@date-io/date-fns": "1.3.11",
@@ -11,7 +11,7 @@
     "@material-ui/icons": "^4.11.2",
     "@material-ui/lab": "^4.0.0-alpha.56",
     "@material-ui/pickers": "3.3.10",
-    "@sourcecred/grain-integration-csv": "^0.0.1-alpha.0",
+    "@sourcecred/grain-integration-csv": "^0.0.1",
     "@walletconnect/web3-provider": "^1.4.1",
     "aphrodite": "^2.4.0",
     "babel-plugin-transform-flow-strip-types": "^6.22.0",

--- a/packages/sourcecred/package.json
+++ b/packages/sourcecred/package.json
@@ -3,7 +3,7 @@
   "description": "a tool for communities to measure and reward value creation",
   "homepage": "https://sourcecred.io",
   "repository": "github:sourcecred/sourcecred",
-  "version": "0.9.2",
+  "version": "0.9.3-alpha.0",
   "private": false,
   "dependencies": {
     "@date-io/date-fns": "1.3.11",
@@ -11,7 +11,7 @@
     "@material-ui/icons": "^4.11.2",
     "@material-ui/lab": "^4.0.0-alpha.56",
     "@material-ui/pickers": "3.3.10",
-    "@sourcecred/grain-integration-csv": "^0.0.1",
+    "@sourcecred/grain-integration-csv": "^0.0.1-alpha.0",
     "@walletconnect/web3-provider": "^1.4.1",
     "aphrodite": "^2.4.0",
     "babel-plugin-transform-flow-strip-types": "^6.22.0",


### PR DESCRIPTION
I published some prereleases to npm to conduct some release testing. Tests on that pre-release publish commit failed because the test utils failed to parse the prerelease semver suffix.

The pre-release suffixes will not be merged back to main, so this test can be fixed later