### PR TITLE
CredEquate: create MVP GitHub plugin

### DIFF
--- a/packages/sourcecred/src/plugins/github/createContributions.js
+++ b/packages/sourcecred/src/plugins/github/createContributions.js
@@ -1,0 +1,116 @@
+// @flow
+
+import * as NullUtil from "../../util/null";
+import type {RelationalView} from "./relationalView";
+import type {Contribution} from "../../core/credequate/contribution";
+import {OPERATOR_KEY_PREFIX} from "../../core/credequate/operator";
+import {KEYS} from "./declaration";
+import * as GithubNode from "./nodes";
+
+export function* createContributions(
+  repoId: string,
+  view: RelationalView
+): Iterable<Contribution> {
+  for (const pull of view.pulls()) {
+    const commitAddress = pull.mergedAs();
+    if (commitAddress == null) continue; // Skip unmerged PRs
+    const commit = NullUtil.get(view.commit(commitAddress));
+
+    const participants = new Map();
+    const authorLoginSet = new Set();
+    for (const author of pull.authors()) {
+      authorLoginSet.add(author.login);
+      const address = GithubNode.toRaw(author.address());
+      const participant = participants.get(address);
+      if (participant)
+        participant.shares.push({key: KEYS.PULL_AUTHOR, subkey: repoId});
+      else
+        participants.set(address, {
+          id: address,
+          shares: [{key: KEYS.PULL_AUTHOR, subkey: repoId}],
+        });
+    }
+    for (const author of commit.authors()) {
+      const address = GithubNode.toRaw(author.address());
+      const participant = participants.get(address);
+      if (participant)
+        participant.shares.push({key: KEYS.COMMIT_AUTHOR, subkey: repoId});
+      else
+        participants.set(address, {
+          id: address,
+          shares: [{key: KEYS.COMMIT_AUTHOR, subkey: repoId}],
+        });
+    }
+
+    yield {
+      id: pull.number(),
+      plugin: "sourcecred/github",
+      type: "Pull Request",
+      timestampMs: commit.timestampMs(),
+      participants: Array.from(participants.values()),
+      expression: {
+        description: "pull request",
+        operator: "ADD",
+        expressionOperands: [
+          {
+            description: "reactions",
+            operator: OPERATOR_KEY_PREFIX + KEYS.REACTIONS_OPERATOR,
+            expressionOperands: [],
+            weightOperands: pull
+              .reactions()
+              .filter((reaction) => !authorLoginSet.has(reaction.user.login))
+              .map((reaction) => ({
+                key: KEYS.REACTION,
+                subkey: reaction.content,
+              })),
+          },
+        ],
+        weightOperands: [{key: KEYS.PULL, subkey: repoId}],
+      },
+    };
+
+    for (const review of pull.reviews()) {
+      const reviewers = new Map();
+      const authorLoginSet = new Set();
+      for (const author of review.authors()) {
+        authorLoginSet.add(author.login);
+        const address = GithubNode.toRaw(author.address());
+        const reviewer = reviewers.get(address);
+        if (reviewer)
+          reviewer.shares.push({key: KEYS.REVIEW_AUTHOR, subkey: repoId});
+        else
+          reviewers.set(address, {
+            id: address,
+            shares: [{key: KEYS.PULL_AUTHOR, subkey: repoId}],
+          });
+      }
+
+      yield {
+        id: review.address().id,
+        plugin: "sourcecred/github",
+        type: "Review",
+        timestampMs: review.timestampMs(),
+        participants: Array.from(reviewers.values()),
+        expression: {
+          description: "review",
+          operator: "ADD",
+          expressionOperands: [
+            {
+              description: "reactions",
+              operator: OPERATOR_KEY_PREFIX + KEYS.REACTIONS_OPERATOR,
+              expressionOperands: [],
+              weightOperands: Array.from(review.comments())
+                .flatMap((c) => c.reactions())
+                .filter((reaction) => !authorLoginSet.has(reaction.user.login))
+                .map((reaction) => ({
+                  key: KEYS.REACTION,
+                  subkey: reaction.content,
+                })),
+            },
+          ],
+          weightOperands: [{key: KEYS.REVIEW, subkey: repoId}],
+        },
+      };
+    }
+  }
+}

--- a/packages/sourcecred/src/plugins/github/declaration.js
+++ b/packages/sourcecred/src/plugins/github/declaration.js
@@ -206,6 +206,16 @@ const edgeTypes = deepFreeze([
   correspondsToCommitEdgeType,
 ]);
 
