### PR TITLE
Github action for generating docs

### DIFF
--- a/.github/workflows/generate-docs.yml
+++ b/.github/workflows/generate-docs.yml
@@ -1,0 +1,27 @@
+name: Generate Docs
+on:
+  push:
+    tags:
+      - "*sourcecred*"
+    workflow_dispatch:
+
+jobs:
+  GenerateDocs:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2.3.4
+        with:
+          persist-credentials: false # Required to make github pages deployment work correctly
+
+      - name: Install Packages 🔧
+        run: yarn --frozen-lockfile
+
+      - name: Generate Docs
+        run: yarn docs
+
+      - name: Deploy 🚀
+        uses: JamesIves/github-pages-deploy-action@4.1.4
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          branch: gh-pages
+          folder: docs


### PR DESCRIPTION
<!-- Please read our contributor guide before submitting your PR: -->
<!-- https://github.com/sourcecred/sourcecred/blob/master/CONTRIBUTING.md -->

# Description
Automatic deployment of docs when tags are pushed, not in the main branch to keep the main branch clean.
<!-- Possible prompts:
  Why is the change important?
  Did you consider and reject alternate formulations of the same idea?
  Are there relevant issues or discussions elsewhere?
-->

# Test Plan
will be tested after merging
<!-- Possible prompts:
  How well covered by automated tests is this change?
  How did you manually test this change? How can a reviewer replicate the tests?
-->
