### PR TITLE
Bugfix: explicit directory creation for plugin outputs

### DIFF
--- a/packages/sourcecred/src/api/instance/readInstance.js
+++ b/packages/sourcecred/src/api/instance/readInstance.js
@@ -350,7 +350,12 @@ export class ReadInstance implements ReadOnlyInstance {
     }
     const [pluginOwner, pluginName] = idParts;
     const pathComponents = [...components, pluginOwner, pluginName];
-    return pathJoin(...pathComponents);
+    let path = ".";
+    for (const pc of pathComponents) {
+      path = pathJoin(path, pc);
+      this.mkdir(path);
+    }
+    return path;
   }
 
   createPluginGraphDirectory(pluginId: string): string {
@@ -359,5 +364,10 @@ export class ReadInstance implements ReadOnlyInstance {
 
   createPluginContributionsDirectory(pluginId: string): string {
     return this.createPluginDirectory(CONTRIBUTIONS_DIRECTORY, pluginId);
+  }
+
+  // eslint-disable-next-line no-unused-vars
+  mkdir(path: string) {
+    // Override in subclasses
   }
 }

--- a/packages/sourcecred/src/api/instance/writeInstance.js
+++ b/packages/sourcecred/src/api/instance/writeInstance.js
@@ -372,9 +372,4 @@ export class WriteInstance extends ReadInstance implements Instance {
     }
     await Promise.all(promises);
   }
-
-  // eslint-disable-next-line no-unused-vars
-  mkdir(path: string) {
-    // Override in subclasses
-  }
 }


### PR DESCRIPTION
<!-- Please read our contributor guide before submitting your PR: -->
<!-- https://github.com/sourcecred/sourcecred/blob/master/CONTRIBUTING.md -->

# Description
Users are getting blocked by the error `[Error: ENOENT: no such file or directory, open '/home/runner/work/makerdao-cred/makerdao-cred/output/graphs/sourcecred/discourse/graph']` because our code is not running mkdir for plugin output directories. This bug didn't show in testing because on our dev laptops we were just overwriting within existing directories from a gh-pages clone rather than a fresh checkout of the main branch. This PR fixes the bug, making it so that the mkdir method is called down the directory chain before interacting with all plugin output directories.
<!-- Possible prompts:
  Why is the change important?
  Did you consider and reject alternate formulations of the same idea?
  Are there relevant issues or discussions elsewhere?
-->

# Test Plan
1. checkout sourcecred/cred/gh-pages
2. delete the ./output folder
3. scdev go --no-load
<!-- Possible prompts:
  How well covered by automated tests is this change?
  How did you manually test this change? How can a reviewer replicate the tests?
-->
