### PR TITLE
Explorer Home: Make Grain column name match configuration

### DIFF
--- a/packages/sourcecred/src/ui/components/ExplorerHome/ExplorerHome.js
+++ b/packages/sourcecred/src/ui/components/ExplorerHome/ExplorerHome.js
@@ -618,7 +618,11 @@ export const ExplorerHome = ({
                           tsParticipants.setSortFn(value.name, value.fn)
                         }
                       >
-                        <b>{value.name.description}</b>
+                        <b>
+                          {value.name.description === "Grain"
+                            ? currencyName
+                            : value.name.description}
+                        </b>
                       </TableSortLabel>
                     </TableCell>
                   ))}

--- a/packages/sourcecred/src/ui/components/ExplorerHome/ExplorerHome.js
+++ b/packages/sourcecred/src/ui/components/ExplorerHome/ExplorerHome.js
@@ -619,7 +619,7 @@ export const ExplorerHome = ({
                         }
                       >
                         <b>
-                          {value.name.description === "Grain"
+                          {value === GRAIN_SORT
                             ? currencyName
                             : value.name.description}
                         </b>


### PR DESCRIPTION
<!-- Please read our contributor guide before submitting your PR: -->
<!-- https://github.com/sourcecred/sourcecred/blob/master/CONTRIBUTING.md -->

# Description
The grain column name in the explorer page didn't dynamically match currency configuration (it always said Grain). This fixes that.


<!-- Possible prompts:
  Why is the change important?
  Did you consider and reject alternate formulations of the same idea?
  Are there relevant issues or discussions elsewhere?
-->

# Test Plan
yarn start --instance path/to/instance/with/currency/config

also regression test with instance without currency config

<img width="914" alt="Screen Shot 2022-02-04 at 1 20 23 PM" src="https://user-images.githubusercontent.com/11550396/152604718-0191994e-b448-47f3-bdcb-356e3ca4a126.png">


<!-- Possible prompts:
  How well covered by automated tests is this change?
  How did you manually test this change? How can a reviewer replicate the tests?
-->
