### PR TITLE
take and pass args to storage in persist

### DIFF
--- a/packages/sourcecred/src/api/ledgerManager.js
+++ b/packages/sourcecred/src/api/ledgerManager.js
@@ -74,13 +74,17 @@ export class LedgerManager {
    * not overwritten. If they were, we can show an error message to client B with
    * a list of changes that failed to sync.
    */
-  async persist(): Promise<ReloadResult> {
+  async persist(...storageSetArgs: any[]): Promise<ReloadResult> {
     // START RACE CONDITION
     const preWriteReloadRes = await this.reloadLedger();
     if (preWriteReloadRes.error) {
       return preWriteReloadRes;
     }
-    await this._storage.set(this._path, encode(this._ledger.serialize()));
+    await this._storage.set(
+      this._path,
+      encode(this._ledger.serialize()),
+      ...storageSetArgs
+    );
     // END RACE CONDITION
 
     // Reload ledger again to ensure all the changes were persisted into storage


### PR DESCRIPTION
<!-- Please read our contributor guide before submitting your PR: -->
<!-- https://github.com/sourcecred/sourcecred/blob/master/CONTRIBUTING.md -->

# Description
This would make it so that devs using the github plugin pass a message and author arguments when persisting remote ledgers
<!-- Possible prompts:
  Why is the change important?
  Did you consider and reject alternate formulations of the same idea?
  Are there relevant issues or discussions elsewhere?
-->

# Test Plan
yarn test
this should not affect anything in anyway
<!-- Possible prompts:
  How well covered by automated tests is this change?
  How did you manually test this change? How can a reviewer replicate the tests?
-->
