### PR TITLE
Dw 354/discord messages api issue

### DIFF
--- a/packages/sourcecred/package.json
+++ b/packages/sourcecred/package.json
@@ -3,7 +3,7 @@
   "description": "a tool for communities to measure and reward value creation",
   "homepage": "https://sourcecred.io",
   "repository": "github:sourcecred/sourcecred",
-  "version": "0.11.2",
+  "version": "0.11.1",
   "private": false,
   "dependencies": {
     "@aws-sdk/util-base64-browser": "^3.37.0",

--- a/packages/sourcecred/package.json
+++ b/packages/sourcecred/package.json
@@ -3,7 +3,7 @@
   "description": "a tool for communities to measure and reward value creation",
   "homepage": "https://sourcecred.io",
   "repository": "github:sourcecred/sourcecred",
-  "version": "0.11.1",
+  "version": "0.11.2",
   "private": false,
   "dependencies": {
     "@aws-sdk/util-base64-browser": "^3.37.0",

--- a/packages/sourcecred/src/plugins/discord/mirror.js
+++ b/packages/sourcecred/src/plugins/discord/mirror.js
@@ -110,7 +110,7 @@ export class Mirror {
             hasReachedBeginning = true;
             continue;
           }
-          if (!beforeId || beforeId > message.id) {
+          if (!beforeId || Number(beforeId) > Number(message.id)) {
             beforeId = message.id;
           }
           _this._repo.addMessage(message);


### PR DESCRIPTION
Discord message IDs have passed the quintillion mark and this has led to an infinite loop in the codebase due to a string comparison on numeric IDs. This PR proposes a simple fix of casting the IDs to numbers before doing the comparison.

Manually tested and working, thanks to @hozzjss for the work.
