### PR TITLE
Feat/import plugins

### DIFF
--- a/packages/sourcecred/.flowconfig
+++ b/packages/sourcecred/.flowconfig
@@ -12,5 +12,6 @@ flow-typed
 
 [options]
 include_warnings=true
+module.ignore_non_literal_requires=true
 
 [strict]

--- a/packages/sourcecred/src/api/bundledPlugins.js
+++ b/packages/sourcecred/src/api/bundledPlugins.js
@@ -11,11 +11,19 @@ import {
   ExternalPlugin,
   ExternalPluginIdOwner,
 } from "../plugins/external/plugin";
+import {PackagePlugin} from "../plugins/package/plugin";
 import {DiskStorage} from "../core/storage/disk";
 
 /**
  * Returns an object mapping owner-name pairs to CLI plugin
  * declarations; keys are like `sourcecred/github`.
+ *
+ * External plugins use the `external/xxxx` prefix.
+ *
+ * Packaged plugins maybe specified directly as the
+ * node module name or js file. It assumes that the
+ * package is installed in the execution environment.
+ * ex. `@npmorg/my-sourcecred-plugin` or `/path/to/my/plugin.js`
  */
 // TODO(@decentralion): Fix the type signature here.
 export function getPlugin(pluginId: PluginId): ?Plugin {
@@ -32,4 +40,6 @@ export function getPlugin(pluginId: PluginId): ?Plugin {
       pluginId,
       storage: new DiskStorage(process.cwd()),
     });
+  return new PackagePlugin({pluginId});
+
 }

--- a/packages/sourcecred/src/plugins/package/plugin.js
+++ b/packages/sourcecred/src/plugins/package/plugin.js
@@ -1,0 +1,75 @@
+// @flow
+
+import type {Plugin, PluginDirectoryContext} from "../../api/plugin";
+import type {PluginId} from "../../api/pluginId";
+import path from "path";
+import type {PluginDeclaration} from "../../analysis/pluginDeclaration";
+import {type TaskReporter} from "../../util/taskReporter";
+import type {ReferenceDetector} from "../../core/references";
+import {
+  type WeightedGraph,
+} from "../../core/weightedGraph";
+import type {IdentityProposal} from "../../core/ledger/identityProposal";
+
+
+export class PackagePlugin implements Plugin {
+  id: PluginId;
+  plugin: Plugin;
+
+  constructor(options: {|
+    +pluginId: PluginId,
+  |}) {
+    this.id = options.pluginId;
+  }
+
+  async loadPlugin(): Promise<void> {
+    if(this.plugin !== undefined ) return;
+
+    const pluginModule = this.id.startsWith("./") ? path.resolve(process.cwd(), this.id): this.id; 
+    try {
+      // Must import a plugin object from 
+      this.plugin = (await import(pluginModule).default: Plugin);
+    }catch(e){
+      throw new Error("Could not load dynamically imported plugin")
+    }
+  }
+
+  async declaration(): Promise<PluginDeclaration> {
+    await this.loadPlugin();
+    return this.plugin.declaration();
+  }
+
+  async load(
+    ctx: PluginDirectoryContext,
+    reporter: TaskReporter
+  ): Promise<void> {
+    await this.loadPlugin();
+    return this.plugin.load(ctx,reporter);
+  }
+
+  async graph(
+    ctx: PluginDirectoryContext,
+    rd: ReferenceDetector,
+    reporter: TaskReporter
+  ): Promise<WeightedGraph> {
+    await this.loadPlugin();
+    return this.plugin.graph(ctx,rd, reporter);
+  }
+
+  async referenceDetector(
+    ctx: PluginDirectoryContext,
+    reporter: TaskReporter
+  ): Promise<ReferenceDetector> {
+    await this.loadPlugin();
+    return this.plugin.referenceDetector(ctx, reporter);
+  }
+
+  async identities(
+    ctx: PluginDirectoryContext,
+    reporter: TaskReporter
+  ): Promise<$ReadOnlyArray<IdentityProposal>> {
+    this.loadPlugin();
+    return this.plugin.identities(ctx, reporter);
+  }
+
+}

--- a/packages/sourcecred/src/plugins/package/plugin.js
+++ b/packages/sourcecred/src/plugins/package/plugin.js
@@ -27,8 +27,7 @@ export class PackagePlugin implements Plugin {
 
     const pluginModule = this.id.startsWith("./") ? path.resolve(process.cwd(), this.id): this.id; 
     try {
-      // Must import a plugin object from 
-      this.plugin = (await import(pluginModule).default: Plugin);
+      this.plugin = (new (await import(pluginModule).default)(): Plugin);
     }catch(e){
       throw new Error("Could not load dynamically imported plugin")
     }


### PR DESCRIPTION


# Description
This PR is to enable sourcecred to be able to import plugins from npm or local js files. The motivation behind this is to improve the ability for 3rd party developers to extend sourcecred using the existing Plugin interface. 

The approach here was to be a non breaking change that would allow developers to specify plugins as they already due, but with the additional feature set of  "mynpmpackage" or "/some/path/my-local-dev-package.js" as the source for the plugin data. 

I believe this will lessen the pressure for 3rd party integrations to be pushed into sourcecred.
-->

# Test Plan
The test plan is to build a dummy package, that can be locally imported in tests, as well as installed in the local environment to replicate the real world usecase. The local replication can be achieved by using npm pack for the test plugin and then installing that test plugin package into the node environment. 

This will allow us to test the plugin end to end with relying on a network connection or packages outside of sourcecred to verify correctness.
