### PR TITLE
Allow Grain Integrations to update their own configs

### DIFF
--- a/packages/grainIntegration-csv/index.js
+++ b/packages/grainIntegration-csv/index.js
@@ -19,6 +19,7 @@ const csvIntegration /*: any */ = (payoutDistributions, _unused_config) => {
       fileName: `Payouts-${timestamp}.csv`,
       content: csvString,
     },
+    configUpdate: {},
   };
 };
 

--- a/packages/sourcecred/src/api/grainConfig.js
+++ b/packages/sourcecred/src/api/grainConfig.js
@@ -9,10 +9,8 @@ import {
   allocationConfigParser,
 } from "../core/ledger/policies";
 import {type Name, parser as nameParser} from "../core/identity/name";
-import {
-  type GrainIntegration,
-  parser as bundledGrainIntegrationParser,
-} from "./bundledGrainIntegrations";
+import type {GrainIntegration} from "../core/ledger/grainIntegration";
+import {parser as bundledGrainIntegrationParser} from "./bundledGrainIntegrations";
 
 export type RawGrainConfig = {|
   +allocationPolicies: $ReadOnlyArray<AllocationConfig>,

--- a/packages/sourcecred/src/api/instance/instance.js
+++ b/packages/sourcecred/src/api/instance/instance.js
@@ -56,4 +56,10 @@ export interface Instance extends ReadOnlyInstance {
   writeGrainIntegrationOutput(
     result: $Shape<GrainIntegrationMultiResult>
   ): Promise<void>;
+
+  /** Write grain config updates back into the instance */
+  updateGrainIntegrationConfig(
+    result: $Shape<GrainIntegrationMultiResult>,
+    config: GrainInput
+  ): Promise<void>;
 }

--- a/packages/sourcecred/src/api/main/grain.js
+++ b/packages/sourcecred/src/api/main/grain.js
@@ -2,11 +2,11 @@
 
 import {CredGraph} from "../../core/credrank/credGraph";
 import {Ledger} from "../../core/ledger/ledger";
-import type {CurrencyDetails} from "../currencyConfig";
-import {type GrainConfig} from "../grainConfig";
-import {type Currency as IntegrationCurrency} from "../../core/ledger/currency";
-import type {Distribution} from "../../core/ledger/distribution";
 import {applyDistributions} from "../../core/ledger/applyDistributions";
+import type {CurrencyDetails} from "../currencyConfig";
+import type {GrainConfig} from "../grainConfig";
+import type {Currency as IntegrationCurrency} from "../../core/ledger/currency";
+import type {Distribution} from "../../core/ledger/distribution";
 import type {TimestampMs} from "../../util/timestamp";
 import {
   executeGrainIntegration,
@@ -30,6 +30,7 @@ export type GrainOutput = {|
 // since only the most recent ledger is relevant
 export type GrainIntegrationMultiResult = {|
   output?: GrainIntegrationOutput,
+  configUpdate: Object,
   distributionCredTimestamp: TimestampMs,
 |};
 
@@ -60,11 +61,11 @@ export async function grain(input: GrainInput): Promise<GrainOutput> {
  * Marshall grainInput from a Grain Configuration file for use with
  * executeGrainIntegration function
  */
-export function executeGrainIntegrationsFromGrainInput(
+export async function executeGrainIntegrationsFromGrainInput(
   grainInput: GrainInput,
   ledger: Ledger,
   distributions: $ReadOnlyArray<Distribution>
-): GrainIntegrationResults {
+): Promise<GrainIntegrationResults> {
   const integrationCurrency = grainInput.currencyDetails.integrationCurrency;
   const grainIntegration = grainInput.grainConfig.integration;
   const results = [];
@@ -74,16 +75,21 @@ export function executeGrainIntegrationsFromGrainInput(
   // supporting the case where the distributions parameter is an empty array
   let ledgerResult = ledger;
   if (integrationCurrency && grainIntegration) {
-    distributions.forEach((distribution) => {
-      const result = executeGrainIntegration(
+    for (const distribution of distributions) {
+      const result = await executeGrainIntegration(
         ledgerResult,
-        grainIntegration.function,
+        grainIntegration,
         distribution
       );
-      const {output, distributionCredTimestamp, ledger: nextLedger} = result;
+      const {
+        output,
+        distributionCredTimestamp,
+        ledger: nextLedger,
+        configUpdate,
+      } = result;
       ledgerResult = nextLedger;
-      results.push({output, distributionCredTimestamp});
-    });
+      results.push({output, distributionCredTimestamp, configUpdate});
+    }
   }
   return {ledger: ledgerResult, results};
 }

--- a/packages/sourcecred/src/cli/grain.js
+++ b/packages/sourcecred/src/cli/grain.js
@@ -55,14 +55,15 @@ const grainCommand: Command = async (args, std) => {
     grainInput
   );
 
-  const {results, ledger} = executeGrainIntegrationsFromGrainInput(
+  const {results, ledger} = await executeGrainIntegrationsFromGrainInput(
     grainInput,
     ledgerBeforeIntegrations,
     distributions
   );
 
   for (const result of results) {
-    instance.writeGrainIntegrationOutput(result);
+    await instance.writeGrainIntegrationOutput(result);
+    await instance.updateGrainIntegrationConfig(result, grainInput);
   }
 
   let totalDistributed = G.ZERO;

--- a/packages/sourcecred/src/cli/update/v0_10_0.js
+++ b/packages/sourcecred/src/cli/update/v0_10_0.js
@@ -13,10 +13,8 @@ import {
   allocationConfigParser,
 } from "../../core/ledger/policies";
 import {type Name, parser as nameParser} from "../../core/identity/name";
-import {
-  type GrainIntegration,
-  parser as bundledGrainIntegrationParser,
-} from "../../api/bundledGrainIntegrations";
+import type {GrainIntegration} from "../../core/ledger/grainIntegration";
+import {parser as bundledGrainIntegrationParser} from "../../api/bundledGrainIntegrations";
 import {toDiscount} from "../../core/ledger/policies/recent";
 import stringify from "json-stable-stringify";
 import {DiskStorage} from "../../core/storage/disk";

--- a/packages/sourcecred/src/core/ledger/grainIntegration.js
+++ b/packages/sourcecred/src/core/ledger/grainIntegration.js
@@ -49,6 +49,9 @@ export type IntegrationConfig = {|
   // distributed funds via a configured integration
   processDistributions: boolean,
   currency: Currency,
+  // This optional object contains the self-configuration set by the grain
+  // integration on previous runs. It allows the grain integration to
+  // read its own configuration from disk.
   integration: ?Object,
 |};
 


### PR DESCRIPTION
A grain integration might want to store some details within an instance,
  such as a smart contract address. This update allows arbitrary updates
  to a scoped object within the grain config file.

[Merge Plan](https://github.com/sourcecred/sourcecred/issues/3139#issuecomment-978073574)

Test Plan:

Unit tests are provided at the grain integration interface. Integration
testing will be demonstrated in the test instance using the merkle
integration.