### PR TITLE
Change the Go CLI to run contributions, and use hybrid instead of cre…

### DIFF
--- a/packages/sourcecred/src/cli/go.js
+++ b/packages/sourcecred/src/cli/go.js
@@ -5,7 +5,8 @@ import dedent from "../util/dedent";
 
 import load from "./load";
 import graph from "./graph";
-import credrank from "./credrank";
+import contributions from "./contributions";
+import hybrid from "./hybrid";
 
 function die(std, message) {
   std.err("fatal: " + message);
@@ -25,7 +26,8 @@ const goCommand: Command = async (args, std) => {
   const commandSequence = [
     {name: "load", command: load, args: []},
     {name: "graph", command: graph, args: []},
-    {name: "credrank", command: credrank, args: []},
+    {name: "contributions", command: contributions, args: []},
+    {name: "hybrid", command: hybrid, args: []},
   ];
 
   for (const {name, command, args} of commandSequence) {
@@ -45,10 +47,10 @@ export const goHelp: Command = async (args, std) => {
 
       Load data from plugins, build a graph and generate cred scores.
 
-      Under the hood, this runs 'sourcecred load', 'sourcecred graph' and
-      'sourcecred credrank' in sequence. If the '--no-load' argument is
-      provided, then the load step will be skipped, using data from cache
-      instead.
+      Under the hood, this runs 'sourcecred load', 'sourcecred graph',
+      'sourcecred contributions' and 'sourcecred credrank' in sequence. If the
+      '--no-load' argument is provided, then the load step will be skipped,
+      using data from cache instead.
 
       If any command in the sequence fails, the sequence will bail and
       subsequent commands will not be executed.

--- a/packages/sourcecred/src/cli/hybrid.js
+++ b/packages/sourcecred/src/cli/hybrid.js
@@ -103,7 +103,8 @@ const hybridCommand: Command = async (args, std) => {
     taskReporter.start("hybrid: writing changes");
     if (credrankOutput)
       await instance.writeCredrankOutput(credrankOutput, shouldZipOutput);
-    await instance.writeCredequateOutput(credequateOutput, shouldZipOutput);
+    if (hasCredequatePlugins)
+      await instance.writeCredequateOutput(credequateOutput, shouldZipOutput);
     await instance.writeCredGrainView(credGrainView, shouldZipOutput);
     taskReporter.finish("hybrid: writing changes");
   }


### PR DESCRIPTION
# Description
This changes the Go CLI, which is what instances use to shorthand generation of graphs and scores, to perform a hybrid generate flow (credrank + credequate). This won't be very noticeable for users once rolled out, but it will allow people to add or switch to credequate configurations by simply editing the configs in sourcecred.json, without the need to edit the package.json scripts.
<!-- Possible prompts:
  Why is the change important?
  Did you consider and reject alternate formulations of the same idea?
  Are there relevant issues or discussions elsewhere?
-->

# Test Plan
Regression test: checkout sourcecred/cred/gh-pages, run `git pull` and run `scdev go --no-load`

Hybrid has been thoroughly tested in its own PR.
<!-- Possible prompts:
  How well covered by automated tests is this change?
  How did you manually test this change? How can a reviewer replicate the tests?
-->
