### PR TITLE
Fix color property

### DIFF
--- a/packages/sourcecred/src/ui/components/AppBar.js
+++ b/packages/sourcecred/src/ui/components/AppBar.js
@@ -125,7 +125,7 @@ const AppBar = (props: Props): React.Node => {
             enterDelay={500}
           >
             <IconButton
-              color="white"
+              color="default"
               onClick={() => dispatch(toggleSidebar())}
               className={classNames(classes.menuButton)}
             >


### PR DESCRIPTION
# Description
Fixes an error being caused by setting the color property to an invalid value.

This error popped up when I spun up the UI locally: 
```Warning: Failed prop type: Invalid prop `color` of value `white` supplied to `ForwardRef(IconButton)`, expected one of ["default","inherit","primary","secondary"].```

Not sure how I missed this in the latest UI changes but somehow I did.

