### PR TITLE
Util: add batchArray and batchIterator methods

### DIFF
--- a/packages/sourcecred/src/util/batch.js
+++ b/packages/sourcecred/src/util/batch.js
@@ -10,6 +10,7 @@ export function batchArray<T>(
   array: $ReadOnlyArray<T>,
   batchSize: number
 ): $ReadOnlyArray<$ReadOnlyArray<T>> {
+  if (batchSize < 1) throw new Error("BatchSize must be 1 or more.");
   const result = [];
   let backlog = array;
   while (backlog.length) {
@@ -41,6 +42,7 @@ export function batchIterator<T>(
   iterator: Iterator<T> | Generator<T, void, void>,
   batchSize: number
 ): BatchIterator<T> {
+  if (batchSize < 1) throw new Error("BatchSize must be 1 or more.");
   let itemsCompletedInCurrentBatch = 0;
   let queue = iterator.next();
   let hasNext = !queue.done;

--- a/packages/sourcecred/src/util/batch.js
+++ b/packages/sourcecred/src/util/batch.js
@@ -1,0 +1,74 @@
+// @flow
+
+/**
+Returns an array of arrays that contains all of the items in the original
+array parameter, but batched into arrays no larger than the batchSize.
+Example:
+  batch([1,2,3,4,5], 2) = [[1,2], [3,4], [5]]
+*/
+export function batchArray<T>(
+  array: $ReadOnlyArray<T>,
+  batchSize: number
+): $ReadOnlyArray<$ReadOnlyArray<T>> {
+  const result = [];
+  let backlog = array;
+  while (backlog.length) {
+    result.push(backlog.slice(0, batchSize));
+    backlog = backlog.slice(batchSize);
+  }
+  return result;
+}
+
+export type BatchIterator<T> = Iterator<T> & {
+  hasNext: () => boolean,
+  numBatchesCompleted: () => number,
+};
+
+/**
+Returns an iterator that will stop upon reaching the batchSize, and then can be
+reused again for more batches. Use the provided hasNext() method to know when
+there are no more batches available.
+Example:
+  const result = [];
+  while (iterator.hasNext()) {
+    for (const item of iterator) {
+      // code to process item
+    }
+    // code to finalize batch
+  }
+ */
+export function batchIterator<T>(
+  iterator: Iterator<T> | Generator<T, void, void>,
+  batchSize: number
+): BatchIterator<T> {
+  let itemsCompletedInCurrentBatch = 0;
+  let queue = iterator.next();
+  let hasNext = !queue.done;
+  let batchesCompleted = 0;
+
+  const next = () => {
+    if (queue.done) return queue;
+    if (itemsCompletedInCurrentBatch >= batchSize) {
+      itemsCompletedInCurrentBatch = 0;
+      batchesCompleted++;
+      return {value: undefined, done: true};
+    }
+    itemsCompletedInCurrentBatch++;
+    const current = queue;
+    queue = iterator.next();
+    hasNext = !queue.done;
+    if (queue.done) batchesCompleted++;
+    return current;
+  };
+
+  const result = {
+    next,
+    hasNext: () => hasNext,
+    numBatchesCompleted: () => batchesCompleted,
+    ["@@iterator"]: () => this,
+    *[Symbol.iterator]() {
+      for (let r; !(r = next()).done; ) yield r.value;
+    },
+  };
+  return result;
+}

--- a/packages/sourcecred/src/util/batch.test.js
+++ b/packages/sourcecred/src/util/batch.test.js
@@ -1,0 +1,80 @@
+// @flow
+
+import {batchArray, batchIterator} from "./batch";
+
+describe("src/util/batch", () => {
+  describe("batch", () => {
+    it("batches an array bigger than the batch size", () => {
+      expect(batchArray([1, 2, 3, 4, 5, 6, 7, 8], 3)).toEqual([
+        [1, 2, 3],
+        [4, 5, 6],
+        [7, 8],
+      ]);
+    });
+    it("batches an array smaller than the batch size", () => {
+      expect(batchArray([1, 2], 3)).toEqual([[1, 2]]);
+    });
+    it("batches an array equal to the batch size", () => {
+      expect(batchArray([1, 2, 3], 3)).toEqual([[1, 2, 3]]);
+    });
+    it("returns an empty array for an empty array", () => {
+      expect(batchArray([], 3)).toEqual([]);
+    });
+  });
+
+  describe("batchIterator", () => {
+    const getResult = (iterator) => {
+      const result = [];
+      while (iterator.hasNext()) {
+        const batch = [];
+        for (const item of iterator) {
+          batch.push(item);
+        }
+        result.push(batch);
+      }
+      return result;
+    };
+
+    it("batches an iterator bigger than the batch size", () => {
+      const iterator = batchIterator(
+        // $FlowFixMe[incompatible-use]
+        [1, 2, 3, 4, 5, 6, 7, 8][Symbol.iterator](),
+        3
+      );
+
+      expect(getResult(iterator)).toEqual([
+        [1, 2, 3],
+        [4, 5, 6],
+        [7, 8],
+      ]);
+      expect(iterator.numBatchesCompleted()).toEqual(3);
+    });
+    it("batches an iterator equal to the batch size", () => {
+      const iterator = batchIterator(
+        // $FlowFixMe[incompatible-use]
+        [1, 2, 3][Symbol.iterator](),
+        3
+      );
+      expect(getResult(iterator)).toEqual([[1, 2, 3]]);
+      expect(iterator.numBatchesCompleted()).toEqual(1);
+    });
+    it("batches an iterator smaller than the batch size", () => {
+      const iterator = batchIterator(
+        // $FlowFixMe[incompatible-use]
+        [1, 2][Symbol.iterator](),
+        3
+      );
+      expect(getResult(iterator)).toEqual([[1, 2]]);
+      expect(iterator.numBatchesCompleted()).toEqual(1);
+    });
+    it("batches an empty iterator", () => {
+      const iterator = batchIterator(
+        // $FlowFixMe[incompatible-use]
+        [][Symbol.iterator](),
+        3
+      );
+      expect(getResult(iterator)).toEqual([]);
+      expect(iterator.numBatchesCompleted()).toEqual(0);
+    });
+  });
+});

--- a/packages/sourcecred/src/util/batch.test.js
+++ b/packages/sourcecred/src/util/batch.test.js
@@ -20,6 +20,14 @@ describe("src/util/batch", () => {
     it("returns an empty array for an empty array", () => {
       expect(batchArray([], 3)).toEqual([]);
     });
+    it("works when batch size is 1", () => {
+      expect(batchArray([1, 2], 1)).toEqual([[1], [2]]);
+    });
+    it("throws when batch size is <1", () => {
+      expect(() => {
+        batchArray([0, 1], 0);
+      }).toThrowError("BatchSize must be 1 or more.");
+    });
   });
 
   describe("batchIterator", () => {
@@ -66,6 +74,24 @@ describe("src/util/batch", () => {
       );
       expect(getResult(iterator)).toEqual([[1, 2]]);
       expect(iterator.numBatchesCompleted()).toEqual(1);
+    });
+    it("works when batch size is 1", () => {
+      const iterator = batchIterator(
+        // $FlowFixMe[incompatible-use]
+        [1, 2][Symbol.iterator](),
+        1
+      );
+      expect(getResult(iterator)).toEqual([[1], [2]]);
+      expect(iterator.numBatchesCompleted()).toEqual(2);
+    });
+    it("throws when batch size is <1", () => {
+      expect(() => {
+        batchIterator(
+          // $FlowFixMe[incompatible-use]
+          [1, 2][Symbol.iterator](),
+          0
+        );
+      }).toThrowError("BatchSize must be 1 or more.");
     });
     it("batches an empty iterator", () => {
       const iterator = batchIterator(


### PR DESCRIPTION
<!-- Please read our contributor guide before submitting your PR: -->
<!-- https://github.com/sourcecred/sourcecred/blob/master/CONTRIBUTING.md -->

# Description
These methods help batch Arrays and Iterators (split the contents up into chunks).

The `batchIterator` method is used in the follow-up PR: https://github.com/sourcecred/sourcecred/pull/3258

The `batchArray` just because it might be useful at some point soon as we run into more scalability concerns in places we don't have iterators in use yet.
<!-- Possible prompts:
  Why is the change important?
  Did you consider and reject alternate formulations of the same idea?
  Are there relevant issues or discussions elsewhere?
-->

# Test Plan
unit tests + https://github.com/sourcecred/sourcecred/pull/3258
<!-- Possible prompts:
  How well covered by automated tests is this change?
  How did you manually test this change? How can a reviewer replicate the tests?
-->
