### PR TITLE
Add Spacing to stringify output.

### DIFF
--- a/packages/sourcecred/src/util/combo.js
+++ b/packages/sourcecred/src/util/combo.js
@@ -3,6 +3,8 @@
 // Simple parser combinator library for structured types rather than
 // bytestring parsing.
 
+import stringify from "json-stable-stringify";
+
 export type JsonObject =
   | string
   | number
@@ -25,9 +27,11 @@ export class Parser<+T> {
   constructor(f: (JsonObject) => ParseResult<T>) {
     this._f = f;
   }
+
   parse(raw: JsonObject): ParseResult<T> {
     return this._f(raw);
   }
+
   parseOrThrow(raw: JsonObject): T {
     const result = this.parse(raw);
     if (result.ok) {
@@ -228,7 +232,7 @@ export function fmap<T, U>(p: Parser<T>, f: (T) => U): Parser<U> {
 export function orElse<T: $ReadOnlyArray<Parser<mixed>>>(
   parsers: T,
   errorFn?: (string[]) => string = (errors) =>
-    `no parse matched: ${JSON.stringify(errors)}`
+    `no parse matched: ${stringify(errors, {space: 4})}`
 ): Parser<$ElementType<$TupleMap<T, ExtractParserOutput>, number>> {
   return new Parser((x) => {
     const errors = [];
@@ -281,6 +285,7 @@ export function rename<T>(oldKey: string, parser: Parser<T>): RenameField<T> {
 
 class RenameFieldImpl<+T> extends Parser<T> {
   +oldKey: string;
+
   constructor(oldKey: string, parser: Parser<T>) {
     super(parser._f);
     this.oldKey = oldKey;

--- a/packages/sourcecred/src/util/combo.js
+++ b/packages/sourcecred/src/util/combo.js
@@ -202,6 +202,19 @@ export function fmap<T, U>(p: Parser<T>, f: (T) => U): Parser<U> {
   });
 }
 
+// replacer for stringify.JSON, in order to replace empty array with just `[]`.
+//
+// this replacer function can be extended and universally be used with other
+// aspect like empty objects.
+function emptyArrayReplacer(key: string, value: any) {
+  // check if the array is empty.
+  if (Array.isArray(value) && value.length === 0) {
+    return [];
+  }
+
+  return value;
+}
+
 // Create a parser that tries each of the given parsers on the same
 // input, taking the first successful parse or failing if all parsers
 // fail. In the failure case, the provided `errorFn` will be called with
@@ -232,7 +245,10 @@ export function fmap<T, U>(p: Parser<T>, f: (T) => U): Parser<U> {
 export function orElse<T: $ReadOnlyArray<Parser<mixed>>>(
   parsers: T,
   errorFn?: (string[]) => string = (errors) =>
-    `no parse matched: ${stringify(errors, {space: 4})}`
+    `no parse matched: ${stringify(errors, {
+      replacer: emptyArrayReplacer,
+      spacer: 4,
+    })}`
 ): Parser<$ElementType<$TupleMap<T, ExtractParserOutput>, number>> {
   return new Parser((x) => {
     const errors = [];

--- a/packages/sourcecred/src/util/combo.js
+++ b/packages/sourcecred/src/util/combo.js
@@ -205,7 +205,7 @@ export function fmap<T, U>(p: Parser<T>, f: (T) => U): Parser<U> {
 // Create a parser that tries each of the given parsers on the same
 // input, taking the first successful parse or failing if all parsers
 // fail. In the failure case, the provided `errorFn` will be called with
-// the error messages from all the subparsers to form the resulting
+// the error messages from all the sub-parsers to form the resulting
 // error; the default error function includes the full text of all the
 // error messages, but a user-supplied error function may act with
 // domain-specific precision.


### PR DESCRIPTION
<!-- Please read our contributor guide before submitting your PR: -->
<!-- https://github.com/sourcecred/sourcecred/blob/master/CONTRIBUTING.md -->

# Description

Adding spacing to improve error handling.
closes #3097
### Before 
```
Error: line 196: key "action": no parse matched: ["missing key: \"identity\"","key \"type\": expected RENAME_IDENTITY, got string","key \"type\": expected CHANGE_IDENTITY_TYPE, got string","key \"type\": expected ADD_ALIAS, got string","key \"type\": expected MERGE_IDENTITIES, got string","key \"type\": expected TOGGLE_ACTIVATION, got string","key \"type\": expected DISTRIBUTE_GRAIN, got string","key \"type\": expected TRANSFER_GRAIN, got string","key \"type\": expected SET_PAYOUT_ADDRESS, got string","key \"type\": expected ENABLE_GRAIN_INTEGRATION, got string","key \"type\": expected DISABLE_GRAIN_INTEGRATION, got string","key \"type\": expected MARK_DISTRIBUTION_EXECUTED, got string"]
    at eval (webpack:///./src/util/jsonLog.js?:23:670)
    at Array.forEach (<anonymous>)
    at Function.fromString (webpack:///./src/util/jsonLog.js?:23:463)
    at Function.parse (webpack:///./src/core/ledger/ledger.js?:222:97)
    at eval (webpack:///./src/api/instance/readInstance.js?:29:2775)
    at async Promise.all (index 1)
    at async LocalInstance.readGraphInput (webpack:///./src/api/instance/localInstance.js?:28:53)
    at async graphCommand (webpack:///./src/cli/graph.js?:13:867)
```

### After 
```
Error: line 196: key "action": no parse matched: [
    "missing key: \"identity\"",
    "key \"type\": expected RENAME_IDENTITY, got string",
    "key \"type\": expected CHANGE_IDENTITY_TYPE, got string",
    "key \"type\": expected ADD_ALIAS, got string",
    "key \"type\": expected MERGE_IDENTITIES, got string",
    "key \"type\": expected TOGGLE_ACTIVATION, got string",
    "key \"type\": expected DISTRIBUTE_GRAIN, got string",
    "key \"type\": expected TRANSFER_GRAIN, got string",
    "key \"type\": expected SET_PAYOUT_ADDRESS, got string",
    "key \"type\": expected ENABLE_GRAIN_INTEGRATION, got string",
    "key \"type\": expected DISABLE_GRAIN_INTEGRATION, got string",
    "key \"type\": expected MARK_DISTRIBUTION_EXECUTED, got string"
]
    at eval (webpack:///./src/util/jsonLog.js?:23:670)
    at Array.forEach (<anonymous>)
    at Function.fromString (webpack:///./src/util/jsonLog.js?:23:463)
    at Function.parse (webpack:///./src/core/ledger/ledger.js?:222:97)
    at eval (webpack:///./src/api/instance/readInstance.js?:29:2775)
    at async Promise.all (index 1)
    at async LocalInstance.readGraphInput (webpack:///./src/api/instance/localInstance.js?:28:53)
    at async graphCommand (webpack:///./src/cli/graph.js?:13:867)
```
<!-- Possible prompts:
  Why is the change important?
  Did you consider and reject alternate formulations of the same idea?
  Are there relevant issues or discussions elsewhere?
-->

# Test Plan
I guess this won't affect any behavior. 
<!-- Possible prompts:
  How well covered by automated tests is this change?
  How did you manually test this change? How can a reviewer replicate the tests?
-->
