### PR TITLE
CredEquate: expose core code in library

### DIFF
--- a/packages/sourcecred/scripts/shell.js
+++ b/packages/sourcecred/scripts/shell.js
@@ -1,10 +1,13 @@
 // @no-flow
-var repl = require("repl");
-var context = repl.start("$ ").context;
+const repl = require("repl");
+const context = repl.start("$ ").context;
 
 try {
   context.sc = require("../dist/server/api.js").sourcecred;
   context.scClient = require("../dist/client/api.js");
 } catch (e) {
-  throw "Run `yarn build` before opening the shell.";
+  console.log(
+    "\nAn error occurred. Try running `yarn build` before opening the shell.\n"
+  );
+  throw e;
 }

--- a/packages/sourcecred/src/api/lib/base.js
+++ b/packages/sourcecred/src/api/lib/base.js
@@ -33,10 +33,16 @@ import * as ledger from "../../core/ledger/ledger";
 import * as ledgerUtils from "../../core/ledger/utils";
 import * as grain from "../../core/ledger/grain";
 import * as identity from "../../core/identity";
+import * as contribution from "../../core/credequate/contribution";
+import * as scoredContribution from "../../core/credequate/scoredContribution";
+import * as operator from "../../core/credequate/operator";
+import * as config from "../../core/credequate/config";
 
 import * as manager from "../ledgerManager";
 import * as storage from "../../core/storage/github";
 import * as credrank from "../main/credrank";
+import * as contributions from "../main/contributions";
+import * as credequate from "../main/credequate";
 import * as graphApi from "../main/graph";
 import * as grainApi from "../main/grain";
 import * as analysis from "../main/analysis";
@@ -46,6 +52,8 @@ const api = {
   api: {
     graph: graphApi,
     credrank,
+    contributions,
+    credequate,
     grain: grainApi,
     analysis,
   },
@@ -63,6 +71,12 @@ const api = {
     weights,
     credGraph,
     CredGrainView,
+  },
+  credequate: {
+    scoredContribution,
+    contribution,
+    config,
+    operator,
   },
   ledger: {
     ledger,


### PR DESCRIPTION
<!-- Please read our contributor guide before submitting your PR: -->
<!-- https://github.com/sourcecred/sourcecred/blob/master/CONTRIBUTING.md -->

# Description
This puts all of the core code for CredEquate into the library, so that cool 3rd-party integrations can be written. I chose to expose everything because most of it seems like it could be useful, including the parsers for each data structure.

I also baked in an error message improvement for yarn shell because apparently commit 8b987110 broke our distribution quietly and we'll need to debug that before releasing.
<!-- Possible prompts:
  Why is the change important?
  Did you consider and reject alternate formulations of the same idea?
  Are there relevant issues or discussions elsewhere?
-->

# Test Plan
yarn build

<!-- Possible prompts:
  How well covered by automated tests is this change?
  How did you manually test this change? How can a reviewer replicate the tests?
-->
