### PR TITLE
Discord: add support for Channel Category weights

### DIFF
--- a/packages/sourcecred/src/plugins/discord/__snapshots__/fetcher.test.js.snap
+++ b/packages/sourcecred/src/plugins/discord/__snapshots__/fetcher.test.js.snap
@@ -6,60 +6,70 @@ Array [
     "id": "678348980756938813",
     "name": "Text Channels",
     "nsfw": false,
+    "parentId": null,
     "type": "GUILD_CATEGORY",
   },
   Object {
     "id": "678348980798881844",
     "name": "Voice Channels",
     "nsfw": false,
+    "parentId": null,
     "type": "GUILD_CATEGORY",
   },
   Object {
     "id": "678348980849213472",
     "name": "general",
     "nsfw": false,
+    "parentId": "678348980756938813",
     "type": "GUILD_TEXT",
   },
   Object {
     "id": "678348980878573661",
     "name": "General",
     "nsfw": false,
+    "parentId": "678348980798881844",
     "type": "GUILD_VOICE",
   },
   Object {
     "id": "678394406507905129",
     "name": "pagination",
     "nsfw": false,
+    "parentId": "678348980756938813",
     "type": "GUILD_TEXT",
   },
   Object {
     "id": "678696874869522446",
     "name": "notmymessage",
     "nsfw": false,
+    "parentId": "678348980756938813",
     "type": "GUILD_TEXT",
   },
   Object {
     "id": "830088231538130964",
     "name": "rules",
     "nsfw": false,
+    "parentId": null,
     "type": "GUILD_TEXT",
   },
   Object {
     "id": "830088231538130965",
     "name": "moderator-only",
     "nsfw": false,
+    "parentId": null,
     "type": "GUILD_TEXT",
   },
   Object {
     "id": "830089044695187586",
     "name": "test stage",
     "nsfw": false,
+    "parentId": "678348980798881844",
     "type": "UNKNOWN",
   },
   Object {
     "id": "837851969795129344",
     "name": "test-nsfw",
     "nsfw": true,
+    "parentId": "678348980756938813",
     "type": "GUILD_TEXT",
   },
 ]
