### PR TITLE
Change GithubStorage in API to the newer version

### DIFF
--- a/packages/sourcecred/src/api/lib/base.js
+++ b/packages/sourcecred/src/api/lib/base.js
@@ -35,7 +35,7 @@ import * as grain from "../../core/ledger/grain";
 import * as identity from "../../core/identity";
 
 import * as manager from "../ledgerManager";
-import * as storage from "../ledgerStorage";
+import * as storage from "../../core/storage/github";
 import * as credrank from "../main/credrank";
 import * as graphApi from "../main/graph";
 import * as grainApi from "../main/grain";


### PR DESCRIPTION
<!-- Please read our contributor guide before submitting your PR: -->
<!-- https://github.com/sourcecred/sourcecred/blob/master/CONTRIBUTING.md -->

# Description
We changed the LedgerManager to use the new GithubStorage that @amrro created, but we did not change which GithubStorage was exported in our API. This fixes it so that LedgerManager can be used with the GithubStorage provided. We should probably release another patch as soon as this is merged.
<!-- Possible prompts:
  Why is the change important?
  Did you consider and reject alternate formulations of the same idea?
  Are there relevant issues or discussions elsewhere?
-->

# Test Plan
```
yarn build
yarn shell

m = new sc.ledger.manager.LedgerManager({storage: new sc.ledger.storage.GithubStorage({apiToken: "b14641a038b8705996335f02999f5e4e6a740380", repo: "sourcecred/dev-cred", branch: "payout-bot-test"})})
m.reloadLedger()
m.ledger
```
<!-- Possible prompts:
  How well covered by automated tests is this change?
  How did you manually test this change? How can a reviewer replicate the tests?
-->
