### PR TITLE
CredEquate: create credequate CLI/API

### DIFF
--- a/packages/sourcecred/src/api/instance/instance.js
+++ b/packages/sourcecred/src/api/instance/instance.js
@@ -1,5 +1,6 @@
 // @flow
 import {type CredrankInput, type CredrankOutput} from "../main/credrank";
+import {type CredequateInput, type CredequateOutput} from "../main/credequate";
 import {type GraphInput, type GraphOutput} from "../main/graph";
 import {
   type ContributionsInput,
@@ -23,6 +24,8 @@ export interface ReadOnlyInstance {
   readContributionsInput(): Promise<ContributionsInput>;
   /** Reads inputs required to run CredRank. */
   readCredrankInput(): Promise<CredrankInput>;
+  /** Reads inputs required to run CredEquate. */
+  readCredequateInput(): Promise<CredequateInput>;
   /** Reads inputs required to run Grain. */
   readGrainInput(): Promise<GrainInput>;
   /** Reads inputs required to run Analysis. */
@@ -55,6 +58,11 @@ export interface Instance extends ReadOnlyInstance {
   /** Writes output after running CredRank. */
   writeCredrankOutput(
     credrankOutput: CredrankOutput,
+    shouldZip?: boolean
+  ): Promise<void>;
+  /** Writes output after running CredEquate. */
+  writeCredequateOutput(
+    credequateOutput: CredequateOutput,
     shouldZip?: boolean
   ): Promise<void>;
   /** Writes output after running Analysis. */

--- a/packages/sourcecred/src/api/instance/localInstance.js
+++ b/packages/sourcecred/src/api/instance/localInstance.js
@@ -3,6 +3,7 @@
 import {Instance} from "./instance";
 import {ReadInstance} from "./readInstance";
 import type {CredrankOutput} from "../main/credrank";
+import type {CredequateOutput} from "../main/credequate";
 import type {GraphInput, GraphOutput} from "../main/graph";
 import type {GrainInput} from "../main/grain";
 import type {
@@ -49,6 +50,10 @@ const PERSONAL_ATTRIBUTIONS_PATH: $ReadOnlyArray<string> = [
 const GRAIN_PATH: $ReadOnlyArray<string> = ["config", "grain.json"];
 const INSTANCE_CONFIG_PATH: $ReadOnlyArray<string> = ["sourcecred.json"];
 const CREDGRAPH_PATH: $ReadOnlyArray<string> = ["output", "credGraph"];
+const SCORED_CONTRIBUTIONS_PATH: $ReadOnlyArray<string> = [
+  "output",
+  "scoredContributions",
+];
 const CREDGRAINVIEW_PATH: $ReadOnlyArray<string> = ["output", "credGrainView"];
 const GRAPHS_PATH: $ReadOnlyArray<string> = ["graph"];
 const CONTRIBUTIONS_PATH: $ReadOnlyArray<string> = ["contributions"];
@@ -168,6 +173,20 @@ export class LocalInstance extends ReadInstance implements Instance {
       this.writeDependenciesConfig(credrankOutput.dependencies),
       this.writePersonalAttributionsConfig(credrankOutput.personalAttributions),
     ]);
+  }
+
+  async writeCredequateOutput(
+    credequateOutput: CredequateOutput,
+    shouldZip: boolean = true
+  ): Promise<void> {
+    const json = stringify(Array.from(credequateOutput.scoredContributions));
+    const outputPath =
+      pathJoin(...SCORED_CONTRIBUTIONS_PATH) +
+      (shouldZip ? ZIP_SUFFIX : JSON_SUFFIX);
+    const storage = shouldZip
+      ? this._writableZipStorage
+      : this._writableStorage;
+    return storage.set(outputPath, encode(json));
   }
 
   async writeAnalysisOutput(analysisOutput: AnalysisOutput): Promise<void> {

--- a/packages/sourcecred/src/api/main/credequate.js
+++ b/packages/sourcecred/src/api/main/credequate.js
@@ -1,0 +1,53 @@
+// @flow
+
+import type {ContributionsByTarget} from "../../core/credequate/contribution";
+import {
+  type ScoredContribution,
+  scoreContributions,
+} from "../../core/credequate/scoredContribution";
+import {type PluginId} from "../pluginId";
+import type {RawInstanceConfig} from "../rawInstanceConfig";
+
+export type CredequateInput = {|
+  +pluginContributions: Iterable<{|
+    +pluginId: PluginId,
+    +contributionsByTarget: ContributionsByTarget,
+  |}>,
+  +rawInstanceConfig: RawInstanceConfig,
+|};
+
+export type CredequateOutput = {|
+  +scoredContributions: Iterable<ScoredContribution>,
+|};
+
+/**
+
+ */
+export function credequate(input: CredequateInput): CredequateOutput {
+  return {scoredContributions: credequateGenerator(input)};
+}
+
+function* credequateGenerator(
+  input: CredequateInput
+): Iterable<ScoredContribution> {
+  for (const plugin of input.pluginContributions) {
+    const configs = input.rawInstanceConfig.credEquatePlugins.find(
+      (p) => p.id === plugin.pluginId
+    )?.configsByTarget;
+    if (!configs)
+      throw new Error(`CredEquate configurations not found for plugin ${plugin.pluginId}`);
+    for (const target of Object.keys(plugin.contributionsByTarget)) {
+      if (!configs[target])
+        throw new Error(
+          `CredEquate configuration not found for plugin ${plugin.pluginId} and target ${target}`
+        );
+      const iterable = scoreContributions(
+        plugin.contributionsByTarget[target],
+        configs[target]
+      );
+      for (const scoredContribution of iterable) {
+        yield scoredContribution;
+      }
+    }
+  }
+}

--- a/packages/sourcecred/src/api/main/credequate.js
+++ b/packages/sourcecred/src/api/main/credequate.js
@@ -35,7 +35,9 @@ function* credequateGenerator(
       (p) => p.id === plugin.pluginId
     )?.configsByTarget;
     if (!configs)
-      throw new Error(`CredEquate configurations not found for plugin ${plugin.pluginId}`);
+      throw new Error(
+        `CredEquate configurations not found for plugin ${plugin.pluginId}`
+      );
     for (const target of Object.keys(plugin.contributionsByTarget)) {
       if (!configs[target])
         throw new Error(

--- a/packages/sourcecred/src/cli/credequate.js
+++ b/packages/sourcecred/src/cli/credequate.js
@@ -1,0 +1,93 @@
+// @flow
+
+import {LoggingTaskReporter} from "../util/taskReporter";
+import type {Command} from "./command";
+import dedent from "../util/dedent";
+import {LocalInstance} from "../api/instance/localInstance";
+import {credequate} from "../api/main/credequate";
+import {CredGrainView} from "../core/credGrainView";
+import {getEarliestStartForConfigs} from "../core/credequate/config";
+import sortBy from "../util/sortBy";
+import {sum} from "d3-array";
+
+const credequateCommand: Command = async (args, std) => {
+  let isSimulation = false;
+  let shouldZipOutput = true;
+  args.forEach((arg) => {
+    switch (arg) {
+      case "--simulation":
+      case "-s":
+        isSimulation = true;
+        break;
+      case "--no-zip":
+        shouldZipOutput = false;
+        break;
+    }
+  });
+
+  const taskReporter = new LoggingTaskReporter();
+  taskReporter.start("credequate");
+  const baseDir = process.cwd();
+  const instance = new LocalInstance(baseDir);
+  const credequateInput = await instance.readCredequateInput();
+  const credequateOutput = {
+    scoredContributions: Array.from(
+      credequate(credequateInput).scoredContributions
+    ),
+  };
+
+  const credGrainView = CredGrainView.fromScoredContributionsAndLedger(
+    credequateOutput.scoredContributions,
+    await instance.readLedger(),
+    getEarliestStartForConfigs(
+      credequateInput.rawInstanceConfig.credEquatePlugins.map(
+        (p) => p.configsByTarget
+      )
+    )
+  );
+  printCredSummaryTable(credGrainView, std);
+
+  if (!isSimulation) {
+    taskReporter.start("writing changes");
+    instance.writeCredequateOutput(credequateOutput, shouldZipOutput);
+    instance.writeCredGrainView(credGrainView, shouldZipOutput);
+    taskReporter.finish("writing changes");
+  }
+
+  taskReporter.finish("credequate");
+  return 0;
+};
+
+function printCredSummaryTable(credGrainView: CredGrainView, std) {
+  std.out(`# Top Participants By Cred`);
+  std.out(``);
+  std.out(`| Description | Cred | % |`);
+  std.out(`| --- | --- | --- |`);
+  const credParticipants = Array.from(credGrainView.participants());
+  const sortedParticipants = sortBy(credParticipants, (p) => -p.cred);
+  const totalCred = sum(sortedParticipants, (p) => p.cred);
+  function row({cred, identity}) {
+    const percentage = (100 * cred) / totalCred;
+    return `| ${identity.name} | ${cred.toFixed(1)} | ${percentage.toFixed(
+      1
+    )}% |`;
+  }
+  sortedParticipants.slice(0, 20).forEach((n) => std.out(row(n)));
+}
+
+export const credequateHelp: Command = async (args, std) => {
+  std.out(
+    dedent`\
+      usage: sourcecred credequate [options]
+
+      options:
+      -s, --simulation  Skips writing changes to disk.
+      --no-zip  Writes the output as JSON without compressing large files
+
+      Generate a scored contributions list from plugin contributions
+      `.trimRight()
+  );
+  return 0;
+};
+
+export default credequateCommand;

--- a/packages/sourcecred/src/cli/help.js
+++ b/packages/sourcecred/src/cli/help.js
@@ -10,6 +10,7 @@ import {loadHelp} from "./load";
 import {serveHelp} from "./serve";
 import {siteHelp} from "./site";
 import {credRankHelp} from "./credrank";
+import {credequateHelp} from "./credequate";
 import {analysisHelp} from "./analysis";
 import {updateHelp} from "./update";
 import dedent from "../util/dedent";
@@ -29,6 +30,7 @@ const help: Command = async (args, std) => {
     grain: grainHelp,
     site: siteHelp,
     credrank: credRankHelp,
+    credequate: credequateHelp,
     serve: serveHelp,
     analysis: analysisHelp,
     update: updateHelp,

--- a/packages/sourcecred/src/cli/sourcecred.js
+++ b/packages/sourcecred/src/cli/sourcecred.js
@@ -11,6 +11,7 @@ import go from "./go";
 import serve from "./serve";
 import grain from "./grain";
 import credrank from "./credrank";
+import credequate from "./credequate";
 import analysis from "./analysis";
 import update from "./update";
 import help from "./help";
@@ -43,6 +44,8 @@ const sourcecred: Command = async (args, std) => {
       return grain(args.slice(1), std);
     case "credrank":
       return credrank(args.slice(1), std);
+    case "credequate":
+      return credequate(args.slice(1), std);
     case "analysis":
       return analysis(args.slice(1), std);
     case "update":

--- a/packages/sourcecred/src/core/credequate/config.js
+++ b/packages/sourcecred/src/core/credequate/config.js
@@ -8,6 +8,7 @@ import {
 import type {WeightOperand} from "./contribution";
 import {
   type Operator,
+  type OperatorOrKey,
   OPERATOR_KEY_PREFIX,
   OPERATORS,
   operatorParser,
@@ -163,7 +164,7 @@ Throws if the input is not properly prefixed.
 Throws if the key has not been set in the configuration.
 Throws if the configured operator is not a valid operator.
  */
-export function getOperator(rawKey: string, config: Config): Operator {
+export function getOperator(rawKey: OperatorOrKey, config: Config): Operator {
   if (!rawKey.startsWith(OPERATOR_KEY_PREFIX))
     throw new Error(
       `Invalid expression operator [${rawKey}]. This is probably a bug in the plugin. Valid operators are ${OPERATORS.toString()} and operator keys should be prefixed with '${OPERATOR_KEY_PREFIX}'`
@@ -181,4 +182,28 @@ export function getOperator(rawKey: string, config: Config): Operator {
       `Operator [${operator}] for Key [${key}] is an invalid configuration. Please choose from ${OPERATORS.toString()}.`
     );
   return operator;
+}
+
+/**
+Utility function for getting the earliest start time of all configs in an array
+of ConfigsByTarget.
+ */
+export function getEarliestStartForConfigs(
+  configsByTargetArray: $ReadOnlyArray<ConfigsByTarget>
+): TimestampMs {
+  let startTimeMs = Infinity;
+  configsByTargetArray.forEach((configsByTarget) => {
+    const arr = [];
+    for (const key of Object.keys(configsByTarget)) {
+      configsByTarget[key].map((config) => {
+        if (config.startTimeMs < startTimeMs) startTimeMs = config.startTimeMs;
+      });
+    }
+    return arr;
+  });
+  if (startTimeMs == Infinity)
+    throw new Error(
+      "Could not find earliest start time because there are no configs."
+    );
+  return startTimeMs;
 }

--- a/packages/sourcecred/src/core/credequate/config.js
+++ b/packages/sourcecred/src/core/credequate/config.js
@@ -201,7 +201,7 @@ export function getEarliestStartForConfigs(
     }
     return arr;
   });
-  if (startTimeMs == Infinity)
+  if (startTimeMs === Infinity)
     throw new Error(
       "Could not find earliest start time because there are no configs."
     );

--- a/packages/sourcecred/src/core/credequate/operator.js
+++ b/packages/sourcecred/src/core/credequate/operator.js
@@ -10,6 +10,14 @@ type OperatorFunction = (
 ) => number;
 export type Operator = $Keys<typeof OPERATORS_FUNCTION_MAP>;
 export const operatorParser: C.Parser<Operator> = C.string.fmap((s) => {
+  if (!OPERATORS.includes(s))
+    throw new Error(
+      `Invalid operator [${s}], must be one of [${OPERATORS.toString()}]"`
+    );
+  return s;
+});
+export type OperatorOrKey = Operator | string;
+export const operatorKeyParser: C.Parser<OperatorOrKey> = C.string.fmap((s) => {
   if (!OPERATORS.includes(s) && !s.startsWith(OPERATOR_KEY_PREFIX))
     throw new Error(
       `Invalid operator [${s}], must be one of [${OPERATORS.toString()}] or begin with key prefix "${OPERATOR_KEY_PREFIX}"`

--- a/packages/sourcecred/src/core/credequate/scoredContribution.js
+++ b/packages/sourcecred/src/core/credequate/scoredContribution.js
@@ -121,7 +121,9 @@ export function* scoreContributions(
   for (const contribution of contributions) {
     const applicableConfig: Config | void = findLast(
       orderedConfigs,
-      (config) => config.timestampMs < contribution.timestampMs
+      (config) => {
+        return (config: Config).startTimeMs < contribution.timestampMs;
+      }
     );
     if (!applicableConfig) continue;
     yield scoreContribution(contribution, applicableConfig);

--- a/packages/sourcecred/src/ui/load.js
+++ b/packages/sourcecred/src/ui/load.js
@@ -56,7 +56,10 @@ export async function load(): Promise<LoadResult> {
       currencyParser,
       defaultCurrencyConfig
     ),
-    instance.readCredGrainView().catch((e) => {console.log(e);return null}),
+    instance.readCredGrainView().catch((e) => {
+      console.log(e);
+      return null;
+    }),
     loadJsonWithDefault(
       originStorage,
       "config/weights.json",

--- a/packages/sourcecred/src/ui/load.js
+++ b/packages/sourcecred/src/ui/load.js
@@ -56,7 +56,7 @@ export async function load(): Promise<LoadResult> {
       currencyParser,
       defaultCurrencyConfig
     ),
-    instance.readCredGrainView().catch(() => null),
+    instance.readCredGrainView().catch((e) => {console.log(e);return null}),
     loadJsonWithDefault(
       originStorage,
       "config/weights.json",


### PR DESCRIPTION
<!-- Please read our contributor guide before submitting your PR: -->
<!-- https://github.com/sourcecred/sourcecred/blob/master/CONTRIBUTING.md -->

# Description
builds on https://github.com/sourcecred/sourcecred/pull/3295

This adds the `credequate` API/CLI, which is the credequate equivalent of the credrank API/CLI. This CLI turns plugin contributions into scored contributions, creates a CredGrainView, writes the results, and outputs top cred earners to the console.
<!-- Possible prompts:
  Why is the change important?
  Did you consider and reject alternate formulations of the same idea?
  Are there relevant issues or discussions elsewhere?
-->

# Test Plan
Manual tested against sourcecred/cred/gh-pages
Results pushed to https://github.com/sourcecred/cred/tree/credequate-demo

sourcecred.json
```
{
  "bundledPlugins": [
  ],
  "credEquatePlugins": [
    {
      "id": "sourcecred/discord",
      "configsByTarget": {
        "453243919774253079": [
          {
            "memo": "Initial Config",
            "startDate": "1/1/2021",
            "weights": [
              {
                "key": "emoji",
                "default": 1,
                "subkeys": [
                  {
                    "subkey": "sourcecred:626763367893303303",
                    "weight": 3
                  },
                  {
                    "subkey": "👎",
                    "weight": 0
                  }
                ]
              },
              {
                "key": "role",
                "default": 0,
                "subkeys": [
                  {
                    "subkey": "477551557723029514",
                    "memo": "contributors",
                    "weight": 2
                  },
                  {
                    "subkey": "717905734863421472",
                    "memo": "community",
                    "weight": 1
                  }
                ]
              },
              {
                "key": "channel",
                "default": 1,
                "subkeys": [
                  {
                    "subkey": "743545520445718700",
                    "memo": "meeting-notes",
                    "weight": 8
                  },
                  {
                    "subkey": "718512695875469353",
                    "memo": "announcements",
                    "weight": 0.1
                  },
                  {
                    "subkey": "454007860926611478",
                    "memo": "any-questions",
                    "weight": 3
                  },
                  {
                    "subkey": "679064720375808026",
                    "memo": "props",
                    "weight": 15
                  },
                  {
                    "subkey": "543168537062014987",
                    "memo": "did-a-thing",
                    "weight": 12
                  }
                ]
              },
              {
                "key": "category",
                "default": 1,
                "subkeys": []
              }
            ],
            "operators": [
              {
                "key": "reactionsAcrossParticipants",
                "operator": "AVERAGE"
              },
              {
                "key": "reactionsOfSingleParticipant",
                "operator": "MAX"
              }
            ],
            "shares": [
              {
                "key": "author",
                "default": 1,
                "subkeys": [
                  {
                    "subkey": "743545520445718700",
                    "memo": "meeting-notes",
                    "weight": 0.05
                  },
                  {
                    "subkey": "679064720375808026",
                    "memo": "props",
                    "weight": 0
                  }
                ]
              },
              {
                "key": "mention",
                "default": 1,
                "subkeys": []
              }
            ]
          }
        ]
      }
    }
  ]
}
```

1. run `scdev contributions`
2. run `scdev credequate && scdev credequate --no-zip`

console result:
```
  GO   credequate
# Top Participants By Cred

| Description | Cred | % |
| --- | --- | --- |
| Thena | 19363.9 | 13.6% |
| Ryeder | 13586.6 | 9.5% |
| s-ben | 10616.3 | 7.5% |
| KuraFire | 8045.8 | 5.7% |
| AL0YSI0US | 7426.7 | 5.2% |
| topocount | 6737.9 | 4.7% |
| hz | 6248.4 | 4.4% |
| ezrau | 5439.0 | 3.8% |
| lbstrobbe | 5426.2 | 3.8% |
| saintmedusa | 4315.1 | 3.0% |
| panchomiguel | 4166.2 | 2.9% |
| echojuliet | 4108.1 | 2.9% |
| hammad | 3767.0 | 2.6% |
| scrabbleboy | 3627.1 | 2.5% |
| magwalk | 3441.5 | 2.4% |
| joiecousins | 2338.0 | 1.6% |
| lotusleaf | 2074.3 | 1.5% |
| Magey | 1897.0 | 1.3% |
| Willow | 1875.4 | 1.3% |
| Marcie | 1843.4 | 1.3% |
  GO   writing changes
 DONE  writing changes: 1850ms
 DONE  credequate: 5009ms
```

![Screen Shot 2022-01-20 at 3 56 48 PM](https://user-images.githubusercontent.com/11550396/150441057-5e4bfee2-f60c-47f1-a6c1-ad3ffc33d566.png)
![Screen Shot 2022-01-20 at 3 57 09 PM](https://user-images.githubusercontent.com/11550396/150441062-679d637b-1abd-4f77-9b72-984490e03167.png)
![Screen Shot 2022-01-20 at 3 57 20 PM](https://user-images.githubusercontent.com/11550396/150441073-6c2e751f-31a6-43ff-ab20-d7fe06924d91.png)



<!-- Possible prompts:
  How well covered by automated tests is this change?
  How did you manually test this change? How can a reviewer replicate the tests?
-->
