### PR TITLE
fix backward compatibility for gh storage

### DIFF
--- a/packages/sourcecred/src/core/storage/github.js
+++ b/packages/sourcecred/src/core/storage/github.js
@@ -38,7 +38,7 @@ type Author = {
   email: string,
 };
 
-export class GithubStorage implements DataStorage {
+class ReadableGithubStorage implements DataStorage {
   static ENDPOINT: string = "https://api.github.com";
 
   constructor(opts: Opts) {
@@ -99,8 +99,8 @@ export class GithubStorage implements DataStorage {
   }
 }
 
-export class WritableGithubStorage
-  extends GithubStorage
+class GithubStorage
+  extends ReadableGithubStorage
   implements WritableDataStorage {
   async set(
     path: string,
@@ -199,3 +199,5 @@ export class WritableGithubStorage
     });
   }
 }
+
+export {GithubStorage, GithubStorage as WritableGithubStorage};


### PR DESCRIPTION
<!-- Please read our contributor guide before submitting your PR: -->
<!-- https://github.com/sourcecred/sourcecred/blob/master/CONTRIBUTING.md -->

# Description
The GH storage exports two classes `GithubStorage` which only does read operations using the `get` method, and another class called `WritableGithubStorage` which does both read/write operations by extending `GithubStorage` and adding a `set` method, this is not backwards compatible and once you upgrade sourcecred the api breaks since the exported api `GithubStorage` used to do both read/write operations, this patch would still export the old and should be deprecated export of `WritableGithubStorage` as the same export as `GithubStorage`

this should actually make it easier for communities like 1hive which use github storage to upgrade to newer versions of sourcecred without scratching their head looking for the source of the bug, this bug would make it smooth to upgrade https://github.com/1Hive/pollen-onboarding as an example

<!-- Possible prompts:
  Why is the change important?
  Did you consider and reject alternate formulations of the same idea?
  Are there relevant issues or discussions elsewhere?
-->

# Test Plan
yarn test

<!-- Possible prompts:
  How well covered by automated tests is this change?
  How did you manually test this change? How can a reviewer replicate the tests?
-->
