### PR TITLE
Discord message IDs have passed the quintillion mark and this has led…

### DIFF
--- a/packages/sourcecred/src/plugins/discord/mirror.js
+++ b/packages/sourcecred/src/plugins/discord/mirror.js
@@ -110,7 +110,7 @@ export class Mirror {
             hasReachedBeginning = true;
             continue;
           }
-          if (!beforeId || beforeId > message.id) {
+          if (!beforeId || Number(beforeId) > Number(message.id)) {
             beforeId = message.id;
           }
           _this._repo.addMessage(message);


### PR DESCRIPTION
… to an infinite loop in the codebase due to a string comparison on numeric IDs. This PR proposes a simple fix of casting the IDs to numbers before doing the comparison.

<!-- Please read our contributor guide before submitting your PR: -->
<!-- https://github.com/sourcecred/sourcecred/blob/master/CONTRIBUTING.md -->

# Description

<!-- Possible prompts:
  Why is the change important?
  Did you consider and reject alternate formulations of the same idea?
  Are there relevant issues or discussions elsewhere?
-->

# Test Plan

<!-- Possible prompts:
  How well covered by automated tests is this change?
  How did you manually test this change? How can a reviewer replicate the tests?
-->
