### PR TITLE
Recent Policy: add exclusions list of identities

### DIFF
--- a/packages/sourcecred/src/api/grainConfig.js
+++ b/packages/sourcecred/src/api/grainConfig.js
@@ -79,6 +79,7 @@ export function toDistributionPolicy(x: GrainConfig): DistributionPolicy {
       budget: recentPerWeek,
       policyType: "RECENT",
       discount: toDiscount(recentWeeklyDecayRate),
+      exclusions: [],
     });
   }
   if (G.gt(balancedPerWeek, G.ZERO)) {

--- a/packages/sourcecred/src/api/grainConfig.test.js
+++ b/packages/sourcecred/src/api/grainConfig.test.js
@@ -36,6 +36,7 @@ const recent = (budget: number | string, discount: number): RecentPolicy => ({
   policyType: "RECENT",
   budget: toNonnegativeGrain(budget),
   discount: toDiscount(discount),
+  exclusions: [],
 });
 const special = (
   budget: number | string,

--- a/packages/sourcecred/src/core/identity/id.js
+++ b/packages/sourcecred/src/core/identity/id.js
@@ -1,6 +1,7 @@
 // @flow
 
-import {type Uuid, parser} from "../../util/uuid";
+import {type Uuid, parser, delimitedUuidParser} from "../../util/uuid";
 
 export type IdentityId = Uuid;
 export const identityIdParser = parser;
+export const delimitedIdentityIdParser = delimitedUuidParser;

--- a/packages/sourcecred/src/core/identity/index.js
+++ b/packages/sourcecred/src/core/identity/index.js
@@ -1,7 +1,7 @@
 // @flow
 
 export type {IdentityId} from "./id";
-export {identityIdParser} from "./id";
+export {identityIdParser, delimitedIdentityIdParser} from "./id";
 export type {Identity} from "./identity";
 export {
   newIdentity,

--- a/packages/sourcecred/src/util/uuid.js
+++ b/packages/sourcecred/src/util/uuid.js
@@ -124,3 +124,8 @@ export function fromString(s: string): Uuid {
  * with the same semantics as `fromString`.
  */
 export const parser: C.Parser<Uuid> = C.fmap(C.string, fromString);
+
+export const delimitedUuidParser: C.Parser<Uuid> = C.fmap(
+  C.delimited("//"),
+  (s) => fromString(s)
+);


### PR DESCRIPTION
<!-- Please read our contributor guide before submitting your PR: -->
<!-- https://github.com/sourcecred/sourcecred/blob/master/CONTRIBUTING.md -->

# Description
This adds a new `exclusions` field on the RECENT policy containing a list of identity ids that should be excluded in the RECENT allocation. It also uses our new `delimited` parser utility to allow `//` notes appended at the end of the identity id.

# Business Justification
Now that it is possible to include Special Distributions in the grain config, RECENT policy exclusions may actually be a very nice solution to the question of **"how does sourcecred work when some people are getting fixed salaries?"** This is a reality of most organizations and probably will be for some time, and with good reason--it prioritizes meeting human needs, unlike our purely meritocratic paradigm.

The target use case for this PR: People with fixed salaries can be paid through special distributions instead of being paid outside of the sourcecred system, so that if they ever stop being salaried and want to earn normal grain, the Balanced policy will be aware of their salaried pay and will not try to "catch them up" unless they actually were underpaid. At the same time, these salaried people can be excluded from the RECENT policy, so that they aren't double dipping.

This is something the upcoming Product circle will likely dogfood.

<!-- Possible prompts:
  Why is the change important?
  Did you consider and reject alternate formulations of the same idea?
  Are there relevant issues or discussions elsewhere?
-->

# Test Plan
Tested against `sourcecred/cred/gh-pages` with `scdev grain -f -s`
## Regression Test
Verified no error
```
{
  "maxSimultaneousDistributions": 100,
  "allocationPolicies": [
    {
      "policyType": "RECENT",
      "budget": 100,
      "discount": 0.16,
    }
  ]
}
```
```
{
  "immediatePerWeek": 0,
  "balancedPerWeek": 5000,
  "recentPerWeek": 20000,
  "recentWeeklyDecayRate": 0.16,
  "maxSimultaneousDistributions": 100
}
```
## Exclusion with and without delimiter
Verified no error. Verified Thena is excluded.
```

{
  "maxSimultaneousDistributions": 100,
  "allocationPolicies": [
    {
      "policyType": "RECENT",
      "budget": 100,
      "discount": 0.16,
      "exclusions": ["6wyPOVWLmZ2b35eCmOrz1w"]
    }
  ]
}
```
```

{
  "maxSimultaneousDistributions": 100,
  "allocationPolicies": [
    {
      "policyType": "RECENT",
      "budget": 100,
      "discount": 0.16,
      "exclusions": ["6wyPOVWLmZ2b35eCmOrz1w//Thena"]
    }
  ]
}
```
<!-- Possible prompts:
  How well covered by automated tests is this change?
  How did you manually test this change? How can a reviewer replicate the tests?
-->
