### PR TITLE
Fix colSpan so row takes up full width of table

### DIFF
--- a/packages/sourcecred/src/ui/components/ExplorerHome/ExplorerHome.js
+++ b/packages/sourcecred/src/ui/components/ExplorerHome/ExplorerHome.js
@@ -588,7 +588,7 @@ export const ExplorerHome = ({
                   <TablePagination
                     rowsPerPageOptions={PAGINATION_OPTIONS}
                     className={classes.paginator}
-                    colSpan={4}
+                    colSpan={5}
                     count={tsParticipants.length}
                     rowsPerPage={tsParticipants.rowsPerPage}
                     page={tsParticipants.pageIndex}


### PR DESCRIPTION
# Description
We missed modifying this after adding our new % Cred column, so this fixes that UI bug - note the grey box below the "Filter Names" input field.

**BEFORE:**
![Screen Shot 2021-10-21 at 3 46 09 PM](https://user-images.githubusercontent.com/7217000/138367678-a60fac6f-bd44-4939-9180-8676f3334c01.png)

**AFTER:** 
![Screen Shot 2021-10-21 at 3 46 45 PM](https://user-images.githubusercontent.com/7217000/138367668-3679a752-7161-4066-b807-c812c86a2c37.png)



