### PR TITLE
Feature: Disable balance accounting in the ledger

### DIFF
--- a/packages/grainIntegration-csv/index.js
+++ b/packages/grainIntegration-csv/index.js
@@ -19,6 +19,7 @@ const csvIntegration /*: any */ = (payoutDistributions, _unused_config) => {
       fileName: `Payouts-${timestamp}.csv`,
       content: csvString,
     },
+    configUpdate: {},
   };
 };
 

--- a/packages/sourcecred/src/api/grainConfig.js
+++ b/packages/sourcecred/src/api/grainConfig.js
@@ -14,10 +14,9 @@ import {
   parser as bundledGrainIntegrationParser,
 } from "./bundledGrainIntegrations";
 
-// NOTE: This type is deprecated since v0.10.0 and should not be modified
-// further
 export type RawGrainConfig = {|
   +allocationPolicies: $ReadOnlyArray<AllocationConfig>,
+  +accountingEnabled?: boolean,
   +maxSimultaneousDistributions?: number,
   +sinkIdentity?: Name,
   +processDistributions?: boolean,
@@ -41,6 +40,7 @@ export const rawParser: C.Parser<RawGrainConfig> = C.object(
     maxSimultaneousDistributions: C.number,
     sinkIdentity: nameParser,
     processDistributions: C.boolean,
+    accountingEnabled: C.boolean,
     integration: bundledGrainIntegrationParser,
   }
 );
@@ -67,3 +67,5 @@ export const parser: C.Parser<GrainConfig> = C.fmap(
     accountingEnabled: NullUtil.orElse(config.accountingEnabled, true),
   })
 );
+
+// const allocationToPolicyParser<Allocation

--- a/packages/sourcecred/src/api/grainConfig.js
+++ b/packages/sourcecred/src/api/grainConfig.js
@@ -9,10 +9,8 @@ import {
   allocationConfigParser,
 } from "../core/ledger/policies";
 import {type Name, parser as nameParser} from "../core/identity/name";
-import {
-  type GrainIntegration,
-  parser as bundledGrainIntegrationParser,
-} from "./bundledGrainIntegrations";
+import type {GrainIntegration} from "../core/ledger/grainIntegration";
+import {parser as bundledGrainIntegrationParser} from "./bundledGrainIntegrations";
 
 export type RawGrainConfig = {|
   +allocationPolicies: $ReadOnlyArray<AllocationConfig>,

--- a/packages/sourcecred/src/api/grainConfig.js
+++ b/packages/sourcecred/src/api/grainConfig.js
@@ -14,6 +14,8 @@ import {
   parser as bundledGrainIntegrationParser,
 } from "./bundledGrainIntegrations";
 
+// NOTE: This type is deprecated since v0.10.0 and should not be modified
+// further
 export type RawGrainConfig = {|
   +allocationPolicies: $ReadOnlyArray<AllocationConfig>,
   +maxSimultaneousDistributions?: number,
@@ -25,6 +27,7 @@ export type RawGrainConfig = {|
 export type GrainConfig = {|
   +allocationPolicies: $ReadOnlyArray<AllocationPolicy>,
   +maxSimultaneousDistributions: number,
+  +accountingEnabled: boolean,
   +sinkIdentity?: Name,
   +processDistributions?: boolean,
   +integration?: GrainIntegration,
@@ -51,6 +54,7 @@ export const parser: C.Parser<GrainConfig> = C.fmap(
       maxSimultaneousDistributions: C.number,
       sinkIdentity: nameParser,
       processDistributions: C.boolean,
+      accountingEnabled: C.boolean,
       integration: bundledGrainIntegrationParser,
     }
   ),
@@ -60,5 +64,6 @@ export const parser: C.Parser<GrainConfig> = C.fmap(
       config.maxSimultaneousDistributions,
       Infinity
     ),
+    accountingEnabled: NullUtil.orElse(config.accountingEnabled, true),
   })
 );

--- a/packages/sourcecred/src/api/grainConfig.test.js
+++ b/packages/sourcecred/src/api/grainConfig.test.js
@@ -54,6 +54,7 @@ describe("api/grainConfig", () => {
       expect(parser.parseOrThrow({allocationPolicies: []})).toEqual({
         allocationPolicies: [],
         maxSimultaneousDistributions: Infinity,
+        accountingEnabled: true,
       });
     });
 
