### PR TITLE
Discord: Simplify default graph + simplifyGraph config

### DIFF
--- a/packages/sourcecred/src/plugins/discord/config.js
+++ b/packages/sourcecred/src/plugins/discord/config.js
@@ -69,6 +69,8 @@ export type DiscordConfigJson = $ReadOnlyArray<{|
   +propsChannels?: $ReadOnlyArray<Model.Snowflake>,
   // Whether to include NSFW channels in cred distribution or not
   +includeNsfwChannels?: boolean,
+  // This reduces graph size by replacing reaction nodes with message node weights.
+  +simplifyGraph?: boolean,
 |}>;
 
 const parserJson: C.Parser<DiscordConfigJson> = C.array(
@@ -97,6 +99,7 @@ const parserJson: C.Parser<DiscordConfigJson> = C.array(
       }),
       propsChannels: C.array(C.string),
       includeNsfwChannels: C.boolean,
+      simplifyGraph: C.boolean,
     }
   )
 );
@@ -106,6 +109,7 @@ export type DiscordConfig = {|
   +weights: WeightConfig,
   +propsChannels: $ReadOnlyArray<Model.Snowflake>,
   +includeNsfwChannels: boolean,
+  +simplifyGraph: boolean,
 |};
 export type DiscordConfigs = $ReadOnlyArray<DiscordConfig>;
 
@@ -139,6 +143,7 @@ export function _upgrade(json: DiscordConfigJson): DiscordConfigs {
     },
     propsChannels: config.propsChannels || [],
     includeNsfwChannels: config.includeNsfwChannels || false,
+    simplifyGraph: config.simplifyGraph || false,
   }));
 }
 

--- a/packages/sourcecred/src/plugins/discord/config.test.js
+++ b/packages/sourcecred/src/plugins/discord/config.test.js
@@ -30,6 +30,7 @@ describe("plugins/discord/config", () => {
           },
         },
         includeNsfwChannels: true,
+        simplifyGraph: true,
       },
     ];
     const expected = [
@@ -61,6 +62,7 @@ describe("plugins/discord/config", () => {
           },
         },
         includeNsfwChannels: true,
+        simplifyGraph: true,
       },
     ];
     const parsed: DiscordConfigs = parser.parseOrThrow(raw);
@@ -90,6 +92,7 @@ describe("plugins/discord/config", () => {
       defaultWeight: 1,
     });
     expect(parsed[0].includeNsfwChannels).toEqual(false);
+    expect(parsed[0].simplifyGraph).toEqual(false);
   });
   it("can work with delimiters", () => {
     const raw = [
@@ -149,6 +152,7 @@ describe("plugins/discord/config", () => {
           },
         },
         includeNsfwChannels: true,
+        simplifyGraph: false,
       },
     ];
     const parsed: DiscordConfigs = parser.parseOrThrow(raw);

--- a/packages/sourcecred/src/plugins/discord/createGraph.js
+++ b/packages/sourcecred/src/plugins/discord/createGraph.js
@@ -344,29 +344,30 @@ export function _createGraphFromMessages(
         );
       }
     }
