### PR TITLE
Add raw GrainConfig parsers

### DIFF
--- a/packages/sourcecred/src/core/ledger/policies/balanced.js
+++ b/packages/sourcecred/src/core/ledger/policies/balanced.js
@@ -28,6 +28,12 @@ export type BalancedPolicy = {|
   +numIntervalsLookback: number,
 |};
 
+export type BalancedConfig = {|
+  +policyType: Balanced,
+  +budget: string | number,
+  +numIntervalsLookback: number,
+|};
+
 /**
  * Allocate a fixed budget of Grain to the users who were "most underpaid".
  *
@@ -107,6 +113,12 @@ export function balancedReceipts(
     amount: grainAmounts[i],
   }));
 }
+
+export const balancedRawParser: P.Parser<BalancedConfig> = P.object({
+  policyType: P.exactly(["BALANCED"]),
+  budget: P.orElse([P.string, P.number]),
+  numIntervalsLookback: P.number,
+});
 
 export const balancedConfigParser: P.Parser<BalancedPolicy> = P.object({
   policyType: P.exactly(["BALANCED"]),

--- a/packages/sourcecred/src/core/ledger/policies/immediate.js
+++ b/packages/sourcecred/src/core/ledger/policies/immediate.js
@@ -27,6 +27,12 @@ export type ImmediatePolicy = {|
   +numIntervalsLookback: number,
 |};
 
+export type ImmediateConfig = {|
+  +policyType: Immediate,
+  +budget: string | number,
+  +numIntervalsLookback: number,
+|};
+
 /**
  * Split a grain budget in proportion to the cred scores in
  * the most recent time interval, with the option to extend the interval
@@ -64,6 +70,12 @@ export function immediateReceipts(
     amount: amounts[i],
   }));
 }
+
+export const immediateRawParser: P.Parser<ImmediateConfig> = P.object({
+  policyType: P.exactly(["IMMEDIATE"]),
+  budget: P.orElse([P.string, P.number]),
+  numIntervalsLookback: P.number,
+});
 
 export const immediateConfigParser: P.Parser<ImmediatePolicy> = P.object({
   policyType: P.exactly(["IMMEDIATE"]),

--- a/packages/sourcecred/src/core/ledger/policies/index.js
+++ b/packages/sourcecred/src/core/ledger/policies/index.js
@@ -3,30 +3,38 @@
 import * as P from "../../../util/combo";
 import {
   type BalancedPolicy,
+  type BalancedConfig,
   balancedReceipts,
   balancedPolicyParser,
   balancedConfigParser,
+  balancedRawParser,
   toString as toStringBalanced,
 } from "./balanced";
 import {
   type ImmediatePolicy,
+  type ImmediateConfig,
   immediateReceipts,
   immediatePolicyParser,
   immediateConfigParser,
+  immediateRawParser,
   toString as toStringImmediate,
 } from "./immediate";
 import {
   type RecentPolicy,
+  type RecentConfig,
   recentReceipts,
   recentPolicyParser,
   recentConfigParser,
+  recentRawParser,
   toString as toStringRecent,
 } from "./recent";
 import {
   type SpecialPolicy,
+  type SpecialConfig,
   specialReceipts,
   specialPolicyParser,
   specialConfigParser,
+  specialRawParser,
   toString as toStringSpecial,
 } from "./special";
 
@@ -41,11 +49,35 @@ export type AllocationPolicy =
   | RecentPolicy
   | SpecialPolicy;
 
+export type AllocationConfig =
+  | BalancedConfig
+  | ImmediateConfig
+  | RecentConfig
+  | SpecialConfig;
+
+// Simply verifies and types what is in a config with no mutations.
+export const allocationConfigParser: P.Parser<AllocationConfig> = P.orElse([
+  balancedRawParser,
+  immediateRawParser,
+  recentRawParser,
+  specialRawParser,
+]);
+
+// Mutates a config into a policy.
 export const policyConfigParser: P.Parser<AllocationPolicy> = P.orElse([
   balancedConfigParser,
   immediateConfigParser,
   recentConfigParser,
   specialConfigParser,
+]);
+
+// Verifies and possibly mutates a serialized policy into a
+// deserialized policy. This is for use with the ledger log.
+export const allocationPolicyParser: P.Parser<AllocationPolicy> = P.orElse([
+  balancedPolicyParser,
+  immediatePolicyParser,
+  recentPolicyParser,
+  specialPolicyParser,
 ]);
 
 export function toString(policy: AllocationPolicy): string {
@@ -60,10 +92,3 @@ export function toString(policy: AllocationPolicy): string {
       return toStringSpecial(policy);
   }
 }
-
-export const allocationPolicyParser: P.Parser<AllocationPolicy> = P.orElse([
-  balancedPolicyParser,
-  immediatePolicyParser,
-  recentPolicyParser,
-  specialPolicyParser,
-]);

--- a/packages/sourcecred/src/core/ledger/policies/recent.js
+++ b/packages/sourcecred/src/core/ledger/policies/recent.js
@@ -39,6 +39,13 @@ export type RecentPolicy = {|
   +exclusions: $ReadOnlyArray<IdentityId>,
 |};
 
+export type RecentConfig = {|
+  +policyType: Recent,
+  +budget: string | number,
+  +discount: Discount,
+  +exclusions?: $ReadOnlyArray<IdentityId>,
+|};
+
 /**
  * Split a grain budget based on exponentially weighted recent
  * cred.
@@ -78,6 +85,17 @@ export function recentReceipts(
   }));
 }
 
+export const recentRawParser: P.Parser<RecentConfig> = P.object(
+  {
+    policyType: P.exactly(["RECENT"]),
+    budget: P.orElse([P.string, P.number]),
+    discount: P.fmap(P.number, toDiscount),
+  },
+  {
+    exclusions: P.array(delimitedIdentityIdParser),
+  }
+);
+
 export const recentConfigParser: P.Parser<RecentPolicy> = P.fmap(
   P.object(
     {
@@ -89,10 +107,7 @@ export const recentConfigParser: P.Parser<RecentPolicy> = P.fmap(
       exclusions: P.array(delimitedIdentityIdParser),
     }
   ),
-  (p) => ({
-    ...p,
-    exclusions: p.exclusions || [],
-  })
+  (config) => ({...config, exclusions: config.exclusions || []})
 );
 
 export const recentPolicyParser: P.Parser<RecentPolicy> = P.fmap(
@@ -106,10 +121,7 @@ export const recentPolicyParser: P.Parser<RecentPolicy> = P.fmap(
       exclusions: P.array(delimitedIdentityIdParser),
     }
   ),
-  (p) => ({
-    ...p,
-    exclusions: p.exclusions || [],
-  })
+  (config) => ({...config, exclusions: config.exclusions || []})
 );
 
 export opaque type Discount: number = number;

--- a/packages/sourcecred/src/core/ledger/policies/special.js
+++ b/packages/sourcecred/src/core/ledger/policies/special.js
@@ -29,6 +29,13 @@ export type SpecialPolicy = {|
   +recipient: IdentityId,
 |};
 
+export type SpecialConfig = {|
+  +policyType: Special,
+  +budget: string | number,
+  +memo: string,
+  +recipient: IdentityId,
+|};
+
 export function specialReceipts(
   policy: SpecialPolicy,
   identities: $ReadOnlyArray<Identity>
@@ -40,6 +47,13 @@ export function specialReceipts(
   }
   throw new Error(`no active grain account for identity: ${policy.recipient}`);
 }
+
+export const specialRawParser: P.Parser<SpecialConfig> = P.object({
+  policyType: P.exactly(["SPECIAL"]),
+  budget: P.orElse([P.string, P.number]),
+  memo: P.string,
+  recipient: uuidParser,
+});
 
 export const specialConfigParser: P.Parser<SpecialPolicy> = P.object({
   policyType: P.exactly(["SPECIAL"]),


### PR DESCRIPTION
<!-- Please read our contributor guide before submitting your PR: -->
<!-- https://github.com/sourcecred/sourcecred/blob/master/CONTRIBUTING.md -->

# Description
This adds the idea of grain Config types that represent the raw grain JSON. It also adds parsers for these types.

This is part of a larger trend of decoupling validation of JSON and augmentation of JSON. These will be used in upcoming changes, and I anticipate using them more broadly over time.
<!-- Possible prompts:
  Why is the change important?
  Did you consider and reject alternate formulations of the same idea?
  Are there relevant issues or discussions elsewhere?
-->

# Test Plan
I've done some testing already in a follow up change that relies on this. None included in this PR though.
<!-- Possible prompts:
  How well covered by automated tests is this change?
  How did you manually test this change? How can a reviewer replicate the tests?
-->
