### PR TITLE
Support Pagination and Filter-by-accont for Grains Accounts

### DIFF
--- a/packages/sourcecred/src/ui/components/AccountOverview.js
+++ b/packages/sourcecred/src/ui/components/AccountOverview.js
@@ -23,6 +23,7 @@ import {
 import deepFreeze from "deep-freeze";
 import TableSortLabel from "@material-ui/core/TableSortLabel";
 import bigInt from "big-integer";
+import {TableFooter, TablePagination} from "@material-ui/core";
 
 type OverviewProps = {|+currency: CurrencyDetails|};
 
@@ -33,6 +34,8 @@ const useStyles = makeStyles(() => {
     },
   };
 });
+
+const PAGINATION_OPTIONS = deepFreeze([50, 100, 200]);
 
 export const AccountOverview = ({
   currency: {
@@ -87,6 +90,7 @@ export const AccountOverview = ({
   const tsAccounts = useTableState(
     {data: accounts},
     {
+      initialRowsPerPage: PAGINATION_OPTIONS[0],
       initialSort: {
         sortName: BALANCE_SORT.name,
         sortOrder: SortOrders.DESC,
@@ -94,6 +98,14 @@ export const AccountOverview = ({
       },
     }
   );
+
+  const handleChangePage = (event, newIndex) => {
+    tsAccounts.setPageIndex(newIndex);
+  };
+
+  const handleChangeRowsPerPage = (event) => {
+    tsAccounts.setRowsPerPage(Number(event.target.value));
+  };
 
   return (
     <>
@@ -126,6 +138,25 @@ export const AccountOverview = ({
               AccountRow(a, currencySuffix, decimalsToDisplay)
             )}
           </TableBody>
+
+          <TableFooter>
+            <TableRow>
+              <TablePagination
+                rowsPerPageOptions={PAGINATION_OPTIONS}
+                className={classes.paginator}
+                colSpan={4}
+                count={tsAccounts.length}
+                rowsPerPage={tsAccounts.rowsPerPage}
+                page={tsAccounts.pageIndex}
+                SelectProps={{
+                  inputProps: {"aria-label": "rows per page"},
+                  native: true,
+                }}
+                onChangePage={handleChangePage}
+                onChangeRowsPerPage={handleChangeRowsPerPage}
+              />
+            </TableRow>
+          </TableFooter>
         </Table>
       </TableContainer>
       <p align="right">{lastPayoutMessage}</p>

--- a/packages/sourcecred/src/ui/components/AccountOverview.js
+++ b/packages/sourcecred/src/ui/components/AccountOverview.js
@@ -23,7 +23,7 @@ import {
 import deepFreeze from "deep-freeze";
 import TableSortLabel from "@material-ui/core/TableSortLabel";
 import bigInt from "big-integer";
-import {TableFooter, TablePagination} from "@material-ui/core";
+import {TableFooter, TablePagination, TextField} from "@material-ui/core";
 
 type OverviewProps = {|+currency: CurrencyDetails|};
 
@@ -107,8 +107,36 @@ export const AccountOverview = ({
     tsAccounts.setRowsPerPage(Number(event.target.value));
   };
 
+  const filterAccounts = (event: SyntheticInputEvent<HTMLInputElement>) => {
+    // fuzzy match letters "in order, but not necessarily sequentially"
+    const filterString = event.target.value
+      .trim()
+      .toLowerCase()
+      .split("")
+      .join("+.*");
+    const regex = new RegExp(filterString);
+
+    tsAccounts.createOrUpdateFilterFn("filterIdentities", (participant) =>
+      regex.test(participant.identity.name.toLowerCase())
+    );
+  };
+
   return (
     <>
+      <div
+        style={{
+          display: "flex",
+          justifyContent: "flex-end",
+          alignItems: "center",
+          padding: "12px",
+        }}
+      >
+        <TextField
+          label="Filter Accounts"
+          variant="outlined"
+          onChange={filterAccounts}
+        />
+      </div>
       <TableContainer component={Paper} className={classes.container}>
         <Table stickyHeader>
           <TableHead>


### PR DESCRIPTION
<!-- Please read our contributor guide before submitting your PR: -->
<!-- https://github.com/sourcecred/sourcecred/blob/master/CONTRIBUTING.md -->

# Description

<!-- Possible prompts:
  Why is the change important?
  Did you consider and reject alternate formulations of the same idea?
  Are there relevant issues or discussions elsewhere?
-->

User can now filter the grain accounts by name for smoother experience. 
Also, it's paginated to have a unified experience like other tables. 

# Test Plan
- open grain account page. 
- try different existent an non existent accounts. 
- try to access different pages. 

<!-- Possible prompts:
  How well covered by automated tests is this change?
  How did you manually test this change? How can a reviewer replicate the tests?
-->

Closes #3257 #3224 #3225
