### PR TITLE
Initial Cleanup of UI color palette

### DIFF
--- a/packages/sourcecred/src/ui/components/AdminApp.js
+++ b/packages/sourcecred/src/ui/components/AdminApp.js
@@ -38,6 +38,18 @@ const theme = createMuiTheme({
     orange: "#FFDDC6", // color for project/organizations on explorer home
     darkOrange: "#FFAA3D", // color for grain on explorer home
     purple: "#C5A2C5", // color for bots on explorer home
+    white: "#FAFBFD",
+    primary: {
+      main: "#AB92B1",
+      dark: "#7C6881",
+      contrastText: "#fff",
+    },
+    secondary: {
+      light: "#FFD4BD",
+      main: "#DE966F",
+      dark: "#C08565",
+      contrastText: "#fff",
+    },
   },
   overrides: {
     MuiChip: {

--- a/packages/sourcecred/src/ui/components/AdminApp.js
+++ b/packages/sourcecred/src/ui/components/AdminApp.js
@@ -4,7 +4,6 @@ import React, {type Node as ReactNode, useEffect, useState} from "react";
 import {Redirect, Route, useHistory} from "react-router-dom";
 import {Admin, Resource, Layout, Loading} from "react-admin";
 import {createMuiTheme} from "@material-ui/core/styles";
-import pink from "@material-ui/core/colors/pink";
 import {makeStyles} from "@material-ui/core/styles";
 import fakeDataProvider from "ra-data-fakerest";
 import {ExplorerHome} from "./ExplorerHome/ExplorerHome";

--- a/packages/sourcecred/src/ui/components/AdminApp.js
+++ b/packages/sourcecred/src/ui/components/AdminApp.js
@@ -34,29 +34,10 @@ const theme = createMuiTheme({
   palette: {
     type: "dark",
     backgroundColor: "#303030",
-    primary: pink,
-    blueish: "#6174CC",
-    lavender: "#C5A2C5",
-    orange: "#FFDDC6",
-    darkOrange: "#FFAA3D",
-    peach: "#FFF1E8",
-    white: "#FAFBFD",
-    scPink: "#FDBBD1",
-    green: "#4BD76D",
-    sunset: "#FFE9DB",
-    salmon: "#FFE5E1",
-    coral: "#F9D1CB",
-    pink: "#FEDDE8",
-    blue: "#728DFF",
-    purple: "#C5A2C5",
-    violet: "#EDDAEE",
-    warning: {
-      main: "#FFAA3D",
-    },
-    danger: "#FF594D",
-    text: {
-      link: "#31AAEE",
-    },
+    blue: "#6174CC", // color for cred on explorer home
+    orange: "#FFDDC6", // color for project/organizations on explorer home
+    darkOrange: "#FFAA3D", // color for grain on explorer home
+    purple: "#C5A2C5", // color for bots on explorer home
   },
   overrides: {
     MuiChip: {

--- a/packages/sourcecred/src/ui/components/AppBar.js
+++ b/packages/sourcecred/src/ui/components/AppBar.js
@@ -25,10 +25,11 @@ const useStyles = makeStyles(
   (theme) => ({
     toolbar: {
       paddingRight: 24,
+      backgroundColor: theme.palette.primary.dark,
     },
     menuButton: {
-      marginLeft: "0.5em",
-      marginRight: "0.5em",
+      marginLeft: "4px",
+      marginRight: "16px",
     },
     menuButtonIconClosed: {
       transition: theme.transitions.create(["transform"], {
@@ -58,7 +59,7 @@ type Props = {
   children: React.Node,
   classes: Object,
   className: string,
-  color: "default" | "inherit" | "primary" | "secondary" | "transparent",
+  color: "default" | "inherit" | "primary" | "transparent",
   open: boolean,
   isDev: boolean,
 };
@@ -95,7 +96,7 @@ const AppBar = (props: Props): React.Node => {
     children,
     classes: _ /*classesOverride*/,
     className,
-    color = "secondary",
+    color = "primary",
     isDev,
     /*logo*/
     open,
@@ -124,7 +125,7 @@ const AppBar = (props: Props): React.Node => {
             enterDelay={500}
           >
             <IconButton
-              color="inherit"
+              color="white"
               onClick={() => dispatch(toggleSidebar())}
               className={classNames(classes.menuButton)}
             >

--- a/packages/sourcecred/src/ui/components/ExplorerHome/ExplorerHome.js
+++ b/packages/sourcecred/src/ui/components/ExplorerHome/ExplorerHome.js
@@ -751,6 +751,7 @@ export const ExplorerHome = ({
             <FormControlLabel
               control={
                 <Checkbox
+                  color="primary"
                   checked={checkboxes[IdentityTypes.USER]}
                   onChange={handleCheckboxFilter}
                   name={IdentityTypes.USER}
@@ -761,6 +762,7 @@ export const ExplorerHome = ({
             <FormControlLabel
               control={
                 <Checkbox
+                  color="primary"
                   checked={checkboxes[IdentityTypes.BOT]}
                   onChange={handleCheckboxFilter}
                   name={IdentityTypes.BOT}
@@ -771,6 +773,7 @@ export const ExplorerHome = ({
             <FormControlLabel
               control={
                 <Checkbox
+                  color="primary"
                   checked={checkboxes[IdentityTypes.PROJECT]}
                   onChange={handleCheckboxFilter}
                   name={IdentityTypes.PROJECT}
@@ -781,6 +784,7 @@ export const ExplorerHome = ({
             <FormControlLabel
               control={
                 <Checkbox
+                  color="primary"
                   checked={checkboxes[IdentityTypes.ORGANIZATION]}
                   onChange={handleCheckboxFilter}
                   name={IdentityTypes.ORGANIZATION}

--- a/packages/sourcecred/src/ui/components/ExplorerHome/ExplorerHome.js
+++ b/packages/sourcecred/src/ui/components/ExplorerHome/ExplorerHome.js
@@ -108,15 +108,15 @@ const useStyles = makeStyles((theme) => ({
   arrowInput: {width: "40%", display: "inline-block"},
   pageHeader: {color: theme.palette.text.primary},
   credCircle: {
-    borderColor: theme.palette.blueish,
+    borderColor: theme.palette.blue,
     "& .title": {
-      color: theme.palette.blueish,
+      color: theme.palette.blue,
     },
   },
   grainCircle: {
-    borderColor: theme.palette.warning.main,
+    borderColor: theme.palette.darkOrange,
     "& .title": {
-      color: theme.palette.warning.main,
+      color: theme.palette.darkOrange,
     },
   },
   [`label-${IdentityTypes.BOT}`]: {
@@ -132,7 +132,7 @@ const useStyles = makeStyles((theme) => ({
     minWidth: "100px",
   },
   labelCred: {
-    color: theme.palette.blueish,
+    color: theme.palette.blue,
   },
   labelGrain: {
     color: theme.palette.darkOrange,

--- a/packages/sourcecred/src/ui/components/LedgerViewer/LedgerDateFilter.js
+++ b/packages/sourcecred/src/ui/components/LedgerViewer/LedgerDateFilter.js
@@ -63,11 +63,11 @@ export const LedgerDateFilter = (props: LedgerDateFilterProps): ReactNode => {
           <IconButton
             onClick={handleClearStartDate}
             disabled={!startDateFilter}
-            color="secondary"
+            color="primary"
             className={classes.clearButton}
           >
             <span className={classes.clearButtonText}>Clear</span>
-            <ClearIcon color="secondary" fontSize="small" />
+            <ClearIcon color="primary" fontSize="small" />
           </IconButton>
         )}
       </div>
@@ -86,11 +86,11 @@ export const LedgerDateFilter = (props: LedgerDateFilterProps): ReactNode => {
           <IconButton
             onClick={handleClearEndDate}
             disabled={!endDateFilter}
-            color="secondary"
+            color="primary"
             className={classes.clearButton}
           >
             <span className={classes.clearButtonText}>Clear</span>
-            <ClearIcon color="secondary" fontSize="small" />
+            <ClearIcon color="primary" fontSize="small" />
           </IconButton>
         )}
       </div>


### PR DESCRIPTION
# Description
Some initial cleanup of our color palette: 
- removes unused colors
- updates primary/secondary colors to match our logo/branding
- a tiny tweak of the margin on the top bar menu icon so it aligns with the menu icons

The Explorer Home and the Ledger History page still needs some tweaks so they looks nice with the new palette, but I am hoping to get those in pretty soon (ideally before our next release). This at least gets rid of the neon pink (which is the Material UI default secondary color) and is more consistent with our overall brand. 

Take a look at how it all looks:
https://www.loom.com/share/8b099b687a344ad680cd83e6c4790100

# Test Plan
Run `yarn start` and poke around the UI to see if everything looks solid.