### PR TITLE
Add RawGithubReadInstance wrapper for improved UX

### DIFF
--- a/packages/sourcecred/src/api/instance/readInstance.js
+++ b/packages/sourcecred/src/api/instance/readInstance.js
@@ -58,6 +58,16 @@ import * as Combo from "../../util/combo";
 
 export const getNetworkReadInstance = (base: string): ReadInstance =>
   new ReadInstance(new NetworkStorage(base));
+export const getRawGithubReadInstance = (
+  organization: string,
+  repository: string,
+  branch: string
+): ReadInstance =>
+  new ReadInstance(
+    new NetworkStorage(
+      `https://raw.githubusercontent.com/${organization}/${repository}/${branch}/`
+    )
+  );
 export const getOriginReadInstance = (base: string): ReadInstance =>
   new ReadInstance(new OriginStorage(base));
 


### PR DESCRIPTION
<!-- Please read our contributor guide before submitting your PR: -->
<!-- https://github.com/sourcecred/sourcecred/blob/master/CONTRIBUTING.md -->

# Description
Finding and composing a raw github repo url is confusing, and we get tech support questions about it regularly. This adds a more user-friendly factory for instances that use raw github fetching.
<!-- Possible prompts:
  Why is the change important?
  Did you consider and reject alternate formulations of the same idea?
  Are there relevant issues or discussions elsewhere?
-->

# Test Plan
`yarn build && yarn shell`
```
$ i = sc.instance.readInstance.getRawGithubReadInstance("sourcecred","cred","gh-pages")
Vd {
  _storage: Mu {
    _base: 'https://raw.githubusercontent.com/sourcecred/cred/gh-pages/'
  },
  _zipStorage: Su {
    _baseStorage: Mu {
      _base: 'https://raw.githubusercontent.com/sourcecred/cred/gh-pages/'
    }
  }
}
$ i.readLedger().then(l => console.log(l))
```
<!-- Possible prompts:
  How well covered by automated tests is this change?
  How did you manually test this change? How can a reviewer replicate the tests?
-->