-    if (messageWeight) {
-      if (author) {
-        wg.graph.addNode(memberNode(author));
-        wg.graph.addEdge(authorsMessageEdge(message, author));
+    if (!messageWeight) continue;
+
+    if (author) {
+      wg.graph.addNode(memberNode(author));
+      wg.graph.addEdge(authorsMessageEdge(message, author));
+    }
+    wg.graph.addNode(messageNode(message, guildId, channelName));
+    if (config.simplifyGraph)
+      wg.weights.nodeWeights.set(messageAddress(message), messageWeight);
+
+    for (const {member, count} of mentions) {
+      wg.graph.addNode(memberNode(member));
+      let edge;
+      if (propsChannels.has(channelId)) {
+        edge = propsEdge(message, member);
+      } else {
+        edge = mentionsEdge(message, member);
       }
-      wg.graph.addNode(messageNode(message, guildId, channelName));
-      for (const {member, count} of mentions) {
-        wg.graph.addNode(memberNode(member));
-        let edge;
-        if (propsChannels.has(channelId)) {
-          edge = propsEdge(message, member);
-        } else {
-          edge = mentionsEdge(message, member);
-        }
-        wg.graph.addEdge(edge);
-        if (count > 1)
-          wg.weights.edgeWeights.set(edge.address, {
-            forwards: count,
-            backwards: 1,
-          });
-      }
-      if (config.simplifyGraph)
-        wg.weights.nodeWeights.set(messageAddress(message), messageWeight);
+      wg.graph.addEdge(edge);
+      if (count > 1)
+        wg.weights.edgeWeights.set(edge.address, {
+          forwards: count,
+          backwards: 1,
+        });
     }
   }
 

--- a/packages/sourcecred/src/plugins/discord/mirror.test.js
+++ b/packages/sourcecred/src/plugins/discord/mirror.test.js
@@ -28,6 +28,7 @@ describe("plugins/discord/mirror", () => {
       },
     },
     includeNsfwChannels: true,
+    simplifyGraph: true,
   };
 
   describe("smoke test", () => {

--- a/packages/sourcecred/src/plugins/discord/reactionWeights.js
+++ b/packages/sourcecred/src/plugins/discord/reactionWeights.js
@@ -30,15 +30,24 @@ export type WeightConfig = {|
   +emojiWeights: ReactionWeightConfig,
 |};
 
-export function reactionWeight(
-  weights: WeightConfig,
-  message: Model.Message,
-  reaction: Model.Reaction,
-  reactingMember: Model.GuildMember,
-  propsChannels: Set<Model.Snowflake>,
-  reactions: $ReadOnlyArray<GraphReaction>,
-  channelParentId: ?Model.Snowflake
-): NodeWeight {
+export function reactionWeight(options: {|
+  +weights: WeightConfig,
+  +message: Model.Message,
+  +reaction: Model.Reaction,
+  +reactingMember: Model.GuildMember,
+  +propsChannels: Set<Model.Snowflake>,
+  +reactions: $ReadOnlyArray<GraphReaction>,
+  +channelParentId: ?Model.Snowflake,
+|}): NodeWeight {
+  const {
+    weights,
+    message,
+    reaction,
+    reactingMember,
+    propsChannels,
+    reactions,
+    channelParentId,
+  } = options;
   if (
     message.authorId === reaction.authorId &&
     !propsChannels.has(message.channelId)

--- a/packages/sourcecred/src/plugins/discord/reactionWeights.test.js
+++ b/packages/sourcecred/src/plugins/discord/reactionWeights.test.js
@@ -163,14 +163,15 @@ describe("plugins/discord/reactionWeights", () => {
       const channelWeights = {defaultWeight: 1, weights: {[channelId]: 6}};
       const weights = {emojiWeights, roleWeights, channelWeights};
       expect(
-        reactionWeight(
+        reactionWeight({
           weights,
           message,
-          reacterReaction,
-          reacterMember,
-          new Set(),
-          reactions
-        )
+          reaction: reacterReaction,
+          reactingMember: reacterMember,
+          propsChannels: new Set(),
+          reactions,
+          channelParentId: undefined,
+        })
       ).toEqual(4 * 5 * 6);
     });
     it("averages across role-weighted users when averaging is enabled", () => {
@@ -188,14 +189,15 @@ describe("plugins/discord/reactionWeights", () => {
       // This is the role weight of the reactor and excludes the author
       const expectedAveragingModifier = 5;
       expect(
-        reactionWeight(
+        reactionWeight({
           weights,
           message,
-          reacterReaction,
-          reacterMember,
-          new Set(),
-          reactions
-        )
+          reaction: reacterReaction,
+          reactingMember: reacterMember,
+          propsChannels: new Set(),
+          reactions,
+          channelParentId: undefined,
+        })
       ).toEqual((4 * 5 * 6) / expectedAveragingModifier);
     });
     it("averaging is safe against divide-by-zero when all roles are zero", () => {
@@ -211,14 +213,15 @@ describe("plugins/discord/reactionWeights", () => {
       const channelWeights = {defaultWeight: 1, weights: {[channelId]: 6}};
       const weights = {emojiWeights, roleWeights, channelWeights};
       expect(
-        reactionWeight(
+        reactionWeight({
           weights,
           message,
-          reacterReaction,
-          reacterMember,
-          new Set(),
-          reactions
-        )
+          reaction: reacterReaction,
+          reactingMember: reacterMember,
+          propsChannels: new Set(),
+          reactions,
+          channelParentId: undefined,
+        })
       ).toEqual(0);
     });
     it("dampens emoji average when dampener >0", () => {
@@ -237,14 +240,15 @@ describe("plugins/discord/reactionWeights", () => {
       // This is the role weight of the reactor and excludes the author
       const expectedAveragingModifier = 7;
       expect(
-        reactionWeight(
+        reactionWeight({
           weights,
           message,
-          reacterReaction,
-          reacterMember,
-          new Set(),
-          reactions
-        )
+          reaction: reacterReaction,
+          reactingMember: reacterMember,
+          propsChannels: new Set(),
+          reactions,
+          channelParentId: undefined,
+        })
       ).toEqual((4 * 5 * 6) / expectedAveragingModifier);
     });
     it("sets the weight to 0 for a self-reaction", () => {
@@ -257,17 +261,18 @@ describe("plugins/discord/reactionWeights", () => {
       const channelWeights = {defaultWeight: 1, weights: {}};
       const weights = {emojiWeights, roleWeights, channelWeights};
       expect(
-        reactionWeight(
+        reactionWeight({
           weights,
           message,
-          authorSelfReaction,
-          authorMember,
-          new Set(),
-          reactions
-        )
+          reaction: authorSelfReaction,
+          reactingMember: authorMember,
+          propsChannels: new Set(),
+          reactions,
+          channelParentId: undefined,
+        })
       ).toEqual(0);
     });
-    it("sets a  nonzero-weight for a self-reaction in a props channel", () => {
+    it("sets a nonzero-weight for a self-reaction in a props channel", () => {
       const emojiWeights = {
         defaultWeight: 5,
         weights: {},
@@ -278,14 +283,15 @@ describe("plugins/discord/reactionWeights", () => {
       const weights = {emojiWeights, roleWeights, channelWeights};
       const propsChannelSet = new Set([message.channelId]);
       expect(
-        reactionWeight(
+        reactionWeight({
           weights,
           message,
-          authorSelfReaction,
-          authorMember,
-          propsChannelSet,
-          reactions
-        )
+          reaction: authorSelfReaction,
+          reactingMember: authorMember,
+          propsChannels: propsChannelSet,
+          reactions,
+          channelParentId: undefined,
+        })
       ).toEqual(5 * 2 * 3);
     });
   });


### PR DESCRIPTION
<!-- Please read our contributor guide before submitting your PR: -->
<!-- https://github.com/sourcecred/sourcecred/blob/master/CONTRIBUTING.md -->

# Description
This makes two changes:
1. omits messages (and connected reactions and members) when the sum of the reaction weights for that message is 0
2. creates a `simplifyGraph` configuration option that omits reaction nodes (and connected members) and instead adds up the reaction weights and directly sets the sum as the message node weight. This sacrifices analytic possibilities for permance. To use this feature, add the config attribute `"simplifyGraph": true`

Reduced graph size means reduced memory usage during credrank, which is one of our biggest current bottlenecks.


# Test Plan

Set up a baseline graph pre-change (one of our prod channels) and then manually verified with `scdev graph sourcecred/discord -d -s >> results.txt`

1. Changes to default graph: [results-false.txt](https://github.com/sourcecred/sourcecred/files/7227758/results-false.txt)

2. Changes to graph when `"simplifyGraph": true` [results-true.txt](https://github.com/sourcecred/sourcecred/files/7227757/results-true.txt)