@@ -86,9 +87,10 @@ describe("api/grainConfig", () => {
         EXTRA: 30,
       };
 
-      const to = {
+      const to: GrainConfig = {
         allocationPolicies: [],
         maxSimultaneousDistributions: 2,
+        accountingEnabled: true,
       };
 
       expect(parser.parseOrThrow(grainConfig)).toEqual(to);
@@ -100,7 +102,7 @@ describe("api/grainConfig", () => {
         maxSimultaneousDistributions: -5,
       };
 
-      expect(parser.parseOrThrow(grainConfig)).toEqual(grainConfig);
+      expect(() => parser.parseOrThrow(grainConfig)).not.toThrow();
     });
 
     it("rejects improperly formatted allocation policies", () => {
@@ -149,6 +151,7 @@ describe("api/grainConfig", () => {
         maxSimultaneousDistributions: 2,
         sinkIdentity: "testName",
         processDistributions: true,
+        accountingEnabled: false,
       };
 
       const expected: GrainConfig = {
@@ -161,6 +164,7 @@ describe("api/grainConfig", () => {
         maxSimultaneousDistributions: 2,
         sinkIdentity: nameFromString("testName"),
         processDistributions: true,
+        accountingEnabled: false,
       };
 
       expect(parser.parseOrThrow(grainConfig)).toEqual(expected);
@@ -203,6 +207,7 @@ describe("api/grainConfig", () => {
           special("100.11", "howdy", uuid),
         ],
         maxSimultaneousDistributions: 2,
+        accountingEnabled: true,
       };
 
       expect(parser.parseOrThrow(grainConfig)).toEqual(expected);
@@ -228,6 +233,7 @@ describe("api/grainConfig", () => {
       const expected: GrainConfig = {
         allocationPolicies: [recent(20, 0.1), recent(20, 0.1)],
         maxSimultaneousDistributions: 2,
+        accountingEnabled: true,
       };
 
       expect(parser.parseOrThrow(config)).toEqual(expected);

--- a/packages/sourcecred/src/api/instance/instance.js
+++ b/packages/sourcecred/src/api/instance/instance.js
@@ -56,4 +56,10 @@ export interface Instance extends ReadOnlyInstance {
   writeGrainIntegrationOutput(
     result: $Shape<GrainIntegrationMultiResult>
   ): Promise<void>;
+
+  /** Write grain config updates back into the instance */
+  updateGrainIntegrationConfig(
+    result: $Shape<GrainIntegrationMultiResult>,
+    config: GrainInput
+  ): Promise<void>;
 }

--- a/packages/sourcecred/src/api/main/grain.js
+++ b/packages/sourcecred/src/api/main/grain.js
@@ -2,11 +2,11 @@
 
 import {CredGraph} from "../../core/credrank/credGraph";
 import {Ledger} from "../../core/ledger/ledger";
-import type {CurrencyDetails} from "../currencyConfig";
-import {type GrainConfig} from "../grainConfig";
-import {type Currency as IntegrationCurrency} from "../../core/ledger/currency";
-import type {Distribution} from "../../core/ledger/distribution";
 import {applyDistributions} from "../../core/ledger/applyDistributions";
+import type {CurrencyDetails} from "../currencyConfig";
+import type {GrainConfig} from "../grainConfig";
+import type {Currency as IntegrationCurrency} from "../../core/ledger/currency";
+import type {Distribution} from "../../core/ledger/distribution";
 import type {TimestampMs} from "../../util/timestamp";
 import {
   executeGrainIntegration,
@@ -30,6 +30,7 @@ export type GrainOutput = {|
 // since only the most recent ledger is relevant
 export type GrainIntegrationMultiResult = {|
   output?: GrainIntegrationOutput,
+  configUpdate: Object,
   distributionCredTimestamp: TimestampMs,
 |};
 
@@ -62,11 +63,11 @@ export async function grain(input: GrainInput): Promise<GrainOutput> {
  * Marshall grainInput from a Grain Configuration file for use with
  * executeGrainIntegration function
  */
-export function executeGrainIntegrationsFromGrainInput(
+export async function executeGrainIntegrationsFromGrainInput(
   grainInput: GrainInput,
   ledger: Ledger,
   distributions: $ReadOnlyArray<Distribution>
-): GrainIntegrationResults {
+): Promise<GrainIntegrationResults> {
   const integrationCurrency = grainInput.currencyDetails.integrationCurrency;
   const grainIntegration = grainInput.grainConfig.integration;
   const results = [];
@@ -76,16 +77,21 @@ export function executeGrainIntegrationsFromGrainInput(
   // supporting the case where the distributions parameter is an empty array
   let ledgerResult = ledger;
   if (integrationCurrency && grainIntegration) {
-    distributions.forEach((distribution) => {
-      const result = executeGrainIntegration(
+    for (const distribution of distributions) {
+      const result = await executeGrainIntegration(
         ledgerResult,
-        grainIntegration.function,
+        grainIntegration,
         distribution
       );
-      const {output, distributionCredTimestamp, ledger: nextLedger} = result;
+      const {
+        output,
+        distributionCredTimestamp,
+        ledger: nextLedger,
+        configUpdate,
+      } = result;
       ledgerResult = nextLedger;
-      results.push({output, distributionCredTimestamp});
-    });
+      results.push({output, distributionCredTimestamp, configUpdate});
+    }
   }
   return {ledger: ledgerResult, results};
 }

--- a/packages/sourcecred/src/api/main/grain.js
+++ b/packages/sourcecred/src/api/main/grain.js
@@ -68,7 +68,6 @@ export function executeGrainIntegrationsFromGrainInput(
   const integrationCurrency = grainInput.currencyDetails.integrationCurrency;
   const grainIntegration = grainInput.grainConfig.integration;
   const results = [];
-  ledger = configureLedger(ledger, grainInput);
   // track the latest ledger in the for-loop for the purposes of returning it
   // at the top level, observing that any function may deep-copy
   // the ledger (thus creating a new reference we'll need to track) and also

--- a/packages/sourcecred/src/api/main/grain.js
+++ b/packages/sourcecred/src/api/main/grain.js
@@ -46,14 +46,16 @@ export type GrainIntegrationResults = {|
   May mutate the ledger that is passed in.
  */
 export async function grain(input: GrainInput): Promise<GrainOutput> {
+  const configuredLedger = configureLedger(input);
+
   const distributions = applyDistributions(
     input.grainConfig,
     input.credGraph,
-    input.ledger,
+    configuredLedger,
     +Date.now(),
     input.allowMultipleDistributionsPerInterval || false
   );
-  return {distributions, ledger: input.ledger};
+  return {distributions, ledger: configuredLedger};
 }
 
 /**
@@ -88,10 +90,10 @@ export function executeGrainIntegrationsFromGrainInput(
   return {ledger: ledgerResult, results};
 }
 
-export function configureLedger(ledger: Ledger, input: GrainInput): Ledger {
-  const {grainConfig, currencyDetails} = input;
-  ledger = configureIntegrationCurrency(
-    ledger,
+export function configureLedger(input: GrainInput): Ledger {
+  const {grainConfig, currencyDetails, ledger: ledgerInput} = input;
+  let ledger = configureIntegrationCurrency(
+    ledgerInput,
     currencyDetails.integrationCurrency
   );
   ledger = configureLedgerAccounting(ledger, grainConfig.accountingEnabled);

--- a/packages/sourcecred/src/api/main/grain.test.js
+++ b/packages/sourcecred/src/api/main/grain.test.js
@@ -1,0 +1,183 @@
+// @flow
+
+import {
+  createUuidMock,
+  createDateMock,
+  createTestLedgerFixture,
+} from "../../core/ledger/testUtils";
+import {
+  configureIntegrationCurrency,
+  configureIntegrationTracking,
+  configureLedgerAccounting,
+} from "./grain";
+import {buildCurrency} from "../../core/ledger/currency";
+import {diffLedger} from "../../core/ledger/diffLedger";
+import {parseAddress} from "../../plugins/ethereum/ethAddress";
+import {Ledger} from "../../core/ledger/ledger";
+const uuidMock = createUuidMock();
+const dateMock = createDateMock();
+
+const mockTokenAddress = parseAddress(
+  "0x0000000000000000000000000000000000000001"
+);
+const {ledgerWithActiveIdentities} = createTestLedgerFixture(
+  uuidMock,
+  dateMock
+);
+
+describe("src/api/main/grain", () => {
+  const protocolCurrency = buildCurrency("BTC");
+  describe("configureIntegrationCurrency", () => {
+    it("returns a ledger with a configured Protocol currency", () => {
+      const ledger = ledgerWithActiveIdentities();
+      const ledgerStart = ledger.serialize();
+      const newLedger = configureIntegrationCurrency(ledger, protocolCurrency);
+      const result = diffLedger(newLedger, Ledger.parse(ledgerStart));
+      expect(result).toEqual([
+        {
+          "action": {
+            "currency": {
+              "chainId": "BTC",
+              "type": "PROTOCOL",
+            },
+            "type": "SET_EXTERNAL_CURRENCY",
+          },
+          "ledgerTimestamp": 4,
+          "uuid": "000000000000000000004A",
+          "version": "1",
+        },
+      ]);
+    });
+    it("returns a ledger with a configured EVM currency", () => {
+      const ledger = ledgerWithActiveIdentities();
+      const ledgerStart = ledger.serialize();
+      const evmCurrency = buildCurrency("1", mockTokenAddress);
+      const newLedger = configureIntegrationCurrency(ledger, evmCurrency);
+      const result = diffLedger(newLedger, Ledger.parse(ledgerStart));
+      expect(result).toEqual([
+        {
+          "action": {
+            "currency": {
+              "chainId": "1",
+              "tokenAddress": "0x0000000000000000000000000000000000000001",
+              "type": "EVM",
+            },
+            "type": "SET_EXTERNAL_CURRENCY",
+          },
+          "ledgerTimestamp": 4,
+          "uuid": "000000000000000000004A",
+          "version": "1",
+        },
+      ]);
+    });
+    it("returns a ledger with no currency when a currency has been unset", () => {
+      const ledger = ledgerWithActiveIdentities();
+      const ledgerStart = ledger.serialize();
+      const evmCurrency = buildCurrency("1", mockTokenAddress);
+      configureIntegrationCurrency(ledger, evmCurrency);
+      const newLedger = configureIntegrationCurrency(ledger);
+      const result = diffLedger(newLedger, Ledger.parse(ledgerStart));
+      expect(result).toEqual([
+        {
+          "action": {
+            "currency": {
+              "chainId": "1",
+              "tokenAddress": "0x0000000000000000000000000000000000000001",
+              "type": "EVM",
+            },
+            "type": "SET_EXTERNAL_CURRENCY",
+          },
+          "ledgerTimestamp": 4,
+          "uuid": "000000000000000000004A",
+          "version": "1",
+        },
+        {
+          "action": {
+            "type": "REMOVE_EXTERNAL_CURRENCY",
+          },
+          "ledgerTimestamp": 5,
+          "uuid": "000000000000000000005A",
+          "version": "1",
+        },
+      ]);
+    });
+  });
+  describe("configureIntegrationTracking", () => {
+    it("returns a ledger with Integration Tracking enabled", () => {
+      const ledger = ledgerWithActiveIdentities();
+      const ledgerStart = ledger.serialize();
+      const newLedger = configureIntegrationTracking(ledger, true);
+      const result = diffLedger(newLedger, Ledger.parse(ledgerStart));
+      expect(result).toEqual([
+        {
+          "action": {
+            "type": "ENABLE_GRAIN_INTEGRATION",
+          },
+          "ledgerTimestamp": 4,
+          "uuid": "000000000000000000004A",
+          "version": "1",
+        },
+      ]);
+    });
+    it("returns a ledger with Integration Tracking disabled", () => {
+      const ledger = ledgerWithActiveIdentities();
+      const ledgerStart = ledger.serialize();
+      configureIntegrationTracking(ledger, true);
+      const newLedger = configureIntegrationTracking(ledger, false);
+      const result = diffLedger(newLedger, Ledger.parse(ledgerStart));
+      expect(result).toEqual([
+        {
+          "action": {
+            "type": "ENABLE_GRAIN_INTEGRATION",
+          },
+          "ledgerTimestamp": 4,
+          "uuid": "000000000000000000004A",
+          "version": "1",
+        },
+        {
+          "action": {
+            "type": "DISABLE_GRAIN_INTEGRATION",
+          },
+          "ledgerTimestamp": 5,
+          "uuid": "000000000000000000005A",
+          "version": "1",
+        },
+      ]);
+    });
+  });
+  describe("configureLedgerAccounting", () => {
+    it("can return a ledger with accounting disabled and later re-enabled", () => {
+      const ledger = new Ledger();
+      configureIntegrationCurrency(ledger, protocolCurrency);
+      let ledgerSnapshot = ledger.serialize();
+      let newLedger = configureLedgerAccounting(ledger, false);
+      let result = diffLedger(newLedger, Ledger.parse(ledgerSnapshot));
+      expect(result).toEqual([
+        {
+          "action": {
+            "type": "DISABLE_ACCOUNTING",
+          },
+          "ledgerTimestamp": 7,
+          "uuid": "000000000000000000007A",
+          "version": "1",
+        },
+      ]);
+      ledgerSnapshot = ledger.serialize();
+      const updatedLedger = (newLedger = configureLedgerAccounting(
+        ledger,
+        true
+      ));
+      result = diffLedger(updatedLedger, Ledger.parse(ledgerSnapshot));
+      expect(result).toEqual([
+        {
+          "action": {
+            "type": "ENABLE_ACCOUNTING",
+          },
+          "ledgerTimestamp": 8,
+          "uuid": "000000000000000000008A",
+          "version": "1",
+        },
+      ]);
+    });
+  });
+});

--- a/packages/sourcecred/src/cli/grain.js
+++ b/packages/sourcecred/src/cli/grain.js
@@ -7,7 +7,11 @@ import {allocationMarkdownSummary} from "../core/ledger/distributionSummary/allo
 import * as G from "../core/ledger/grain";
 import {Instance} from "../api/instance/instance";
 import {LocalInstance} from "../api/instance/localInstance";
-import {grain, executeGrainIntegrationsFromGrainInput} from "../api/main/grain";
+import {
+  grain,
+  executeGrainIntegrationsFromGrainInput,
+  configureLedger,
+} from "../api/main/grain";
 
 function die(std, message) {
   std.err("fatal: " + message);
@@ -42,6 +46,10 @@ const grainCommand: Command = async (args, std) => {
   const instance: Instance = new LocalInstance(baseDir);
   const grainInput = await instance.readGrainInput();
   grainInput.allowMultipleDistributionsPerInterval = allowMultipleDistributionsPerInterval;
+
+  // the ledger stored in grainInput is modified and subsequently used in the
+  // below grain call.
+  configureLedger(grainInput.ledger, grainInput);
 
   const {distributions, ledger: ledgerBeforeIntegrations} = await grain(
     grainInput

--- a/packages/sourcecred/src/cli/grain.js
+++ b/packages/sourcecred/src/cli/grain.js
@@ -7,11 +7,7 @@ import {allocationMarkdownSummary} from "../core/ledger/distributionSummary/allo
 import * as G from "../core/ledger/grain";
 import {Instance} from "../api/instance/instance";
 import {LocalInstance} from "../api/instance/localInstance";
-import {
-  grain,
-  executeGrainIntegrationsFromGrainInput,
-  configureLedger,
-} from "../api/main/grain";
+import {grain, executeGrainIntegrationsFromGrainInput} from "../api/main/grain";
 
 function die(std, message) {
   std.err("fatal: " + message);
@@ -46,10 +42,6 @@ const grainCommand: Command = async (args, std) => {
   const instance: Instance = new LocalInstance(baseDir);
   const grainInput = await instance.readGrainInput();
   grainInput.allowMultipleDistributionsPerInterval = allowMultipleDistributionsPerInterval;
-
-  // the ledger stored in grainInput is modified and subsequently used in the
-  // below grain call.
-  configureLedger(grainInput.ledger, grainInput);
 
   const {distributions, ledger: ledgerBeforeIntegrations} = await grain(
     grainInput

--- a/packages/sourcecred/src/cli/grain.js
+++ b/packages/sourcecred/src/cli/grain.js
@@ -47,14 +47,15 @@ const grainCommand: Command = async (args, std) => {
     grainInput
   );
 
-  const {results, ledger} = executeGrainIntegrationsFromGrainInput(
+  const {results, ledger} = await executeGrainIntegrationsFromGrainInput(
     grainInput,
     ledgerBeforeIntegrations,
     distributions
   );
 
   for (const result of results) {
-    instance.writeGrainIntegrationOutput(result);
+    await instance.writeGrainIntegrationOutput(result);
+    await instance.updateGrainIntegrationConfig(result, grainInput);
   }
 
   let totalDistributed = G.ZERO;

--- a/packages/sourcecred/src/cli/update/v0_10_0.js
+++ b/packages/sourcecred/src/cli/update/v0_10_0.js
@@ -13,10 +13,8 @@ import {
   allocationConfigParser,
 } from "../../core/ledger/policies";
 import {type Name, parser as nameParser} from "../../core/identity/name";
-import {
-  type GrainIntegration,
-  parser as bundledGrainIntegrationParser,
-} from "../../api/bundledGrainIntegrations";
+import type {GrainIntegration} from "../../core/ledger/grainIntegration";
+import {parser as bundledGrainIntegrationParser} from "../../api/bundledGrainIntegrations";
 import {toDiscount} from "../../core/ledger/policies/recent";
 import stringify from "json-stable-stringify";
 import {DiskStorage} from "../../core/storage/disk";

--- a/packages/sourcecred/src/core/ledger/grainIntegration.js
+++ b/packages/sourcecred/src/core/ledger/grainIntegration.js
@@ -28,6 +28,9 @@ export type PayoutResult = {|
   // If Grain balances are tracked in the ledger, these will be recorded as
   // transfers in the ledger to the "sink" Identity.
   transferredGrain: TransferredGrain,
+  // integration-specific config changes that need to be persisted are
+  // returned in the configUpdate object.
+  configUpdate: Object,
   // output files and content
   outputFile?: GrainIntegrationOutput,
 |};
@@ -46,6 +49,10 @@ export type IntegrationConfig = {|
   // distributed funds via a configured integration
   processDistributions: boolean,
   currency: Currency,
+  // This optional object contains the self-configuration set by the grain
+  // integration on previous runs. It allows the grain integration to
+  // read its own configuration from disk.
+  integration: ?Object,
 |};
 
 /**
@@ -60,12 +67,19 @@ export type IntegrationConfig = {|
 export type GrainIntegrationFunction = (
   PayoutDistributions,
   IntegrationConfig
-) => PayoutResult;
+) => Promise<PayoutResult>;
+
+export type GrainIntegration = {|
+  name: string,
+  function: GrainIntegrationFunction,
+  config?: Object,
+|};
 
 export type GrainIntegrationResult = {|
   ledger: Ledger,
-  output?: GrainIntegrationOutput,
   distributionCredTimestamp: TimestampMs,
+  configUpdate: Object,
+  output?: GrainIntegrationOutput,
 |};
 
 ///////////////////
@@ -75,12 +89,12 @@ export type GrainIntegrationResult = {|
 // TODO @topocount: Refactor interface using instance/config properties
 // after grainConfig is updated to include The payout currency details and
 // sink identity
-export function executeGrainIntegration(
+export async function executeGrainIntegration(
   ledger: Ledger,
-  integration: GrainIntegrationFunction,
+  integration: GrainIntegration,
   distribution: Distribution,
   sink?: IdentityId
-): GrainIntegrationResult {
+): Promise<GrainIntegrationResult> {
   const currency = ledger.externalCurrency();
   const {
     enabled: accountingEnabled,
@@ -96,8 +110,9 @@ export function executeGrainIntegration(
   // the fixed-point amount for some reason.
   let result;
   try {
-    result = integration(payoutDistributions, {
+    result = await integration.function(payoutDistributions, {
       accounting: ledger.accounting(),
+      integration: integration.config,
       processDistributions,
       currency,
     });
@@ -122,6 +137,7 @@ export function executeGrainIntegration(
   return {
     ledger,
     output: result.outputFile,
+    configUpdate: result.configUpdate,
     distributionCredTimestamp: distribution.credTimestamp,
   };
 }

--- a/packages/sourcecred/src/core/ledger/grainIntegration.js
+++ b/packages/sourcecred/src/core/ledger/grainIntegration.js
@@ -84,7 +84,7 @@ export function executeGrainIntegration(
   const currency = ledger.externalCurrency();
   const {
     enabled: accountingEnabled,
-    trackDistributions: processDistributions,
+    trackGrainIntegration: processDistributions,
   } = ledger.accounting();
   const {payoutDistributions, payoutAddressToId} = buildDistributionIndexes(
     ledger,

--- a/packages/sourcecred/src/core/ledger/ledger.js
+++ b/packages/sourcecred/src/core/ledger/ledger.js
@@ -68,6 +68,7 @@ type AllocationReceipt = {|
  */
 export type AccountingStatus = {|
   +enabled: boolean,
+  +trackDistributions: boolean,
   +currency: ?Currency,
 |};
 /**
@@ -903,7 +904,7 @@ export class Ledger {
    */
   disableAccounting(): Ledger {
     // ensure an external currency is set
-    this._getExternalCurrency();
+    this.externalCurrency();
     // ensure accounting isn't already disabled
     if (this._balanceAccountingEnabled) {
       this._createAndProcessEvent({
@@ -917,7 +918,7 @@ export class Ledger {
   _disableAccounting(_: DisableAccounting) {
     this._balanceAccountingEnabled = false;
 
-    const currencyKey = getCurrencyKey(this._getExternalCurrency());
+    const currencyKey = getCurrencyKey(this.externalCurrency());
 
     // Warning! Mutations below
     const accountsIterator = this._accounts.values();
@@ -1000,6 +1001,7 @@ export class Ledger {
   accounting(): AccountingStatus {
     return {
       enabled: this._balanceAccountingEnabled,
+      trackDistributions: this._shouldTrackGrainIntegration,
       currency: this._externalCurrency,
     };
   }
@@ -1009,7 +1011,7 @@ export class Ledger {
    * externalCurrency prop. This should only be invoked when accounting
    * is disabled.
    */
-  _getExternalCurrency(): Currency {
+  externalCurrency(): Currency {
     if (!this._externalCurrency) throw new Error("No External Currency Set");
     return this._externalCurrency;
   }

--- a/packages/sourcecred/src/core/ledger/ledger.test.js
+++ b/packages/sourcecred/src/core/ledger/ledger.test.js
@@ -1845,6 +1845,10 @@ describe("core/ledger/ledger", () => {
             .disableAccounting();
           expect(ledger.account(id1).balance).toBe(G.ZERO);
           expect(ledger.account(id1).active).toBe(false);
+
+          // ensure no timestamps are out of order
+          const serializedResult = ledger.eventLog();
+          expect(() => Ledger.fromEventLog(serializedResult)).not.toThrow();
         });
         it("accounts with relevant payout addresses can be active", () => {
           const ledger = ledgerWithActiveIdentities();

--- a/packages/sourcecred/src/core/ledger/ledger.test.js
+++ b/packages/sourcecred/src/core/ledger/ledger.test.js
@@ -46,11 +46,11 @@ const allocationId3: uuid.Uuid = uuid.random();
 function getAccountingStatus(
   enabled: boolean,
   chainId = "1",
-  trackDistributions = false
+  trackGrainIntegration = false
 ): AccountingStatus {
   return {
     enabled,
-    trackDistributions,
+    trackGrainIntegration,
     currency: buildCurrency(chainId, ETH_CURRENCY_ADDRESS),
   };
 }
@@ -1795,7 +1795,7 @@ describe("core/ledger/ledger", () => {
           ).removeExternalCurrency();
           expect(l.accounting()).toEqual({
             enabled: true,
-            trackDistributions: false,
+            trackGrainIntegration: false,
           });
         });
         it("cannot be unset if accounting is disabled", () => {

--- a/packages/sourcecred/src/core/ledger/ledger.test.js
+++ b/packages/sourcecred/src/core/ledger/ledger.test.js
@@ -1,7 +1,7 @@
 // @flow
 
 import {NodeAddress} from "../graph";
-import {Ledger} from "./ledger";
+import {Ledger, type AccountingStatus} from "./ledger";
 import {newIdentity} from "../identity";
 import {
   parseAddress as parseEthAddress,
@@ -12,6 +12,7 @@ import {
   parseEvmChainId,
   protocolSymbolParser,
   getCurrencyKey,
+  buildCurrency,
 } from "./currency";
 import * as G from "./grain";
 import * as uuid from "../../util/uuid";
@@ -41,6 +42,22 @@ const {setFakeDate} = dateMock;
 const allocationId1: uuid.Uuid = uuid.random();
 const allocationId2: uuid.Uuid = uuid.random();
 const allocationId3: uuid.Uuid = uuid.random();
+
+function getAccountingStatus(
+  enabled: boolean,
+  chainId = "1"
+): AccountingStatus {
+  return {
+    enabled,
+    currency: buildCurrency(chainId, ETH_CURRENCY_ADDRESS),
+  };
+}
+const fullAddress = parseEthAddress(
+  "0xffffffffffffffffffffffffffffffffffffffff"
+);
+const nearlyFullAddress = parseEthAddress(
+  "0xfffffffffffffffffffffffffffffffffffffff0"
+);
 
 describe("core/ledger/ledger", () => {
   const alias = {
@@ -1756,6 +1773,163 @@ describe("core/ledger/ledger", () => {
               true
             );
           });
+        });
+      });
+      describe("external currency", () => {
+        it("is empty by default", () => {
+          const l = ledgerWithActiveIdentities();
+          expect(l.accounting().currency).toEqual(undefined);
+        });
+        it("can be set", () => {
+          const l = ledgerWithActiveIdentities();
+          l.setExternalCurrency(parseEvmChainId("1"), ETH_CURRENCY_ADDRESS);
+          expect(l.accounting()).toEqual(getAccountingStatus(true));
+        });
+        it("can be unset", () => {
+          const l = ledgerWithActiveIdentities();
+          l.setExternalCurrency(
+            parseEvmChainId("1"),
+            ETH_CURRENCY_ADDRESS
+          ).removeExternalCurrency();
+          expect(l.accounting()).toEqual({enabled: true});
+        });
+        it("cannot be unset if accounting is disabled", () => {
+          const l = ledgerWithActiveIdentities();
+          l.setExternalCurrency(
+            parseEvmChainId("1"),
+            ETH_CURRENCY_ADDRESS
+          ).disableAccounting();
+          const thunk = () => l.removeExternalCurrency();
+          expect(thunk).toThrowError("Cannot remove the external currency");
+        });
+        it("can call setExternalCurrency to update external currency", () => {
+          const ledger = ledgerWithActiveIdentities()
+            .setExternalCurrency(parseEvmChainId("1"), ETH_CURRENCY_ADDRESS)
+            .setExternalCurrency(parseEvmChainId("100"), ETH_CURRENCY_ADDRESS);
+          expect(ledger.accounting()).toEqual(getAccountingStatus(true, "100"));
+        });
+      });
+      describe("balance accounting", () => {
+        it("is enabled by default", () => {
+          const l = ledgerWithActiveIdentities();
+          expect(l.accounting().enabled).toEqual(true);
+        });
+        it("can be disabled and reenabled", () => {
+          const l = ledgerWithActiveIdentities();
+          expect(
+            l
+              .setExternalCurrency(parseEvmChainId("1"), ETH_CURRENCY_ADDRESS)
+              .disableAccounting()
+              .accounting()
+          ).toEqual(getAccountingStatus(false));
+          expect(l.enableAccounting().accounting()).toEqual(
+            getAccountingStatus(true)
+          );
+        });
+        it("zeros out grain balances and disables accounts without Payout Addresses", () => {
+          const ledger = ledgerWithActiveIdentities();
+          ledger._allocateGrain({
+            grainReceipt: {id: id1, amount: g("2")},
+            allocationId: allocationId1,
+            credTimestampMs: 1,
+          });
+          expect(ledger.account(id1).balance).toBe(g("2"));
+          expect(ledger.account(id1).active).toBe(true);
+          ledger
+            .setExternalCurrency(parseEvmChainId("1"), ETH_CURRENCY_ADDRESS)
+            .disableAccounting();
+          expect(ledger.account(id1).balance).toBe(G.ZERO);
+          expect(ledger.account(id1).active).toBe(false);
+        });
+        it("accounts with relevant payout addresses can be active", () => {
+          const ledger = ledgerWithActiveIdentities();
+          ledger._allocateGrain({
+            grainReceipt: {id: id1, amount: g("2")},
+            allocationId: allocationId1,
+            credTimestampMs: 1,
+          });
+          ledger._allocateGrain({
+            grainReceipt: {id: id2, amount: g("5")},
+            allocationId: allocationId2,
+            credTimestampMs: 1,
+          });
+          ledger.setPayoutAddress(
+            id1,
+            fullAddress,
+            parseEvmChainId("1"),
+            ETH_CURRENCY_ADDRESS
+          );
+          ledger.setPayoutAddress(
+            id2,
+            nearlyFullAddress,
+            // inactive chainID
+            parseEvmChainId("2"),
+            ETH_CURRENCY_ADDRESS
+          );
+          ledger
+            .setExternalCurrency(parseEvmChainId("1"), ETH_CURRENCY_ADDRESS)
+            .disableAccounting();
+          expect(ledger.account(id1).active).toBe(true);
+          expect(ledger.account(id2).active).toBe(false);
+        });
+        it("disables grain transfers when accounting is disabled", () => {
+          const ledger = ledgerWithActiveIdentities();
+          ledger._allocateGrain({
+            grainReceipt: {id: id1, amount: g("2")},
+            allocationId: allocationId1,
+            credTimestampMs: 1,
+          });
+          ledger._allocateGrain({
+            grainReceipt: {id: id2, amount: g("5")},
+            allocationId: allocationId2,
+            credTimestampMs: 1,
+          });
+          ledger
+            .setExternalCurrency(parseEvmChainId("1"), ETH_CURRENCY_ADDRESS)
+            .disableAccounting();
+          const thunk = () =>
+            ledger.transferGrain({
+              from: id2,
+              to: id1,
+              amount: g("1"),
+              memo: null,
+            });
+          expect(thunk).toThrowError("Transfers are disabled");
+        });
+        it(
+          "cannot activate a user missing the matching " +
+            "payoutaddress when accounting is disabled",
+          () => {
+            const ledger = ledgerWithActiveIdentities();
+            ledger.setExternalCurrency(
+              parseEvmChainId("1"),
+              ETH_CURRENCY_ADDRESS
+            );
+            const thunk = () => ledger.activate(id1);
+            expect(thunk).toThrowError("No payout address set");
+
+            ledger.setPayoutAddress(
+              id1,
+              fullAddress,
+              parseEvmChainId("2"),
+              ETH_CURRENCY_ADDRESS
+            );
+            expect(thunk).toThrowError("No payout address set");
+
+            ledger.setPayoutAddress(
+              id1,
+              fullAddress,
+              parseEvmChainId("1"),
+              ETH_CURRENCY_ADDRESS
+            );
+            ledger.activate(id1);
+            expect(ledger.account(id1).active).toBe(true);
+          }
+        );
+        it("cannot disable accounting without a configured external currency", () => {
+          const ledger = ledgerWithActiveIdentities();
+          const thunk = () => ledger.disableAccounting();
+          expect(thunk).toThrowError("No External Currency Set");
         });
       });
     });

--- a/packages/sourcecred/src/core/ledger/ledger.test.js
+++ b/packages/sourcecred/src/core/ledger/ledger.test.js
@@ -1713,30 +1713,30 @@ describe("core/ledger/ledger", () => {
               "action": {
                 type: "ENABLE_GRAIN_INTEGRATION",
               },
-              ledgerTimestamp: 5,
-              uuid: "000000000000000000024A",
+              ledgerTimestamp: 6,
+              uuid: "000000000000000000025A",
               version: "1",
             },
             {
-              uuid: "000000000000000000025A",
+              uuid: "000000000000000000026A",
               version: "1",
-              ledgerTimestamp: 6,
+              ledgerTimestamp: 7,
               action: {
                 "distribution": {
                   "allocations": [],
                   "credTimestamp": 1,
-                  "id": "000000000000000000023A",
+                  "id": "000000000000000000024A",
                 },
                 type: "DISTRIBUTE_GRAIN",
               },
             },
             {
               "action": {
-                "id": "000000000000000000023A",
+                "id": "000000000000000000024A",
                 "type": "MARK_DISTRIBUTION_EXECUTED",
               },
-              "ledgerTimestamp": 7,
-              "uuid": "000000000000000000026A",
+              "ledgerTimestamp": 8,
+              "uuid": "000000000000000000027A",
               "version": "1",
             },
           ]);
@@ -1906,10 +1906,9 @@ describe("core/ledger/ledger", () => {
             "payoutaddress when accounting is disabled",
           () => {
             const ledger = ledgerWithActiveIdentities();
-            ledger.setExternalCurrency(
-              parseEvmChainId("1"),
-              ETH_CURRENCY_ADDRESS
-            );
+            ledger
+              .setExternalCurrency(parseEvmChainId("1"), ETH_CURRENCY_ADDRESS)
+              .disableAccounting();
             const thunk = () => ledger.activate(id1);
             expect(thunk).toThrowError("No payout address set");
 
@@ -1929,6 +1928,7 @@ describe("core/ledger/ledger", () => {
             );
             ledger.activate(id1);
             expect(ledger.account(id1).active).toBe(true);
+            expect(ledger.accounting().enabled).toBe(false);
           }
         );
         it("cannot disable accounting without a configured external currency", () => {

--- a/packages/sourcecred/src/core/ledger/ledger.test.js
+++ b/packages/sourcecred/src/core/ledger/ledger.test.js
@@ -45,10 +45,12 @@ const allocationId3: uuid.Uuid = uuid.random();
 
 function getAccountingStatus(
   enabled: boolean,
-  chainId = "1"
+  chainId = "1",
+  trackDistributions = false
 ): AccountingStatus {
   return {
     enabled,
+    trackDistributions,
     currency: buildCurrency(chainId, ETH_CURRENCY_ADDRESS),
   };
 }
@@ -1791,7 +1793,10 @@ describe("core/ledger/ledger", () => {
             parseEvmChainId("1"),
             ETH_CURRENCY_ADDRESS
           ).removeExternalCurrency();
-          expect(l.accounting()).toEqual({enabled: true});
+          expect(l.accounting()).toEqual({
+            enabled: true,
+            trackDistributions: false,
+          });
         });
         it("cannot be unset if accounting is disabled", () => {
           const l = ledgerWithActiveIdentities();


### PR DESCRIPTION
# Description

When utilizing an on chain grain integration, tracking account balances
in the SourceCred ledger makes little sense. These changes disable
balance accounting, while preserving the functionality key to
SourceCred, which is tracking distributions across identities. While
balances are no longer tracked, paid totals will continue to be. This
feature, combined with Distribution execution tracking, narrows the
scope of the ledgers focus to the state of distributions, and whether or
not they have been executed outside of SourceCred.

When account balance tracking is disabled, the following changes are
made to ledger behavior:
- all grain balances are zeroed out in mutable accounts tracked by the
  ledger
- grain transfers are disabled
- The ledger stores the currently configured `integrationCurrency` at the instant
  accounting is disabled as `externalCurrency`. This allows for the configuration
  to be historically tracked in case the configuration is accidentally changed, and
  allows for more predictable behavior in the ledger in this mode. If the `integrationCurrency`
  needs to be updated, the `disableAccounting` method can just be re-run with the
  new currency to update the configuration within the ledger.
- distributed grain is not added to a user's balance. the paid total is
  updated, however. Undistributed balances are tracked as a whole through
  the distribution tracking functionality added earlier.
- identities without a relevant payout address will be deactivated
- identities that have no relevant payout addresses configured cannot be
  activated. relevant means the external currency configured in the
  ledger's state.

Now that all integration functionality has settled in the ledger, the `executeGrainIntegration`
interface can be simplified and cleaned up. No information has been
lost; Config details can now simply be queried from the ledger directly.

Config inconsistencies are now tracked in the main/grain.js API file.
The main api will be tracking changes to the external currency config and
update the ledger dynamically before any integrations run. This seemed like
the best compromise between "magic" and usability. I think it's important that
the ledger tracks all integration currency changes for the purpose of transparency,
but also using a config file seems to be the best input method for now. This
tracking can be deprecated when we migrate to a webUI for config management.

test plan: unit tests have been updated

# Test Plan

Unit tests included

# Merge Plan
[merge plan can be found here](https://github.com/sourcecred/sourcecred/issues/3139#issuecomment-978073574)
# Future Work

~~The current entry point is integration currency config in the `grain.json` config file. However, I'd really like to set up a CLI dialog for setting this and other integration config in the near-term. This is a hard requirement for the smart contract deployment for the merkle distribution integration, so I might as well include these few extra dialogs as a part of that story.~~


Update: I ended up just creating config entries in config/grain.json that are checked against the ledger every time grain distribution runs via the CLI.