### PR TITLE
CredEquate: Fix circular dependencies

### DIFF
--- a/packages/sourcecred/src/core/credequate/config.js
+++ b/packages/sourcecred/src/core/credequate/config.js
@@ -5,7 +5,6 @@ import {
   timestampISOParser,
   fromISO,
 } from "../../util/timestamp";
-import type {WeightOperand} from "./contribution";
 import {
   type Operator,
   type OperatorOrKey,
@@ -97,14 +96,6 @@ export type Config = {|
   +shares: WeightConfig,
 |};
 
-function getWeightConfigs(config, key: string, subkey) {
-  const keyConfig = config.find((x) => x.key === key);
-  if (keyConfig === undefined)
-    throw new Error(`Key [${key}] has not been set in the weights config.`);
-  const subkeyConfig = keyConfig.subkeys.find((x) => x.subkey === subkey);
-  return {keyConfig, subkeyConfig};
-}
-
 /**
 Groups Configs together by target strings that may represent
 a server ID/endpoint, a repository name, etc.
@@ -129,33 +120,6 @@ export const configsByTargetParser: C.Parser<ConfigsByTarget> = C.dict(
   ),
   C.string
 );
-
-/**
-Returns true if the subkey exists in the subkeys array of the key.
-Returns false if the subkey does not exist in the subkeys array.
-Throws if the key has not been set in the configuration.
- */
-export function hasExplicitWeight(
-  {key, subkey}: WeightOperand,
-  config: WeightConfig
-): boolean {
-  const {subkeyConfig} = getWeightConfigs(config, key, subkey);
-  return subkeyConfig !== undefined;
-}
-
-/**
-If the subkey is found, returns the subkey's weight.
-If the subkey is not found, returns the key's default.
-Throws if the key has not been set in the configuration.
- */
-export function getWeight(
-  {key, subkey}: WeightOperand,
-  config: WeightConfig
-): number {
-  const {keyConfig, subkeyConfig} = getWeightConfigs(config, key, subkey);
-  if (!subkey || !subkeyConfig) return keyConfig.default;
-  return subkeyConfig.weight;
-}
 
 /**
 Takes a prefixed key and returns the configured operator queried by the

--- a/packages/sourcecred/src/core/credequate/config.test.js
+++ b/packages/sourcecred/src/core/credequate/config.test.js
@@ -1,6 +1,7 @@
 // @flow
 
-import {getOperator, getWeight, hasExplicitWeight} from "./config";
+import {getWeight, hasExplicitWeight} from "./utils";
+import {getOperator} from "./config";
 import {buildConfig} from "./testUtils";
 
 describe("core/credequate/config", () => {

--- a/packages/sourcecred/src/core/credequate/operator.js
+++ b/packages/sourcecred/src/core/credequate/operator.js
@@ -1,6 +1,7 @@
 // @flow
 import type {ScoredExpression, ScoredWeightOperand} from "./scoredContribution";
-import {hasExplicitWeight, type Config} from "./config";
+import {hasExplicitWeight} from "./utils";
+import type {Config} from "./config";
 import * as C from "../../util/combo";
 
 type OperatorFunction = (

--- a/packages/sourcecred/src/core/credequate/scoredContribution.js
+++ b/packages/sourcecred/src/core/credequate/scoredContribution.js
@@ -1,7 +1,8 @@
 // @flow
 import type {Contribution, Expression} from "./contribution";
 import {type Operator, applyOperator, OPERATORS} from "./operator";
-import {getWeight, getOperator, type Config} from "./config";
+import {getOperator, type Config} from "./config";
+import {getWeight} from "./utils";
 import type {TimestampMs} from "../../util/timestamp";
 import findLast from "lodash.findlast";
 import type {NodeAddressT} from "../graph";

--- a/packages/sourcecred/src/core/credequate/utils.js
+++ b/packages/sourcecred/src/core/credequate/utils.js
@@ -1,0 +1,39 @@
+// @flow
+
+import type {WeightOperand} from "./contribution";
+import type {WeightConfig} from "./config";
+
+function getWeightConfigs(config, key: string, subkey) {
+  const keyConfig = config.find((x) => x.key === key);
+  if (keyConfig === undefined)
+    throw new Error(`Key [${key}] has not been set in the weights config.`);
+  const subkeyConfig = keyConfig.subkeys.find((x) => x.subkey === subkey);
+  return {keyConfig, subkeyConfig};
+}
+
+/**
+If the subkey is found, returns the subkey's weight.
+If the subkey is not found, returns the key's default.
+Throws if the key has not been set in the configuration.
+ */
+export function getWeight(
+  {key, subkey}: WeightOperand,
+  config: WeightConfig
+): number {
+  const {keyConfig, subkeyConfig} = getWeightConfigs(config, key, subkey);
+  if (!subkey || !subkeyConfig) return keyConfig.default;
+  return subkeyConfig.weight;
+}
+
+/**
+Returns true if the subkey exists in the subkeys array of the key.
+Returns false if the subkey does not exist in the subkeys array.
+Throws if the key has not been set in the configuration.
+ */
+export function hasExplicitWeight(
+  {key, subkey}: WeightOperand,
+  config: WeightConfig
+): boolean {
+  const {subkeyConfig} = getWeightConfigs(config, key, subkey);
+  return subkeyConfig !== undefined;
+}


### PR DESCRIPTION
<!-- Please read our contributor guide before submitting your PR: -->
<!-- https://github.com/sourcecred/sourcecred/blob/master/CONTRIBUTING.md -->

# Description
closes https://github.com/sourcecred/sourcecred/issues/3311

This fixes the circular dependency that was causing an error when trying to import the library.

## My process, for those interested
I just eyeballed where the loop was happening, and found the `config` file and the `operator` file pointing to each other. Many files imported from operator, so operator seemed like the lowest level file, so I considered it a violation for operator to import from config. I looked at what was being imported from config into operator, found that it was a few utils with no coupling outside of the config file, and I separated those 3 methods into their own lowest level utils file. I then made sure to put `type` on the outside of the brackets where possible, so that those imports are cleaned up before runtime (not sure if this was necessary but good hygiene).
<!-- Possible prompts:
  Why is the change important?
  Did you consider and reject alternate formulations of the same idea?
  Are there relevant issues or discussions elsewhere?
-->

# Test Plan
`yarn build && yarn shell` and verified the shell opened without error
<!-- Possible prompts:
  How well covered by automated tests is this change?
  How did you manually test this change? How can a reviewer replicate the tests?
-->
