### PR TITLE
Better error message for dependency id missing in ledger

### DIFF
--- a/packages/sourcecred/src/api/dependenciesConfig.js
+++ b/packages/sourcecred/src/api/dependenciesConfig.js
@@ -162,8 +162,15 @@ export function ensureIdentityExists(
       return {...dep, id};
     }
   } else {
-    // Will throw if the id is not in the ledger.
-    const identity = ledger.account(depId).identity;
+    let identity;
+    try {
+      identity = ledger.account(depId).identity;
+    } catch {
+      throw new Error(
+        `The identity for the dependency ${dep.name} has been deleted from the ledger, or the ledger has been reset. ` +
+          `If this was intentional, go to your dependencies.json file and delete the 'id' attribute to reset.`
+      );
+    }
     if (identity.name !== dep.name) {
       throw new Error(
         `dependency name discrepancy: dep has name ${dep.name} in ` +


### PR DESCRIPTION
<!-- Please read our contributor guide before submitting your PR: -->
<!-- https://github.com/sourcecred/sourcecred/blob/master/CONTRIBUTING.md -->

# Description
Improves an error message that comes up a lot in tech support. Question: would it be better to just overwrite the ID attribute with a new one and save the user from having to deal with this manually?
<!-- Possible prompts:
  Why is the change important?
  Did you consider and reject alternate formulations of the same idea?
  Are there relevant issues or discussions elsewhere?
-->

# Test Plan
1. `scdev credrank` and verify no errors
2. wipe the ledger, `scdev credrank` and verify errors
<!-- Possible prompts:
  How well covered by automated tests is this change?
  How did you manually test this change? How can a reviewer replicate the tests?
-->
