### PR TITLE
Utilize an Opaque type to key on currencies in the Ledger

### DIFF
--- a/packages/sourcecred/src/core/ledger/currency.js
+++ b/packages/sourcecred/src/core/ledger/currency.js
@@ -4,6 +4,7 @@ import {
   ethAddressParser,
   type EthAddress,
 } from "../../plugins/ethereum/ethAddress";
+import stringify from "json-stable-stringify";
 import * as C from "../../util/combo";
 
 /**
@@ -82,6 +83,17 @@ export const currencyParser: C.Parser<Currency> = C.orElse([
   evmParser,
   protocolParser,
 ]);
+
+/**
+ * The Currency key must be stringified to ensure the data is retrievable.
+ * Keying on the raw Currency object means keying on the object reference,
+ * rather than the contents of the object.
+ */
+export opaque type CurrencyKey = string;
+
+export function getCurrencyKey(currency: Currency): CurrencyKey {
+  return stringify(currency);
+}
 
 export function buildCurrency(
   chainId: string,

--- a/packages/sourcecred/src/core/ledger/grainIntegration.js
+++ b/packages/sourcecred/src/core/ledger/grainIntegration.js
@@ -1,9 +1,9 @@
 // @flow
 
-import {Ledger, type PayoutAddress, type CurrencyId} from "./ledger";
+import {Ledger, type PayoutAddress} from "./ledger";
 import {type Distribution} from "./distribution";
 import {getDistributionBalances} from "./distributionSummary/distributionSummary.js";
-import {type Currency} from "./currency.js";
+import {type Currency, type CurrencyKey, getCurrencyKey} from "./currency.js";
 import {type IdentityId} from "../identity";
 import * as NullUtil from "../../util/null";
 import {type TimestampMs} from "../../util/timestamp";
@@ -89,7 +89,7 @@ export function executeGrainIntegration(
   const {payoutDistributions, payoutAddressToId} = buildDistributionIndexes(
     ledger,
     distribution,
-    JSON.stringify(currency)
+    getCurrencyKey(currency)
   );
   // Need to receive actual allocations so users don't lose funds if
   // decimals are truncated in L2 or in some other environment that must modify
@@ -129,7 +129,7 @@ export function executeGrainIntegration(
 export function buildDistributionIndexes(
   ledger: Ledger,
   distribution: Distribution,
-  currencyId: CurrencyId
+  currencyId: CurrencyKey
 ): {
   payoutDistributions: PayoutDistributions,
   payoutAddressToId: PayoutAddressToId,

--- a/packages/sourcecred/src/core/ledger/ledger.js
+++ b/packages/sourcecred/src/core/ledger/ledger.js
@@ -23,9 +23,11 @@ import {
 } from "../identity";
 import {
   type Currency,
+  type CurrencyKey,
   type ChainId,
   currencyParser,
   buildCurrency,
+  getCurrencyKey,
 } from "./currency";
 import {type NodeAddressT, NodeAddress} from "../graph";
 import {type TimestampMs} from "../../util/timestamp";
@@ -85,13 +87,6 @@ type MutableAccount = {|
 |};
 export type Account = $ReadOnly<MutableAccount>;
 
-/**
- * The Currency key must be stringified to ensure the data is retrievable.
- * Keying on the raw Currency object means keying on the object reference,
- * rather than the contents of the object.
- */
-export type CurrencyId = string;
-
 // Only Eth Addresses are supported at the moment
 export type PayoutAddress = EthAddress;
 
@@ -102,7 +97,7 @@ export type PayoutAddress = EthAddress;
  * themselves that the address they are supplying is capable of receiving their
  * share of a grain distribution.
  */
-type PayableAddressStore = Map<CurrencyId, PayoutAddress>;
+type PayableAddressStore = Map<CurrencyKey, PayoutAddress>;
 
 /**
  * The Ledger is an append-only auditable data store which tracks
@@ -765,13 +760,13 @@ export class Ledger {
       }
       // Mutations! Method must not fail below this comment.
       account.payoutAddresses.set(
-        JSON.stringify(currencyResult.value),
+        getCurrencyKey(currencyResult.value),
         payoutAddress
       );
       return;
     }
     // else (payoutAddress === null) and we delete the entry
-    account.payoutAddresses.delete(JSON.stringify(currencyResult.value));
+    account.payoutAddresses.delete(getCurrencyKey(currencyResult.value));
   }
 
   /**

--- a/packages/sourcecred/src/core/ledger/ledger.test.js
+++ b/packages/sourcecred/src/core/ledger/ledger.test.js
@@ -11,6 +11,7 @@ import {
   type EvmChainId,
   parseEvmChainId,
   protocolSymbolParser,
+  getCurrencyKey,
 } from "./currency";
 import * as G from "./grain";
 import * as uuid from "../../util/uuid";
@@ -921,7 +922,7 @@ describe("core/ledger/ledger", () => {
       it("can set a payout address for an existing user", () => {
         const ledger = setupLedgerwithPayoutAddress();
         const account = ledger.account(id1);
-        expect(account.payoutAddresses.get(JSON.stringify(evmId))).toBe(
+        expect(account.payoutAddresses.get(getCurrencyKey(evmId))).toBe(
           fullAddress
         );
       });
@@ -929,7 +930,9 @@ describe("core/ledger/ledger", () => {
         const ledger = setupLedgerwithPayoutAddress();
         ledger.setPayoutAddress(id1, null, evmChainId, ethAddress);
         const account = ledger.account(id1);
-        expect(account.payoutAddresses.get(evmId.toString())).toBe(undefined);
+        expect(account.payoutAddresses.get(getCurrencyKey(evmId))).toBe(
+          undefined
+        );
       });
       it("cannot set an address for a non-existent user", () => {
         const badId = uuid.random();
@@ -952,7 +955,7 @@ describe("core/ledger/ledger", () => {
         const ledger = ledgerWithIdentities();
         ledger.setPayoutAddress(id1, fullAddress, btcChainId);
         const account = ledger.account(id1);
-        expect(account.payoutAddresses.get(JSON.stringify(protocolId))).toBe(
+        expect(account.payoutAddresses.get(getCurrencyKey(protocolId))).toBe(
           fullAddress
         );
       });


### PR DESCRIPTION
By utilizing an opaque type, we can eliminate the details of
stringifying the Currency objects from the ledger. This allows for some
cleaner scope of concern.

The opaque type prevents the decoding of keys, which
should not be necessary, Generating a key should be a one-way operation,
in case we ever move to generating hashes instead of just stringified
objects, or some other operation to that changes the characteristics of
keys.

Additionally, json-stable-stringify is utilized over JSON.stringify
because it produces the same string across all platforms. Some
JSON.stringify implementations differ and therefore it is potentially
unstable.

test plan: unit tests have been updated

Merge plan: this is a prereq to #3156 