### PR TITLE
Discord: Channel Category weight to use inheritance instead of multiply

### DIFF
--- a/packages/sourcecred/src/plugins/discord/reactionWeights.js
+++ b/packages/sourcecred/src/plugins/discord/reactionWeights.js
@@ -1,7 +1,7 @@
 // @flow
 
 import * as Model from "./models";
-import * as NullUtil from "../../util/null";
+import {orElse} from "../../util/null";
 import {type NodeWeight} from "../../core/weights";
 import {type GraphReaction} from "./createGraph";
 
@@ -93,13 +93,12 @@ export function channelWeight(
   channelParentId: ?Model.Snowflake
 ): NodeWeight {
   const {defaultWeight, weights} = config;
-  let parentWeight = channelParentId ? weights[channelParentId] : undefined;
-  let channelWeight = weights[channelId];
-  if (parentWeight === undefined && channelWeight === undefined)
-    return defaultWeight * defaultWeight;
-  if (channelWeight === undefined) channelWeight = defaultWeight || 1;
-  if (parentWeight === undefined) parentWeight = defaultWeight || 1;
-  return parentWeight * channelWeight;
+  return orElse(
+    channelParentId
+      ? orElse(weights[channelId], weights[channelParentId])
+      : weights[channelId],
+    defaultWeight
+  );
 }
 
 export function _emojiWeight(
@@ -107,8 +106,5 @@ export function _emojiWeight(
   reaction: Model.Reaction
 ): NodeWeight {
   const {defaultWeight, weights} = config;
-  return NullUtil.orElse(
-    weights[Model.emojiToRef(reaction.emoji)],
-    defaultWeight
-  );
+  return orElse(weights[Model.emojiToRef(reaction.emoji)], defaultWeight);
 }

--- a/packages/sourcecred/src/plugins/discord/reactionWeights.test.js
+++ b/packages/sourcecred/src/plugins/discord/reactionWeights.test.js
@@ -98,42 +98,34 @@ describe("plugins/discord/reactionWeights", () => {
   });
 
   describe("channelWeight", () => {
-    it("defaults to the defaultWeight squared if no weights match", () => {
+    it("defaults to the defaultWeight if no weights match", () => {
       const cw = {defaultWeight: 3, weights: {}};
-      expect(channelWeight(cw, channelId, categoryId)).toEqual(9);
-    });
-    it("defaults to the 0 defaultWeight if no weights match", () => {
-      const cw = {defaultWeight: 0, weights: {}};
       expect(channelWeight(cw, channelId, categoryId)).toEqual(
         cw.defaultWeight
       );
     });
-    it("chooses a matching channel weight and defaults category weight", () => {
+    it("chooses a matching channel weight", () => {
       const cw = {defaultWeight: 3, weights: {[channelId]: 2}};
-      expect(channelWeight(cw, channelId, categoryId)).toEqual(6);
-    });
-    it("chooses a matching category weight and defaults channel weight", () => {
-      const cw = {defaultWeight: 3, weights: {[categoryId]: 2}};
-      expect(channelWeight(cw, channelId, categoryId)).toEqual(6);
-    });
-    it("chooses a matching channel weight when defaultWeight is 0", () => {
-      const cw = {defaultWeight: 0, weights: {[channelId]: 2}};
       expect(channelWeight(cw, channelId, categoryId)).toEqual(2);
     });
-    it("chooses a matching category weight when defaultWeight is 0", () => {
-      const cw = {defaultWeight: 0, weights: {[categoryId]: 2}};
+    it("chooses a matching category weight", () => {
+      const cw = {defaultWeight: 3, weights: {[categoryId]: 7}};
+      expect(channelWeight(cw, channelId, categoryId)).toEqual(7);
+    });
+    it("overrides category weight with channel weight", () => {
+      const cw = {defaultWeight: 3, weights: {[categoryId]: 7, [channelId]: 2}};
       expect(channelWeight(cw, channelId, categoryId)).toEqual(2);
     });
-    it("multiplies category and channel weight", () => {
-      const cw = {defaultWeight: 7, weights: {[categoryId]: 2, [channelId]: 2}};
-      expect(channelWeight(cw, channelId, categoryId)).toEqual(4);
+    it("respects 0 default weight", () => {
+      const cw = {defaultWeight: 0, weights: {}};
+      expect(channelWeight(cw, channelId, categoryId)).toEqual(0);
     });
     it("respects 0 channel weight", () => {
-      const cw = {defaultWeight: 7, weights: {[categoryId]: 2, [channelId]: 0}};
+      const cw = {defaultWeight: 3, weights: {[categoryId]: 7, [channelId]: 0}};
       expect(channelWeight(cw, channelId, categoryId)).toEqual(0);
     });
     it("respects 0 category weight", () => {
-      const cw = {defaultWeight: 7, weights: {[categoryId]: 0, [channelId]: 2}};
+      const cw = {defaultWeight: 3, weights: {[categoryId]: 0}};
       expect(channelWeight(cw, channelId, categoryId)).toEqual(0);
     });
   });
@@ -294,7 +286,7 @@ describe("plugins/discord/reactionWeights", () => {
           propsChannelSet,
           reactions
         )
-      ).toEqual(5 * 2 * 3 * 3);
+      ).toEqual(5 * 2 * 3);
     });
   });
 });


### PR DESCRIPTION
<!-- Please read our contributor guide before submitting your PR: -->
<!-- https://github.com/sourcecred/sourcecred/blob/master/CONTRIBUTING.md -->

# Description
@hozzjss pointed out that inheritance would be a much better interaction than multiplication between discord categories and discord channels. This PR changes the behavior so only one of the following is used (ordered highest to lowest precedent): channel weight, category weight, default weight.
<!-- Possible prompts:
  Why is the change important?
  Did you consider and reject alternate formulations of the same idea?
  Are there relevant issues or discussions elsewhere?
-->

# Test Plan
didn't manual test, just trusting unit tests
<!-- Possible prompts:
  How well covered by automated tests is this change?
  How did you manually test this change? How can a reviewer replicate the tests?
-->
