### PR TITLE
Combo: Add fmap as a parser class method

### DIFF
--- a/packages/sourcecred/src/api/config/personalAttributionsConfig.js
+++ b/packages/sourcecred/src/api/config/personalAttributionsConfig.js
@@ -109,7 +109,7 @@ export function toPersonalAttributions(
   });
 }
 
-const proportionParser = C.fmap(C.number, (n) => {
+const proportionParser = C.number.fmap((n) => {
   if (n < 0 || n > 1) {
     throw new Error(`Proportion ${n} is not in range [0,1]`);
   }

--- a/packages/sourcecred/src/api/instanceConfig.js
+++ b/packages/sourcecred/src/api/instanceConfig.js
@@ -22,4 +22,4 @@ function upgrade(raw: RawInstanceConfig): InstanceConfig {
   return {bundledPlugins};
 }
 
-export const parser: P.Parser<InstanceConfig> = P.fmap(rawParser, upgrade);
+export const parser: P.Parser<InstanceConfig> = rawParser.fmap(upgrade);

--- a/packages/sourcecred/src/core/credGrainView.js
+++ b/packages/sourcecred/src/core/credGrainView.js
@@ -55,22 +55,19 @@ export type CredGrainViewJSON = {|
   +participants: $ReadOnlyArray<ParticipantCredGrain>,
   +intervals: IntervalSequence,
 |};
-export const credGrainViewParser: C.Parser<CredGrainView> = C.fmap(
-  C.object({
-    participants: C.array(
-      C.object({
-        active: C.boolean,
-        identity: identityParser,
-        cred: C.number,
-        credPerInterval: C.array(C.number),
-        grainEarned: G.parser,
-        grainEarnedPerInterval: C.array(G.parser),
-      })
-    ),
-    intervals: intervalSequenceParser,
-  }),
-  (json) => CredGrainView.fromJSON(json)
-);
+export const credGrainViewParser: C.Parser<CredGrainView> = C.object({
+  participants: C.array(
+    C.object({
+      active: C.boolean,
+      identity: identityParser,
+      cred: C.number,
+      credPerInterval: C.array(C.number),
+      grainEarned: G.parser,
+      grainEarnedPerInterval: C.array(G.parser),
+    })
+  ),
+  intervals: intervalSequenceParser,
+}).fmap((json) => CredGrainView.fromJSON(json));
 
 /**
  * Aggregates data across a CredGraph and Ledger.

--- a/packages/sourcecred/src/core/interval.js
+++ b/packages/sourcecred/src/core/interval.js
@@ -56,15 +56,12 @@ export function intervalSequence(
   }));
 }
 
-export const intervalSequenceParser: C.Parser<IntervalSequence> = C.fmap(
-  C.array(
-    C.object({
-      startTimeMs: C.number,
-      endTimeMs: C.number,
-    })
-  ),
-  (arr) => intervalSequence(arr)
-);
+export const intervalSequenceParser: C.Parser<IntervalSequence> = C.array(
+  C.object({
+    startTimeMs: C.number,
+    endTimeMs: C.number,
+  })
+).fmap((arr) => intervalSequence(arr));
 
 /**
  * Represents a slice of a time-partitioned graph

--- a/packages/sourcecred/src/util/combo.js
+++ b/packages/sourcecred/src/util/combo.js
@@ -36,6 +36,9 @@ export class Parser<+T> {
       throw new Error(result.err);
     }
   }
+  fmap<U>(f: (T) => U): Parser<U> {
+    return fmap(this, f);
+  }
 }
 
 // Helper type to extract the underlying type of a parser: for instance,


### PR DESCRIPTION
<!-- Please read our contributor guide before submitting your PR: -->
<!-- https://github.com/sourcecred/sourcecred/blob/master/CONTRIBUTING.md -->

# Description

BEHOLD. I'm always so annoyed working with fmap because in order to add or remove it, you have to make two edits: one on either side of the base parser. This adds a class method on the Parser class that wraps fmap, making it syntactically similar to Array.prototype.map() which makes it much nicer to work with in my opinion.

```
// Before

C.fmap(baseParser, (base) => base.toString())

// After

baseParser.fmap((base) => base.toString())
```

I included some example usages in this PR. I'll be baking such migrations into other PRs as I go along.
<!-- Possible prompts:
  Why is the change important?
  Did you consider and reject alternate formulations of the same idea?
  Are there relevant issues or discussions elsewhere?
-->

# Test Plan
sourcecred/cred/gh-pages
1. `scdev credrank` and verify no errors
2. `scdev serve` open site and verify no errors
<!-- Possible prompts:
  How well covered by automated tests is this change?
  How did you manually test this change? How can a reviewer replicate the tests?
-->
