### PR TITLE
Add hybrid CLI that calls both credrank and credequate

### DIFF
--- a/packages/sourcecred/src/cli/help.js
+++ b/packages/sourcecred/src/cli/help.js
@@ -11,6 +11,7 @@ import {serveHelp} from "./serve";
 import {siteHelp} from "./site";
 import {credRankHelp} from "./credrank";
 import {credequateHelp} from "./credequate";
+import {hybridHelp} from "./hybrid";
 import {analysisHelp} from "./analysis";
 import {updateHelp} from "./update";
 import dedent from "../util/dedent";
@@ -31,6 +32,7 @@ const help: Command = async (args, std) => {
     site: siteHelp,
     credrank: credRankHelp,
     credequate: credequateHelp,
+    hybrid: hybridHelp,
     serve: serveHelp,
     analysis: analysisHelp,
     update: updateHelp,
@@ -61,8 +63,11 @@ function usage(print: (string) => void): void {
       AUXILIARY
       load          load plugin data into cache
       graph         build Cred graph from cached plugin data
+      contributions build Contributions from cached plugin data
       site          update your cred site with the latest changes
       credrank      calculate cred scores from existing graph
+      credequate    calculate cred scores from existing contributions
+      hybrid        run both credrank and credequate and sum the results
       analysis      generates useful data analysis structures
       help          show this help message
 

--- a/packages/sourcecred/src/cli/hybrid.js
+++ b/packages/sourcecred/src/cli/hybrid.js
@@ -1,0 +1,124 @@
+// @flow
+
+import {LoggingTaskReporter} from "../util/taskReporter";
+import type {Command} from "./command";
+import dedent from "../util/dedent";
+import {LocalInstance} from "../api/instance/localInstance";
+import {credequate} from "../api/main/credequate";
+import {credrank} from "../api/main/credrank";
+import {CredGrainView} from "../core/credGrainView";
+import {getEarliestStartForConfigs} from "../core/credequate/config";
+import sortBy from "../util/sortBy";
+import {sum} from "d3-array";
+
+const hybridCommand: Command = async (args, std) => {
+  let isSimulation = false;
+  let shouldZipOutput = true;
+  args.forEach((arg) => {
+    switch (arg) {
+      case "--simulation":
+      case "-s":
+        isSimulation = true;
+        break;
+      case "--no-zip":
+        shouldZipOutput = false;
+        break;
+    }
+  });
+
+  const taskReporter = new LoggingTaskReporter();
+  taskReporter.start("hybrid");
+  const baseDir = process.cwd();
+  const instance = new LocalInstance(baseDir);
+
+  taskReporter.start("hybrid: running credrank");
+  const credrankInput = await instance.readCredrankInput();
+  const credrankOutput = credrankInput.pluginGraphs.length
+    ? await credrank(credrankInput)
+    : null;
+  taskReporter.finish("hybrid: running credrank");
+
+  taskReporter.start("hybrid: running credequate");
+  const credequateInput = await instance.readCredequateInput();
+  const credequateOutput = {
+    scoredContributions: Array.from(
+      credequate(credequateInput).scoredContributions
+    ),
+  };
+  taskReporter.finish("hybrid: running credequate");
+
+  taskReporter.start("hybrid: generating CredGrainView");
+  const credGrainViewCE = CredGrainView.fromScoredContributionsAndLedger(
+    credequateOutput.scoredContributions,
+    credrankOutput?.ledger || credrankInput.ledger,
+    getEarliestStartForConfigs(
+      credequateInput.rawInstanceConfig.credEquatePlugins.map(
+        (p) => p.configsByTarget
+      )
+    )
+  );
+  const credGrainViewCR = credrankOutput
+    ? CredGrainView.fromCredGraphAndLedger(
+        credrankOutput.credGraph,
+        credrankOutput.ledger
+      )
+    : new CredGrainView();
+  const credGrainView = CredGrainView.fromCredGrainViews(
+    credGrainViewCE,
+    credGrainViewCR
+  );
+  taskReporter.finish("hybrid: generating CredGrainView");
+
+  std.out("\n\n# CredEquate Scores");
+  printCredSummaryTable(credGrainViewCE, std);
+  std.out("\n\n# CredRank Scores");
+  printCredSummaryTable(credGrainViewCR, std);
+  std.out("\n\n# Hybrid Scores");
+  printCredSummaryTable(credGrainView, std);
+
+  if (!isSimulation) {
+    taskReporter.start("writing changes");
+    await instance.writeCredequateOutput(credequateOutput, shouldZipOutput);
+    if (credrankOutput)
+      await instance.writeCredrankOutput(credrankOutput, shouldZipOutput);
+    await instance.writeCredGrainView(credGrainView, shouldZipOutput);
+    taskReporter.finish("writing changes");
+  }
+
+  taskReporter.finish("hybrid");
+  return 0;
+};
+
+function printCredSummaryTable(credGrainView: CredGrainView, std) {
+  std.out(`## Top Participants By Cred`);
+  std.out(``);
+  std.out(`| Description | Cred | % |`);
+  std.out(`| --- | --- | --- |`);
+  const credParticipants = Array.from(credGrainView.participants());
+  const sortedParticipants = sortBy(credParticipants, (p) => -p.cred);
+  const totalCred = sum(sortedParticipants, (p) => p.cred);
+  function row({cred, identity}) {
+    const percentage = (100 * cred) / totalCred;
+    return `| ${identity.name} | ${cred.toFixed(1)} | ${percentage.toFixed(
+      1
+    )}% |`;
+  }
+  sortedParticipants.slice(0, 20).forEach((n) => std.out(row(n)));
+}
+
+export const hybridHelp: Command = async (args, std) => {
+  std.out(
+    dedent`\
+      usage: sourcecred hybrid [options]
+
+      options:
+      -s, --simulation  Skips writing changes to disk.
+      --no-zip  Writes the output as JSON without compressing large files
+
+      Run both CredRank and CredEquate and sum the results into one CredGrainView.
+      `.trimRight()
+  );
+  return 0;
+};
+
+export default hybridCommand;

--- a/packages/sourcecred/src/cli/sourcecred.js
+++ b/packages/sourcecred/src/cli/sourcecred.js
@@ -12,6 +12,7 @@ import serve from "./serve";
 import grain from "./grain";
 import credrank from "./credrank";
 import credequate from "./credequate";
+import hybrid from "./hybrid";
 import analysis from "./analysis";
 import update from "./update";
 import help from "./help";
@@ -46,6 +47,8 @@ const sourcecred: Command = async (args, std) => {
       return credrank(args.slice(1), std);
     case "credequate":
       return credequate(args.slice(1), std);
+    case "hybrid":
+      return hybrid(args.slice(1), std);
     case "analysis":
       return analysis(args.slice(1), std);
     case "update":

--- a/packages/sourcecred/src/core/credGrainView.js
+++ b/packages/sourcecred/src/core/credGrainView.js
@@ -413,7 +413,6 @@ that participant in the params.
   static fromCredGrainViews(
     ...views: $ReadOnlyArray<CredGrainView>
   ): CredGrainView {
-    const seen = new Set();
     const allIntervals = views.flatMap((view) => view.intervals());
     const intervals = weekIntervals(
       Math.min(...allIntervals.map((i) => i.startTimeMs)),
@@ -427,8 +426,8 @@ that participant in the params.
       for (const participant of view.participants()) {
         let existing = participants.get(participant.identity.id);
         if (!existing) {
-          const credPerInterval = intervals.map((x) => 0);
-          const grainEarnedPerInterval = intervals.map((x) => G.ZERO);
+          const credPerInterval = intervals.map(() => 0);
+          const grainEarnedPerInterval = intervals.map(() => G.ZERO);
           existing = {
             credPerInterval,
             grainEarnedPerInterval,

--- a/packages/sourcecred/src/core/credGrainView.js
+++ b/packages/sourcecred/src/core/credGrainView.js
@@ -81,19 +81,22 @@ export const credGrainViewParser: C.Parser<CredGrainView> = C.object({
  */
 export class CredGrainView {
   _participants: $ReadOnlyArray<ParticipantCredGrain>;
+  _participantsMap: Map<IdentityId, ParticipantCredGrain>;
   _intervals: IntervalSequence;
   _credTotals: Array<number>;
   _grainTotals: Array<Grain>;
 
   constructor(
-    participants: $ReadOnlyArray<ParticipantCredGrain>,
-    intervals: IntervalSequence
+    participants: $ReadOnlyArray<ParticipantCredGrain> = [],
+    intervals: IntervalSequence = intervalSequence([])
   ) {
     this._participants = participants;
     this._intervals = intervals;
     this._credTotals = [];
     this._grainTotals = [];
+    this._participantsMap = new Map();
     participants.forEach((participant) => {
+      this._participantsMap.set(participant.identity.id, participant);
       for (let i = 0; i < this._intervals.length; i++) {
         this._credTotals[i] =
           participant.credPerInterval[i] + (this._credTotals[i] || 0);
@@ -169,7 +172,7 @@ export class CredGrainView {
         throw new Error(`participant grain per interval length mismatch`);
       }
 
-      if (sum(p.credPerInterval) !== p.cred) {
+      if (sum(p.credPerInterval).toFixed(6) !== p.cred.toFixed(6)) {
         throw new Error(
           `participant cred per interval sum [${sum(
             p.credPerInterval
@@ -236,6 +239,16 @@ export class CredGrainView {
     return this._participants;
   }
 
+  /** Returns the data for the participant with the given ID */
+  participant(id: IdentityId): ParticipantCredGrain {
+    const result = this._participantsMap.get(id);
+    if (!result)
+      throw new Error(
+        `Participant [${id}] does not exist in the CredGrainView.`
+      );
+    return result;
+  }
+
   activeParticipants(): $ReadOnlyArray<ParticipantCredGrain> {
     return this._participants.filter((participant) => participant.active);
   }
@@ -260,6 +273,9 @@ export class CredGrainView {
     return new CredGrainView(json.participants, json.intervals);
   }
 
+  /**
+Creates a CredGrainView using the output of the CredRank API.
+ */
   static fromCredGraphAndLedger(
     credGraph: CredGraph,
     ledger: Ledger
@@ -322,6 +338,9 @@ export class CredGrainView {
     return new CredGrainView(participants, intervals);
   }
 
+  /**
+Creates a CredGrainView using the output of the CredEquate API.
+ */
   static fromScoredContributionsAndLedger(
     scoredContributions: Iterable<ScoredContribution>,
     ledger: Ledger,
@@ -384,6 +403,66 @@ export class CredGrainView {
 
     return new CredGrainView(participants, intervals);
   }
+
+  /**
+Combines multiple CredGrainViews into a single one. The intervals will span the
+earliest to the latest of all intervals in all the CredGrainViews.
+Participant identity/active data will match that of the first occurrence of
+that participant in the params.
+ */
+  static fromCredGrainViews(
+    ...views: $ReadOnlyArray<CredGrainView>
+  ): CredGrainView {
+    const seen = new Set();
+    const allIntervals = views.flatMap((view) => view.intervals());
+    const intervals = weekIntervals(
+      Math.min(...allIntervals.map((i) => i.startTimeMs)),
+      Math.max(...allIntervals.map((i) => i.endTimeMs - 1))
+    );
+    const participants = new Map();
+    for (const view of views) {
+      const indexOffset = intervals.findIndex(
+        (i) => i.startTimeMs === view.intervals()[0].startTimeMs
+      );
+      for (const participant of view.participants()) {
+        let existing = participants.get(participant.identity.id);
+        if (!existing) {
+          const credPerInterval = intervals.map((x) => 0);
+          const grainEarnedPerInterval = intervals.map((x) => G.ZERO);
+          existing = {
+            credPerInterval,
+            grainEarnedPerInterval,
+            grainEarned: G.ZERO,
+            cred: 0,
+            identity: participant.identity,
+            active: participant.active,
+          };
+          participants.set(existing.identity.id, existing);
+        }
+        participant.credPerInterval.forEach((cred, index) => {
+          if (!existing)
+            // Makes flow happy
+            throw "CredGrainView.fromCredGrainViews: this should not happen";
+          existing.cred += cred;
+          existing.credPerInterval[index + indexOffset] += cred;
+        });
+        participant.grainEarnedPerInterval.forEach((grain, index) => {
+          if (!existing)
+            // Makes flow happy
+            throw "CredGrainView.fromCredGrainViews: this should not happen";
+          existing.grainEarned = G.add(existing.grainEarned, grain);
+          existing.grainEarnedPerInterval[index + indexOffset] = G.add(
+            existing.grainEarnedPerInterval[index + indexOffset],
+            grain
+          );
+        });
+      }
+    }
+    return new CredGrainView(
+      Array.from(participants.values()),
+      intervalSequence(intervals)
+    );
+  }
 }
 
 /**
@@ -394,6 +473,7 @@ export class CredGrainView {
  */
 export class TimeScopedCredGrainView {
   _participants: $ReadOnlyArray<ParticipantCredGrain>;
+  _participantsMap: Map<IdentityId, ParticipantCredGrain>;
   _intervals: IntervalSequence;
   _credTotals: $ReadOnlyArray<number>;
   _grainTotals: $ReadOnlyArray<Grain>;
@@ -421,6 +501,7 @@ export class TimeScopedCredGrainView {
         originalIntervals.slice(inclusiveStartIndex, exclusiveEndIndex)
       )
     );
+    this._participantsMap = new Map();
     this._participants = deepFreeze(
       credGrainView.participants().map((participant) => {
         const credPerInterval = participant.credPerInterval.slice(
@@ -431,7 +512,7 @@ export class TimeScopedCredGrainView {
           inclusiveStartIndex,
           exclusiveEndIndex
         );
-        return {
+        const result = {
           active: participant.active,
           identity: participant.identity,
           cred: credPerInterval.reduce((a, b) => a + b, 0),
@@ -442,6 +523,8 @@ export class TimeScopedCredGrainView {
           ),
           grainEarnedPerInterval,
         };
+        this._participantsMap.set(result.identity.id, result);
+        return result;
       })
     );
     this._credTotals = credGrainView
@@ -458,6 +541,15 @@ export class TimeScopedCredGrainView {
 
   participants(): $ReadOnlyArray<ParticipantCredGrain> {
     return this._participants;
+  }
+
+  participant(id: IdentityId): ParticipantCredGrain {
+    const result = this._participantsMap.get(id);
+    if (!result)
+      throw new Error(
+        `Participant [${id}] does not exist in the CredGrainView.`
+      );
+    return result;
   }
 
   activeParticipants(): $ReadOnlyArray<ParticipantCredGrain> {

--- a/packages/sourcecred/src/core/credGrainView.test.js
+++ b/packages/sourcecred/src/core/credGrainView.test.js
@@ -77,6 +77,59 @@ describe("core/credGrainView", () => {
       );
     });
 
+    it("should combines 2 CredGrainViews with same intervals", async () => {
+      const credGraph2 = await GraphUtil.credGraph();
+      const ledger2 = ledgerWithActiveIdentities(id1, id2);
+      ledger2.distributeGrain(distribution1);
+      ledger2.distributeGrain(distribution2);
+      const credGrainView2 = CredGrainView.fromCredGraphAndLedger(
+        credGraph2,
+        ledger2
+      );
+
+      const combinedCredGrainViews = CredGrainView.fromCredGrainViews(
+        credGrainView,
+        credGrainView2
+      );
+
+      const expectedCredGrainView = CredGrainView.fromJSON(
+        JSON.parse(
+          '{"intervals":[{"endTimeMs":1643500800000,"startTimeMs":1642896000000},{"endTimeMs":1644105600000,\
+          "startTimeMs":1643500800000}],"participants":[{"active":true,"cred":5.999998675930378,\
+          "credPerInterval":[1.895894362437521,4.104104313492857],"grainEarned":"46","grainEarnedPerInterval":["26","20"],\
+          "identity":{"address":"N\\u0000sourcecred\\u0000core\\u0000IDENTITY\\u0000YVZhbGlkVXVpZEF0TGFzdA\\u0000",\
+          "aliases":[],"id":"YVZhbGlkVXVpZEF0TGFzdA","name":"steven","subtype":"USER"}},{"active":true,"cred":2.573231098488234e-19,\
+          "credPerInterval":[1.0292924393952936e-19,1.5439386590929404e-19],"grainEarned":"54","grainEarnedPerInterval":["34","20"],\
+          "identity":{"address":"N\\u0000sourcecred\\u0000core\\u0000IDENTITY\\u0000URgLrCxgvjHxtGJ9PgmckQ\\u0000",\
+          "aliases":[],"id":"URgLrCxgvjHxtGJ9PgmckQ","name":"crystal-gems","subtype":"ORGANIZATION"}}]}'
+        )
+      );
+      expect(combinedCredGrainViews).toEqual(expectedCredGrainView);
+    });
+
+    it("should combines 2 CredGrainViews with zero-overlapped intervals", async () => {
+      const credGraph2 = await GraphUtil.credGraph3();
+      const ledger2 = ledgerWithActiveIdentities(id1, id2);
+      ledger2.distributeGrain(distribution1);
+      ledger2.distributeGrain(distribution2);
+      const credGrainView2 = CredGrainView.fromCredGraphAndLedger(
+        credGraph2,
+        ledger2
+      );
+
+      const combinedCredGrainViews = CredGrainView.fromCredGrainViews(
+        credGrainView,
+        credGrainView2
+      );
+
+      const expectedCredGrainView = CredGrainView.fromJSON(
+        JSON.parse(
+          '{"intervals":[{"endTimeMs":1641686400000,"startTimeMs":1641081600000},{"endTimeMs":1642291200000,"startTimeMs":1641686400000},{"endTimeMs":1642896000000,"startTimeMs":1642291200000},{"endTimeMs":1643500800000,"startTimeMs":1642896000000},{"endTimeMs":1644105600000,"startTimeMs":1643500800000}],"participants":[{"active":true,"cred":3.624999337965189,"credPerInterval":[0.25,0.375,0,0.9479471812187605,2.0520521567464285],"grainEarned":"46","grainEarnedPerInterval":["0","0","0","26","20"],"identity":{"address":"N\\u0000sourcecred\\u0000core\\u0000IDENTITY\\u0000YVZhbGlkVXVpZEF0TGFzdA\\u0000","aliases":[],"id":"YVZhbGlkVXVpZEF0TGFzdA","name":"steven","subtype":"USER"}},{"active":true,"cred":0.625,"credPerInterval":[0.25,0.375,0,5.146462196976468e-20,7.719693295464702e-20],"grainEarned":"54","grainEarnedPerInterval":["0","0","0","34","20"],"identity":{"address":"N\\u0000sourcecred\\u0000core\\u0000IDENTITY\\u0000URgLrCxgvjHxtGJ9PgmckQ\\u0000","aliases":[],"id":"URgLrCxgvjHxtGJ9PgmckQ","name":"crystal-gems","subtype":"ORGANIZATION"}}]}'
+        )
+      );
+      expect(combinedCredGrainViews).toEqual(expectedCredGrainView);
+    });
+
     it("should have participant data for all intervals", () => {
       const expectedIntervals = GraphUtil.intervals;
       const expectedParticipants = [

--- a/packages/sourcecred/src/core/credrank/testUtils.js
+++ b/packages/sourcecred/src/core/credrank/testUtils.js
@@ -36,9 +36,15 @@ const na = (name) => NA.fromParts([name]);
 const ea = (name) => EA.fromParts([name]);
 
 export const week: number = 604800000;
+/** Date: Sunday, January 23, 2022 12:00:00 AM */
 export const week1: number = 1642896000000;
 export const week2: number = week1 + week;
 export const week3: number = week1 + 2 * week;
+
+/** Date: Sunday, January 2, 2022 12:00:00 AM */
+export const week4: number = week1 - 3 * week;
+export const week5: number = week1 - 2 * week;
+export const week6: number = week1 - week;
 
 export const participantNode1: GraphNode = {
   description: "participant1",
@@ -126,6 +132,13 @@ export const intervals: IntervalSequence = deepFreeze(
   intervalSequence([
     {startTimeMs: week1, endTimeMs: week2},
     {startTimeMs: week2, endTimeMs: week3},
+  ])
+);
+
+export const intervals2: IntervalSequence = deepFreeze(
+  intervalSequence([
+    {startTimeMs: week4, endTimeMs: week5},
+    {startTimeMs: week5, endTimeMs: week6},
   ])
 );
 
@@ -326,8 +339,18 @@ export const args2 = (
   participants: [participant3, participant4],
   personalAttributions,
 });
+
+export const args3 = (
+  personalAttributions?: PersonalAttributions = []
+): MarkovProcessGraphArguments => ({
+  weightedGraph: weightedGraph2(),
+  parameters,
+  intervals: intervals2,
+  participants: [participant1, participant2],
+  personalAttributions,
+});
 const attribution3 = {
-  fromParticipantId: participant3.id,
+  fromParticipantId: participant1.id,
   recipients: [
     {
       toParticipantId: participant4.id,
@@ -357,3 +380,10 @@ export const markovProcessGraph2 = (
 
 export const credGraph2: () => Promise<CredGraph> = async () =>
   markovProcessGraphPagerank(markovProcessGraph2());
+
+export const markovProcessGraph3 = (
+  attributions3?: PersonalAttributions = []
+): MarkovProcessGraph => MarkovProcessGraph.new(args3(attributions3));
+
+export const credGraph3: () => Promise<CredGraph> = async () =>
+  markovProcessGraphPagerank(markovProcessGraph3());


### PR DESCRIPTION

# Description
This adds a `hybrid` CLI that calls both credequate and credrank, and writes the output of each, except the CredGrainView is a merged CredGrainView based on the outputs of both algorithms.

This allows different plugins to be run with different algorithms, or even the same plugin to be run in both algorithms for comparison.
<!-- Possible prompts:
  Why is the change important?
  Did you consider and reject alternate formulations of the same idea?
  Are there relevant issues or discussions elsewhere?
-->

# Test Plan
1. checkout sourcecred/cred2
1. scdev contributions & scdev graph
2. scdev hybrid
3. Try with no plugins, a plugin in each algorithm one at a time, a plugin in both algorithms

```
{
  "bundledPlugins": ["sourcecred/discord"],
  "credEquatePlugins": [
    {
      "id": "sourcecred/discord",
      "configsByTarget": {
        "453243919774253079": [
          {
            "memo": "Initial Config",
            "startDate": "1/1/2021",
            "weights": [
              {
                "key": "emoji",
                "default": 1,
                "subkeys": [
                  {
                    "subkey": "sourcecred:626763367893303303",
                    "weight": 3
                  },
                  {
                    "subkey": "👎",
                    "weight": 0
                  }
                ]
              },
              {
                "key": "role",
                "default": 0,
                "subkeys": [
                  {
                    "subkey": "477551557723029514",
                    "memo": "contributors",
                    "weight": 2
                  },
                  {
                    "subkey": "717905734863421472",
                    "memo": "community",
                    "weight": 1
                  }
                ]
              },
              {
                "key": "channel",
                "default": 1,
                "subkeys": [
                  {
                    "subkey": "743545520445718700",
                    "memo": "meeting-notes",
                    "weight": 8
                  },
                  {
                    "subkey": "718512695875469353",
                    "memo": "announcements",
                    "weight": 0.1
                  },
                  {
                    "subkey": "454007860926611478",
                    "memo": "any-questions",
                    "weight": 3
                  },
                  {
                    "subkey": "679064720375808026",
                    "memo": "props",
                    "weight": 15
                  },
                  {
                    "subkey": "543168537062014987",
                    "memo": "did-a-thing",
                    "weight": 12
                  }
                ]
              },
              {
                "key": "category",
                "default": 1,
                "subkeys": []
              }
            ],
            "operators": [
              {
                "key": "reactionsAcrossParticipants",
                "operator": "AVERAGE"
              },
              {
                "key": "reactionsOfSingleParticipant",
                "operator": "MAX"
              }
            ],
            "shares": [
              {
                "key": "author",
                "default": 1,
                "subkeys": [
                  {
                    "subkey": "743545520445718700",
                    "memo": "meeting-notes",
                    "weight": 0.05
                  },
                  {
                    "subkey": "679064720375808026",
                    "memo": "props",
                    "weight": 0
                  }
                ]
              },
              {
                "key": "mention",
                "default": 1,
                "subkeys": []
              }
            ]
          }
        ]
      }
    }
  ]
}
```
<!-- Possible prompts:
  How well covered by automated tests is this change?
  How did you manually test this change? How can a reviewer replicate the tests?
-->
