### PR TITLE
support delimiter for Discord's guildid

### DIFF
--- a/packages/sourcecred/src/plugins/discord/config.js
+++ b/packages/sourcecred/src/plugins/discord/config.js
@@ -71,7 +71,7 @@ export type DiscordConfigJson = $ReadOnlyArray<{|
 const parserJson: C.Parser<DiscordConfigJson> = C.array(
   C.object(
     {
-      guildId: C.string,
+      guildId: C.delimited("//"),
       reactionWeightConfig: C.object(
         {
           weights: C.dict(C.number),

--- a/packages/sourcecred/src/plugins/discord/config.test.js
+++ b/packages/sourcecred/src/plugins/discord/config.test.js
@@ -6,7 +6,7 @@ describe("plugins/discord/config", () => {
   it("can load a basic config", () => {
     const raw = [
       {
-        guildId: "453243919774253079//sourcecred",
+        guildId: "453243919774253079",
         reactionWeightConfig: {
           weights: {
             "🥰": 4,
@@ -90,5 +90,68 @@ describe("plugins/discord/config", () => {
       defaultWeight: 1,
     });
     expect(parsed[0].includeNsfwChannels).toEqual(false);
+  });
+  it("can work with delimiters", () => {
+    const raw = [
+      {
+        guildId: "453243919774253079//sourcecred",
+        reactionWeightConfig: {
+          weights: {
+            "🥰": 4,
+            "sourcecred:626763367893303303": 16,
+          },
+          applyAveraging: true,
+          defaultWeight: 2,
+        },
+        roleWeightConfig: {
+          defaultWeight: 0,
+          weights: {
+            "759191073943191613//first-role": 0.5,
+            "762085832181153872//second-role": 1,
+            "698296035889381403": 1,
+          },
+        },
+        channelWeightConfig: {
+          defaultWeight: 0,
+          weights: {
+            "759191073943191613//channel name": 0.25,
+          },
+        },
+        includeNsfwChannels: true,
+      },
+    ];
+    const expected = [
+      {
+        guildId: "453243919774253079",
+        propsChannels: [],
+        weights: {
+          emojiWeights: {
+            weights: {
+              "🥰": 4,
+              "sourcecred:626763367893303303": 16,
+            },
+            applyAveraging: true,
+            defaultWeight: 2,
+          },
+          channelWeights: {
+            defaultWeight: 0,
+            weights: {
+              "759191073943191613": 0.25,
+            },
+          },
+          roleWeights: {
+            defaultWeight: 0,
+            weights: {
+              "759191073943191613": 0.5,
+              "762085832181153872": 1,
+              "698296035889381403": 1,
+            },
+          },
+        },
+        includeNsfwChannels: true,
+      },
+    ];
+    const parsed: DiscordConfigs = parser.parseOrThrow(raw);
+    expect(parsed).toEqual(expected);
   });
 });

--- a/packages/sourcecred/src/plugins/discord/config.test.js
+++ b/packages/sourcecred/src/plugins/discord/config.test.js
@@ -6,7 +6,7 @@ describe("plugins/discord/config", () => {
   it("can load a basic config", () => {
     const raw = [
       {
-        guildId: "453243919774253079",
+        guildId: "453243919774253079//sourcecred",
         reactionWeightConfig: {
           weights: {
             "🥰": 4,


### PR DESCRIPTION
<!-- Please read our contributor guide before submitting your PR: -->
<!-- https://github.com/sourcecred/sourcecred/blob/master/CONTRIBUTING.md -->

# Description

Enable to delimiter to `guildId` in order to recognize numbers and id just like comments
as described in #3178
<!-- Possible prompts:
  Why is the change important?
  Did you consider and reject alternate formulations of the same idea?
  Are there relevant issues or discussions elsewhere?
-->

# Test Plan

Unit tests included with an example of delimiter.
<!-- Possible prompts:
  How well covered by automated tests is this change?
  How did you manually test this change? How can a reviewer replicate the tests?
-->
