### PR TITLE
Get CSV grain integration production-ready

### DIFF
--- a/packages/grainIntegration-csv/distributionToCsv.js
+++ b/packages/grainIntegration-csv/distributionToCsv.js
@@ -1,5 +1,10 @@
 // @flow
 
+const HARDCODED_DECIMAL_PRECISION = 18;
+const ZEROS = Array.from(Array(HARDCODED_DECIMAL_PRECISION + 1))
+  .map(() => "0")
+  .join("");
+
 /*:: type PayoutDistributions = $ReadOnlyArray<[string, string]>;*/
 /*:: type IntegrationConfig = {
   currency: {tokenAddress?: string},
@@ -14,7 +19,23 @@ module.exports = function payoutDistributionToCsv(
     prefix = "erc20," + (config.currency.tokenAddress || "") + ",";
   let csvString = "";
   for (const [payoutAddress, amount] of payoutDistributions) {
-    csvString += prefix + `${payoutAddress},${amount}\n`;
+    const amountWithZerosPrefix = ZEROS + amount;
+    const beforeDecimal = amountWithZerosPrefix.slice(
+      0,
+      amountWithZerosPrefix.length - HARDCODED_DECIMAL_PRECISION
+    );
+    const afterDecimal = amountWithZerosPrefix.slice(
+      amountWithZerosPrefix.length - HARDCODED_DECIMAL_PRECISION
+    );
+    let formattedAmount = (beforeDecimal + "." + afterDecimal).replace(
+      /^0+|0+$/g,
+      ""
+    );
+    if (formattedAmount.startsWith("."))
+      formattedAmount = "0" + formattedAmount;
+    if (formattedAmount.endsWith(".")) formattedAmount = formattedAmount + "0";
+
+    csvString += prefix + `${payoutAddress},${formattedAmount}\n`;
   }
   return csvString;
 };

--- a/packages/grainIntegration-csv/payoutDistributionToCsv.test.js
+++ b/packages/grainIntegration-csv/payoutDistributionToCsv.test.js
@@ -3,36 +3,39 @@ const payoutDistributionToCsv = require("./distributionToCsv");
 describe("payoutDistributionToCsv", () => {
   it("serializes entries into a csv when gnosis config is absent", () => {
     const mockDistributions = [
-      ["abc", "123"],
+      ["abc", "99123456789012345678"],
       ["def", "456"],
+      ["lol", "1000000000000000000"],
     ];
     const result = payoutDistributionToCsv(mockDistributions, {
       currency: { tokenAddress: "0x1234" },
       integration: undefined,
     });
-    expect(result).toBe(`abc,123\ndef,456\n`);
+    expect(result).toBe(`abc,99.123456789012345678\ndef,0.000000000000000456\nlol,1.0\n`);
   });
   it("serializes entries into a csv with gnosis prefix", () => {
     const mockDistributions = [
-      ["abc", "123"],
+      ["abc", "99123456789012345678"],
       ["def", "456"],
+      ["lol", "1000000000000000000"],
     ];
     const result = payoutDistributionToCsv(mockDistributions, {
       currency: { tokenAddress: "0x1234" },
       integration: { gnosis: true },
     });
-    expect(result).toBe(`erc20,0x1234,abc,123\nerc20,0x1234,def,456\n`);
+    expect(result).toBe(`erc20,0x1234,abc,99.123456789012345678\nerc20,0x1234,def,0.000000000000000456\nerc20,0x1234,lol,1.0\n`);
   });
   it("serializes entries into a csv with gnosis prefix when the tokenAddress is absent", () => {
     const mockDistributions = [
-      ["abc", "123"],
+      ["abc", "99123456789012345678"],
       ["def", "456"],
+      ["lol", "1000000000000000000"],
     ];
     const result = payoutDistributionToCsv(mockDistributions, {
       currency: {},
       integration: { gnosis: true },
     });
-    expect(result).toBe(`erc20,,abc,123\nerc20,,def,456\n`);
+    expect(result).toBe(`erc20,,abc,99.123456789012345678\nerc20,,def,0.000000000000000456\nerc20,,lol,1.0\n`);
   });
   it("returns an empty string when receiving an empty array", () => {
     const result = payoutDistributionToCsv([], {

--- a/packages/sourcecred/src/api/instance/localInstance.js
+++ b/packages/sourcecred/src/api/instance/localInstance.js
@@ -227,7 +227,7 @@ export class LocalInstance extends ReadInstance implements Instance {
     const configName = config.grainConfig.integration?.name;
     if (!configName) return;
     const configUpdate = result.configUpdate;
-    if (Object.keys(configUpdate).length > 0) {
+    if (configUpdate && Object.keys(configUpdate).length > 0) {
       const grainConfigPath = pathJoin(...GRAIN_PATH);
       const currentConfig = await loadJson<any>(
         this._storage,

--- a/packages/sourcecred/src/api/main/grain.js
+++ b/packages/sourcecred/src/api/main/grain.js
@@ -51,7 +51,7 @@ export async function grain(input: GrainInput): Promise<GrainOutput> {
 
   const distributions = applyDistributions(
     input.grainConfig,
-    input.credGrainView,
+    input.credGrainView.withNewLedger(configuredLedger),
     configuredLedger,
     +Date.now(),
     input.allowMultipleDistributionsPerInterval || false

--- a/packages/sourcecred/src/cli/grain.js
+++ b/packages/sourcecred/src/cli/grain.js
@@ -53,9 +53,11 @@ const grainCommand: Command = async (args, std) => {
     distributions
   );
 
-  for (const result of results) {
-    await instance.writeGrainIntegrationOutput(result);
-    await instance.updateGrainIntegrationConfig(result, grainInput);
+  if (!simulation) {
+    for (const result of results) {
+      await instance.writeGrainIntegrationOutput(result);
+      await instance.updateGrainIntegrationConfig(result, grainInput);
+    }
   }
 
   let totalDistributed = G.ZERO;

--- a/packages/sourcecred/src/ui/components/AccountOverview.js
+++ b/packages/sourcecred/src/ui/components/AccountOverview.js
@@ -85,16 +85,26 @@ export const AccountOverview = ({
     []
   );
 
-  const sortingOptions = [ACTIVE_SORT, BALANCE_SORT, EARNED_SORT];
+  const sortingOptions = useMemo(
+    () =>
+      ledger.accounting().enabled
+        ? [ACTIVE_SORT, BALANCE_SORT, EARNED_SORT]
+        : [ACTIVE_SORT, EARNED_SORT],
+    [ledger]
+  );
+  const initialSort = useMemo(
+    () => (ledger.accounting().enabled ? BALANCE_SORT : EARNED_SORT),
+    [ledger]
+  );
 
   const tsAccounts = useTableState(
     {data: accounts},
     {
       initialRowsPerPage: PAGINATION_OPTIONS[0],
       initialSort: {
-        sortName: BALANCE_SORT.name,
+        sortName: initialSort.name,
         sortOrder: SortOrders.DESC,
-        sortFn: BALANCE_SORT.fn,
+        sortFn: initialSort.fn,
       },
     }
   );
@@ -163,7 +173,12 @@ export const AccountOverview = ({
           </TableHead>
           <TableBody>
             {tsAccounts.currentPage.map((a) =>
-              AccountRow(a, currencySuffix, decimalsToDisplay)
+              AccountRow(
+                a,
+                currencySuffix,
+                decimalsToDisplay,
+                ledger.accounting().enabled
+              )
             )}
           </TableBody>
 
@@ -192,15 +207,22 @@ export const AccountOverview = ({
   );
 };
 
-const AccountRow = (account: Account, suffix: string, decimals: number) => (
+const AccountRow = (
+  account: Account,
+  suffix: string,
+  decimals: number,
+  accountingEnabled: boolean
+) => (
   <TableRow key={account.identity.id}>
     <TableCell component="th" scope="row">
       <IdentityDetails id={account.identity.id} name={account.identity.name} />
     </TableCell>
     <TableCell align="right">{account.active ? "✅" : "🛑"}</TableCell>
-    <TableCell align="right">
-      {G.format(account.balance, decimals, suffix)}
-    </TableCell>
+    {accountingEnabled && (
+      <TableCell align="right">
+        {G.format(account.balance, decimals, suffix)}
+      </TableCell>
+    )}
     <TableCell align="right">
       {G.format(account.paid, decimals, suffix)}
     </TableCell>


### PR DESCRIPTION
<!-- Please read our contributor guide before submitting your PR: -->
<!-- https://github.com/sourcecred/sourcecred/blob/master/CONTRIBUTING.md -->

# Description
This PR makes sure the CSV grain integration is ready for use. There were some minor features missing as well as some bugs that got introduced by recent changes.

- removes the balance column from the UI when ledger accounting is disabled
- do not write grain integration results to disk when -s flag is used
- fixes config update writing bug
- fixes credGrainview related bug
<!-- Possible prompts:
  Why is the change important?
  Did you consider and reject alternate formulations of the same idea?
  Are there relevant issues or discussions elsewhere?
-->

# Test Plan
currencyDetails.json:
```
{
  "currencyName": "USDC",
  "currencySuffix": " USDC",
  "integrationCurrency": {
    "type": "EVM",
    "chainId": "1",
    "tokenAddress": "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48"
  }
}
```
grain.json:
```
{
  "allocationPolicies": [
    {
      "budget": "100.1234",
      "numIntervalsLookback": 8,
      "policyType": "IMMEDIATE"
    }
  ],
  "maxSimultaneousDistributions": 1,
  "integration": { "type": "csv" },
  "accountingEnabled": false
}
```

1. checkout a production instance
2. regression testing: scdev grain -f -s && scdev serve
2. make the config changes above
2. scdev serve
3. identities > select identity > add payout address and save
4. scdev credequate or scdev credrank, depending on what instance you are using
5. scdev grain -f
6. verify only the person with a payout address gets grain
7. verify the csv file in ./output/grainintegration

<!-- Possible prompts:
  How well covered by automated tests is this change?
  How did you manually test this change? How can a reviewer replicate the tests?
-->
