### PR TITLE
Support for Gnosis in Csv Grain Integration

### DIFF
--- a/packages/grainIntegration-csv/distributionToCsv.js
+++ b/packages/grainIntegration-csv/distributionToCsv.js
@@ -1,12 +1,20 @@
 // @flow
 
 /*:: type PayoutDistributions = $ReadOnlyArray<[string, string]>;*/
+/*:: type IntegrationConfig = {
+  currency: {tokenAddress?: string},
+  integration: ?Object,
+};;*/
 module.exports = function payoutDistributionToCsv(
-  payoutDistributions /*: PayoutDistributions*/
+  payoutDistributions /*: PayoutDistributions*/,
+  config /*: IntegrationConfig*/
 ) /*: string*/ {
+  let prefix = "";
+  if (config.integration && config.integration.gnosis)
+    prefix = "erc20," + (config.currency.tokenAddress || "") + ",";
   let csvString = "";
   for (const [payoutAddress, amount] of payoutDistributions) {
-    csvString += `${payoutAddress},${amount}\n`;
+    csvString += prefix + `${payoutAddress},${amount}\n`;
   }
   return csvString;
 };

--- a/packages/grainIntegration-csv/index.js
+++ b/packages/grainIntegration-csv/index.js
@@ -6,8 +6,8 @@ const payoutDistributionToCsv = require("./distributionToCsv");
 // packages/sourcecred though, since that'll create a circular depedency.
 // Code we want to import from core needs to be split out into it's own
 // package first.
-const csvIntegration /*: any */ = (payoutDistributions, _unused_config) => {
-  const csvString = payoutDistributionToCsv(payoutDistributions);
+const csvIntegration /*: any */ = (payoutDistributions, config) => {
+  const csvString = payoutDistributionToCsv(payoutDistributions, config);
 
   const timestamp = Date.now();
 

--- a/packages/grainIntegration-csv/payoutDistributionToCsv.test.js
+++ b/packages/grainIntegration-csv/payoutDistributionToCsv.test.js
@@ -1,16 +1,44 @@
 // @flow
 const payoutDistributionToCsv = require("./distributionToCsv");
 describe("payoutDistributionToCsv", () => {
-  it("serializes entries into a csv", () => {
+  it("serializes entries into a csv when gnosis config is absent", () => {
     const mockDistributions = [
       ["abc", "123"],
       ["def", "456"],
     ];
-    const result = payoutDistributionToCsv(mockDistributions);
+    const result = payoutDistributionToCsv(mockDistributions, {
+      currency: { tokenAddress: "0x1234" },
+      integration: undefined,
+    });
     expect(result).toBe(`abc,123\ndef,456\n`);
   });
+  it("serializes entries into a csv with gnosis prefix", () => {
+    const mockDistributions = [
+      ["abc", "123"],
+      ["def", "456"],
+    ];
+    const result = payoutDistributionToCsv(mockDistributions, {
+      currency: { tokenAddress: "0x1234" },
+      integration: { gnosis: true },
+    });
+    expect(result).toBe(`erc20,0x1234,abc,123\nerc20,0x1234,def,456\n`);
+  });
+  it("serializes entries into a csv with gnosis prefix when the tokenAddress is absent", () => {
+    const mockDistributions = [
+      ["abc", "123"],
+      ["def", "456"],
+    ];
+    const result = payoutDistributionToCsv(mockDistributions, {
+      currency: {},
+      integration: { gnosis: true },
+    });
+    expect(result).toBe(`erc20,,abc,123\nerc20,,def,456\n`);
+  });
   it("returns an empty string when receiving an empty array", () => {
-    const result = payoutDistributionToCsv([]);
+    const result = payoutDistributionToCsv([], {
+      currency: { tokenAddress: "0x1234" },
+      integration: undefined,
+    });
     expect(result).toBe("");
   });
 });


### PR DESCRIPTION
<!-- Please read our contributor guide before submitting your PR: -->
<!-- https://github.com/sourcecred/sourcecred/blob/master/CONTRIBUTING.md -->

# Description
The CSV Grain Integration only supported the disburse.app formatting, so this PR adds support for gnosis csv formatting.

To use, make the config in grain.json look like this:
```
"integration": { "type": "csv", "config": { "gnosis": true } },
```
<!-- Possible prompts:
  Why is the change important?
  Did you consider and reject alternate formulations of the same idea?
  Are there relevant issues or discussions elsewhere?
-->

# Test Plan
United tests added, and also manual tested rebased on https://github.com/sourcecred/sourcecred/pull/3320

result:
```
erc20,0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48,0x79229C990Bdb9a9E70f432E224e151F26edAEcd5,100000000000000000000
```

<!-- Possible prompts:
  How well covered by automated tests is this change?
  How did you manually test this change? How can a reviewer replicate the tests?
-->