+export const KEYS = {
+  REACTIONS_OPERATOR: "reactionsOperator",
+  PULL_AUTHOR: "pull author",
+  COMMIT_AUTHOR: "commit author",
+  REVIEW_AUTHOR: "review author",
+  PULL: "pull request",
+  REVIEW: "review",
+  REACTION: "reaction",
+};
+
 export const declaration: PluginDeclaration = deepFreeze({
   name: "GitHub",
   nodePrefix: N.Prefix.base,
@@ -214,8 +224,8 @@ export const declaration: PluginDeclaration = deepFreeze({
   edgeTypes: edgeTypes,
   userTypes: [userNodeType],
   keys: {
-    operatorKeys: [],
-    shareKeys: [],
-    weightKeys: [],
+    operatorKeys: [KEYS.REACTIONS_OPERATOR],
+    shareKeys: [KEYS.PULL_AUTHOR, KEYS.COMMIT_AUTHOR, KEYS.REVIEW_AUTHOR],
+    weightKeys: [KEYS.PULL, KEYS.REACTION, KEYS.REACTION],
   },
 });


### PR DESCRIPTION
<!-- Please read our contributor guide before submitting your PR: -->
<!-- https://github.com/sourcecred/sourcecred/blob/master/CONTRIBUTING.md -->

# Description
This creates a minimum viable GitHub plugin for CredEquate. It is very simple and could be improved/expanded to be much better, but this produces reasonable and acceptable outcomes.

Benefits/differences of this MVP compared to the existing credrank GitHub plugin includes:
- You can set per-repository weights
- Reviews on a merged Pull Request mint their own cred, meaning that reviewers aren't in competition with each other or with the author.
- Comments outside of Reviews are not counted.
<!-- Possible prompts:
  Why is the change important?
  Did you consider and reject alternate formulations of the same idea?
  Are there relevant issues or discussions elsewhere?
-->

# Test Plan

1. Checkout sourcecred/cred/gh-pages
2. replace sourcecred.json with the config below
3. `scdev contributions && scdev contributions --no-zip` and verify output/contributions/sourcecred/github/contributions.json looks as expected
4. `scdev credequate` and verify console output scores are reasonable
5. Make config adjustments and verify expected score changes with `scdev credequate`

```
{
  "bundledPlugins": [],
  "credEquatePlugins": [
    {
      "id": "sourcecred/github",
      "configsByTarget": {
        "sourcecred/sourcecred": [
          {
            "memo": "Initial Config",
            "startDate": "8/1/2021",
            "weights": [
              {
                "key": "pull request",
                "default": 10,
                "subkeys": []
              },
              {
                "key": "reaction",
                "default": 1,
                "subkeys": []
              },
              {
                "key": "review",
                "default": 5,
                "subkeys": []
              }
            ],
            "operators": [
              {
                "key": "reactionsOperator",
                "operator": "ADD"
              }
            ],
            "shares": [
              {
                "key": "pull author",
                "default": 1,
                "subkeys": []
              },
              {
                "key": "commit author",
                "default": 1,
                "subkeys": []
              },
              {
                "key": "review author",
                "default": 1,
                "subkeys": []
              }
            ]
          }
        ]
      }
    }
  ]
}
```

Scores with the above config:

| Description | Cred | % |
| --- | --- | --- |
| Thena | 749.3 | 37.4% |
| topocount | 386.7 | 19.3% |
| hz | 308.0 | 15.4% |
| amrro | 192.7 | 9.6% |
| dependabot | 80.0 | 4.0% |
| magwalk | 55.0 | 2.7% |
| Randall | 55.0 | 2.7% |
| bsodenkamp | 51.0 | 2.5% |
| mahmoud | 40.0 | 2.0% |
| decentralion | 25.0 | 1.2% |
| META-DREAMER-github | 22.0 | 1.1% |
| Cali93 | 13.3 | 0.7% |
| AL0YSI0US | 10.0 | 0.5% |
| black32167 | 10.0 | 0.5% |
| wchargin | 5.0 | 0.2% |
| beanow | 0.0 | 0.0% |
| brianlitwin | 0.0 | 0.0% |
| mzargham | 0.0 | 0.0% |
| s-ben | 0.0 | 0.0% |
| ryanmorton | 0.0 | 0.0% |