@@ -89,8 +99,8 @@ Array [
   Object {
     "nick": null,
     "roles": Array [
-      "678349848684003359",
       "678350026946117694",
+      "678349848684003359",
     ],
     "user": Object {
       "bot": false,
@@ -126,21 +136,21 @@ Array [
   Object {
     "nick": null,
     "roles": Array [
-      "678349848684003359",
       "678350026946117694",
+      "678349848684003359",
     ],
     "user": Object {
       "bot": false,
       "discriminator": "3370",
       "id": "420341518948237331",
-      "username": "DandeLion",
+      "username": "dandelion",
     },
   },
   Object {
     "nick": null,
     "roles": Array [
-      "678349848684003359",
       "678350026946117694",
+      "678349848684003359",
     ],
     "user": Object {
       "bot": false,
@@ -152,8 +162,8 @@ Array [
   Object {
     "nick": null,
     "roles": Array [
-      "678349848684003359",
       "678350026946117694",
+      "678349848684003359",
     ],
     "user": Object {
       "bot": false,
@@ -165,8 +175,8 @@ Array [
   Object {
     "nick": null,
     "roles": Array [
-      "678349848684003359",
       "678350026946117694",
+      "678349848684003359",
     ],
     "user": Object {
       "bot": false,
@@ -185,6 +195,16 @@ Array [
       "discriminator": "3969",
       "id": "579830927287386126",
       "username": "sandpiper",
+    },
+  },
+  Object {
+    "nick": null,
+    "roles": Array [],
+    "user": Object {
+      "bot": false,
+      "discriminator": "7902",
+      "id": "664562775770791966",
+      "username": "BrianBelhumeur",
     },
   },
   Object {

--- a/packages/sourcecred/src/plugins/discord/config.js
+++ b/packages/sourcecred/src/plugins/discord/config.js
@@ -48,7 +48,7 @@ export type DiscordConfigJson = $ReadOnlyArray<{|
   // Note that roles use a snowflake id only.
   // defaultWeight is used to set weights for members who don't have a specified role
   +roleWeightConfig?: RoleWeightConfig,
-  // An object mapping a channel to a weight, as in:
+  // An object mapping a channel or a channel category to a weight, as in:
   // {
   //   "defaultWeight": 0,
   //   "weights": {
@@ -56,7 +56,10 @@ export type DiscordConfigJson = $ReadOnlyArray<{|
   //   }
   // }
   // Note that channels use a snowflake id only.
-  // defaultWeight is used to set weights for channels that don't have a specified weight
+  // If both a channel and a category weight apply to a channel, they will be multiplied
+  // defaultWeight is used to set weights for channels and categories that don't have a specified weight
+  // this means that defaultWeight^2 is used when neither a channel nor a category weight is specified
+  // we therefore only recommend a defaultWeight of 1 or 0
   +channelWeightConfig?: ChannelWeightConfig,
   // List of channels which are considered "props channels".
   // In a props channel, we have an extra rule: if someone is mentioned in a message,

--- a/packages/sourcecred/src/plugins/discord/createGraph.js
+++ b/packages/sourcecred/src/plugins/discord/createGraph.js
@@ -231,6 +231,7 @@ export type GraphMessage = {|
   +channelId: Model.Snowflake,
   // Included because we want the channel name in the node description.
   +channelName: string,
+  +channelParentId?: Model.Snowflake,
 |};
 
 /**
@@ -284,6 +285,7 @@ export function* findGraphMessages(
         mentions,
         channelName: channel.name,
         channelId: channel.id,
+        channelParentId: channel.parentId,
       };
     }
   }
@@ -316,6 +318,7 @@ export function _createGraphFromMessages(
       mentions,
       channelName,
       channelId,
+      channelParentId,
     } = graphMessage;
     if (author) {
       wg.graph.addNode(memberNode(author));
@@ -333,7 +336,8 @@ export function _createGraphFromMessages(
           reaction,
           reactingMember,
           propsChannels,
-          reactions
+          reactions,
+          channelParentId
         )
       );
       wg.graph.addNode(node);

--- a/packages/sourcecred/src/plugins/discord/fetcher.js
+++ b/packages/sourcecred/src/plugins/discord/fetcher.js
@@ -123,6 +123,7 @@ export class Fetcher implements DiscordApi {
     const channels = await this._fetchJson(`/guilds/${guild}/channels`);
     return channels.map((x) => ({
       id: x.id,
+      parentId: x.parent_id,
       name: x.name,
       type: Model.channelTypeFromId(x.type),
       nsfw: x.nsfw,

--- a/packages/sourcecred/src/plugins/discord/mirror.js
+++ b/packages/sourcecred/src/plugins/discord/mirror.js
@@ -34,7 +34,7 @@ export class Mirror {
     for (const channel of channels) {
       reporter.start(`discord/${guild.name}/#${channel.name}`);
       try {
-        await this.addMessages(channel.id);
+        await this.addMessages(channel.id, channel.parentId);
       } catch (e) {
         const warn = e?.message?.includes("403")
           ? "Skipping private channel."
@@ -82,6 +82,7 @@ export class Mirror {
 
   async addMessages(
     channel: Model.Snowflake,
+    category?: Model.Snowflake,
     messageLimit?: number
   ): Promise<$ReadOnlyArray<Model.Message>> {
     const loadStart = this._repo.nthMessageFromTail(channel, RELOAD_DEPTH);

--- a/packages/sourcecred/src/plugins/discord/mirrorRepository.js
+++ b/packages/sourcecred/src/plugins/discord/mirrorRepository.js
@@ -74,7 +74,8 @@ export class SqliteMirrorRepository {
         CREATE TABLE channels (
             id TEXT PRIMARY KEY,
             type TEXT NOT NULL,
-            name TEXT NOT NULL
+            name TEXT NOT NULL,
+            parent_id TEXT
         )
       `,
       dedent`\
@@ -173,10 +174,17 @@ export class SqliteMirrorRepository {
         SELECT
           id,
           type,
-          name
+          name,
+          parent_id
         FROM channels`
       )
-      .all();
+      .all()
+      .map((res) => ({
+        id: res.id,
+        type: res.type,
+        name: res.name,
+        parentId: res.parent_id,
+      }));
   }
 
   messages(channel: Model.Snowflake): $ReadOnlyArray<Model.Message> {
@@ -314,11 +322,13 @@ export class SqliteMirrorRepository {
           INSERT OR IGNORE INTO channels (
               id,
               type,
-              name
+              name,
+              parent_id
           ) VALUES (
               :id,
               :type,
-              :name
+              :name,
+              :parent_id
           )
         `
       )
@@ -326,6 +336,7 @@ export class SqliteMirrorRepository {
         id: channel.id,
         type: channel.type,
         name: channel.name,
+        parent_id: channel.parentId || null,
       });
   }
 

--- a/packages/sourcecred/src/plugins/discord/models.js
+++ b/packages/sourcecred/src/plugins/discord/models.js
@@ -50,6 +50,7 @@ export type Channel = {|
   +type: ChannelType,
   +name: string,
   +nsfw?: boolean,
+  +parentId?: Snowflake,
 |};
 
 export type Role = {|

--- a/packages/sourcecred/src/plugins/discord/snapshots/aHR0cHM6Ly9kaXNjb3JkYXBwLmNvbS9hcGkvZ3VpbGRzLzY3ODM0ODk4MDYzOTQ5ODQyOA
+++ b/packages/sourcecred/src/plugins/discord/snapshots/aHR0cHM6Ly9kaXNjb3JkYXBwLmNvbS9hcGkvZ3VpbGRzLzY3ODM0ODk4MDYzOTQ5ODQyOA
@@ -6,8 +6,8 @@
   "splash": null,
   "discovery_splash": null,
   "features": [
-    "COMMUNITY",
-    "NEWS"
+    "NEWS",
+    "COMMUNITY"
   ],
   "emojis": [
     {
@@ -20,6 +20,7 @@
       "available": true
     }
   ],
+  "stickers": [],
   "banner": null,
   "owner_id": "420341518948237331",
   "application_id": null,
@@ -40,7 +41,9 @@
       "hoist": false,
       "managed": false,
       "mentionable": false,
-      "permissions_new": "6476071936"
+      "icon": null,
+      "unicode_emoji": null,
+      "permissions_new": "1071627961344"
     },
     {
       "id": "678349848684003359",
@@ -51,6 +54,8 @@
       "hoist": false,
       "managed": false,
       "mentionable": false,
+      "icon": null,
+      "unicode_emoji": null,
       "permissions_new": "6546775617"
     },
     {
@@ -62,6 +67,8 @@
       "hoist": false,
       "managed": false,
       "mentionable": false,
+      "icon": null,
+      "unicode_emoji": null,
       "permissions_new": "6546775625"
     },
     {
@@ -73,6 +80,8 @@
       "hoist": false,
       "managed": true,
       "mentionable": false,
+      "icon": null,
+      "unicode_emoji": null,
       "tags": {
         "bot_id": "678351352770068560"
       },
@@ -87,6 +96,8 @@
       "hoist": false,
       "managed": true,
       "mentionable": false,
+      "icon": null,
+      "unicode_emoji": null,
       "tags": {
         "bot_id": "728738433199112280"
       },
@@ -101,6 +112,8 @@
       "hoist": false,
       "managed": true,
       "mentionable": false,
+      "icon": null,
+      "unicode_emoji": null,
       "tags": {
         "bot_id": "761705425870782516"
       },
@@ -115,6 +128,8 @@
       "hoist": false,
       "managed": true,
       "mentionable": false,
+      "icon": null,
+      "unicode_emoji": null,
       "tags": {
         "bot_id": "758370311774404618"
       },
@@ -129,6 +144,8 @@
       "hoist": false,
       "managed": true,
       "mentionable": false,
+      "icon": null,
+      "unicode_emoji": null,
       "tags": {
         "bot_id": "772886503830323210"
       },
@@ -139,7 +156,7 @@
   "mfa_level": 0,
   "explicit_content_filter": 2,
   "max_presences": null,
-  "max_members": 100000,
+  "max_members": 250000,
   "max_video_channel_users": 25,
   "vanity_url_code": null,
   "premium_tier": 0,
@@ -148,7 +165,9 @@
   "preferred_locale": "en-US",
   "rules_channel_id": "830088231538130964",
   "public_updates_channel_id": "830088231538130965",
+  "hub_type": null,
   "nsfw": false,
+  "nsfw_level": 0,
   "embed_enabled": false,
   "embed_channel_id": null
 }

--- a/packages/sourcecred/src/plugins/discord/snapshots/aHR0cHM6Ly9kaXNjb3JkYXBwLmNvbS9hcGkvZ3VpbGRzLzY3ODM0ODk4MDYzOTQ5ODQyOC9jaGFubmVscw
+++ b/packages/sourcecred/src/plugins/discord/snapshots/aHR0cHM6Ly9kaXNjb3JkYXBwLmNvbS9hcGkvZ3VpbGRzLzY3ODM0ODk4MDYzOTQ5ODQyOC9jaGFubmVscw
@@ -21,7 +21,7 @@
   },
   {
     "id": "678348980849213472",
-    "last_message_id": "837852251984363589",
+    "last_message_id": "841261006906327070",
     "type": 0,
     "name": "general",
     "position": 0,
@@ -34,6 +34,7 @@
   },
   {
     "id": "678348980878573661",
+    "last_message_id": null,
     "type": 2,
     "name": "General",
     "position": 0,
@@ -95,7 +96,7 @@
   },
   {
     "id": "830088231538130965",
-    "last_message_id": "830088232083521567",
+    "last_message_id": "870202554259214396",
     "type": 0,
     "name": "moderator-only",
     "position": 0,
@@ -123,7 +124,7 @@
     "parent_id": "678348980798881844",
     "topic": null,
     "bitrate": 40000,
-    "user_limit": 1000,
+    "user_limit": 10000,
     "rtc_region": null,
     "guild_id": "678348980639498428",
     "permission_overwrites": [

--- a/packages/sourcecred/src/plugins/discord/snapshots/aHR0cHM6Ly9kaXNjb3JkYXBwLmNvbS9hcGkvZ3VpbGRzLzY3ODM0ODk4MDYzOTQ5ODQyOC9tZW1iZXJzP2FmdGVyPTAmbGltaXQ9MTAwMA
+++ b/packages/sourcecred/src/plugins/discord/snapshots/aHR0cHM6Ly9kaXNjb3JkYXBwLmNvbS9hcGkvZ3VpbGRzLzY3ODM0ODk4MDYzOTQ5ODQyOC9tZW1iZXJzP2FmdGVyPTAmbGltaXQ9MTAwMA
@@ -1,10 +1,11 @@
 [
   {
     "roles": [
-      "678349848684003359",
-      "678350026946117694"
+      "678350026946117694",
+      "678349848684003359"
     ],
     "nick": null,
+    "avatar": null,
     "premium_since": null,
     "joined_at": "2020-02-15T21:16:40.215000+00:00",
     "is_pending": false,
@@ -24,6 +25,7 @@
       "678349848684003359"
     ],
     "nick": null,
+    "avatar": null,
     "premium_since": null,
     "joined_at": "2020-11-02T18:02:40.116000+00:00",
     "is_pending": false,
@@ -43,6 +45,7 @@
       "678349848684003359"
     ],
     "nick": null,
+    "avatar": null,
     "premium_since": null,
     "joined_at": "2021-04-27T01:08:45.585000+00:00",
     "is_pending": false,
@@ -50,7 +53,7 @@
     "user": {
       "id": "318552163649454081",
       "username": "hz",
-      "avatar": "9354e5b8f1227fc95c494d3b08df59a5",
+      "avatar": "4dd1aa262e7e332bf2680428f03793bf",
       "discriminator": "8826",
       "public_flags": 0
     },
@@ -59,18 +62,19 @@
   },
   {
     "roles": [
-      "678349848684003359",
-      "678350026946117694"
+      "678350026946117694",
+      "678349848684003359"
     ],
     "nick": null,
+    "avatar": null,
     "premium_since": null,
     "joined_at": "2020-02-15T22:31:31.243000+00:00",
     "is_pending": false,
     "pending": false,
     "user": {
       "id": "420341518948237331",
-      "username": "DandeLion",
-      "avatar": "ccec4bb861a03f5c30fb7c68ca672a92",
+      "username": "dandelion",
+      "avatar": "43653169c81b2fdbb9b93cc39d1f0e2a",
       "discriminator": "3370",
       "public_flags": 0
     },
@@ -79,10 +83,11 @@
   },
   {
     "roles": [
-      "678349848684003359",
-      "678350026946117694"
+      "678350026946117694",
+      "678349848684003359"
     ],
     "nick": null,
+    "avatar": null,
     "premium_since": null,
     "joined_at": "2020-02-15T22:21:55.613000+00:00",
     "is_pending": false,
@@ -99,10 +104,11 @@
   },
   {
     "roles": [
-      "678349848684003359",
-      "678350026946117694"
+      "678350026946117694",
+      "678349848684003359"
     ],
     "nick": null,
+    "avatar": null,
     "premium_since": null,
     "joined_at": "2020-02-16T00:45:23.478000+00:00",
     "is_pending": false,
@@ -119,10 +125,11 @@
   },
   {
     "roles": [
-      "678349848684003359",
-      "678350026946117694"
+      "678350026946117694",
+      "678349848684003359"
     ],
     "nick": null,
+    "avatar": null,
     "premium_since": null,
     "joined_at": "2020-10-02T18:07:37.732000+00:00",
     "is_pending": false,
@@ -130,7 +137,7 @@
     "user": {
       "id": "489154203714060300",
       "username": "topocount",
-      "avatar": "ae3bc648fc34000087134ff7eb9a7533",
+      "avatar": "bfeb654e20eb959163e64a206c517e1d",
       "discriminator": "1337",
       "public_flags": 0
     },
@@ -142,6 +149,7 @@
       "678350026946117694"
     ],
     "nick": null,
+    "avatar": null,
     "premium_since": null,
     "joined_at": "2020-10-02T18:07:44.893000+00:00",
     "is_pending": false,
@@ -157,10 +165,29 @@
     "deaf": false
   },
   {
+    "roles": [],
+    "nick": null,
+    "avatar": null,
+    "premium_since": null,
+    "joined_at": "2021-05-10T10:30:53.883000+00:00",
+    "is_pending": false,
+    "pending": false,
+    "user": {
+      "id": "664562775770791966",
+      "username": "BrianBelhumeur",
+      "avatar": "02425177ceec3724217793f7e26b2b7b",
+      "discriminator": "7902",
+      "public_flags": 0
+    },
+    "mute": false,
+    "deaf": false
+  },
+  {
     "roles": [
       "678359229433905152"
     ],
     "nick": null,
+    "avatar": null,
     "premium_since": null,
     "joined_at": "2020-02-15T21:57:23.609000+00:00",
     "is_pending": false,
@@ -181,6 +208,7 @@
       "728740243926286386"
     ],
     "nick": null,
+    "avatar": null,
     "premium_since": null,
     "joined_at": "2020-07-03T22:33:33.496000+00:00",
     "is_pending": false,
@@ -201,6 +229,7 @@
       "767909888226492448"
     ],
     "nick": null,
+    "avatar": null,
     "premium_since": null,
     "joined_at": "2020-10-20T00:39:44.545000+00:00",
     "is_pending": false,
@@ -221,6 +250,7 @@
       "761706197606334535"
     ],
     "nick": null,
+    "avatar": null,
     "premium_since": null,
     "joined_at": "2020-10-02T21:48:29.344000+00:00",
     "is_pending": false,
@@ -241,6 +271,7 @@
       "772890579632652339"
     ],
     "nick": null,
+    "avatar": null,
     "premium_since": null,
     "joined_at": "2020-11-02T18:31:13.848000+00:00",
     "is_pending": false,

--- a/packages/sourcecred/src/plugins/discord/snapshots/aHR0cHM6Ly9kaXNjb3JkYXBwLmNvbS9hcGkvZ3VpbGRzLzY3ODM0ODk4MDYzOTQ5ODQyOC9yb2xlcw
+++ b/packages/sourcecred/src/plugins/discord/snapshots/aHR0cHM6Ly9kaXNjb3JkYXBwLmNvbS9hcGkvZ3VpbGRzLzY3ODM0ODk4MDYzOTQ5ODQyOC9yb2xlcw
@@ -8,7 +8,9 @@
     "hoist": false,
     "managed": false,
     "mentionable": false,
-    "permissions_new": "6476071936"
+    "icon": null,
+    "unicode_emoji": null,
+    "permissions_new": "1071627961344"
   },
   {
     "id": "678349848684003359",
@@ -19,6 +21,8 @@
     "hoist": false,
     "managed": false,
     "mentionable": false,
+    "icon": null,
+    "unicode_emoji": null,
     "permissions_new": "6546775617"
   },
   {
@@ -30,6 +34,8 @@
     "hoist": false,
     "managed": false,
     "mentionable": false,
+    "icon": null,
+    "unicode_emoji": null,
     "permissions_new": "6546775625"
   },
   {
@@ -41,6 +47,8 @@
     "hoist": false,
     "managed": true,
     "mentionable": false,
+    "icon": null,
+    "unicode_emoji": null,
     "tags": {
       "bot_id": "678351352770068560"
     },
@@ -55,6 +63,8 @@
     "hoist": false,
     "managed": true,
     "mentionable": false,
+    "icon": null,
+    "unicode_emoji": null,
     "tags": {
       "bot_id": "728738433199112280"
     },
@@ -69,6 +79,8 @@
     "hoist": false,
     "managed": true,
     "mentionable": false,
+    "icon": null,
+    "unicode_emoji": null,
     "tags": {
       "bot_id": "761705425870782516"
     },
@@ -83,6 +95,8 @@
     "hoist": false,
     "managed": true,
     "mentionable": false,
+    "icon": null,
+    "unicode_emoji": null,
     "tags": {
       "bot_id": "758370311774404618"
     },
@@ -97,6 +111,8 @@
     "hoist": false,
     "managed": true,
     "mentionable": false,
+    "icon": null,
+    "unicode_emoji": null,
     "tags": {
       "bot_id": "772886503830323210"
     },

--- a/packages/sourcecred/src/plugins/discord/snapshots/aHR0cHM6Ly9kaXNjb3JkYXBwLmNvbS9hcGkvdXNlcnMvQG1lL2d1aWxkcw
+++ b/packages/sourcecred/src/plugins/discord/snapshots/aHR0cHM6Ly9kaXNjb3JkYXBwLmNvbS9hcGkvdXNlcnMvQG1lL2d1aWxkcw
@@ -9,6 +9,6 @@
       "NEWS",
       "COMMUNITY"
     ],
-    "permissions_new": "6476071936"
+    "permissions_new": "1071627961344"
   }
 ]


### PR DESCRIPTION
<!-- Please read our contributor guide before submitting your PR: -->
<!-- https://github.com/sourcecred/sourcecred/blob/master/CONTRIBUTING.md -->

# Description
closes https://github.com/sourcecred/sourcecred/issues/3188

This adds support for Category-wide weights on Discord. You can add channel category IDs into the same channelWeightConfig.weights array, and they will be applied. The semantics are:
- **If no weight is set for channel or category,** use defaultWeight^2
- **If a weight is set for channel but not category, or vice versa,** use specified weight * (defaultWeight || 1)
- **If both a channel weight and a category weight is set,** multiply them together

# Design decisions
The defaultWeight^2 looks a little odd, but considering the defaultWeight is generally either 0 or 1, this won't have much effect. This is important for relative weight consistency between various use cases in the case that someone does set a default besides 0 or 1.

I chose to include the category ids in the same configuration array as channel ids because when we build support for threads, the parent_id will be polymorphic to either a category or a channel. We will also have to consider channelGrandparents at that point... wee!

I chose not to follow the existing pattern of attaching the channel metadata to the reactions in the DB because it will be much more efficient to just pass the channel metadata down during createGraph, as I have done. It may be worth changing the channelId to work similarly in the future.
<!-- Possible prompts:
  Why is the change important?
  Did you consider and reject alternate formulations of the same idea?
  Are there relevant issues or discussions elsewhere?
-->

# Test Plan
`yarn test` - updated unit tests thoroughly and also updated snapshot tests

## Manual Testing
1. `yarn clean-all && scdev load` on our prod instance
2. `scdev graph && scdev credrank` to set the baseline and do some basic regression testing
3. Added `"678302244524785699": 99` (PRODUCT category in our server) to the channelWeightConfig.weights array in the discord config file
4. `scdev graph -d` and made sure the node weight changes looked right.
```
NodeAddress["sourcecred","discord","REACTION","670490733077332000","🥳","778446953004007475","875846029881278534"]
Old:    297
New:    3

NodeAddress["sourcecred","discord","REACTION","670490733077332000","🪲","258786206387666944","804454196656209982"]
Old:    297
New:    3

=============================================================
  sourcecred/discord - Summary of Changes
=============================================================
Node Diffs: 0
Node Weight Diffs: 1009
Edge Diffs: 0
Edge Weight Diffs: 0
```

<!-- Possible prompts:
  How well covered by automated tests is this change?
  How did you manually test this change? How can a reviewer replicate the tests?
-->
