### PR TITLE
Instructional sharness snapshot error message

### DIFF
--- a/packages/sourcecred/sharness/load_test_instance.t
+++ b/packages/sourcecred/sharness/load_test_instance.t
@@ -59,6 +59,8 @@ test_expect_success LOADED,UPDATE_SNAPSHOT \
 '
 
 test_expect_success LOADED "should be identical to the snapshot" '
+    # if this fails after a legitimate code change to a SourceCred output,
+    # try running ./scripts/update_snapshots.sh
     diff -qr . "$snapshot_directory"
 '
 


### PR DESCRIPTION
<!-- Please read our contributor guide before submitting your PR: -->
<!-- https://github.com/sourcecred/sourcecred/blob/master/CONTRIBUTING.md -->

# Description
When sharness-full fails, it's usually just because a code change was made that requires the snapshots to be updated, but currently that's only really passed on person to person as institutional knowledge. This PR adds some comments in the test file that are output in the console log so that any future maintainer or contributor can be pointed in the direction of the update_snapshots.sh script.
<!-- Possible prompts:
  Why is the change important?
  Did you consider and reject alternate formulations of the same idea?
  Are there relevant issues or discussions elsewhere?
-->

# Test Plan
I had CI run with this on code that needed a snapshot update. Open this run and browser search "not ok" to see the helpful tip displayed.
https://app.circleci.com/pipelines/github/sourcecred/sourcecred/7447/workflows/e66948ff-2814-4c11-a2c2-d77813ccd700/jobs/19653

<!-- Possible prompts:
  How well covered by automated tests is this change?
  How did you manually test this change? How can a reviewer replicate the tests?
-->
