### PR TITLE
combo bugfix: `spacer` option renamed to `space`

### DIFF
--- a/packages/sourcecred/src/core/ledger/nonnegativeGrain.test.js
+++ b/packages/sourcecred/src/core/ledger/nonnegativeGrain.test.js
@@ -8,6 +8,7 @@ import {
 } from "./nonnegativeGrain";
 import {ONE, type Grain} from "./grain";
 import {g} from "./testUtils";
+import dedent from "../../util/dedent";
 
 describe("core/ledger/nonnegativeGrain", () => {
   describe("fromGrain", () => {
@@ -87,8 +88,11 @@ describe("core/ledger/nonnegativeGrain", () => {
     it("fails on 3.5 (number)", () => {
       expect(numberOrFloatStringParser.parse(3.5)).toEqual({
         ok: false,
-        err:
-          'no parse matched: ["expected integer, got number","expected string, got number"]',
+        err: dedent`\
+              orElse Parser: no parse matched: [
+                  "expected integer, got number",
+                  "expected string, got number"
+              ]`,
       });
     });
   });

--- a/packages/sourcecred/src/util/combo.js
+++ b/packages/sourcecred/src/util/combo.js
@@ -205,19 +205,6 @@ export function fmap<T, U>(p: Parser<T>, f: (T) => U): Parser<U> {
   });
 }
 
-// replacer for stringify.JSON, in order to replace empty array with just `[]`.
-//
-// this replacer function can be extended and universally be used with other
-// aspect like empty objects.
-function emptyArrayReplacer(key: string, value: any) {
-  // check if the array is empty.
-  if (Array.isArray(value) && value.length === 0) {
-    return [];
-  }
-
-  return value;
-}
-
 // Create a parser that tries each of the given parsers on the same
 // input, taking the first successful parse or failing if all parsers
 // fail. In the failure case, the provided `errorFn` will be called with
@@ -248,10 +235,11 @@ function emptyArrayReplacer(key: string, value: any) {
 export function orElse<T: $ReadOnlyArray<Parser<mixed>>>(
   parsers: T,
   errorFn?: (string[]) => string = (errors) =>
-    `no parse matched: ${stringify(errors, {
-      replacer: emptyArrayReplacer,
-      spacer: 4,
-    })}`
+    errors.length === 0
+      ? "orElse Parser: no parsers entered"
+      : `orElse Parser: no parse matched: ${stringify(errors, {
+          space: 4,
+        })}`
 ): Parser<$ElementType<$TupleMap<T, ExtractParserOutput>, number>> {
   return new Parser((x) => {
     const errors = [];

--- a/packages/sourcecred/src/util/combo.test.js
+++ b/packages/sourcecred/src/util/combo.test.js
@@ -1,6 +1,7 @@
 // @flow
 
 import * as C from "./combo";
+import dedent from "./dedent";
 
 describe("src/util/combo", () => {
   describe("type JsonObject", () => {
@@ -255,7 +256,9 @@ describe("src/util/combo", () => {
     });
     it("permits an empty set of parsers, always rejecting", () => {
       const p: C.Parser<empty> = C.orElse([]);
-      expect(() => p.parseOrThrow("anything")).toThrow("no parse matched: []");
+      expect(() => p.parseOrThrow("anything")).toThrow(
+        "orElse Parser: no parsers entered"
+      );
     });
 
     function extractError(result: C.ParseResult<mixed>): string {
@@ -285,7 +288,12 @@ describe("src/util/combo", () => {
         C.fmap(C.number, checkZero),
       ]);
       expect(() => p.parseOrThrow(NaN)).toThrow(
-        'no parse matched: ["not positive","not negative","not zero"]'
+        dedent`\
+          no parse matched: [
+              "not positive",
+              "not negative",
+              "not zero"
+          ]`
       );
     });
     it("applies a user-specified error combination function", () => {


### PR DESCRIPTION
`spacer` is not an option in `json-stable-stringify`
and therefore has no effect on the formatting of strings passed in. As
demonstrated in the updated unit tests, spacing is now applied to the
expected strings.

Additionally instead of finding a way to correctly render an empty
array, a more verbose, human readable error messsage is supplied when
the empty case throws. I also added a contextual prefix to improve the
readability of both the empty and non-empty case.

paired with: @amrro

test plan:
Unit tests updated to demonstrate the correct indentation.