### PR TITLE
Discord: Skip channels with a weight of zero

### DIFF
--- a/packages/sourcecred/src/plugins/discord/mirror.test.js
+++ b/packages/sourcecred/src/plugins/discord/mirror.test.js
@@ -6,46 +6,85 @@ import {SqliteMirrorRepository} from "./mirrorRepository";
 import {Mirror} from "./mirror";
 
 describe("plugins/discord/mirror", () => {
-  describe("smoke test", () => {
-    const guildId = "678348980639498428";
-    // const channelId = "678394406507905129";
+  const config = {
+    guildId: "453243919774253079",
+    propsChannels: [],
+    weights: {
+      emojiWeights: {
+        weights: {},
+        applyAveraging: true,
+        defaultWeight: 2,
+      },
+      channelWeights: {
+        defaultWeight: 1,
+        weights: {
+          "759191073943191613": 2,
+          "678348980849213472": 1,
+        },
+      },
+      roleWeights: {
+        defaultWeight: 0,
+        weights: {},
+      },
+    },
+    includeNsfwChannels: true,
+  };
 
-    it("should print", async () => {
-      const includeNsfwChannels = true;
+  describe("smoke test", () => {
+    config.guildId = "678348980639498428";
+
+    it("should omit zero-weighted channels", async () => {
+      config.weights.channelWeights.weights["678348980849213472"] = 0;
       // Given
       const repo = new SqliteMirrorRepository(
         new Database(":memory:"),
-        guildId
+        config.guildId
       );
       const api = snapshotFetcher();
 
       // When
-      const mirror = new Mirror(repo, api, guildId, includeNsfwChannels);
+      const mirror = new Mirror(repo, api, config);
+      await mirror.addMembers();
+      await mirror.addTextChannels();
+      expect(
+        repo.channels().some((channel) => channel.id === "678348980849213472")
+      ).toBe(false);
+    });
+
+    it("should work when NSFW enabled", async () => {
+      config.includeNsfwChannels = true;
+      // Given
+      const repo = new SqliteMirrorRepository(
+        new Database(":memory:"),
+        config.guildId
+      );
+      const api = snapshotFetcher();
+
+      // When
+      const mirror = new Mirror(repo, api, config);
       await mirror.addMembers();
       await mirror.addTextChannels();
       expect(
         repo.channels().some((channel) => channel.name.includes("nsfw"))
       ).toBe(true);
-      // await mirror.addMessages(channelId, 10);
     });
 
-    it("should print", async () => {
-      const includeNsfwChannels = false;
+    it("should work when NSFW disabled", async () => {
+      config.includeNsfwChannels = false;
       // Given
       const repo = new SqliteMirrorRepository(
         new Database(":memory:"),
-        guildId
+        config.guildId
       );
       const api = snapshotFetcher();
 
       // When
-      const mirror = new Mirror(repo, api, guildId, includeNsfwChannels);
+      const mirror = new Mirror(repo, api, config);
       await mirror.addMembers();
       await mirror.addTextChannels();
       expect(
         repo.channels().every((channel) => !channel.name.includes("nsfw"))
       ).toBe(true);
-      // await mirror.addMessages(channelId, 10);
     });
   });
 });

--- a/packages/sourcecred/src/plugins/discord/plugin.js
+++ b/packages/sourcecred/src/plugins/discord/plugin.js
@@ -55,9 +55,9 @@ export class DiscordPlugin implements Plugin {
     const configs = await loadConfig(ctx);
     const token = getTokenFromEnv();
     const fetcher = new Fetcher({token});
-    for (const {guildId, includeNsfwChannels} of configs) {
-      const repo = await repository(ctx, guildId);
-      const mirror = new Mirror(repo, fetcher, guildId, includeNsfwChannels);
+    for (const config of configs) {
+      const repo = await repository(ctx, config.guildId);
+      const mirror = new Mirror(repo, fetcher, config);
       await mirror.update(reporter);
     }
   }

--- a/packages/sourcecred/src/plugins/discord/reactionWeights.js
+++ b/packages/sourcecred/src/plugins/discord/reactionWeights.js
@@ -66,7 +66,7 @@ export function reactionWeight(
 
   return (
     _roleWeight(weights.roleWeights, reactingMember) *
-    _channelWeight(weights.channelWeights, reaction, channelParentId) *
+    channelWeight(weights.channelWeights, reaction.channelId, channelParentId) *
     _emojiWeight(weights.emojiWeights, reaction) *
     averagingMultiplier
   );
@@ -87,14 +87,14 @@ export function _roleWeight(
   return weight;
 }
 
-export function _channelWeight(
+export function channelWeight(
   config: ChannelWeightConfig,
-  reaction: Model.Reaction,
+  channelId: Model.Snowflake,
   channelParentId: ?Model.Snowflake
 ): NodeWeight {
   const {defaultWeight, weights} = config;
   let parentWeight = channelParentId ? weights[channelParentId] : undefined;
-  let channelWeight = weights[reaction.channelId];
+  let channelWeight = weights[channelId];
   if (parentWeight === undefined && channelWeight === undefined)
     return defaultWeight * defaultWeight;
   if (channelWeight === undefined) channelWeight = defaultWeight || 1;

--- a/packages/sourcecred/src/plugins/discord/reactionWeights.test.js
+++ b/packages/sourcecred/src/plugins/discord/reactionWeights.test.js
@@ -3,7 +3,7 @@
 import deepFreeze from "deep-freeze";
 import type {Message, Reaction, GuildMember} from "./models";
 import {
-  _channelWeight,
+  channelWeight,
   _roleWeight,
   _emojiWeight,
   reactionWeight,
@@ -62,13 +62,6 @@ describe("plugins/discord/reactionWeights", () => {
     emoji: heartEmoji,
   });
 
-  const categoryReaction: Reaction = deepFreeze({
-    channelId,
-    messageId,
-    authorId,
-    emoji: heartEmoji,
-  });
-
   const reacterReaction: Reaction = deepFreeze({
     channelId,
     messageId,
@@ -104,44 +97,44 @@ describe("plugins/discord/reactionWeights", () => {
     });
   });
 
-  describe("_channelWeight", () => {
+  describe("channelWeight", () => {
     it("defaults to the defaultWeight squared if no weights match", () => {
       const cw = {defaultWeight: 3, weights: {}};
-      expect(_channelWeight(cw, categoryReaction, categoryId)).toEqual(9);
+      expect(channelWeight(cw, channelId, categoryId)).toEqual(9);
     });
     it("defaults to the 0 defaultWeight if no weights match", () => {
       const cw = {defaultWeight: 0, weights: {}};
-      expect(_channelWeight(cw, categoryReaction, categoryId)).toEqual(
+      expect(channelWeight(cw, channelId, categoryId)).toEqual(
         cw.defaultWeight
       );
     });
     it("chooses a matching channel weight and defaults category weight", () => {
       const cw = {defaultWeight: 3, weights: {[channelId]: 2}};
-      expect(_channelWeight(cw, categoryReaction, categoryId)).toEqual(6);
+      expect(channelWeight(cw, channelId, categoryId)).toEqual(6);
     });
     it("chooses a matching category weight and defaults channel weight", () => {
       const cw = {defaultWeight: 3, weights: {[categoryId]: 2}};
-      expect(_channelWeight(cw, categoryReaction, categoryId)).toEqual(6);
+      expect(channelWeight(cw, channelId, categoryId)).toEqual(6);
     });
     it("chooses a matching channel weight when defaultWeight is 0", () => {
       const cw = {defaultWeight: 0, weights: {[channelId]: 2}};
-      expect(_channelWeight(cw, categoryReaction, categoryId)).toEqual(2);
+      expect(channelWeight(cw, channelId, categoryId)).toEqual(2);
     });
     it("chooses a matching category weight when defaultWeight is 0", () => {
       const cw = {defaultWeight: 0, weights: {[categoryId]: 2}};
-      expect(_channelWeight(cw, categoryReaction, categoryId)).toEqual(2);
+      expect(channelWeight(cw, channelId, categoryId)).toEqual(2);
     });
     it("multiplies category and channel weight", () => {
       const cw = {defaultWeight: 7, weights: {[categoryId]: 2, [channelId]: 2}};
-      expect(_channelWeight(cw, categoryReaction, categoryId)).toEqual(4);
+      expect(channelWeight(cw, channelId, categoryId)).toEqual(4);
     });
     it("respects 0 channel weight", () => {
       const cw = {defaultWeight: 7, weights: {[categoryId]: 2, [channelId]: 0}};
-      expect(_channelWeight(cw, categoryReaction, categoryId)).toEqual(0);
+      expect(channelWeight(cw, channelId, categoryId)).toEqual(0);
     });
     it("respects 0 category weight", () => {
       const cw = {defaultWeight: 7, weights: {[categoryId]: 0, [channelId]: 2}};
-      expect(_channelWeight(cw, categoryReaction, categoryId)).toEqual(0);
+      expect(channelWeight(cw, channelId, categoryId)).toEqual(0);
     });
   });
 


### PR DESCRIPTION
<!-- Please read our contributor guide before submitting your PR: -->
<!-- https://github.com/sourcecred/sourcecred/blob/master/CONTRIBUTING.md -->

# Description
When a discord channel is weighted 0, we currently include its messages in the graph. This PR makes it so that zero-weighted channels are skipped during `load`, preventing the messages in those channels from being fetched. This reduces the graph size and speeds up load, graph, and credrank in instances that have zero-weighted channels. This also prevents some cred from leaking out of participant epochs, so cred scores will change slightly as a result of this change.
<!-- Possible prompts:
  Why is the change important?
  Did you consider and reject alternate formulations of the same idea?
  Are there relevant issues or discussions elsewhere?
-->

# Test Plan
Manual test:
1. in `sourcecred/cred/gh-pages` run `yarn clean-all`
2. Set default channel weight to 0 and remove all but one channel weight.
3. run `scdev load` and verify in console output that only one channel is loaded.
<!-- Possible prompts:
  How well covered by automated tests is this change?
  How did you manually test this change? How can a reviewer replicate the tests?
-->
