### PR TITLE
CredEquate support in Load CLI

### DIFF
--- a/packages/sourcecred/src/cli/load.js
+++ b/packages/sourcecred/src/cli/load.js
@@ -29,8 +29,12 @@ const loadCommand: Command = async (args, std) => {
   let pluginsToLoad: PluginId[] = [];
   const baseDir = process.cwd();
   const config = await loadInstanceConfig(baseDir);
+  const combinedPlugins = new Map(config.bundledPlugins);
+  config.credEquatePlugins.forEach((plugin) => {
+    combinedPlugins.set(plugin.id, plugin.plugin);
+  });
   if (args.length === 0) {
-    pluginsToLoad = Array.from(config.bundledPlugins.keys());
+    pluginsToLoad = Array.from(combinedPlugins.keys());
     if (pluginsToLoad.length === 0) {
       std.err(
         "No plugins configured; Please set up at least one plugin: " +
@@ -40,7 +44,7 @@ const loadCommand: Command = async (args, std) => {
   } else {
     for (const arg of args) {
       const id = pluginIdParser.parseOrThrow(arg);
-      if (config.bundledPlugins.has(id)) {
+      if (combinedPlugins.has(id)) {
         pluginsToLoad.push(id);
       } else {
         return die(
@@ -56,7 +60,7 @@ const loadCommand: Command = async (args, std) => {
   const loadPromises = [];
   const cacheEmpty = new Map<PluginId, boolean>();
   for (const name of pluginsToLoad) {
-    const plugin = NullUtil.get(config.bundledPlugins.get(name));
+    const plugin = NullUtil.get(combinedPlugins.get(name));
     const task = `loading ${name}`;
     taskReporter.start(task);
     const dirContext = pluginDirectoryContext(baseDir, name);


### PR DESCRIPTION
<!-- Please read our contributor guide before submitting your PR: -->
<!-- https://github.com/sourcecred/sourcecred/blob/master/CONTRIBUTING.md -->

# Description
The `load` CLI was only paying attention to credrank's "bundledPlugins" attribute in the sourcecred.json file. This causes the user to add credequate plugins to the bundled plugin array as well. This PR makes the CLI load from a de-duped union of the plugins in bundledPlugins and credEquatePlugins.
<!-- Possible prompts:
  Why is the change important?
  Did you consider and reject alternate formulations of the same idea?
  Are there relevant issues or discussions elsewhere?
-->

# Test Plan
scdev load

1. With a plugin in both attributes (bundledPlugins and credEquatePlugins)
2. With a plugin in each attribute, and not in the other
<!-- Possible prompts:
  How well covered by automated tests is this change?
  How did you manually test this change? How can a reviewer replicate the tests?
-->
