### PR TITLE
Bugfix: use discord user id if the name is all special characters

### DIFF
--- a/packages/sourcecred/src/plugins/discord/createIdentities.js
+++ b/packages/sourcecred/src/plugins/discord/createIdentities.js
@@ -10,7 +10,9 @@ import {coerce, nameFromString} from "../../core/identity/name";
 export function createIdentity(member: Model.GuildMember): IdentityProposal {
   let name = member.nick || member.user.username;
   name = coerce(name.slice(0, 39));
-  if (name.match(/^\-+$/) name = coerce("discord-" + member.user.id);
+  if (name.match(/^-+$/)) {
+    name = coerce("discord-" + member.user.id);
+  }
   const description = `discord/${escape(name)}#${member.user.discriminator}`;
   const alias = {
     description,


### PR DESCRIPTION
<!-- Please read our contributor guide before submitting your PR: -->
<!-- https://github.com/sourcecred/sourcecred/blob/master/CONTRIBUTING.md -->

# Description
Solves https://github.com/sourcecred/sourcecred/issues/3213 by using the discord user id for identity proposals instead of the discord name if the name is all special characters (coerced for the ledger as all dashes).
<!-- Possible prompts:
  Why is the change important?
  Did you consider and reject alternate formulations of the same idea?
  Are there relevant issues or discussions elsewhere?
-->

# Test Plan
@hozzjss will test and approve if it works.
<!-- Possible prompts:
  How well covered by automated tests is this change?
  How did you manually test this change? How can a reviewer replicate the tests?
-->
